### PR TITLE
Placeholders for Postgres tests.

### DIFF
--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/ActionDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/ActionDaoTests.java
@@ -1,0 +1,205 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import static org.junit.Assert.*;
+
+import javax.annotation.Resource;
+
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.ActionDetail;
+import com.imageworks.spcue.FilterDetail;
+import com.imageworks.spcue.Show;
+import com.imageworks.spcue.CueIce.ActionType;
+import com.imageworks.spcue.CueIce.ActionValueType;
+import com.imageworks.spcue.CueIce.FilterType;
+import com.imageworks.spcue.dao.ActionDao;
+import com.imageworks.spcue.dao.FilterDao;
+import com.imageworks.spcue.dao.GroupDao;
+import com.imageworks.spcue.dao.ShowDao;
+import com.imageworks.spcue.service.JobManager;
+
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class ActionDaoTests extends AbstractTransactionalJUnit4SpringContextTests  {
+
+    private static final ActionType ActionType = null;
+
+    @Resource
+    ActionDao actionDao;
+
+    @Resource
+    FilterDao filterDao;
+
+    @Resource
+    ShowDao showDao;
+
+    @Resource
+    GroupDao groupDao;
+
+    @Resource
+    JobManager jobManager;
+
+    private static String FILTER_NAME = "test_filter";
+
+    public Show getShow() {
+        return showDao.getShowDetail("00000000-0000-0000-0000-000000000000");
+    }
+
+    public FilterDetail buildFilter() {
+        FilterDetail filter = new FilterDetail();
+        filter.name = FILTER_NAME;
+        filter.showId = "00000000-0000-0000-0000-000000000000";
+        filter.type = FilterType.MatchAny;
+        filter.enabled = true;
+
+        return filter;
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testCreateAction() {
+
+        FilterDetail f = buildFilter();
+        filterDao.insertFilter(f);
+
+        ActionDetail a1 = new ActionDetail();
+        a1.type = ActionType.PauseJob;
+        a1.filterId = f.getFilterId();
+        a1.booleanValue = true;
+        a1.valueType = ActionValueType.BooleanType;
+        actionDao.createAction(a1);
+
+        ActionDetail a2 = new ActionDetail();
+        a2.type = ActionType.MoveJobToGroup;
+        a2.filterId = f.getFilterId();
+        a2.groupValue = groupDao.getRootGroupId(getShow());
+        a2.valueType = ActionValueType.GroupType;
+        actionDao.createAction(a2);
+
+        ActionDetail a3 = new ActionDetail();
+        a3.type = ActionType.SetJobMaxCores;
+        a3.filterId = f.getFilterId();
+        a3.floatValue = 1f;
+        a3.valueType = ActionValueType.FloatType;
+        actionDao.createAction(a3);
+
+        ActionDetail a4 = new ActionDetail();
+        a4.type = ActionType.SetJobMinCores;
+        a4.filterId = f.getFilterId();
+        a4.floatValue = 1;
+        a4.valueType = ActionValueType.FloatType;
+        actionDao.createAction(a4);
+
+        ActionDetail a5 = new ActionDetail();
+        a5.type = ActionType.StopProcessing;
+        a5.filterId = f.getFilterId();
+        a5.valueType = ActionValueType.NoneType;
+        actionDao.createAction(a5);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testDeleteAction() {
+
+        FilterDetail f = buildFilter();
+        filterDao.insertFilter(f);
+
+        ActionDetail a = new ActionDetail();
+        a.type = ActionType.StopProcessing;
+        a.filterId = f.getFilterId();
+        a.valueType = ActionValueType.NoneType;
+        actionDao.createAction(a);
+        actionDao.deleteAction(a);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetAction() {
+        FilterDetail f = buildFilter();
+        filterDao.insertFilter(f);
+
+        ActionDetail a = new ActionDetail();
+        a.type = ActionType.StopProcessing;
+        a.filterId = f.getFilterId();
+        a.valueType = ActionValueType.NoneType;
+        actionDao.createAction(a);
+        actionDao.getAction(a);
+        actionDao.getAction(a.getActionId());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateAction() {
+        FilterDetail f = buildFilter();
+        filterDao.insertFilter(f);
+
+        ActionDetail a = new ActionDetail();
+        a.type = ActionType.StopProcessing;
+        a.filterId = f.getFilterId();
+        a.name = null;
+        a.valueType = ActionValueType.NoneType;
+        actionDao.createAction(a);
+
+        a.floatValue = 1f;
+        a.type = ActionType.SetJobMinCores;
+        a.valueType = ActionValueType.FloatType;
+
+        actionDao.updateAction(a);
+
+        assertEquals(Integer.valueOf(1),
+                jdbcTemplate.queryForObject(
+                        "SELECT float_value FROM action WHERE pk_action=?",
+                        Integer.class, a.id));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetActions() {
+        FilterDetail f = buildFilter();
+        filterDao.insertFilter(f);
+
+        ActionDetail a = new ActionDetail();
+        a.type = ActionType.StopProcessing;
+        a.filterId = f.getFilterId();
+        a.name = null;
+        a.valueType = ActionValueType.NoneType;
+        actionDao.createAction(a);
+
+        actionDao.getActions(f);
+    }
+}
+
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/AllocationDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/AllocationDaoTests.java
@@ -1,0 +1,180 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import static org.junit.Assert.*;
+
+import javax.annotation.Resource;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.AllocationEntity;
+import com.imageworks.spcue.FacilityInterface;
+import com.imageworks.spcue.ShowDetail;
+import com.imageworks.spcue.dao.AllocationDao;
+import com.imageworks.spcue.dao.FacilityDao;
+import com.imageworks.spcue.service.AdminManager;
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class AllocationDaoTests extends AbstractTransactionalJUnit4SpringContextTests  {
+
+    @Resource
+    AllocationDao allocDao;
+
+    @Resource
+    FacilityDao facilityDao;
+
+    @Resource
+    AdminManager adminManager;
+
+    public static final String ALLOC_FQN = "spi.test_alloc";
+    public static final String ALLOC_NAME = "test_alloc";
+    public static final String ALLOC_TAG = "test";
+
+    private AllocationEntity alloc;
+
+    @Before
+    public void before() {
+
+        alloc = new AllocationEntity();
+        alloc.name = ALLOC_NAME;
+        alloc.tag = ALLOC_TAG;
+
+        allocDao.insertAllocation(
+                facilityDao.getFacility("spi"),  alloc);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetAllocation() {
+        allocDao.getAllocationEntity(alloc.getId());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindAllocation() {
+        FacilityInterface f = facilityDao.getFacility("spi");
+        allocDao.findAllocationEntity(f.getName(), ALLOC_NAME);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindAllocation2() {
+        FacilityInterface f = facilityDao.getFacility("spi");
+        allocDao.findAllocationEntity(ALLOC_FQN);
+    }
+
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testDeleteAllocation() {
+        allocDao.deleteAllocation(alloc);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testDeleteAllocationWithProc() {
+
+        // Use the alloc so deleting triggers it just to be disaled.
+        ShowDetail show = adminManager.getShowDetail(
+                "00000000-0000-0000-0000-000000000000");
+        adminManager.createSubscription(show, alloc, 10, 10);
+        allocDao.deleteAllocation(alloc);
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT COUNT(1) FROM alloc WHERE pk_alloc=? AND b_enabled = 0",
+                Integer.class, alloc.getAllocationId()));
+
+        assertEquals(ALLOC_FQN, jdbcTemplate.queryForObject(
+                "SELECT str_name FROM alloc WHERE pk_alloc=? AND b_enabled = 0",
+                String.class, alloc.getAllocationId()));
+
+        // Now re-enable it.
+        allocDao.insertAllocation(facilityDao.getDefaultFacility(), alloc);
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT COUNT(1) FROM alloc WHERE pk_alloc=? AND b_enabled = 1",
+                Integer.class, alloc.getAllocationId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateAllocationName() {
+        allocDao.updateAllocationName(alloc, "frickjack");
+        assertEquals("spi.frickjack", jdbcTemplate.queryForObject(
+                "SELECT str_name FROM alloc WHERE pk_alloc=?",
+                String.class,
+                alloc.getId()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    @Transactional
+    @Rollback(true)
+    public void testUpdateAllocationNameBad() {
+        allocDao.updateAllocationName(alloc, "spi.frickjack");
+        assertEquals("spi.frickjack", jdbcTemplate.queryForObject(
+                "SELECT str_name FROM alloc WHERE pk_alloc=?",
+                String.class, alloc.getId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateAllocationTag() {
+        allocDao.updateAllocationTag(alloc, "foo");
+        assertEquals("foo",jdbcTemplate.queryForObject(
+                "SELECT str_tag FROM alloc WHERE pk_alloc=?",
+                String.class, alloc.getId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateAllocationBillable() {
+        allocDao.updateAllocationBillable(alloc, false);
+
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT b_billable FROM alloc WHERE pk_alloc=?",
+                Integer.class, alloc.getId()));
+
+        allocDao.updateAllocationBillable(alloc, true);
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT b_billable FROM alloc WHERE pk_alloc=?",
+                Integer.class, alloc.getId()));
+    }
+}
+
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/BookingDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/BookingDaoTests.java
@@ -1,0 +1,454 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import javax.annotation.Resource;
+
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.DispatchHost;
+import com.imageworks.spcue.Frame;
+import com.imageworks.spcue.JobDetail;
+import com.imageworks.spcue.Layer;
+import com.imageworks.spcue.LocalHostAssignment;
+import com.imageworks.spcue.CueClientIce.RenderPartition;
+import com.imageworks.spcue.CueIce.RenderPartitionType;
+import com.imageworks.spcue.dao.BookingDao;
+import com.imageworks.spcue.dao.DispatcherDao;
+import com.imageworks.spcue.dao.HostDao;
+import com.imageworks.spcue.dao.ProcDao;
+import com.imageworks.spcue.grpc.host.HardwareState;
+import com.imageworks.spcue.grpc.report.RenderHost;
+import com.imageworks.spcue.service.AdminManager;
+import com.imageworks.spcue.service.HostManager;
+import com.imageworks.spcue.service.JobLauncher;
+import com.imageworks.spcue.service.JobManager;
+import com.imageworks.spcue.service.Whiteboard;
+import com.imageworks.spcue.util.CueUtil;
+
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class BookingDaoTests  extends AbstractTransactionalJUnit4SpringContextTests {
+
+    @Resource
+    HostManager hostManager;
+
+    @Resource
+    AdminManager adminManager;
+
+    @Resource
+    JobLauncher jobLauncher;
+
+    @Resource
+    JobManager jobManager;
+
+    @Resource
+    HostDao hostDao;
+
+    @Resource
+    BookingDao bookingDao;
+
+    @Resource
+    DispatcherDao dispatcherDao;
+
+    @Resource
+    ProcDao procDao;
+
+    @Resource
+    Whiteboard whiteboard;
+
+    public DispatchHost createHost() {
+        RenderHost host = RenderHost.newBuilder()
+                .setName("test_host")
+                .setBootTime(1192369572)
+                .setFreeMcp(76020)
+                .setFreeMem(53500)
+                .setFreeSwap(20760)
+                .setLoad(1)
+                .setTotalMcp(195430)
+                .setTotalMem((int) CueUtil.GB16)
+                .setTotalSwap((int) CueUtil.GB16)
+                .setNimbyEnabled(false)
+                .setNumProcs(2)
+                .setCoresPerProc(100)
+                .setState(HardwareState.UP)
+                .setFacility("spi")
+                .addTags("general")
+                .putAttributes("freeGpu", String.format("%d", CueUtil.MB512))
+                .putAttributes("totalGpu", String.format("%d", CueUtil.MB512))
+                .build();
+        DispatchHost dh = hostManager.createHost(host);
+        hostManager.setAllocation(dh,
+                adminManager.findAllocationDetail("spi", "general"));
+
+        return dh;
+    }
+
+    public JobDetail launchJob() {
+        jobLauncher.testMode = true;
+        jobLauncher.launch(new File("src/test/resources/conf/jobspec/jobspec.xml"));
+        JobDetail d = jobManager.findJobDetail("pipe-dev.cue-testuser_shell_v1");
+        jobManager.setJobPaused(d, false);
+        return d;
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void insertLocalJobAssignment() {
+
+        DispatchHost h = createHost();
+        JobDetail j = launchJob();
+
+        LocalHostAssignment lja = new LocalHostAssignment();
+        lja.setMaxCoreUnits(200);
+        lja.setMaxMemory(CueUtil.GB4);
+        lja.setMaxGpu(1);
+        lja.setThreads(2);
+
+        bookingDao.insertLocalHostAssignment(h, j, lja);
+
+
+        assertEquals(Integer.valueOf(2), jdbcTemplate.queryForObject(
+                "SELECT int_threads FROM host_local WHERE pk_job=?",
+                Integer.class, j.getJobId()));
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT int_gpu_max FROM host_local WHERE pk_job=?",
+                Integer.class, j.getJobId()));
+
+        assertEquals(Integer.valueOf(200), jdbcTemplate.queryForObject(
+                "SELECT int_cores_max FROM host_local WHERE pk_job=?",
+                Integer.class, j.getJobId()));
+
+        assertEquals(Long.valueOf(CueUtil.GB4), jdbcTemplate.queryForObject(
+                "SELECT int_mem_max FROM host_local WHERE pk_job=?",
+                Long.class, j.getJobId()));
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT int_gpu_max FROM host_local WHERE pk_job=?",
+                Integer.class, j.getJobId()));
+
+        assertEquals(Integer.valueOf(200), jdbcTemplate.queryForObject(
+                "SELECT int_cores_idle FROM host_local WHERE pk_job=?",
+                Integer.class, j.getJobId()));
+
+        assertEquals(Long.valueOf(CueUtil.GB4), jdbcTemplate.queryForObject(
+                "SELECT int_mem_idle FROM host_local WHERE pk_job=?",
+                Long.class, j.getJobId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void insertLocalLayerAssignment() {
+
+        DispatchHost h = createHost();
+        JobDetail j = launchJob();
+        Layer layer = jobManager.getLayers(j).get(0);
+
+        LocalHostAssignment lja = new LocalHostAssignment();
+        lja.setMaxCoreUnits(200);
+        lja.setMaxMemory(CueUtil.GB4);
+        lja.setMaxGpu(1);
+        lja.setThreads(2);
+
+        bookingDao.insertLocalHostAssignment(h, layer, lja);
+
+        assertEquals(layer.getLayerId(), jdbcTemplate.queryForObject(
+                "SELECT pk_layer FROM host_local WHERE pk_host_local=?",
+                String.class, lja.getId()));
+
+        assertEquals(RenderPartitionType.LayerPartition.toString(),
+                jdbcTemplate.queryForObject(
+                "SELECT str_type FROM host_local WHERE pk_host_local=?",
+                String.class, lja.getId()));
+
+        assertEquals(Integer.valueOf(2), jdbcTemplate.queryForObject(
+                "SELECT int_threads FROM host_local WHERE pk_job=?",
+                Integer.class, j.getJobId()));
+
+        assertEquals(Integer.valueOf(200), jdbcTemplate.queryForObject(
+                "SELECT int_cores_max FROM host_local WHERE pk_job=?",
+                Integer.class, j.getJobId()));
+
+        assertEquals(Long.valueOf(CueUtil.GB4), jdbcTemplate.queryForObject(
+                "SELECT int_mem_max FROM host_local WHERE pk_job=?",
+                Long.class, j.getJobId()));
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT int_gpu_max FROM host_local WHERE pk_job=?",
+                Integer.class, j.getJobId()));
+
+        assertEquals(Integer.valueOf(200), jdbcTemplate.queryForObject(
+                "SELECT int_cores_idle FROM host_local WHERE pk_job=?",
+                Integer.class, j.getJobId()));
+
+        assertEquals(Long.valueOf(CueUtil.GB4), jdbcTemplate.queryForObject(
+                "SELECT int_mem_idle FROM host_local WHERE pk_job=?",
+                Long.class, j.getJobId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void insertLocalFrameAssignment() {
+
+        DispatchHost h = createHost();
+        JobDetail j = launchJob();
+        Layer layer = jobManager.getLayers(j).get(0);
+        Frame frame = jobManager.findFrame(layer, 1);
+
+        LocalHostAssignment lja = new LocalHostAssignment();
+        lja.setMaxCoreUnits(200);
+        lja.setMaxMemory(CueUtil.GB4);
+        lja.setMaxGpu(1);
+        lja.setThreads(2);
+
+        bookingDao.insertLocalHostAssignment(h, frame, lja);
+
+        assertEquals(frame.getFrameId(), jdbcTemplate.queryForObject(
+                "SELECT pk_frame FROM host_local WHERE pk_host_local=?",
+                String.class, lja.getId()));
+
+        assertEquals(RenderPartitionType.FramePartition.toString(),
+                jdbcTemplate.queryForObject(
+                "SELECT str_type FROM host_local WHERE pk_host_local=?",
+                String.class, lja.getId()));
+
+        assertEquals(Integer.valueOf(2), jdbcTemplate.queryForObject(
+                "SELECT int_threads FROM host_local WHERE pk_job=?",
+                Integer.class, j.getJobId()));
+
+        assertEquals(Integer.valueOf(200), jdbcTemplate.queryForObject(
+                "SELECT int_cores_max FROM host_local WHERE pk_job=?",
+                Integer.class, j.getJobId()));
+
+        assertEquals(Long.valueOf(CueUtil.GB4), jdbcTemplate.queryForObject(
+                "SELECT int_mem_max FROM host_local WHERE pk_job=?",
+                Long.class, j.getJobId()));
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT int_gpu_max FROM host_local WHERE pk_job=?",
+                Integer.class, j.getJobId()));
+
+        assertEquals(Integer.valueOf(200), jdbcTemplate.queryForObject(
+                "SELECT int_cores_idle FROM host_local WHERE pk_job=?",
+                Integer.class, j.getJobId()));
+
+        assertEquals(Long.valueOf(CueUtil.GB4), jdbcTemplate.queryForObject(
+                "SELECT int_mem_idle FROM host_local WHERE pk_job=?",
+                Long.class, j.getJobId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetLocalJobAssignment() {
+
+        DispatchHost h = createHost();
+        JobDetail j = launchJob();
+
+        LocalHostAssignment lja = new LocalHostAssignment();
+        lja.setMaxCoreUnits(200);
+        lja.setMaxMemory(CueUtil.GB4);
+        lja.setThreads(2);
+        lja.setMaxGpu(1);
+
+        bookingDao.insertLocalHostAssignment(h, j, lja);
+
+        LocalHostAssignment lja2 = bookingDao.getLocalJobAssignment(h.getHostId(),
+                                                                    j.getJobId());
+
+        assertEquals(lja.getMaxCoreUnits(), lja2.getMaxCoreUnits());
+        assertEquals(lja.getMaxMemory(), lja2.getMaxMemory());
+        assertEquals(lja.getMaxGpu(), lja2.getMaxGpu());
+        assertEquals(lja.getThreads(), lja2.getThreads());
+
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetRenderPartition() {
+
+        DispatchHost h = createHost();
+        JobDetail j = launchJob();
+
+        LocalHostAssignment lja = new LocalHostAssignment();
+        lja.setMaxCoreUnits(200);
+        lja.setMaxMemory(CueUtil.GB4);
+        lja.setThreads(2);
+        lja.setMaxGpu(1);
+
+        bookingDao.insertLocalHostAssignment(h, j, lja);
+
+        LocalHostAssignment lja2 = bookingDao.getLocalJobAssignment(h.getHostId(),
+                                                                    j.getJobId());
+
+        assertEquals(lja.getMaxCoreUnits(), lja2.getMaxCoreUnits());
+        assertEquals(lja.getMaxMemory(), lja2.getMaxMemory());
+        assertEquals(lja.getThreads(), lja2.getThreads());
+        assertEquals(lja.getMaxGpu(), lja2.getMaxGpu());
+
+        RenderPartition rp = whiteboard.getRenderPartition(lja2);
+
+        assertEquals(lja2.getMaxCoreUnits(), rp.maxCores);
+        assertEquals(lja2.getMaxMemory(), rp.maxMemory);
+        assertEquals(lja2.getThreads(), rp.threads);
+        logger.info("--------------------");
+        logger.info(lja2.getMaxGpu());
+        logger.info(rp.maxGpu);
+        assertEquals(lja2.getMaxGpu(), rp.maxGpu);
+        assertEquals(h.getName(), rp.host);
+        assertEquals(j.getName(), rp.job);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetProcs() {
+
+        DispatchHost h = createHost();
+        JobDetail j = launchJob();
+
+        LocalHostAssignment lja = new LocalHostAssignment();
+        lja.setMaxCoreUnits(200);
+        lja.setMaxMemory(CueUtil.GB4);
+        lja.setThreads(2);
+        lja.setMaxGpu(1);
+
+        bookingDao.insertLocalHostAssignment(h, j, lja);
+
+        assertEquals(0, procDao.findVirtualProcs(lja).size());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void updateMaxCores() {
+
+        DispatchHost h = createHost();
+        JobDetail j = launchJob();
+
+        LocalHostAssignment lja = new LocalHostAssignment();
+        lja.setMaxCoreUnits(200);
+        lja.setMaxMemory(CueUtil.GB4);
+        lja.setThreads(2);
+        lja.setMaxGpu(1);
+
+        bookingDao.insertLocalHostAssignment(h, j, lja);
+        assertTrue(bookingDao.updateMaxCores(lja, 100));
+        assertEquals(Integer.valueOf(100), jdbcTemplate.queryForObject(
+                "SELECT int_cores_max FROM host_local WHERE pk_host=?",
+                Integer.class, h.getHostId()));
+
+        LocalHostAssignment lj2 = bookingDao.getLocalJobAssignment(lja.id);
+
+        assertEquals(100, lj2.getIdleCoreUnits());
+        assertEquals(100, lj2.getMaxCoreUnits());
+
+        bookingDao.updateMaxCores(lja, 200);
+
+        lj2 = bookingDao.getLocalJobAssignment(lja.id);
+
+        assertEquals(200, lj2.getIdleCoreUnits());
+        assertEquals(200, lj2.getMaxCoreUnits());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void updateMaxMemory() {
+
+        DispatchHost h = createHost();
+        JobDetail j = launchJob();
+
+        LocalHostAssignment lja = new LocalHostAssignment();
+        lja.setMaxCoreUnits(200);
+        lja.setMaxMemory(CueUtil.GB4);
+        lja.setThreads(2);
+        lja.setMaxGpu(1);
+
+        bookingDao.insertLocalHostAssignment(h, j, lja);
+        bookingDao.updateMaxMemory(lja, CueUtil.GB2);
+
+        LocalHostAssignment lj2 = bookingDao.getLocalJobAssignment(lja.id);
+
+        assertEquals(CueUtil.GB2, lj2.getIdleMemory());
+        assertEquals(CueUtil.GB2, lj2.getMaxMemory());
+
+        bookingDao.updateMaxMemory(lja, CueUtil.GB4);
+
+        lj2 = bookingDao.getLocalJobAssignment(lja.id);
+
+        assertEquals(CueUtil.GB4, lj2.getIdleMemory());
+        assertEquals(CueUtil.GB4, lj2.getMaxMemory());
+}
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void updateMaxGpu() {
+
+        DispatchHost h = createHost();
+        JobDetail j = launchJob();
+
+        LocalHostAssignment lja = new LocalHostAssignment();
+        lja.setMaxCoreUnits(200);
+        lja.setMaxMemory(CueUtil.GB4);
+        lja.setThreads(2);
+        lja.setMaxGpu(1);
+
+        bookingDao.insertLocalHostAssignment(h, j, lja);
+        bookingDao.updateMaxMemory(lja, CueUtil.GB2);
+
+        LocalHostAssignment lj2 = bookingDao.getLocalJobAssignment(lja.id);
+
+        assertEquals(CueUtil.GB2, lj2.getIdleMemory());
+        assertEquals(CueUtil.GB2, lj2.getMaxMemory());
+        assertEquals(1, lj2.getMaxGpu());
+
+        bookingDao.updateMaxGpu(lja, 2);
+
+        lj2 = bookingDao.getLocalJobAssignment(lja.id);
+
+        assertEquals(CueUtil.GB2, lj2.getIdleMemory());
+        assertEquals(CueUtil.GB2, lj2.getMaxMemory());
+        assertEquals(2, lj2.getMaxGpu());
+    }
+}
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/CommentDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/CommentDaoTests.java
@@ -1,0 +1,236 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import javax.annotation.Resource;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.CommentDetail;
+import com.imageworks.spcue.DispatchHost;
+import com.imageworks.spcue.JobDetail;
+import com.imageworks.spcue.dao.CommentDao;
+import com.imageworks.spcue.grpc.host.HardwareState;
+import com.imageworks.spcue.grpc.report.RenderHost;
+import com.imageworks.spcue.service.HostManager;
+import com.imageworks.spcue.service.JobLauncher;
+import com.imageworks.spcue.service.JobManager;
+import com.imageworks.spcue.util.CueUtil;
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class CommentDaoTests  extends AbstractTransactionalJUnit4SpringContextTests  {
+
+    @Resource
+    CommentDao commentDao;
+
+    @Resource
+    JobManager jobManager;
+
+    @Resource
+    JobLauncher jobLauncher;
+
+    @Resource
+    HostManager hostManager;
+
+    @Before
+    public void testMode() {
+        jobLauncher.testMode = true;
+        jobLauncher.launch(new File("src/test/resources/conf/jobspec/jobspec.xml"));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testDeleteComment() {
+
+        JobDetail job = jobManager.findJobDetail("pipe-dev.cue-testuser_shell_v1");
+
+        CommentDetail d = new CommentDetail();
+        d.message = "a message";
+        d.subject = "a subject";
+        d.user = "user";
+
+        commentDao.insertComment(job, d);
+        commentDao.deleteComment(d.getId());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetComment() {
+
+        JobDetail job = jobManager.findJobDetail("pipe-dev.cue-testuser_shell_v1");
+
+        CommentDetail d = new CommentDetail();
+        d.message = "a message";
+        d.subject = "a subject";
+        d.user = "user";
+
+        commentDao.insertComment(job, d);
+
+        CommentDetail nd = commentDao.getCommentDetail(d.getId());
+
+        assertEquals(d.message,nd.message);
+        assertEquals(d.subject,nd.subject);
+        assertEquals(d.user,nd.user);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertCommentOnJob() {
+
+        JobDetail job = jobManager.findJobDetail("pipe-dev.cue-testuser_shell_v1");
+
+        CommentDetail d = new CommentDetail();
+        d.message = "a message";
+        d.subject = "a subject";
+        d.user = "user";
+
+        commentDao.insertComment(job, d);
+
+        CommentDetail nd = commentDao.getCommentDetail(d.getId());
+
+        assertEquals(d.message,nd.message);
+        assertEquals(d.subject,nd.subject);
+        assertEquals(d.user,nd.user);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertCommentOnHost() {
+
+        RenderHost host = RenderHost.newBuilder()
+                .setName("boo")
+                .setBootTime(1192369572)
+                .setFreeMcp(76020)
+                .setFreeMem(15290520)
+                .setFreeSwap(2076)
+                .setLoad(1)
+                .setTotalMcp(19543)
+                .setTotalMem(15290520)
+                .setTotalSwap(2096)
+                .setNimbyEnabled(false)
+                .setNumProcs(2)
+                .setCoresPerProc(400)
+                .addTags("linux")
+                .setState(HardwareState.UP)
+                .setFacility("spi")
+                .putAttributes("freeGpu", String.format("%d", CueUtil.MB512))
+                .putAttributes("totalGpu", String.format("%d", CueUtil.MB512))
+                .build();
+
+        CommentDetail d = new CommentDetail();
+        d.message = "a message";
+        d.subject = "a subject";
+        d.user = "user";
+
+        DispatchHost h = hostManager.createHost(host);
+        commentDao.insertComment(h, d);
+
+        assertNotNull(d.id);
+
+        CommentDetail nd = commentDao.getCommentDetail(d.getId());
+
+        assertEquals(d.message,nd.message);
+        assertEquals(d.subject,nd.subject);
+        assertEquals(d.user,nd.user);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateComment() {
+
+        JobDetail job = jobManager.findJobDetail("pipe-dev.cue-testuser_shell_v1");
+
+        CommentDetail d = new CommentDetail();
+        d.message = "a message";
+        d.subject = "a subject";
+        d.user = "user";
+
+        commentDao.insertComment(job, d);
+
+        d.message = "no";
+        d.subject = "no";
+
+        commentDao.updateComment(d);
+
+        CommentDetail nd = commentDao.getCommentDetail(d.getId());
+
+        assertEquals("no",nd.message);
+        assertEquals("no",nd.subject);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateCommentMessage() {
+
+        JobDetail job = jobManager.findJobDetail("pipe-dev.cue-testuser_shell_v1");
+
+        CommentDetail d = new CommentDetail();
+        d.message = "a message";
+        d.subject = "a subject";
+        d.user = "user";
+
+        commentDao.insertComment(job, d);
+        commentDao.updateCommentMessage(d.getId(), "no");
+        CommentDetail nd = commentDao.getCommentDetail(d.getId());
+        assertEquals("no",nd.message);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateCommentSubject() {
+
+        JobDetail job = jobManager.findJobDetail("pipe-dev.cue-testuser_shell_v1");
+
+        CommentDetail d = new CommentDetail();
+        d.message = "a message";
+        d.subject = "a subject";
+        d.user = "user";
+
+        commentDao.insertComment(job, d);
+        commentDao.updateCommentSubject(d.getId(), "no");
+        CommentDetail nd = commentDao.getCommentDetail(d.getId());
+        assertEquals("no",nd.subject);
+    }
+}
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/DeedDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/DeedDaoTests.java
@@ -1,0 +1,213 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import static org.junit.Assert.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import javax.annotation.Resource;
+
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.Deed;
+import com.imageworks.spcue.DispatchHost;
+import com.imageworks.spcue.Owner;
+import com.imageworks.spcue.Show;
+import com.imageworks.spcue.dao.DeedDao;
+import com.imageworks.spcue.grpc.host.HardwareState;
+import com.imageworks.spcue.grpc.report.RenderHost;
+import com.imageworks.spcue.service.AdminManager;
+import com.imageworks.spcue.service.HostManager;
+import com.imageworks.spcue.service.OwnerManager;
+import com.imageworks.spcue.util.CueUtil;
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class DeedDaoTests  extends AbstractTransactionalJUnit4SpringContextTests {
+
+    @Resource
+    OwnerManager ownerManager;
+
+    @Resource
+    DeedDao deedDao;
+
+    @Resource
+    AdminManager adminManager;
+
+    @Resource
+    HostManager hostManager;
+
+    public DispatchHost createHost() {
+
+        RenderHost host = RenderHost.newBuilder()
+                .setName("test_host")
+                .setBootTime(1192369572)
+                .setFreeMcp(76020)
+                .setFreeMem(15290520)
+                .setFreeSwap(2076)
+                .setLoad(1)
+                .setTotalMcp(19543)
+                .setTotalMem((int) CueUtil.GB16)
+                .setTotalSwap((int) CueUtil.GB16)
+                .setNimbyEnabled(false)
+                .setNumProcs(2)
+                .setCoresPerProc(100)
+                .addTags("general")
+                .setState(HardwareState.UP)
+                .setFacility("spi")
+                .putAttributes("freeGpu", String.format("%d", CueUtil.MB512))
+                .putAttributes("totalGpu", String.format("%d", CueUtil.MB512))
+                .build();
+
+        DispatchHost dh = hostManager.createHost(host);
+        hostManager.setAllocation(dh,
+                adminManager.findAllocationDetail("spi", "general"));
+
+        return dh;
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertDeed() {
+
+        DispatchHost host = createHost();
+        Show s = adminManager.findShowDetail("pipe");
+        Owner o = ownerManager.createOwner("squarepants", s);
+        Deed d = deedDao.insertDeed(o, host);
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT COUNT(1) FROM deed WHERE pk_deed=?",
+                Integer.class, d.getId()));
+
+        assertEquals(host.getName(), d.host);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void tesDeleteDeed() {
+
+        DispatchHost host = createHost();
+        Show s = adminManager.findShowDetail("pipe");
+        Owner o = ownerManager.createOwner("squarepants", s);
+        Deed d = deedDao.insertDeed(o, host);
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT COUNT(1) FROM deed WHERE pk_deed=?",
+                Integer.class, d.getId()));
+
+        assertTrue(deedDao.deleteDeed(d));
+
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT COUNT(1) FROM deed WHERE pk_deed=?",
+                Integer.class, d.getId()));
+
+        assertFalse(deedDao.deleteDeed(d));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void tesGetDeed() {
+
+        DispatchHost host = createHost();
+        Show s = adminManager.findShowDetail("pipe");
+        Owner o = ownerManager.createOwner("squarepants", s);
+        Deed d = deedDao.insertDeed(o, host);
+
+        Deed d2 = deedDao.getDeed(d.id);
+
+        assertEquals(d, d2);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void tesGetDeeds() {
+
+        DispatchHost host = createHost();
+        Show s = adminManager.findShowDetail("pipe");
+        Owner o = ownerManager.createOwner("squarepants", s);
+        Deed d = deedDao.insertDeed(o, host);
+
+        assertEquals(1, deedDao.getDeeds(o).size());
+        assertEquals(d, deedDao.getDeeds(o).get(0));
+    }
+
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testEnableDisableBlackoutTime() {
+
+        DispatchHost host = createHost();
+        Show s = adminManager.findShowDetail("pipe");
+        Owner o = ownerManager.createOwner("squarepants", s);
+        Deed d = deedDao.insertDeed(o, host);
+
+        deedDao.updateBlackoutTimeEnabled(d, true);
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT b_blackout FROM deed WHERE pk_deed=?",
+                Integer.class, d.getId()));
+
+        deedDao.updateBlackoutTimeEnabled(d, false);
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT b_blackout FROM deed WHERE pk_deed=?",
+                Integer.class, d.getId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testSetBlackOutTimes() {
+
+        DispatchHost host = createHost();
+        Show s = adminManager.findShowDetail("pipe");
+        Owner o = ownerManager.createOwner("squarepants", s);
+        Deed d = deedDao.insertDeed(o, host);
+
+        deedDao.setBlackoutTime(d, 3600, 7200);
+
+        assertEquals(Integer.valueOf(3600), jdbcTemplate.queryForObject(
+                "SELECT  int_blackout_start FROM deed WHERE pk_deed=?",
+                Integer.class, d.getId()));
+
+        assertEquals(Integer.valueOf(7200), jdbcTemplate.queryForObject(
+                "SELECT int_blackout_stop FROM deed WHERE pk_deed=?",
+                Integer.class, d.getId()));
+    }
+}
+
+
+
+
+
+
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/DepartmentDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/DepartmentDaoTests.java
@@ -1,0 +1,105 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import javax.annotation.Resource;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.Department;
+import com.imageworks.spcue.dao.DepartmentDao;
+import com.imageworks.spcue.service.AdminManager;
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class DepartmentDaoTests extends AbstractTransactionalJUnit4SpringContextTests  {
+
+    @Resource
+    DepartmentDao departmentDao;
+
+    @Resource
+    AdminManager adminManager;
+
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetDepartment() {
+        String dept= "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAA0";
+        assertEquals(dept, departmentDao.getDepartment(dept).getId());
+        assertEquals(dept, departmentDao.getDepartment(dept).getDepartmentId());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindDepartment() {
+        String dept= "Hair";
+        assertEquals(dept, departmentDao.findDepartment(dept).getName());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testgetDefaultDepartment() {
+        assertEquals(jdbcTemplate.queryForObject(
+                "SELECT pk_dept FROM dept WHERE b_default=1",
+                String.class),departmentDao.getDefaultDepartment().getId());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testDepartmentExists() {
+        String dept= "Cloth";
+        assertTrue(departmentDao.departmentExists(dept));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertDepartment() {
+        String deptName = "TestDept";
+        departmentDao.insertDepartment(deptName);
+        Department d = departmentDao.findDepartment(deptName);
+        assertEquals(d.getName(), deptName);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testDeleteDepartment() {
+        String deptName = "TestDept";
+        departmentDao.insertDepartment(deptName);
+        Department d = departmentDao.findDepartment(deptName);
+        assertEquals(d.getName(), deptName);
+        departmentDao.deleteDepartment(d);
+    }
+}
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/DependDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/DependDaoTests.java
@@ -1,0 +1,440 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import javax.annotation.Resource;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.FrameDetail;
+import com.imageworks.spcue.LightweightDependency;
+
+import com.imageworks.spcue.JobDetail;
+
+import com.imageworks.spcue.Layer;
+import com.imageworks.spcue.CueIce.DependTarget;
+import com.imageworks.spcue.CueIce.DependType;
+import com.imageworks.spcue.dao.DependDao;
+import com.imageworks.spcue.dao.FrameDao;
+import com.imageworks.spcue.dao.LayerDao;
+import com.imageworks.spcue.depend.*;
+import com.imageworks.spcue.service.DependManager;
+import com.imageworks.spcue.service.JobLauncher;
+import com.imageworks.spcue.service.JobManager;
+import com.imageworks.spcue.service.JobManagerSupport;
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class DependDaoTests extends AbstractTransactionalJUnit4SpringContextTests  {
+
+    @Resource
+    DependDao dependDao;
+
+    @Resource
+    FrameDao frameDao;
+
+    @Resource
+    LayerDao layerDao;
+
+    @Resource
+    JobManager jobManager;
+
+    @Resource
+    DependManager dependManager;
+
+    @Resource
+    JobManagerSupport jobManagerSupport;
+
+    @Resource
+    JobLauncher jobLauncher;
+
+    @Before
+    public void launchTestJobs() {
+        jobLauncher.testMode = true;
+        jobLauncher.launch(new File("src/test/resources/conf/jobspec/jobspec_depend_test.xml"));
+    }
+
+    public JobDetail getJobA() {
+        return jobManager.findJobDetail("pipe-dev.cue-testuser_depend_test_a");
+    }
+
+    public JobDetail getJobB() {
+        return jobManager.findJobDetail("pipe-dev.cue-testuser_depend_test_b");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertJobOnJob() {
+
+        JobDetail job_a = getJobA();
+        JobDetail job_b = getJobB();
+
+        JobOnJob depend = new JobOnJob(job_a, job_b);
+        dependDao.insertDepend(depend);
+
+        LightweightDependency lwd = dependDao.getDepend(depend.getId());
+        assertEquals(depend.getId(), lwd.getId());
+        assertEquals(DependType.JobOnJob, lwd.type);
+        assertEquals(DependTarget.External, lwd.target);
+        assertTrue(lwd.active);
+        assertFalse(lwd.anyFrame);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertJobOnLayer() {
+
+        JobDetail job_a = getJobA();
+        JobDetail job_b = getJobB();
+
+        Layer layer = layerDao.findLayer(job_b, "pass_1");
+        JobOnLayer depend = new JobOnLayer(job_a, layer);
+        dependDao.insertDepend(depend);
+
+        LightweightDependency lwd = dependDao.getDepend(depend.getId());
+        assertEquals(depend.getId(), lwd.getId());
+        assertEquals(DependType.JobOnLayer, lwd.type);
+        assertEquals(DependTarget.External, lwd.target);
+        assertTrue(lwd.active);
+        assertFalse(lwd.anyFrame);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertJobOnFrame() {
+
+        JobDetail job_a = getJobA();
+        JobDetail job_b = getJobB();
+
+        FrameDetail frame = frameDao.findFrameDetail(job_b, "0001-pass_1");
+        JobOnFrame depend = new JobOnFrame(job_a, frame);
+        dependDao.insertDepend(depend);
+
+        LightweightDependency lwd = dependDao.getDepend(depend.getId());
+        assertEquals(depend.getId(), lwd.getId());
+        assertEquals(DependType.JobOnFrame, lwd.type);
+        assertEquals(DependTarget.External, lwd.target);
+        assertTrue(lwd.active);
+        assertFalse(lwd.anyFrame);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertLayerOnJob() {
+
+        JobDetail job_a = getJobA();
+        JobDetail job_b = getJobB();
+        Layer layer = layerDao.findLayer(job_b, "pass_1");
+
+        LayerOnJob depend = new LayerOnJob(layer, job_a);
+        dependDao.insertDepend(depend);
+
+        LightweightDependency lwd = dependDao.getDepend(depend.getId());
+        assertEquals(depend.getId(), lwd.getId());
+        assertEquals(DependType.LayerOnJob, lwd.type);
+        assertEquals(DependTarget.External, lwd.target);
+        assertTrue(lwd.active);
+        assertFalse(lwd.anyFrame);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertLayerOnLayer() {
+
+        JobDetail job_a = getJobA();
+        JobDetail job_b = getJobB();
+        Layer layer_a = layerDao.findLayer(job_a, "pass_1");
+        Layer layer_b = layerDao.findLayer(job_b, "pass_1");
+
+        LayerOnLayer depend = new LayerOnLayer(layer_a, layer_b);
+        dependDao.insertDepend(depend);
+
+        LightweightDependency lwd = dependDao.getDepend(depend.getId());
+        assertEquals(depend.getId(), lwd.getId());
+        assertEquals(DependType.LayerOnLayer, lwd.type);
+        assertEquals(DependTarget.External, lwd.target);
+        assertTrue(lwd.active);
+        assertFalse(lwd.anyFrame);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertLayerOnFrame() {
+
+        JobDetail job_a = getJobA();
+        JobDetail job_b = getJobB();
+        Layer layer = layerDao.findLayer(job_a, "pass_1");
+        FrameDetail frame = frameDao.findFrameDetail(job_b, "0001-pass_1");
+
+        LayerOnFrame depend = new LayerOnFrame(layer, frame);
+        dependDao.insertDepend(depend);
+
+        LightweightDependency lwd = dependDao.getDepend(depend.getId());
+        assertEquals(depend.getId(), lwd.getId());
+        assertEquals(DependType.LayerOnFrame, lwd.type);
+        assertEquals(DependTarget.External, lwd.target);
+        assertTrue(lwd.active);
+        assertFalse(lwd.anyFrame);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertFrameOnJob() {
+
+        JobDetail job_a = getJobA();
+        JobDetail job_b = getJobB();
+        FrameDetail frame = frameDao.findFrameDetail(job_b, "0001-pass_1");
+
+        FrameOnJob depend = new FrameOnJob(frame, job_a);
+        dependDao.insertDepend(depend);
+
+        LightweightDependency lwd = dependDao.getDepend(depend.getId());
+        assertEquals(depend.getId(), lwd.getId());
+        assertEquals(DependType.FrameOnJob, lwd.type);
+        assertEquals(DependTarget.External, lwd.target);
+        assertTrue(lwd.active);
+        assertFalse(lwd.anyFrame);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertFrameOnLayer() {
+
+        JobDetail job_a = getJobA();
+        JobDetail job_b = getJobB();
+        Layer layer = layerDao.findLayer(job_a, "pass_1");
+        FrameDetail frame = frameDao.findFrameDetail(job_b, "0001-pass_1");
+
+        FrameOnLayer depend = new FrameOnLayer(frame,layer);
+        dependDao.insertDepend(depend);
+
+        LightweightDependency lwd = dependDao.getDepend(depend.getId());
+        assertEquals(depend.getId(), lwd.getId());
+        assertEquals(DependType.FrameOnLayer, lwd.type);
+        assertEquals(DependTarget.External, lwd.target);
+        assertTrue(lwd.active);
+        assertFalse(lwd.anyFrame);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertFrameOnFrame() {
+
+        JobDetail job_a = getJobA();
+        JobDetail job_b = getJobB();
+
+        FrameDetail frame_a = frameDao.findFrameDetail(job_a, "0001-pass_1");
+        FrameDetail frame_b = frameDao.findFrameDetail(job_b, "0001-pass_1");
+
+        FrameOnFrame depend = new FrameOnFrame(frame_a, frame_b);
+        dependDao.insertDepend(depend);
+
+        LightweightDependency lwd = dependDao.getDepend(depend.getId());
+        assertEquals(depend.getId(), lwd.getId());
+        assertEquals(DependType.FrameOnFrame, lwd.type);
+        assertEquals(DependTarget.External, lwd.target);
+        assertTrue(lwd.active);
+        assertFalse(lwd.anyFrame);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertFrameByFrame() {
+
+        JobDetail job_a = getJobA();
+        JobDetail job_b = getJobB();
+        Layer layer_a = layerDao.findLayer(job_a, "pass_1");
+        Layer layer_b = layerDao.findLayer(job_b, "pass_1");
+
+        FrameByFrame depend = new FrameByFrame(layer_a, layer_b);
+        dependDao.insertDepend(depend);
+
+        LightweightDependency lwd = dependDao.getDepend(depend.getId());
+        assertEquals(depend.getId(), lwd.getId());
+        assertEquals(DependType.FrameByFrame, lwd.type);
+        assertEquals(DependTarget.External, lwd.target);
+        assertTrue(lwd.active);
+        assertFalse(lwd.anyFrame);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertPreviousFrame() {
+
+        JobDetail job_a = getJobA();
+        JobDetail job_b = getJobB();
+        Layer layer_a = layerDao.findLayer(job_a, "pass_1");
+        Layer layer_b = layerDao.findLayer(job_b, "pass_1");
+
+        PreviousFrame depend = new PreviousFrame(layer_a, layer_b);
+        dependDao.insertDepend(depend);
+
+        LightweightDependency lwd = dependDao.getDepend(depend.getId());
+        assertEquals(depend.getId(), lwd.getId());
+        assertEquals(DependType.PreviousFrame, lwd.type);
+        assertEquals(DependTarget.External, lwd.target);
+        assertTrue(lwd.active);
+        assertFalse(lwd.anyFrame);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testReinsertFrameOnFrame() {
+
+        JobDetail job_a = getJobA();
+        JobDetail job_b = getJobB();
+
+        FrameDetail frame_a = frameDao.findFrameDetail(job_a, "0001-pass_1");
+        FrameDetail frame_b = frameDao.findFrameDetail(job_b, "0001-pass_1");
+
+        FrameOnFrame depend = new FrameOnFrame(frame_a, frame_b);
+        dependDao.insertDepend(depend);
+
+        LightweightDependency lwd = dependDao.getDepend(depend.getId());
+        assertEquals(depend.getId(), lwd.getId());
+        assertEquals(DependType.FrameOnFrame, lwd.type);
+        assertEquals(DependTarget.External, lwd.target);
+        assertTrue(lwd.active);
+        assertFalse(lwd.anyFrame);
+
+        dependDao.setInactive(lwd);
+
+        // Try to reinsert it now that the original is inactive.
+        depend = new FrameOnFrame(frame_a, frame_b);
+        dependDao.insertDepend(depend);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetWhatDependsOnJob() {
+        JobDetail job_a = getJobA();
+        JobDetail job_b = getJobB();
+
+        JobOnJob depend = new JobOnJob(job_a, job_b);
+        dependDao.insertDepend(depend);
+
+        assertEquals(1, dependDao.getWhatDependsOn(job_b).size());
+        assertEquals(0, dependDao.getWhatDependsOn(job_a).size());
+    }
+
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetWhatDependsOnLayer() {
+
+        JobDetail job_a = getJobA();
+        JobDetail job_b = getJobB();
+
+        Layer layer_a = layerDao.findLayer(job_a, "pass_1");
+        Layer layer_b = layerDao.findLayer(job_b, "pass_1");
+
+        LayerOnLayer depend = new LayerOnLayer(layer_a, layer_b);
+        dependDao.insertDepend(depend);
+
+        assertEquals(1, dependDao.getWhatDependsOn(layer_b).size());
+        assertEquals(0, dependDao.getWhatDependsOn(layer_a).size());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetWhatDependsOnLayerInactive() {
+
+        JobDetail job_a = getJobA();
+        JobDetail job_b = getJobB();
+
+        Layer layer_a = layerDao.findLayer(job_a, "pass_1");
+        Layer layer_b = layerDao.findLayer(job_b, "pass_1");
+
+        LayerOnLayer depend = new LayerOnLayer(layer_a, layer_b);
+        dependDao.insertDepend(depend);
+
+        dependDao.setInactive(dependDao.getDepend(depend.getId()));
+
+        assertEquals(1, dependDao.getWhatDependsOn(layer_b, false).size());
+        assertEquals(0, dependDao.getWhatDependsOn(layer_b, true).size());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetWhatDependsOnFrame() {
+
+        JobDetail job_a = getJobA();
+        JobDetail job_b = getJobB();
+
+        FrameDetail frame_a = frameDao.findFrameDetail(job_a, "0001-pass_1");
+        FrameDetail frame_b = frameDao.findFrameDetail(job_b, "0001-pass_1");
+
+        FrameOnFrame depend = new FrameOnFrame(frame_a, frame_b);
+        dependDao.insertDepend(depend);
+
+        assertEquals(1, dependDao.getWhatDependsOn(frame_b).size());
+        assertEquals(0, dependDao.getWhatDependsOn(frame_a).size());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetWhatDependsOnFrameInactive() {
+
+        JobDetail job_a = getJobA();
+        JobDetail job_b = getJobB();
+
+        FrameDetail frame_a = frameDao.findFrameDetail(job_a, "0001-pass_1");
+        FrameDetail frame_b = frameDao.findFrameDetail(job_b, "0001-pass_1");
+
+        FrameOnFrame depend = new FrameOnFrame(frame_a, frame_b);
+        dependDao.insertDepend(depend);
+
+        dependDao.setInactive(dependDao.getDepend(depend.getId()));
+
+        assertEquals(1, dependDao.getWhatDependsOn(frame_b, false).size());
+        assertEquals(0, dependDao.getWhatDependsOn(frame_b, true).size());
+        assertEquals(0, dependDao.getWhatDependsOn(frame_a, true).size());
+    }
+}
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/DispatcherDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/DispatcherDaoTests.java
@@ -1,0 +1,412 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.Resource;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.DispatchFrame;
+import com.imageworks.spcue.DispatchHost;
+import com.imageworks.spcue.JobDetail;
+import com.imageworks.spcue.Layer;
+import com.imageworks.spcue.LayerDetail;
+import com.imageworks.spcue.LocalHostAssignment;
+import com.imageworks.spcue.VirtualProc;
+import com.imageworks.spcue.CueIce.JobState;
+import com.imageworks.spcue.dao.AllocationDao;
+import com.imageworks.spcue.dao.BookingDao;
+import com.imageworks.spcue.dao.DispatcherDao;
+import com.imageworks.spcue.dao.HostDao;
+import com.imageworks.spcue.dao.JobDao;
+import com.imageworks.spcue.dao.LayerDao;
+import com.imageworks.spcue.dao.ProcDao;
+import com.imageworks.spcue.dispatcher.DispatchSupport;
+import com.imageworks.spcue.dispatcher.Dispatcher;
+import com.imageworks.spcue.grpc.host.HardwareState;
+import com.imageworks.spcue.grpc.report.RenderHost;
+import com.imageworks.spcue.service.AdminManager;
+import com.imageworks.spcue.service.GroupManager;
+import com.imageworks.spcue.service.HostManager;
+import com.imageworks.spcue.service.JobLauncher;
+import com.imageworks.spcue.service.JobManager;
+import com.imageworks.spcue.util.CueUtil;
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class DispatcherDaoTests extends AbstractTransactionalJUnit4SpringContextTests  {
+
+    @Resource
+    DispatcherDao dispatcherDao;
+
+    @Resource
+    HostDao hostDao;
+
+    @Resource
+    ProcDao procDao;
+
+    @Resource
+    LayerDao layerDao;
+
+    @Resource
+    JobDao jobDao;
+
+    @Resource
+    AllocationDao allocationDao;
+
+    @Resource
+    JobManager jobManager;
+
+    @Resource
+    DispatchSupport dispatchSupport;
+
+    @Resource
+    HostManager hostManager;
+
+    @Resource
+    AdminManager adminManager;
+
+    @Resource
+    GroupManager groupManager;
+
+    @Resource
+    Dispatcher dispatcher;
+
+    @Resource
+    JobLauncher jobLauncher;
+
+    @Resource
+    BookingDao bookingDao;
+
+    private static final String HOSTNAME="beta";
+
+    public DispatchHost getHost() {
+        return hostDao.findDispatchHost(HOSTNAME);
+    }
+
+    public JobDetail getJob1() {
+        return jobManager.findJobDetail(
+                "pipe-dev.cue-testuser_shell_dispatch_test_v1");
+    }
+
+    public JobDetail getJob2() {
+        return jobManager.findJobDetail(
+                "pipe-dev.cue-testuser_shell_dispatch_test_v2");
+    }
+
+    @Before
+    public void launchJob() {
+        dispatcher.setTestMode(true);
+        jobLauncher.testMode = true;
+        jobLauncher.launch(
+                new File("src/test/resources/conf/jobspec/jobspec_dispatch_test.xml"));
+    }
+
+    @Before
+    public void createHost() {
+        RenderHost host = RenderHost.newBuilder()
+                .setName(HOSTNAME)
+                .setBootTime(1192369572)
+                .setFreeMcp(76020)
+                .setFreeMem(53500)
+                .setFreeSwap(20760)
+                .setLoad(1)
+                .setTotalMcp(195430)
+                .setTotalMem(8173264)
+                .setTotalSwap(20960)
+                .setNimbyEnabled(false)
+                .setNumProcs(2)
+                .setCoresPerProc(100)
+                .addTags("test")
+                .setState(HardwareState.UP)
+                .setFacility("spi")
+                .putAttributes("SP_OS", "Linux")
+                .build();
+
+        hostManager.createHost(host,
+                adminManager.findAllocationDetail("spi", "general"));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindNextDispatchFrameByHost() {
+        DispatchHost host = getHost();
+        JobDetail job = getJob1();
+
+        for (LayerDetail layer: layerDao.getLayerDetails(job)) {
+            assertTrue(layer.tags.contains("general"));
+        }
+
+        assertTrue(jdbcTemplate.queryForObject(
+                "SELECT str_tags FROM host WHERE pk_host=?",String.class,
+                host.id).contains("general"));
+
+        DispatchFrame frame =  dispatcherDao.findNextDispatchFrame(job, host);
+        assertNotNull(frame);
+        assertEquals(frame.name, "0001-pass_1");
+    }
+
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindNextDispatchFrameByProc() {
+        DispatchHost host = getHost();
+        JobDetail job = getJob1();
+
+        // TODO: fix the fact you can book the same proc on multiple frames
+        // probably just need to make sure you can't update a proc's frame
+        // assignment unless the frame id is null.
+
+        DispatchFrame frame =  dispatcherDao.findNextDispatchFrame(job, host);
+        assertNotNull(frame);
+        assertEquals("0001-pass_1", frame.name);
+
+        VirtualProc proc = VirtualProc.build(host, frame);
+        proc.coresReserved = 100;
+        dispatcher.dispatch(frame, proc);
+
+        frame =  dispatcherDao.findNextDispatchFrame(job, proc);
+        assertNotNull(frame);
+        assertEquals("0001-pass_2", frame.name);
+        dispatcher.dispatch(frame, proc);
+
+        frame =  dispatcherDao.findNextDispatchFrame(job, proc);
+        assertNotNull(frame);
+        assertEquals("0002-pass_1", frame.name);
+        dispatcher.dispatch(frame, proc);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindNextDispatchFramesByProc() {
+        DispatchHost host = getHost();
+        JobDetail job = getJob1();
+
+        // TODO: fix the fact you can book the same proc on multiple frames
+        // probably just need to make sure you can't update a proc's frame
+        // assignment unless the frame id is null.
+
+        List<DispatchFrame> frames =
+            dispatcherDao.findNextDispatchFrames(job, host,10);
+        assertEquals(10, frames.size());
+
+        DispatchFrame frame = frames.get(0);
+
+        VirtualProc proc = VirtualProc.build(host, frame);
+        proc.coresReserved = 100;
+        dispatcher.dispatch(frame, proc);
+
+        frame =  dispatcherDao.findNextDispatchFrame(job, proc);
+        assertNotNull(frame);
+        assertEquals(frame.name,"0001-pass_2");
+        dispatcher.dispatch(frame, proc);
+
+        frame =  dispatcherDao.findNextDispatchFrame(job, proc);
+        assertNotNull(frame);
+        assertEquals(frame.name,"0002-pass_1");
+        dispatcher.dispatch(frame, proc);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindNextDispatchFramesByHostAndJobLocal() {
+        DispatchHost host = getHost();
+        JobDetail job = getJob1();
+        host.isLocalDispatch = true;
+        List<DispatchFrame> frames =
+            dispatcherDao.findNextDispatchFrames(job, host, 10);
+        assertEquals(10, frames.size());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindNextDispatchFramesByHostAndLayerLocal() {
+        DispatchHost host = getHost();
+        JobDetail job = getJob1();
+        Layer layer = jobManager.getLayers(job).get(0);
+        host.isLocalDispatch = true;
+
+        List<DispatchFrame> frames =
+            dispatcherDao.findNextDispatchFrames(layer, host, 10);
+        assertEquals(10, frames.size());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindNextDispatchFramesByProcAndJobLocal() {
+        DispatchHost host = getHost();
+        JobDetail job = getJob1();
+        host.isLocalDispatch = true;
+        List<DispatchFrame> frames =
+            dispatcherDao.findNextDispatchFrames(job, host, 10);
+        assertEquals(10, frames.size());
+
+        DispatchFrame frame = frames.get(0);
+        VirtualProc proc = VirtualProc.build(host, frame);
+        proc.coresReserved = 100;
+        proc.isLocalDispatch = true;
+
+        frames = dispatcherDao.findNextDispatchFrames(job, proc, 10);
+        assertEquals(10, frames.size());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindNextDispatchFramesByProcAndLayerLocal() {
+        DispatchHost host = getHost();
+        JobDetail job = getJob1();
+        Layer layer = jobManager.getLayers(job).get(0);
+        host.isLocalDispatch = true;
+
+        List<DispatchFrame> frames =
+            dispatcherDao.findNextDispatchFrames(layer, host, 10);
+        assertEquals(10, frames.size());
+
+        DispatchFrame frame = frames.get(0);
+        VirtualProc proc = VirtualProc.build(host, frame);
+        proc.coresReserved = 100;
+        proc.isLocalDispatch = true;
+
+        frames = dispatcherDao.findNextDispatchFrames(layer, proc, 10);
+        assertEquals(10, frames.size());
+    }
+
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindDispatchJobs() {
+        DispatchHost host = getHost();
+
+        assertTrue(jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM job WHERE str_state='Pending'", Integer.class) > 0);
+
+        Set<String> jobs = dispatcherDao.findDispatchJobs(host, 10);
+        assertTrue(jobs.size() > 0);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindDispatchJobsByGroup() {
+        DispatchHost host = getHost();
+        final JobDetail job = getJob1();
+
+        assertNotNull(job);
+        assertNotNull(job.groupId);
+
+        Set<String> jobs = dispatcherDao.findDispatchJobs(host,
+                groupManager.getGroupDetail(job));
+        assertTrue(jobs.size() > 0);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindDispatchJobsByShow() {
+        DispatchHost host = getHost();
+        final JobDetail job = getJob1();
+        assertNotNull(job);
+
+        Set<String> jobs = dispatcherDao.findDispatchJobs(host,
+                adminManager.findShowDetail("pipe"), 5);
+        assertTrue(jobs.size() > 0);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindDispatchJobsByLocal() {
+        DispatchHost host = getHost();
+        final JobDetail job = getJob1();
+        assertNotNull(job);
+
+        Set<String> jobs = dispatcherDao.findLocalDispatchJobs(host);
+        assertEquals(0, jobs.size());
+
+        LocalHostAssignment lja = new LocalHostAssignment();
+        lja.setThreads(1);
+        lja.setMaxMemory(CueUtil.GB16);
+        lja.setMaxCoreUnits(200);
+        lja.setMaxGpu(1);
+        bookingDao.insertLocalHostAssignment(host, job, lja);
+
+        jobs = dispatcherDao.findLocalDispatchJobs(host);
+        assertTrue(jobs.size() > 0);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testfindUnderProcedJob() {
+        DispatchHost host = getHost();
+        JobDetail job1 = getJob1();
+        JobDetail job2 = getJob2();
+
+        jobDao.updateMinCores(job1, 0);
+        jobDao.updateMinCores(job2, 1000);
+
+        DispatchFrame frame = dispatcherDao.findNextDispatchFrame(job1, host);
+        assertNotNull(frame);
+
+        assertEquals(JobState.Pending.toString(),
+                jdbcTemplate.queryForObject(
+                "SELECT str_state FROM job WHERE pk_job=?",
+                String.class, job1.id));
+
+        assertEquals(JobState.Pending.toString(),
+                jdbcTemplate.queryForObject(
+                "SELECT str_state FROM job WHERE pk_job=?",
+                String.class, job2.id));
+
+        VirtualProc proc = VirtualProc.build(host, frame);
+        proc.coresReserved = 100;
+        dispatcher.dispatch(frame, proc);
+
+        boolean under = dispatcherDao.findUnderProcedJob(job1, proc);
+        assertTrue(under);
+    }
+}
+
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/FacilityInterfaceDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/FacilityInterfaceDaoTests.java
@@ -1,0 +1,71 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import javax.annotation.Resource;
+
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.dao.FacilityDao;
+
+import static org.junit.Assert.*;
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class FacilityInterfaceDaoTests extends AbstractTransactionalJUnit4SpringContextTests {
+
+    @Resource
+    FacilityDao facilityDao;
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetDetaultFacility() {
+        assertEquals(jdbcTemplate.queryForObject(
+                "SELECT pk_facility FROM facility WHERE b_default=1",
+                String.class),facilityDao.getDefaultFacility().getId());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetFacility() {
+        String id = "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAA0";
+        assertEquals(id, facilityDao.getFacility(id).getId());
+        assertEquals(id, facilityDao.getFacility("spi").getId());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFacilityExists() {
+        assertTrue(facilityDao.facilityExists("spi"));
+        assertFalse(facilityDao.facilityExists("rambo"));
+    }
+}
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/FilterDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/FilterDaoTests.java
@@ -1,0 +1,297 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import static org.junit.Assert.*;
+
+import javax.annotation.Resource;
+
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.FilterDetail;
+import com.imageworks.spcue.Show;
+import com.imageworks.spcue.ShowDetail;
+import com.imageworks.spcue.CueIce.FilterType;
+import com.imageworks.spcue.dao.FilterDao;
+import com.imageworks.spcue.dao.ShowDao;
+import com.imageworks.spcue.service.AdminManager;
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class FilterDaoTests extends AbstractTransactionalJUnit4SpringContextTests  {
+
+    @Resource
+    FilterDao filterDao;
+
+    @Resource
+    ShowDao showDao;
+
+    @Resource
+    AdminManager adminManager;
+
+    private static String FILTER_NAME = "test_filter";
+
+    public Show createShow() {
+        ShowDetail show = new ShowDetail();
+        show.name = "testtest";
+        adminManager.createShow(show);
+        return show;
+    }
+
+    public Show getShow() {
+        return showDao.findShowDetail("testtest");
+    }
+
+    public FilterDetail buildFilter(Show show) {
+        FilterDetail filter = new FilterDetail();
+        filter.name = FILTER_NAME;
+        filter.showId = show.getId();
+        filter.type = FilterType.MatchAny;
+        filter.enabled = true;
+
+        return filter;
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetActiveFilters() {
+        filterDao.getActiveFilters(createShow());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetFilters() {
+        filterDao.getFilters(createShow());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateSetFilterEnabled() {
+        FilterDetail f = buildFilter(createShow());
+        filterDao.insertFilter(f);
+        filterDao.updateSetFilterEnabled(f, false);
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT b_enabled FROM filter WHERE pk_filter=?",
+                Integer.class, f.getFilterId()));
+        filterDao.updateSetFilterEnabled(f, true);
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT b_enabled FROM filter WHERE pk_filter=?",
+                Integer.class, f.getFilterId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateSetFilterName() {
+        FilterDetail f = buildFilter(createShow());
+        filterDao.insertFilter(f);
+        assertEquals(FILTER_NAME, jdbcTemplate.queryForObject(
+                "SELECT str_name FROM filter WHERE pk_filter=?",
+                String.class,
+                f.getFilterId()));
+        filterDao.updateSetFilterName(f, "TEST");
+        assertEquals("TEST", jdbcTemplate.queryForObject(
+                "SELECT str_name FROM filter WHERE pk_filter=?",
+                String.class,
+                f.getFilterId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateSetFilterType() {
+        FilterDetail f = buildFilter(createShow());
+        filterDao.insertFilter(f);
+        assertEquals(FilterType.MatchAny.toString(), jdbcTemplate.queryForObject(
+                "SELECT str_type FROM filter WHERE pk_filter=?",
+                String.class,
+                f.getFilterId()));
+        filterDao.updateSetFilterType(f, FilterType.MatchAll);
+        assertEquals(FilterType.MatchAll.toString(), jdbcTemplate.queryForObject(
+                "SELECT str_type FROM filter WHERE pk_filter=?",
+                String.class,
+                f.getFilterId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateSetFilterOrder() {
+
+        Show show = createShow();
+        int currentFilters = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM filter WHERE pk_show=?",
+                Integer.class, show.getShowId());
+
+        FilterDetail f1 = buildFilter(show);
+        filterDao.insertFilter(f1);
+
+        FilterDetail f2 = buildFilter(show);
+        f2.name = "TEST";
+        filterDao.insertFilter(f2);
+
+        assertEquals(Integer.valueOf(currentFilters+1), jdbcTemplate.queryForObject(
+                "SELECT f_order FROM filter WHERE pk_filter=?",
+                Integer.class, f1.getFilterId()));
+
+        assertEquals(Integer.valueOf(currentFilters+2), jdbcTemplate.queryForObject(
+                "SELECT f_order FROM filter WHERE pk_filter=?",
+                Integer.class, f2.getFilterId()));
+
+        filterDao.updateSetFilterOrder(f2,1);
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT f_order FROM filter WHERE pk_filter=?",
+                Integer.class, f2.getFilterId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testDeleteFilter() {
+        FilterDetail f = buildFilter(createShow());
+        filterDao.insertFilter(f);
+        filterDao.deleteFilter(f);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertFilter() {
+        FilterDetail f = buildFilter(createShow());
+        filterDao.insertFilter(f);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testReorderFilters() {
+        buildFilter(createShow());
+        filterDao.reorderFilters(getShow());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testLowerFilterOrder() {
+
+        Show show = createShow();
+
+        FilterDetail f1 = buildFilter(show);
+        filterDao.insertFilter(f1);
+
+        FilterDetail f2 = buildFilter(show);
+        f2.name = "TEST";
+        filterDao.insertFilter(f2);
+
+
+        /**
+         * These could fail if the test DB has other filters.
+         */
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT f_order FROM filter WHERE pk_filter=?",
+                Integer.class, f1.getFilterId()));
+
+        assertEquals(Integer.valueOf(2), jdbcTemplate.queryForObject(
+                "SELECT f_order FROM filter WHERE pk_filter=?",
+                Integer.class, f2.getFilterId()));
+
+        filterDao.lowerFilterOrder(f2,1);
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT f_order FROM filter WHERE pk_filter=?",
+                Integer.class, f1.getFilterId()));
+
+        assertEquals(Integer.valueOf(2), jdbcTemplate.queryForObject(
+                "SELECT f_order FROM filter WHERE pk_filter=?",
+                Integer.class, f2.getFilterId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testRaiseFilterOrder() {
+
+        Show show = createShow();
+
+        FilterDetail f1 = buildFilter(show);
+        filterDao.insertFilter(f1);
+
+        FilterDetail f2 = buildFilter(show);
+        f2.name = "TEST";
+        filterDao.insertFilter(f2);
+
+        /**
+         * These could fail if the test DB has other filters.
+         */
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT f_order FROM filter WHERE pk_filter=?",
+                Integer.class, f1.getFilterId()));
+
+        assertEquals(Integer.valueOf(2), jdbcTemplate.queryForObject(
+                "SELECT f_order FROM filter WHERE pk_filter=?",
+                Integer.class, f2.getFilterId()));
+
+        filterDao.raiseFilterOrder(f1, 1);
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT f_order FROM filter WHERE pk_filter=?",
+                Integer.class, f1.getFilterId()));
+
+        assertEquals(Integer.valueOf(2), jdbcTemplate.queryForObject(
+                "SELECT f_order FROM filter WHERE pk_filter=?",
+                Integer.class, f2.getFilterId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetFilter() {
+        FilterDetail f = buildFilter(createShow());
+        filterDao.insertFilter(f);
+
+        filterDao.getFilter(f);
+        filterDao.getFilter(f.getId());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindFilter() {
+        FilterDetail f = buildFilter(createShow());
+        filterDao.insertFilter(f);
+
+        filterDao.findFilter(getShow(), FILTER_NAME);
+    }
+
+}
+
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/FrameDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/FrameDaoTests.java
@@ -1,0 +1,646 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Resource;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.transaction.AfterTransaction;
+import org.springframework.test.context.transaction.BeforeTransaction;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.DispatchFrame;
+import com.imageworks.spcue.DispatchHost;
+import com.imageworks.spcue.Frame;
+import com.imageworks.spcue.FrameDetail;
+import com.imageworks.spcue.JobDetail;
+import com.imageworks.spcue.Layer;
+import com.imageworks.spcue.VirtualProc;
+import com.imageworks.spcue.CueIce.CheckpointState;
+import com.imageworks.spcue.CueIce.FrameState;
+import com.imageworks.spcue.dao.AllocationDao;
+import com.imageworks.spcue.dao.FrameDao;
+import com.imageworks.spcue.dao.HostDao;
+import com.imageworks.spcue.dao.LayerDao;
+import com.imageworks.spcue.dao.ProcDao;
+import com.imageworks.spcue.dao.criteria.FrameSearch;
+import com.imageworks.spcue.depend.FrameOnFrame;
+import com.imageworks.spcue.dispatcher.DispatchSupport;
+import com.imageworks.spcue.grpc.host.HardwareState;
+import com.imageworks.spcue.grpc.report.RenderHost;
+import com.imageworks.spcue.service.DependManager;
+import com.imageworks.spcue.service.HostManager;
+import com.imageworks.spcue.service.JobLauncher;
+import com.imageworks.spcue.service.JobManager;
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class FrameDaoTests extends AbstractTransactionalJUnit4SpringContextTests  {
+
+    @Resource
+    FrameDao frameDao;
+
+    @Resource
+    LayerDao layerDao;
+
+    @Resource
+    JobManager jobManager;
+
+    @Resource
+    JobLauncher jobLauncher;
+
+    @Resource
+    HostDao hostDao;
+
+    @Resource
+    ProcDao procDao;
+
+    @Resource
+    AllocationDao allocationDao;
+
+    @Resource
+    HostManager hostManager;
+
+    @Resource
+    DependManager dependManager;
+
+    @Resource
+    DispatchSupport dispatchSupport;
+
+    private static final String HOST = "beta";
+
+    public DispatchHost createHost() {
+        return hostDao.findDispatchHost(HOST);
+    }
+
+    @BeforeTransaction
+    public void create() {
+
+        RenderHost host = RenderHost.newBuilder()
+                .setName(HOST)
+                .setBootTime(1192369572)
+                .setFreeMcp(76020)
+                .setFreeMem(53500)
+                .setFreeSwap(20760)
+                .setLoad(1)
+                .setTotalMcp(195430)
+                .setTotalMem(8173264)
+                .setTotalSwap(20960)
+                .setNimbyEnabled(false)
+                .setNumProcs(1)
+                .setCoresPerProc(100)
+                .addAllTags(ImmutableList.of("mcore", "4core", "8g"))
+                .setState(HardwareState.UP)
+                .setFacility("spi")
+                .putAttributes("freeGpu", "512")
+                .putAttributes("totalGpu", "512")
+                .build();
+
+        hostManager.createHost(host);
+    }
+
+    @AfterTransaction
+    public void destroy() {
+        jdbcTemplate.update(
+            "DELETE FROM host WHERE str_name=?",HOST);
+    }
+
+    public JobDetail launchJob() {
+        jobLauncher.testMode = true;
+        jobLauncher.launch(new File("src/test/resources/conf/jobspec/jobspec.xml"));
+        return jobManager.findJobDetail("pipe-dev.cue-testuser_shell_v1");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testCheckRetries() {
+        JobDetail job = launchJob();
+        frameDao.checkRetries(frameDao.findFrame(job,"0001-pass_1"));
+        //TODO: check to see if it actually works
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetFrameDetail() {
+        JobDetail job = launchJob();
+        Frame f = frameDao.findFrame(job, "0001-pass_1");
+        FrameDetail frame = frameDao.getFrameDetail(f);
+        frame = frameDao.getFrameDetail(f.getFrameId());
+        assertEquals("0001-pass_1", frame.name);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindFrameDetail() {
+        JobDetail job = launchJob();
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1");
+        assertEquals("0001-pass_1", frame.name);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetFrame() {
+        JobDetail job = launchJob();
+        Frame f = frameDao.findFrame(job, "0001-pass_1");
+        Frame frame = frameDao.getFrame(f.getFrameId());
+        assertEquals("0001-pass_1", frame.getName());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetFrameByLayer() {
+        JobDetail job = launchJob();
+        Frame f = frameDao.findFrame(job, "0001-pass_1");
+        Frame f2 = frameDao.findFrame((Layer)f, 1);
+
+        assertEquals(f.getFrameId(), f2.getFrameId());
+        assertEquals(f.getLayerId(), f2.getLayerId());
+        assertEquals(f.getJobId(), f2.getJobId());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindFrame() {
+        JobDetail job = launchJob();
+        Frame f = frameDao.findFrame(job, "0001-pass_1");
+        assertEquals(f.getName(),"0001-pass_1");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindFrames() {
+        JobDetail job = launchJob();
+        FrameSearch r = new FrameSearch(job);
+        r.getCriteria().frames.add("0001-pass_1");
+        assertTrue(frameDao.findFrames(r).size() == 1);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindFrameDetails() {
+        JobDetail job = launchJob();
+        FrameSearch r = new FrameSearch(job);
+        r.getCriteria().frames.add("0001-pass_1");
+        assertTrue(frameDao.findFrameDetails(r).size() == 1);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testgetOrphanedFrames() {
+        assertEquals(0, frameDao.getOrphanedFrames().size());
+
+        JobDetail job = launchJob();
+        Frame f = frameDao.findFrame(job, "0001-pass_1");
+
+        /*
+         * Update the first frame to the orphan state, which is a frame
+         * that is in the running state, has no corresponding proc entry
+         * and has not been udpated in the last 5 min.
+         */
+        jdbcTemplate.update(
+                "UPDATE frame SET str_state='Running', " +
+                "ts_updated=systimestamp - interval '301' second WHERE pk_frame=?",
+                f.getFrameId());
+
+        assertEquals(1, frameDao.getOrphanedFrames().size());
+        assertTrue(frameDao.isOrphan(f));
+
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateFrameState() {
+        JobDetail job = launchJob();
+        Frame f = frameDao.findFrame(job, "0001-pass_1");
+        assertEquals(true, frameDao.updateFrameState(f,FrameState.Running));
+
+        assertEquals(FrameState.Running.toString(),
+                jdbcTemplate.queryForObject(
+                "SELECT str_state FROM frame WHERE pk_frame=?",
+                String.class,
+                f.getFrameId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFailUpdateFrameState() {
+        JobDetail job = launchJob();
+        Frame f = frameDao.findFrame(job, "0001-pass_1");
+
+        /** Change the version so the update fails **/
+        jdbcTemplate.update(
+                "UPDATE frame SET int_version = int_version + 1 WHERE pk_frame=?",
+                f.getFrameId());
+
+        assertEquals(false, frameDao.updateFrameState(f, FrameState.Running));
+    }
+
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateFrameStarted() {
+
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1_preprocess");
+        DispatchFrame fd = frameDao.getDispatchFrame(frame.getId());
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = host.allocationId;
+        proc.coresReserved = 100;
+        proc.hostId = host.id;
+        proc.hostName = host.name;
+        proc.jobId = job.id;
+        proc.frameId = frame.id;
+        proc.layerId = frame.layerId;
+        proc.showId = frame.showId;
+
+        assertEquals(FrameState.Waiting, frame.state);
+
+        procDao.insertVirtualProc(proc);
+        procDao.verifyRunningProc(proc.getId(), frame.getId());
+        frameDao.updateFrameStarted(proc, fd);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateFrameStopped() {
+
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1_preprocess");
+        DispatchFrame fd = frameDao.getDispatchFrame(frame.getId());
+
+        assertEquals("0001-pass_1_preprocess",frame.getName());
+        assertEquals(FrameState.Waiting,frame.state);
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = host.allocationId;
+        proc.coresReserved = 100;
+        proc.hostId = host.id;
+        proc.hostName = host.name;
+        proc.jobId = job.id;
+        proc.frameId = frame.id;
+        proc.layerId = frame.layerId;
+        proc.showId = frame.showId;
+
+        procDao.insertVirtualProc(proc);
+        procDao.verifyRunningProc(proc.getId(), frame.getId());
+
+        frameDao.updateFrameStarted(proc, fd);
+
+        try {
+            Thread.sleep(1001);
+        } catch (InterruptedException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+
+        DispatchFrame fd2 = frameDao.getDispatchFrame(frame.getId());
+        assertTrue(frameDao.updateFrameStopped(fd2, FrameState.Dead, 1, 1000l));
+
+        assertEquals(FrameState.Dead.toString(),jdbcTemplate.queryForObject(
+                "SELECT str_state FROM frame WHERE pk_frame=?",
+                String.class, frame.getFrameId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateFrameFixed() {
+
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1_preprocess");
+        DispatchFrame fd = frameDao.getDispatchFrame(frame.getId());
+
+        assertEquals("0001-pass_1_preprocess",frame.getName());
+        assertEquals(FrameState.Waiting,frame.state);
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = host.allocationId;
+        proc.coresReserved = 100;
+        proc.hostId = host.id;
+        proc.hostName = host.name;
+        proc.jobId = job.id;
+        proc.frameId = frame.id;
+        proc.layerId = frame.layerId;
+        proc.showId = frame.showId;
+
+        procDao.insertVirtualProc(proc);
+        procDao.verifyRunningProc(proc.getId(), frame.getId());
+        frameDao.updateFrameStarted(proc, fd);
+
+        try {
+            Thread.sleep(1001);
+        } catch (InterruptedException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+        frameDao.updateFrameState(frame, FrameState.Waiting);
+        frameDao.updateFrameFixed(proc, frame);
+
+        assertEquals(FrameState.Running.toString(),
+                jdbcTemplate.queryForObject(
+                "SELECT str_state FROM frame WHERE pk_frame=?",
+                String.class, frame.getFrameId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetDispatchFrame() {
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1");
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = host.allocationId;
+        proc.coresReserved = 100;
+        proc.hostId = host.id;
+        proc.hostName = host.name;
+        proc.jobId = job.id;
+        proc.frameId = frame.id;
+        proc.layerId = frame.layerId;
+        proc.showId = frame.showId;
+
+        procDao.insertVirtualProc(proc);
+        procDao.verifyRunningProc(proc.getId(), frame.getId());
+
+        DispatchFrame dframe = frameDao.getDispatchFrame(frame.id);
+        assertEquals(dframe.id, frame.id);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testMarkFrameAsWaiting() {
+        JobDetail job = launchJob();
+
+        Frame f = frameDao.findFrameDetail(job, "0001-pass_1");
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT int_depend_count FROM frame WHERE pk_frame=?",
+                Integer.class, f.getFrameId()));
+
+        frameDao.markFrameAsWaiting(f);
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT int_depend_count FROM frame WHERE pk_frame=?",
+                Integer.class, f.getFrameId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testMarkFrameAsDepend() {
+        JobDetail job = launchJob();
+
+        Frame f = frameDao.findFrameDetail(job, "0001-pass_1");
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT int_depend_count FROM frame WHERE pk_frame=?",
+                Integer.class, f.getFrameId()));
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT b_active FROM depend WHERE pk_layer_depend_er=?",
+                Integer.class, f.getLayerId()));
+
+        frameDao.markFrameAsWaiting(f);
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT int_depend_count FROM frame WHERE pk_frame=?",
+                Integer.class, f.getFrameId()));
+
+        /*
+         * Need to grab new version of frame
+         * object once the state has changed.
+         */
+        f = frameDao.findFrameDetail(job, "0001-pass_1");
+
+        frameDao.markFrameAsDepend(f);
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT int_depend_count FROM frame WHERE pk_frame=?",
+                Integer.class, f.getFrameId()));
+    }
+
+    @Test(expected=org.springframework.dao.EmptyResultDataAccessException.class)
+    @Transactional
+    @Rollback(true)
+    public void testFindLongestFrame() {
+        JobDetail job = launchJob();
+        frameDao.findLongestFrame(job);
+    }
+
+    @Test(expected=org.springframework.dao.EmptyResultDataAccessException.class)
+    @Transactional
+    @Rollback(true)
+    public void testFindShortestFrame() {
+        JobDetail job = launchJob();
+        frameDao.findShortestFrame(job);
+    }
+
+    @Test(expected=org.springframework.dao.EmptyResultDataAccessException.class)
+    @Transactional
+    @Rollback(true)
+    public void findHighestMemoryFrame() {
+        JobDetail job = launchJob();
+        frameDao.findHighestMemoryFrame(job);
+    }
+
+    @Test(expected=org.springframework.dao.EmptyResultDataAccessException.class)
+    @Transactional
+    @Rollback(true)
+    public void findLowestMemoryFrame() {
+        JobDetail job = launchJob();
+        frameDao.findLowestMemoryFrame(job);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetDependentFrames() {
+        JobDetail job = launchJob();
+        Frame frame_a = frameDao.findFrame(job, "0001-pass_1");
+        Frame frame_b = frameDao.findFrame(job, "0002-pass_1");
+
+        dependManager.createDepend(new FrameOnFrame(
+                frame_a, frame_b));
+
+        assertEquals(1, frameDao.getDependentFrames(
+                dependManager.getWhatDependsOn(frame_b).get(0)).size(),1);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetResourceUsage() {
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1");
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = host.allocationId;
+        proc.coresReserved = 100;
+        proc.hostId = host.id;
+        proc.hostName = host.name;
+        proc.jobId = job.id;
+        proc.frameId = frame.id;
+        proc.layerId = frame.layerId;
+        proc.showId = frame.showId;
+
+        procDao.insertVirtualProc(proc);
+        procDao.verifyRunningProc(proc.getId(), frame.getId());
+
+        DispatchFrame dframe = frameDao.getDispatchFrame(frame.id);
+        frameDao.getResourceUsage(dframe);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateFrameCleared() {
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1");
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = host.allocationId;
+        proc.coresReserved = 100;
+        proc.hostId = host.id;
+        proc.hostName = host.name;
+        proc.jobId = job.id;
+        proc.frameId = frame.id;
+        proc.layerId = frame.layerId;
+        proc.showId = frame.showId;
+
+        procDao.insertVirtualProc(proc);
+        procDao.verifyRunningProc(proc.getId(), frame.getId());
+
+        /*
+         * Only frames without active procs can be cleared.
+         */
+
+        DispatchFrame dframe = frameDao.getDispatchFrame(frame.id);
+        assertFalse(frameDao.updateFrameCleared(dframe));
+
+        dispatchSupport.unbookProc(proc);
+        assertTrue(frameDao.updateFrameCleared(dframe));
+
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetStaleCheckpoints() {
+
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1_preprocess");
+
+        assertEquals(0, frameDao.getStaleCheckpoints(300).size());
+        jdbcTemplate.update("UPDATE frame SET str_state=?, " +
+                "ts_stopped=systimestamp - interval '400' second WHERE pk_frame=?",
+                FrameState.Checkpoint.toString(), frame.getFrameId());
+        assertEquals(1, frameDao.getStaleCheckpoints(300).size());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testSetCheckpointState() {
+
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1_preprocess");
+
+        frameDao.updateFrameCheckpointState(frame, CheckpointState.Enabled);
+
+        String state = jdbcTemplate.queryForObject(
+                "SELECT str_checkpoint_state FROM frame WHERE pk_frame=?",
+                String.class, frame.getFrameId());
+
+        assertEquals(CheckpointState.Enabled.toString(), state);
+
+        /**
+         * To set a checkpoint complete the frame state must be in the checkpoint state.
+         */
+        frameDao.updateFrameState(frame, FrameState.Checkpoint);
+        jdbcTemplate.update(
+                "UPDATE frame SET ts_started=systimestamp, ts_stopped=systimestamp + INTERVAL '20' second WHERE pk_frame=?",
+                frame.getFrameId());
+
+        assertTrue(frameDao.updateFrameCheckpointState(frame, CheckpointState.Complete));
+        Map<String, Object> result = jdbcTemplate.queryForMap(
+                "SELECT int_checkpoint_count FROM frame WHERE pk_frame=?",
+                frame.getFrameId());
+
+        BigDecimal checkPointCount = (BigDecimal) result.get("int_checkpoint_count");
+        assertEquals(1, checkPointCount.intValue());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testIsFrameComplete() {
+
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1_preprocess");
+
+        frameDao.updateFrameState(frame, FrameState.Eaten);
+        assertTrue(frameDao.isFrameComplete(frame));
+
+        frame = frameDao.findFrameDetail(job, "0001-pass_1_preprocess");
+        frameDao.updateFrameState(frame, FrameState.Succeeded);
+        assertTrue(frameDao.isFrameComplete(frame));
+
+        frame = frameDao.findFrameDetail(job, "0001-pass_1_preprocess");
+        frameDao.updateFrameState(frame, FrameState.Waiting);
+        assertFalse(frameDao.isFrameComplete(frame));
+    }
+}
+
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/GroupDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/GroupDaoTests.java
@@ -1,0 +1,387 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Resource;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.Group;
+import com.imageworks.spcue.GroupDetail;
+import com.imageworks.spcue.JobDetail;
+import com.imageworks.spcue.Show;
+import com.imageworks.spcue.dao.DepartmentDao;
+import com.imageworks.spcue.dao.GroupDao;
+import com.imageworks.spcue.dao.ShowDao;
+import com.imageworks.spcue.service.JobLauncher;
+import com.imageworks.spcue.service.JobManager;
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class GroupDaoTests extends AbstractTransactionalJUnit4SpringContextTests  {
+
+    @Resource
+    GroupDao groupDao;
+
+    @Resource
+    ShowDao showDao;
+
+    @Resource
+    DepartmentDao departmentDao;
+
+    @Resource
+    JobManager jobManager;
+
+    @Resource
+    JobLauncher jobLauncher;
+
+    @Before
+    public void before() {
+        jobLauncher.testMode = true;
+    }
+
+    public Show getShow() {
+        return showDao.getShowDetail("00000000-0000-0000-0000-000000000000");
+    }
+
+    public JobDetail launchJob() {
+        jobLauncher.launch(new File("src/test/resources/conf/jobspec/jobspec.xml"));
+        return jobManager.findJobDetail("pipe-dev.cue-testuser_shell_v1");
+    }
+
+    public GroupDetail createGroup() {
+        GroupDetail group = new GroupDetail();
+        group.name = "Shit";
+        group.parentId =  groupDao.getRootGroupId(getShow());
+        group.showId = getShow().getId();
+        group.deptId = departmentDao.getDefaultDepartment().getId();
+        groupDao.insertGroup(group, groupDao.getRootGroupDetail(getShow()));
+        return group;
+    }
+
+    public GroupDetail createSubGroup(GroupDetail parent) {
+        GroupDetail group = new GroupDetail();
+        group.name = "SubShit";
+        group.parentId =  parent.id;
+        group.showId = getShow().getId();
+        group.deptId = departmentDao.getDefaultDepartment().getId();
+        groupDao.insertGroup(group, groupDao.getGroup(parent.id));
+        return group;
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetGroup() {
+        GroupDetail group = createGroup();
+        Group g = groupDao.getGroup(group.id);
+        assertEquals(group.id,g.getGroupId());
+        assertEquals(group.id,g.getId());
+        assertEquals(group.name, g.getName());
+        assertEquals(group.showId, g.getShowId());
+    }
+
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetGroups() {
+        GroupDetail group = createGroup();
+        List<String> l = new ArrayList<String>();
+        l.add(group.id);
+        List<Group> g = groupDao.getGroups(l);
+        assertEquals(1, g.size());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetRootGroupId() {
+        groupDao.getRootGroupId(getShow());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertGroup() {
+        GroupDetail group = createGroup();
+        assertFalse(group.isNew());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertGroupAlternateMethod() {
+        GroupDetail group = new GroupDetail();
+        group.name = "Shit";
+        group.parentId =  groupDao.getRootGroupId(getShow());
+        group.showId = getShow().getId();
+        group.deptId = departmentDao.getDefaultDepartment().getId();
+        groupDao.insertGroup(group);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testDeleteGroup() {
+        // Can't delete groups yet, will fail
+        GroupDetail group = createGroup();
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM folder WHERE pk_folder=?",
+                Integer.class, group.getId()));
+
+        groupDao.deleteGroup(group);
+
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM folder WHERE pk_folder=?",
+                Integer.class, group.getId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateGroupParent() {
+        GroupDetail group =  createGroup();
+        GroupDetail subgroup = createSubGroup(group);
+        groupDao.updateGroupParent(subgroup,
+                groupDao.getGroupDetail(
+                        groupDao.getRootGroupId(getShow())));
+
+        assertEquals(Integer.valueOf(1),jdbcTemplate.queryForObject(
+                "SELECT int_level FROM folder_level WHERE pk_folder=?",
+                Integer.class, subgroup.getId()));
+
+        groupDao.updateGroupParent(subgroup, group);
+
+        assertEquals(Integer.valueOf(2),jdbcTemplate.queryForObject(
+                "SELECT int_level FROM folder_level WHERE pk_folder=?",
+                Integer.class, subgroup.getId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateDefaultJobMaxCores() {
+        GroupDetail group =  createGroup();
+        assertEquals(Integer.valueOf(-1), jdbcTemplate.queryForObject(
+                "SELECT int_job_max_cores FROM folder WHERE pk_folder=?",
+                Integer.class, group.getGroupId()));
+        groupDao.updateDefaultJobMaxCores(group, 100);
+        assertEquals(Integer.valueOf(100), jdbcTemplate.queryForObject(
+                "SELECT int_job_max_cores FROM folder WHERE pk_folder=?",
+                Integer.class, group.getGroupId()));
+        groupDao.updateDefaultJobMaxCores(group, -1);
+        assertEquals(Integer.valueOf(-1), jdbcTemplate.queryForObject(
+                "SELECT int_job_max_cores FROM folder WHERE pk_folder=?",
+                Integer.class, group.getGroupId()));
+
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateDefaultJobMinCores() {
+        GroupDetail group =  createGroup();
+        assertEquals(Integer.valueOf(-1), jdbcTemplate.queryForObject(
+                "SELECT int_job_min_cores FROM folder WHERE pk_folder=?",
+                Integer.class, group.getGroupId()));
+        groupDao.updateDefaultJobMinCores(group, 100);
+        assertEquals(Integer.valueOf(100), jdbcTemplate.queryForObject(
+                "SELECT int_job_min_cores FROM folder WHERE pk_folder=?",
+                Integer.class, group.getGroupId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateDefaultJobPriority() {
+        GroupDetail group =  createGroup();
+        assertEquals(Integer.valueOf(-1), jdbcTemplate.queryForObject(
+                "SELECT int_job_priority FROM folder WHERE pk_folder=?",
+                Integer.class, group.getGroupId()));
+        groupDao.updateDefaultJobPriority(group, 1000);
+        assertEquals(Integer.valueOf(1000), jdbcTemplate.queryForObject(
+                "SELECT int_job_priority FROM folder WHERE pk_folder=?",
+                Integer.class, group.getGroupId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateMinCores() {
+        GroupDetail group =  createGroup();
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT int_min_cores FROM folder_resource WHERE pk_folder=?",
+                Integer.class, group.getGroupId()));
+        groupDao.updateMinCores(group, 10);
+        assertEquals(Integer.valueOf(10), jdbcTemplate.queryForObject(
+                "SELECT int_min_cores FROM folder_resource WHERE pk_folder=?",
+                Integer.class, group.getGroupId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateMaxCores() {
+        GroupDetail group =  createGroup();
+        assertEquals(Integer.valueOf(-1), jdbcTemplate.queryForObject(
+                "SELECT int_max_cores FROM folder_resource WHERE pk_folder=?",
+                Integer.class, group.getGroupId()));
+        groupDao.updateMaxCores(group, 100);
+        assertEquals(Integer.valueOf(100), jdbcTemplate.queryForObject(
+                "SELECT int_max_cores FROM folder_resource WHERE pk_folder=?",
+                Integer.class, group.getGroupId()));
+        groupDao.updateMaxCores(group, -5);
+        assertEquals(Integer.valueOf(-1), jdbcTemplate.queryForObject(
+                "SELECT int_max_cores FROM folder_resource WHERE pk_folder=?",
+                Integer.class, group.getGroupId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testIsManaged() {
+        GroupDetail group =  createGroup();
+        assertEquals(false, groupDao.isManaged(group));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateName() {
+        GroupDetail group =  createGroup();
+        groupDao.updateName(group, "NewName");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateDepartment() {
+        GroupDetail group = createGroup();
+        groupDao.updateDepartment(group, departmentDao.findDepartment("Lighting"));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetGroupDetail() {
+        GroupDetail group = createGroup();
+        GroupDetail group2 = groupDao.getGroupDetail(group.id);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetChildrenRecursive() {
+        boolean is_test2 = false;
+        boolean is_test3 = false;
+
+        GroupDetail g1 = new GroupDetail();
+        g1.name = "Test1";
+        g1.showId = getShow().getId();
+        g1.deptId = departmentDao.getDefaultDepartment().getId();
+        groupDao.insertGroup(g1, groupDao.getRootGroupDetail(getShow()));
+
+        GroupDetail g2 = new GroupDetail();
+        g2.name = "Test2";
+        g2.showId = getShow().getId();
+        g2.deptId = departmentDao.getDefaultDepartment().getId();
+        groupDao.insertGroup(g2, groupDao.getRootGroupDetail(getShow()));
+
+        for ( Group g: groupDao.getChildrenRecursive(groupDao.getGroup("A0000000-0000-0000-0000-000000000000"))) {
+            if (g.getName().equals("Test1")) {
+                is_test2 = true;
+            }
+            if (g.getName().equals("Test2")) {
+                is_test3 = true;
+            }
+        }
+        assertTrue(is_test2);
+        assertTrue(is_test3);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetChildren() {
+        boolean is_testuserA = false;
+        boolean is_testuserB = false;
+
+        GroupDetail g1 = new GroupDetail();
+        g1.name = "testuserA";
+        g1.showId = getShow().getId();
+        g1.deptId = departmentDao.getDefaultDepartment().getId();
+        groupDao.insertGroup(g1, groupDao.getRootGroupDetail(getShow()));
+
+        GroupDetail g2 = new GroupDetail();
+        g2.name = "testuserB";
+        g2.showId = getShow().getId();
+        g2.deptId = departmentDao.getDefaultDepartment().getId();
+        groupDao.insertGroup(g2, groupDao.getRootGroupDetail(getShow()));
+
+        List<Group> groups = groupDao.getChildren(groupDao.getGroup("A0000000-0000-0000-0000-000000000000"));
+        for (Group g : groups) {
+            if (g.getName().equals("testuserA")) {
+                is_testuserA = true;
+            }
+            if (g.getName().equals("testuserB")) {
+                is_testuserB = true;
+            }
+        }
+        assertTrue(is_testuserA);
+        assertTrue(is_testuserB);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testIsOverMinCores() {
+
+        JobDetail job = launchJob();
+        assertFalse(groupDao.isOverMinCores(job));
+
+        String groupid =  jdbcTemplate.queryForObject("SELECT pk_folder FROM job WHERE pk_job=?",
+                String.class, job.getJobId());
+
+        // Now update some values so it returns true.
+        jdbcTemplate.update("UPDATE folder_resource SET int_cores = int_min_cores + 1 WHERE pk_folder=?",
+                groupid);
+
+        assertTrue(groupDao.isOverMinCores(job));
+    }
+}
+
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/HistoricalDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/HistoricalDaoTests.java
@@ -1,0 +1,78 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+
+import javax.annotation.Resource;
+
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.JobDetail;
+import com.imageworks.spcue.dao.HistoricalDao;
+import com.imageworks.spcue.service.JobLauncher;
+import com.imageworks.spcue.service.JobManager;
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class HistoricalDaoTests extends
+        AbstractTransactionalJUnit4SpringContextTests {
+
+    @Resource
+    private JobManager jobManager;
+
+    @Resource
+    private JobLauncher jobLauncher;
+
+    @Resource
+    private HistoricalDao historicalDao;
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetFinishedJobs() {
+        historicalDao.getFinishedJobs(24);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testTransferJob() {
+        jobLauncher.launch(new File("src/test/resources/conf/jobspec/jobspec.xml"));
+        JobDetail j = jobManager.findJobDetail("pipe-dev.cue-testuser_shell_v1");
+        jobManager.shutdownJob(j);
+        historicalDao.transferJob(j);
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM job_history WHERE pk_job=?",
+                Integer.class, j.getJobId()));
+    }
+}
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/HostDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/HostDaoTests.java
@@ -1,0 +1,567 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import static org.junit.Assert.*;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Resource;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.transaction.AfterTransaction;
+import org.springframework.test.context.transaction.BeforeTransaction;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.DispatchHost;
+import com.imageworks.spcue.Host;
+import com.imageworks.spcue.HostDetail;
+import com.imageworks.spcue.Source;
+import com.imageworks.spcue.CueIce.HostTagType;
+import com.imageworks.spcue.CueIce.LockState;
+import com.imageworks.spcue.CueIce.ThreadMode;
+import com.imageworks.spcue.dao.AllocationDao;
+import com.imageworks.spcue.dao.FacilityDao;
+import com.imageworks.spcue.dao.HostDao;
+import com.imageworks.spcue.dispatcher.Dispatcher;
+import com.imageworks.spcue.grpc.host.HardwareState;
+import com.imageworks.spcue.grpc.report.HostReport;
+import com.imageworks.spcue.grpc.report.RenderHost;
+import com.imageworks.spcue.service.HostManager;
+import com.imageworks.spcue.util.CueUtil;
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class HostDaoTests extends AbstractTransactionalJUnit4SpringContextTests  {
+
+    private static final String TEST_HOST = "beta";
+
+    @Resource
+    protected AllocationDao allocationDao;
+
+    @Resource
+    protected HostDao hostDao;
+
+    @Resource
+    protected HostManager hostManager;
+
+    @Resource
+    protected FacilityDao facilityDao;
+
+    public HostDaoTests() { }
+
+    public static RenderHost buildRenderHost(String name) {
+        RenderHost host = RenderHost.newBuilder()
+                .setName(name)
+                .setBootTime(1192369572)
+                .setFreeMcp(7602)
+                .setFreeMem(15290520)
+                .setFreeSwap((int) CueUtil.MB512)
+                .setLoad(1)
+                .setNimbyEnabled(false)
+                .setTotalMcp(19543)
+                .setTotalMem((int) CueUtil.GB16)
+                .setTotalSwap((int) CueUtil.GB2)
+                .setNimbyEnabled(false)
+                .setNumProcs(2)
+                .setCoresPerProc(400)
+                .addAllTags(ImmutableList.of("linux", "64bit"))
+                .setState(HardwareState.UP)
+                .setFacility("spi")
+                .putAttributes("freeGpu", String.format("%d", CueUtil.MB512))
+                .putAttributes("totalGpu", String.format("%d", CueUtil.MB512))
+                .build();
+
+        return host;
+    }
+
+    @Test
+    public void testInit() { }
+
+    @BeforeTransaction
+    public void clear() {
+        jdbcTemplate.update(
+            "DELETE FROM host WHERE str_name=?", TEST_HOST);
+    }
+
+    @AfterTransaction
+    public void destroy() {
+        jdbcTemplate.update(
+            "DELETE FROM host WHERE str_name=?", TEST_HOST);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertHost() {
+        hostDao.insertRenderHost(buildRenderHost(TEST_HOST),
+                hostManager.getDefaultAllocationDetail(),
+                false);
+
+        assertEquals(Long.valueOf(CueUtil.GB16 - Dispatcher.MEM_RESERVED_SYSTEM), jdbcTemplate.queryForObject(
+                "SELECT int_mem FROM host WHERE str_name=?",
+                Long.class, TEST_HOST));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertHostFQDN1() {
+        String TEST_HOST_NEW = "ice-ns1.yvr";
+        String FQDN_HOST = TEST_HOST_NEW + ".spimageworks.com";
+        hostDao.insertRenderHost(buildRenderHost(FQDN_HOST),
+                hostManager.getDefaultAllocationDetail(),
+                true);
+
+        HostDetail hostDetail = hostDao.findHostDetail(TEST_HOST_NEW);
+        assertEquals(TEST_HOST_NEW, hostDetail.name);
+
+        Host host = hostDao.findHost(FQDN_HOST);
+        HostDetail hostDetail2 = hostDao.getHostDetail(host);
+        assertEquals(TEST_HOST_NEW, hostDetail2.name);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertHostFQDN2() {
+        String TEST_HOST_NEW = "compile21";
+        String FQDN_HOST = TEST_HOST_NEW + ".spimageworks.com";
+        hostDao.insertRenderHost(buildRenderHost(FQDN_HOST),
+                hostManager.getDefaultAllocationDetail(),
+                false);
+
+        HostDetail hostDetail = hostDao.findHostDetail(TEST_HOST_NEW);
+        assertEquals(TEST_HOST_NEW, hostDetail.name);
+
+        Host host = hostDao.findHost(FQDN_HOST);
+        HostDetail hostDetail2 = hostDao.getHostDetail(host);
+        assertEquals(TEST_HOST_NEW, hostDetail2.name);
+
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertHostFQDN3() {
+        String TEST_HOST_NEW = "hostname";
+        String FQDN_HOST = TEST_HOST_NEW + ".fake.co.uk";
+        hostDao.insertRenderHost(buildRenderHost(FQDN_HOST),
+            hostManager.getDefaultAllocationDetail(),
+            false);
+
+        HostDetail hostDetail = hostDao.findHostDetail(TEST_HOST_NEW);
+        assertEquals(TEST_HOST_NEW, hostDetail.name);
+
+        Host host = hostDao.findHost(FQDN_HOST);
+        HostDetail hostDetail2 = hostDao.getHostDetail(host);
+        assertEquals(TEST_HOST_NEW, hostDetail2.name);
+
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertHostAlternateOS() {
+
+        RenderHost host = buildRenderHost(TEST_HOST).toBuilder()
+                .putAttributes("SP_OS", "spinux1")
+                .build();
+
+        hostDao.insertRenderHost(host,
+                hostManager.getDefaultAllocationDetail(),
+                false);
+
+        assertEquals("spinux1",jdbcTemplate.queryForObject(
+                "SELECT str_os FROM host_stat, host " +
+                "WHERE host.pk_host = host_stat.pk_host " +
+                "AND host.str_name=?",String.class, TEST_HOST), "spinux1");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertHostDesktop() {
+
+        RenderHost host = buildRenderHost(TEST_HOST);
+        hostDao.insertRenderHost(host,
+                hostManager.getDefaultAllocationDetail(),
+                false);
+
+        assertEquals(Long.valueOf(CueUtil.GB16 - Dispatcher.MEM_RESERVED_SYSTEM), jdbcTemplate.queryForObject(
+                "SELECT int_mem FROM host WHERE str_name=?",
+                Long.class, TEST_HOST));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateThreadMode() {
+
+        RenderHost host = buildRenderHost(TEST_HOST);
+        host.toBuilder().setNimbyEnabled(true).build();
+        hostDao.insertRenderHost(host,
+                hostManager.getDefaultAllocationDetail(),
+                false);
+
+        HostDetail d = hostDao.findHostDetail(TEST_HOST);
+        hostDao.updateThreadMode(d, ThreadMode.Auto);
+
+        assertEquals(Integer.valueOf(ThreadMode.Auto.value()), jdbcTemplate.queryForObject(
+                "SELECT int_thread_mode FROM host WHERE pk_host=?",
+                Integer.class, d.id));
+
+        hostDao.updateThreadMode(d, ThreadMode.All);
+
+        assertEquals(Integer.valueOf(ThreadMode.All.value()), jdbcTemplate.queryForObject(
+                "SELECT int_thread_mode FROM host WHERE pk_host=?",
+                Integer.class, d.id));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetHostDetail() {
+
+        hostDao.insertRenderHost(buildRenderHost(TEST_HOST),
+                hostManager.getDefaultAllocationDetail(),
+                false);
+
+        HostDetail host = hostDao.findHostDetail(TEST_HOST);
+        hostDao.getHostDetail(host);
+        hostDao.getHostDetail(host.getHostId());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testIsHostLocked() {
+        hostDao.insertRenderHost(buildRenderHost(TEST_HOST),
+                hostManager.getDefaultAllocationDetail(),
+                false);
+
+        HostDetail host = hostDao.findHostDetail(TEST_HOST);
+        assertEquals(hostDao.isHostLocked(host),false);
+
+        hostDao.updateHostLock(host, LockState.Locked, new Source("TEST"));
+        assertEquals(hostDao.isHostLocked(host),true);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testIsKillMode() {
+        hostDao.insertRenderHost(buildRenderHost(TEST_HOST),
+                hostManager.getDefaultAllocationDetail(),
+                false);
+
+        HostDetail host = hostDao.findHostDetail(TEST_HOST);
+        assertFalse(hostDao.isKillMode(host));
+
+        jdbcTemplate.update(
+                "UPDATE host_stat SET int_swap_free = ?, int_mem_free = ? WHERE pk_host = ?",
+                CueUtil.MB256, CueUtil.MB256, host.getHostId());
+
+        assertTrue(hostDao.isKillMode(host));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testIsHostUp() {
+        hostDao.insertRenderHost(buildRenderHost(TEST_HOST),
+                hostManager.getDefaultAllocationDetail(),
+                false);
+
+        assertTrue(hostDao.isHostUp(hostDao.findHostDetail(TEST_HOST)));
+
+        hostDao.updateHostState(hostDao.findHostDetail(TEST_HOST),
+                HardwareState.DOWN);
+        assertFalse(hostDao.isHostUp(hostDao.findHostDetail(TEST_HOST)));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testHostExists() {
+        hostDao.insertRenderHost(buildRenderHost(TEST_HOST),
+                hostManager.getDefaultAllocationDetail(),
+                false);
+
+        assertEquals(hostDao.hostExists(TEST_HOST),true);
+        assertEquals(hostDao.hostExists("frickjack"),false);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testDeleteHost() {
+        hostDao.insertRenderHost(buildRenderHost(TEST_HOST),
+                hostManager.getDefaultAllocationDetail(),
+                false);
+
+        HostDetail host = hostDao.findHostDetail(TEST_HOST);
+        assertEquals(hostDao.hostExists(TEST_HOST),true);
+        hostDao.deleteHost(host);
+        assertEquals(hostDao.hostExists(TEST_HOST),false);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateHostRebootWhenIdle() {
+        hostDao.insertRenderHost(buildRenderHost(TEST_HOST),
+                hostManager.getDefaultAllocationDetail(),
+                false);
+
+        HostDetail host = hostDao.findHostDetail(TEST_HOST);
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT b_reboot_idle FROM host WHERE pk_host=?",
+                Integer.class, host.getHostId()));
+        hostDao.updateHostRebootWhenIdle(host, true);
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT b_reboot_idle FROM host WHERE pk_host=?",
+                Integer.class, host.getHostId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void updateHostStats() {
+
+        hostDao.insertRenderHost(buildRenderHost(TEST_HOST),
+                hostManager.getDefaultAllocationDetail(),
+                false);
+
+        DispatchHost dispatchHost = hostDao.findDispatchHost(TEST_HOST);
+        hostDao.updateHostStats(dispatchHost,
+                CueUtil.GB8,
+                CueUtil.GB8,
+                CueUtil.GB8,
+                CueUtil.GB8,
+                CueUtil.GB8,
+                CueUtil.GB8,
+                1,
+                1,
+                100,
+                new Timestamp(1247526000 * 1000l),
+                "spinux1");
+
+        Map<String,Object> result = jdbcTemplate.queryForMap(
+                "SELECT * FROM host_stat WHERE pk_host=?",
+                dispatchHost.getHostId());
+
+        assertEquals(CueUtil.GB8, ((BigDecimal)
+                (result.get("int_mem_total"))).longValue());
+        assertEquals(CueUtil.GB8, ((BigDecimal)
+                (result.get("int_mem_free"))).longValue());
+        assertEquals(CueUtil.GB8, ((BigDecimal)
+                (result.get("int_swap_total"))).longValue());
+        assertEquals(CueUtil.GB8, ((BigDecimal)
+                (result.get("int_swap_free"))).longValue());
+        assertEquals(CueUtil.GB8, ((BigDecimal)
+                (result.get("int_mcp_total"))).longValue());
+        assertEquals(CueUtil.GB8, ((BigDecimal)
+                (result.get("int_mcp_free"))).longValue());
+        assertEquals(100, ((BigDecimal)
+                (result.get("int_load"))).intValue());
+        assertEquals(new Timestamp(1247526000 * 1000l),
+                (Timestamp) result.get("ts_booted"));
+
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void updateHostResources() {
+
+        hostDao.insertRenderHost(buildRenderHost(TEST_HOST),
+                hostManager.getDefaultAllocationDetail(),
+                false);
+
+        DispatchHost dispatchHost = hostDao.findDispatchHost(TEST_HOST);
+        HostReport report = HostReport.newBuilder()
+                .setHost(
+                        buildRenderHost(TEST_HOST).toBuilder()
+                                .setCoresPerProc(1200)
+                                .setNumProcs(2)
+                                .setTotalMem((int) CueUtil.GB32)
+                ).build();
+        hostDao.updateHostResources(dispatchHost, report);
+
+        // Verify what the original values are
+        assertEquals(800, dispatchHost.cores);
+        assertEquals(800, dispatchHost.idleCores);
+        assertEquals(CueUtil.GB16 - Dispatcher.MEM_RESERVED_SYSTEM,
+                dispatchHost.idleMemory);
+        assertEquals(CueUtil.GB16-  Dispatcher.MEM_RESERVED_SYSTEM,
+                dispatchHost.memory);
+
+        dispatchHost = hostDao.findDispatchHost(TEST_HOST);
+
+        // Now verify they've changed.
+        assertEquals(2400, dispatchHost.cores);
+        assertEquals(2400, dispatchHost.idleCores);
+        assertEquals(CueUtil.GB32 -  Dispatcher.MEM_RESERVED_SYSTEM,
+                dispatchHost.idleMemory);
+        assertEquals(CueUtil.GB32-  Dispatcher.MEM_RESERVED_SYSTEM,
+                dispatchHost.memory);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetDispatchHost() {
+        hostDao.insertRenderHost(buildRenderHost(TEST_HOST),
+                hostManager.getDefaultAllocationDetail(),
+                false);
+
+        HostDetail hostDetail = hostDao.findHostDetail(TEST_HOST);
+        DispatchHost dispatchHost = hostDao.findDispatchHost(TEST_HOST);
+
+        assertEquals(dispatchHost.name, TEST_HOST);
+        assertEquals(dispatchHost.allocationId, hostDetail.getAllocationId());
+        assertEquals(dispatchHost.id, hostDetail.getHostId());
+        assertEquals(dispatchHost.cores, hostDetail.cores);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateHostSetAllocation() {
+
+        hostDao.insertRenderHost(buildRenderHost(TEST_HOST),
+                hostManager.getDefaultAllocationDetail(),
+                false);
+
+        HostDetail hostDetail = hostDao.findHostDetail(TEST_HOST);
+
+        hostDao.updateHostSetAllocation(hostDetail,
+                hostManager.getDefaultAllocationDetail());
+
+        hostDetail = hostDao.findHostDetail(TEST_HOST);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateHostSetManualTags() {
+        DispatchHost host = hostManager.createHost(buildRenderHost(TEST_HOST));
+
+        hostDao.tagHost(host,"frick", HostTagType.Manual);
+        hostDao.tagHost(host,"jack", HostTagType.Manual);
+        hostDao.recalcuateTags(host.id);
+
+        String tag = jdbcTemplate.queryForObject(
+                "SELECT str_tags FROM host WHERE pk_host=?",String.class, host.id);
+        assertEquals("unassigned beta frick jack", tag);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateHostSetOS() {
+        DispatchHost host = hostManager.createHost(buildRenderHost(TEST_HOST));
+        hostDao.updateHostOs(host, "foo");
+        String tag = jdbcTemplate.queryForObject(
+                "SELECT str_os FROM host_stat WHERE pk_host=?",String.class, host.id);
+        assertEquals("foo", tag);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testChangeTags() {
+        DispatchHost host = hostManager.createHost(buildRenderHost(TEST_HOST));
+
+        String tag = jdbcTemplate.queryForObject(
+                "SELECT str_tags FROM host WHERE pk_host=?",String.class, host.id);
+        assertEquals("unassigned beta", tag);
+
+        hostDao.removeTag(host, "linux");
+        hostDao.recalcuateTags(host.id);
+
+        assertEquals("unassigned beta", jdbcTemplate.queryForObject(
+                "SELECT str_tags FROM host WHERE pk_host=?",String.class, host.id));
+
+        hostDao.tagHost(host, "32bit",HostTagType.Manual);
+        hostDao.recalcuateTags(host.id);
+
+        assertEquals("unassigned beta 32bit", jdbcTemplate.queryForObject(
+                "SELECT str_tags FROM host WHERE pk_host=?",String.class, host.id));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetStrandedCoreUnits() {
+        DispatchHost host = hostManager.createHost(buildRenderHost(TEST_HOST));
+
+        jdbcTemplate.update(
+                "UPDATE host SET int_mem_idle = ? WHERE pk_host = ?",
+                CueUtil.GB, host.getHostId());
+
+        assertEquals(host.idleCores, hostDao.getStrandedCoreUnits(host));
+
+        jdbcTemplate.update(
+                "UPDATE host SET int_mem_idle = ? WHERE pk_host = ?",
+                CueUtil.GB2, host.getHostId());
+
+        assertEquals(0, hostDao.getStrandedCoreUnits(host));
+
+        // Check to see if fractional cores is rounded to the lowest
+        // whole core properly.
+        jdbcTemplate.update(
+                "UPDATE host SET int_cores_idle=150, int_mem_idle = ? WHERE pk_host = ?",
+                CueUtil.GB, host.getHostId());
+
+        assertEquals(100, hostDao.getStrandedCoreUnits(host));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testIsPreferShow() {
+        DispatchHost host = hostManager.createHost(buildRenderHost(TEST_HOST));
+        assertFalse(hostDao.isPreferShow(host));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testIsNimby() {
+        DispatchHost host = hostManager.createHost(buildRenderHost(TEST_HOST));
+        assertFalse(hostDao.isNimbyHost(host));
+    }
+}
+
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/JobDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/JobDaoTests.java
@@ -1,0 +1,671 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Resource;
+
+import com.imageworks.spcue.FacilityEntity;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.DispatchJob;
+import com.imageworks.spcue.ExecutionSummary;
+import com.imageworks.spcue.Group;
+import com.imageworks.spcue.GroupDetail;
+import com.imageworks.spcue.Job;
+import com.imageworks.spcue.JobDetail;
+import com.imageworks.spcue.Point;
+import com.imageworks.spcue.ResourceUsage;
+import com.imageworks.spcue.TaskDetail;
+import com.imageworks.spcue.CueIce.JobState;
+import com.imageworks.spcue.dao.DepartmentDao;
+import com.imageworks.spcue.dao.FacilityDao;
+import com.imageworks.spcue.dao.GroupDao;
+import com.imageworks.spcue.dao.JobDao;
+import com.imageworks.spcue.dao.PointDao;
+import com.imageworks.spcue.dao.ShowDao;
+import com.imageworks.spcue.dao.TaskDao;
+import com.imageworks.spcue.service.JobLauncher;
+import com.imageworks.spcue.service.JobManager;
+import com.imageworks.spcue.service.JobSpec;
+import com.imageworks.spcue.util.JobLogUtil;
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class JobDaoTests extends AbstractTransactionalJUnit4SpringContextTests  {
+
+    @Resource
+    JobManager jobManager;
+
+    @Resource
+    JobLauncher jobLauncher;
+
+    @Resource
+    JobDao jobDao;
+
+    @Resource
+    PointDao pointDao;
+
+    @Resource
+    ShowDao showDao;
+
+    @Resource
+    TaskDao taskDao;
+
+    @Resource
+    GroupDao groupDao;
+
+    @Resource
+    FacilityDao facilityDao;
+
+    @Resource
+    DepartmentDao departmentDao;
+
+    private static String ROOT_FOLDER = "A0000000-0000-0000-0000-000000000000";
+    private static String ROOT_SHOW = "00000000-0000-0000-0000-000000000000";
+    private static String JOB_NAME = "pipe-dev.cue-testuser_shell_v1";
+
+    @Before
+    public void testMode() {
+        jobLauncher.testMode = true;
+    }
+
+    public JobDetail buildJobDetail() {
+        JobSpec spec = jobLauncher.parse(new File("src/test/resources/conf/jobspec/jobspec.xml"));
+        return spec.getJobs().get(0).detail;
+    }
+
+    public JobDetail insertJob() {
+        JobDetail job = this.buildJobDetail();
+        job.groupId = ROOT_FOLDER;
+        job.showId = ROOT_SHOW;
+        job.logDir = JobLogUtil.getJobLogPath(job);
+        job.deptId = departmentDao.getDefaultDepartment().getId();
+        job.facilityId = facilityDao.getDefaultFacility().getId();
+        job.state = JobState.Pending;
+        jobDao.insertJob(job);
+        return job;
+    }
+
+
+    public JobDetail launchJob() {
+        jobLauncher.launch(new File("src/test/resources/conf/jobspec/jobspec.xml"));
+        return jobManager.findJobDetail("pipe-dev.cue-testuser_shell_v1");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetDispatchJob() {
+        JobDetail job = insertJob();
+        DispatchJob djob = jobDao.getDispatchJob(job.id);
+        assertEquals(djob.id, job.id);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testIsJobComplete() {
+        JobDetail job = insertJob();
+        // returns true because there are no dispatchable frames
+        assertEquals(true,jobDao.isJobComplete(job));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertJob() {
+        JobDetail job = this.buildJobDetail();
+        job.groupId = ROOT_FOLDER;
+        job.showId = ROOT_SHOW;
+        job.logDir = JobLogUtil.getJobLogPath(job);
+        job.deptId = departmentDao.getDefaultDepartment().getId();
+        job.facilityId= facilityDao.getDefaultFacility().getId();
+        jobDao.insertJob(job);
+        assertNotNull(job.id);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindJob() {
+        JobDetail job = insertJob();
+        Job j1 = jobDao.findJob(job.name);
+        JobDetail j2 = jobDao.findJobDetail(job.name);
+        assertEquals(job.name, j1.getName());
+        assertEquals(job.name, j2.getName());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetJob() {
+        JobDetail job = insertJob();
+        jobDao.getJobDetail(job.id);
+        jobDao.getJob(job.id);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetJobsByTask() {
+
+        Point p = pointDao.getPointConfigDetail(
+                showDao.findShowDetail("pipe"),
+                departmentDao.getDefaultDepartment());
+
+        TaskDetail t = new TaskDetail(p, "dev.cue");
+        taskDao.insertTask(t);
+        jobDao.getJobs(t);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testJobExists() {
+        assertFalse(jobDao.exists(JOB_NAME));
+        JobDetail job = insertJob();
+        jdbcTemplate.update("UPDATE job SET str_state='Pending' WHERE pk_job=?",
+                job.id);
+        assertTrue(jobDao.exists(JOB_NAME));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testDeleteJob() {
+       jobDao.deleteJob(insertJob());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testActivateJob() {
+        jobDao.activateJob(insertJob(), JobState.Pending);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateJobState() {
+        JobDetail job = insertJob();
+        assertEquals(JobState.Pending, job.state);
+        jobDao.updateState(job, JobState.Finished);
+        assertEquals(JobState.Finished.toString(),
+                jdbcTemplate.queryForObject(
+                        "SELECT str_state FROM job WHERE pk_job=?",
+                        String.class, job.getJobId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateJobFinished() {
+        jobDao.updateJobFinished(insertJob());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testIsJobOverMinProc() {
+        JobDetail job = insertJob();
+        assertFalse(jobDao.isOverMinCores(job));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testHasPendingFrames() {
+        assertFalse(jobDao.hasPendingFrames(insertJob()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testIsJobOverMaxProc() {
+        JobDetail job = insertJob();
+        assertFalse(jobDao.isOverMaxCores(job));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testIsJobAtMaxCores() {
+        JobDetail job = insertJob();
+        assertFalse(jobDao.isAtMaxCores(job));
+
+        jdbcTemplate.update(
+                "UPDATE job_resource SET int_cores = int_max_cores WHERE pk_job=?",
+                job.getJobId());
+
+        assertTrue(jobDao.isAtMaxCores(job));
+
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testIsOverMaxCores() {
+        JobDetail job = insertJob();
+        jobDao.updateMaxCores(job, 500);
+        jdbcTemplate.update(
+                "UPDATE job_resource SET int_cores = 450 WHERE pk_job=?",
+                job.getJobId());
+
+        assertFalse(jobDao.isOverMaxCores(job));
+        assertFalse(jobDao.isOverMaxCores(job, 50));
+        assertTrue(jobDao.isOverMaxCores(job, 100));
+
+        jdbcTemplate.update(
+                "UPDATE job_resource SET int_max_cores = 200 WHERE pk_job=?",
+                job.getJobId());
+        assertTrue(jobDao.isOverMaxCores(job));
+    }
+
+    @Test(expected=org.springframework.jdbc.UncategorizedSQLException.class)
+    @Transactional
+    @Rollback(true)
+    public void testMaxCoreTrigger() {
+        JobDetail job = insertJob();
+        int maxCores = jdbcTemplate.queryForObject(
+                "SELECT int_max_cores FROM job_resource WHERE pk_job=?",
+                Integer.class, job.getJobId());
+
+        jdbcTemplate.update(
+                "UPDATE job_resource SET int_cores = ? WHERE pk_job=?",
+                maxCores + 1, job.getJobId());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateJobPriority() {
+        JobDetail job = insertJob();
+        jobDao.updatePriority(job, 199);
+        assertEquals(Integer.valueOf(199), jdbcTemplate.queryForObject(
+                "SELECT int_priority FROM job_resource WHERE pk_job=?",
+                Integer.class, job.getJobId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateJobMinCores() {
+        JobDetail job = insertJob();
+        jobDao.updateMinCores(job, 100);
+        assertEquals(Integer.valueOf(100), jdbcTemplate.queryForObject(
+                "SELECT int_min_cores FROM job_resource WHERE pk_job=?",
+                Integer.class, job.getJobId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateJobMaxCores() {
+        JobDetail job = insertJob();
+        jobDao.updateMaxCores(job, 100);
+        assertEquals(Integer.valueOf(100), jdbcTemplate.queryForObject(
+                "SELECT int_max_cores FROM job_resource WHERE pk_job=?",
+                Integer.class, job.getJobId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateJobMinCoresByGroup() {
+        JobDetail job = insertJob();
+        Group g = groupDao.getGroup(job.groupId);
+        jobDao.updateMinCores(g, 100);
+        assertEquals(Integer.valueOf(100), jdbcTemplate.queryForObject(
+                "SELECT int_min_cores FROM job_resource WHERE pk_job=?",
+                Integer.class, job.getJobId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateJobMaxCoresByGroup() {
+        JobDetail job = insertJob();
+        Group g = groupDao.getGroup(job.groupId);
+        jobDao.updateMaxCores(g, 100);
+        assertEquals(Integer.valueOf(100), jdbcTemplate.queryForObject(
+                "SELECT int_max_cores FROM job_resource WHERE pk_job=?",
+                Integer.class, job.getJobId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateJobPriorityByGroup() {
+        JobDetail job = insertJob();
+        Group g = groupDao.getGroup(job.groupId);
+        jobDao.updatePriority(g, 100);
+        assertEquals(Integer.valueOf(100), jdbcTemplate.queryForObject(
+                "SELECT int_priority FROM job_resource WHERE pk_job=?",
+                Integer.class, job.getJobId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateJobMaxRss() {
+        long maxRss = 100000;
+        JobDetail job = insertJob();
+        jobDao.updateMaxRSS(job, maxRss);
+        assertEquals(Long.valueOf(maxRss), jdbcTemplate.queryForObject(
+                "SELECT int_max_rss FROM job_mem WHERE pk_job=?",
+                Long.class, job.getJobId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateJobPaused() {
+        JobDetail job = insertJob();
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT b_paused FROM job WHERE pk_job=?",
+                Integer.class, job.getJobId()));
+
+        jobDao.updatePaused(job, false);
+
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT b_paused FROM job WHERE pk_job=?",
+                Integer.class, job.getJobId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateJobAutoEat() {
+        JobDetail job = insertJob();
+
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT b_autoeat FROM job WHERE pk_job=?",
+                Integer.class, job.getJobId()));
+
+        jobDao.updateAutoEat(job, true);
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT b_autoeat FROM job WHERE pk_job=?",
+                Integer.class, job.getJobId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateJobMaxRetries() {
+        JobDetail job = insertJob();
+        jobDao.updateMaxFrameRetries(job,10);
+        assertEquals(Integer.valueOf(10), jdbcTemplate.queryForObject(
+                "SELECT int_max_retries FROM job WHERE pk_job=?",
+                Integer.class, job.getJobId()));
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    @Transactional
+    @Rollback(true)
+    public void testUpdateJobMaxRetriesTooLow() {
+        JobDetail job = insertJob();
+        jobDao.updateMaxFrameRetries(job,-1);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    @Transactional
+    @Rollback(true)
+    public void testUpdateJobMaxRetriesTooHigh() {
+        JobDetail job = insertJob();
+        jobDao.updateMaxFrameRetries(job,100000);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetFrameStateTotals() {
+        JobSpec spec = jobLauncher.parse(new File("src/test/resources/conf/jobspec/jobspec.xml"));
+        jobLauncher.launch(spec);
+        jobDao.getFrameStateTotals(spec.getJobs().get(0).detail);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetExecutionSummary() {
+        JobDetail job = launchJob();
+        ExecutionSummary summary = jobDao.getExecutionSummary(job);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetJobEnvironment() {
+        JobDetail job = launchJob();
+        Map<String,String> map = jobDao.getEnvironment(job);
+        for (Map.Entry<String,String> e : map.entrySet()) {
+            assertEquals("VNP_VCR_SESSION", e.getKey());
+            assertEquals( "9000", e.getValue());
+        }
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertJobEnvironment() {
+        JobDetail job = launchJob();
+        jobDao.insertEnvironment(job, "CHAMBERS","123");
+        Map<String,String> map = jobDao.getEnvironment(job);
+        assertEquals(2,map.size());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertJobEnvironmentMap() {
+        JobDetail job = launchJob();
+        Map<String,String> map = new HashMap<String,String>();
+        map.put("CHAMBERS","123");
+        map.put("OVER9000","123");
+
+        jobDao.insertEnvironment(job, map);
+        Map<String,String> env = jobDao.getEnvironment(job);
+        assertEquals(3,env.size());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindLastJob() {
+        JobSpec spec = jobLauncher.parse(new File("src/test/resources/conf/jobspec/jobspec.xml"));
+        jobLauncher.launch(spec);
+
+        Job job = spec.getJobs().get(0).detail;
+        jobDao.getFrameStateTotals(job);
+        jobManager.shutdownJob(job);
+        // this might fail
+        JobDetail oldJob = jobDao.findLastJob(job.getName());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateJobLogPath() {
+        JobDetail job = launchJob();
+        String newLogDir =  "/path/to/nowhere";
+        jobDao.updateLogPath(job,newLogDir);
+        assertEquals(newLogDir,jdbcTemplate.queryForObject(
+                "SELECT str_log_dir FROM job WHERE pk_job=?",String.class, job.id));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateJobParent() {
+        JobDetail job = launchJob();
+
+        // Make a new test group.
+        GroupDetail root = groupDao.getRootGroupDetail(job);
+
+        GroupDetail testGroup = new GroupDetail();
+        testGroup.name = "testGroup";
+        testGroup.deptId = departmentDao.getDefaultDepartment().getId();
+        testGroup.showId = root.getShowId();
+
+        groupDao.insertGroup(testGroup, root);
+
+        jdbcTemplate.update(
+                "UPDATE folder SET int_job_max_cores=-1, int_job_min_cores=-1, int_job_priority=-1 WHERE pk_folder=?",
+                testGroup.getId());
+
+        GroupDetail group = groupDao.getGroupDetail(testGroup.getId());
+        jobDao.updateParent(job, group);
+
+        assertEquals(-1,group.jobMaxCores);
+        assertEquals(-1,group.jobMinCores);
+        assertEquals(-1,group.jobPriority);
+
+        assertEquals(group.getGroupId(),jdbcTemplate.queryForObject(
+                "SELECT pk_folder FROM job WHERE pk_job=?",String.class, job.id));
+
+        assertEquals(group.getDepartmentId(),jdbcTemplate.queryForObject(
+                "SELECT pk_dept FROM job WHERE pk_job=?",String.class, job.id));
+
+        group.jobMaxCores = 100;
+        group.jobMinCores = 100;
+        group.jobPriority = 100;
+
+        jobDao.updateParent(job, group);
+
+        assertEquals(Integer.valueOf(group.jobMaxCores) ,jdbcTemplate.queryForObject(
+                "SELECT int_max_cores FROM job_resource WHERE pk_job=?",
+                Integer.class, job.id));
+
+        assertEquals(Integer.valueOf(group.jobMinCores) ,jdbcTemplate.queryForObject(
+                "SELECT int_min_cores FROM job_resource WHERE pk_job=?",
+                Integer.class, job.id));
+
+        assertEquals(Integer.valueOf(group.jobPriority) ,jdbcTemplate.queryForObject(
+                "SELECT int_priority FROM job_resource WHERE pk_job=?",
+                Integer.class, job.id));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testCueHasPendingJobs() {
+        jobDao.cueHasPendingJobs(new FacilityEntity("0"));
+
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void mapPostJob() {
+        JobSpec spec = jobLauncher.parse(
+                new File("src/test/resources/conf/jobspec/jobspec_postframes.xml"));
+        jobLauncher.launch(spec);
+
+        final String pk_job = spec.getJobs().get(0).detail.id;
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM job_post WHERE pk_job=?",
+                Integer.class, pk_job));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void activatePostJob() {
+        JobSpec spec = jobLauncher.parse(
+                new File("src/test/resources/conf/jobspec/jobspec_postframes.xml"));
+        jobLauncher.launch(spec);
+
+        jobDao.activatePostJob(spec.getJobs().get(0).detail);
+
+        assertEquals(JobState.Pending.toString(),jdbcTemplate.queryForObject(
+                "SELECT str_state FROM job WHERE pk_job=?", String.class,
+                spec.getJobs().get(0).getPostJob().detail.id));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateUsage() {
+
+        JobSpec spec = jobLauncher.parse(
+                new File("src/test/resources/conf/jobspec/jobspec.xml"));
+        jobLauncher.launch(spec);
+
+        Job job = jobDao.findJob(spec.getJobs().get(0).detail.name);
+
+        /** 60 seconds of 100 core units **/
+        ResourceUsage usage = new ResourceUsage(60, 33);
+
+        assertTrue(usage.getClockTimeSeconds() > 0);
+        assertTrue(usage.getCoreTimeSeconds() > 0);
+
+        /**
+         * Successful frame
+         */
+        jobDao.updateUsage(job, usage, 0);
+        assertEquals(Long.valueOf(usage.getClockTimeSeconds()), jdbcTemplate.queryForObject(
+                "SELECT int_clock_time_success FROM job_usage WHERE pk_job=?",
+                Long.class, job.getId()));
+
+        assertEquals(Long.valueOf(usage.getCoreTimeSeconds()), jdbcTemplate.queryForObject(
+                "SELECT int_core_time_success FROM job_usage WHERE pk_job=?",
+                Long.class, job.getId()));
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT int_frame_success_count FROM job_usage WHERE pk_job=?",
+                Integer.class, job.getId()));
+
+        /**
+         * Failed frame
+         */
+        jobDao.updateUsage(job, usage, 1);
+        assertEquals(Long.valueOf(usage.getClockTimeSeconds()), jdbcTemplate.queryForObject(
+                "SELECT int_clock_time_fail FROM job_usage WHERE pk_job=?",
+                Long.class, job.getId()));
+
+        assertEquals(Long.valueOf(usage.getCoreTimeSeconds()), jdbcTemplate.queryForObject(
+                "SELECT int_core_time_fail FROM job_usage WHERE pk_job=?",
+                Long.class, job.getId()));
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT int_frame_fail_count FROM job_usage WHERE pk_job=?",
+                Integer.class, job.getId()));
+    }
+}
+
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/LayerDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/LayerDaoTests.java
@@ -1,0 +1,648 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import javax.annotation.Resource;
+
+import org.apache.commons.lang.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.BuildableLayer;
+import com.imageworks.spcue.JobDetail;
+import com.imageworks.spcue.LayerDetail;
+import com.imageworks.spcue.ResourceUsage;
+import com.imageworks.spcue.CueIce.JobState;
+import com.imageworks.spcue.CueIce.LayerType;
+import com.imageworks.spcue.dao.DepartmentDao;
+import com.imageworks.spcue.dao.FacilityDao;
+import com.imageworks.spcue.dao.JobDao;
+import com.imageworks.spcue.dao.LayerDao;
+import com.imageworks.spcue.dispatcher.Dispatcher;
+import com.imageworks.spcue.service.JobLauncher;
+import com.imageworks.spcue.service.JobManager;
+import com.imageworks.spcue.service.JobSpec;
+import com.imageworks.spcue.util.CueUtil;
+import com.imageworks.spcue.util.JobLogUtil;
+import com.imageworks.spcue.util.FrameSet;
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class LayerDaoTests extends AbstractTransactionalJUnit4SpringContextTests  {
+
+    @Resource
+    JobDao jobDao;
+
+    @Resource
+    LayerDao layerDao;
+
+    @Resource
+    JobManager jobManager;
+
+    @Resource
+    JobLauncher jobLauncher;
+
+
+    @Resource
+    DepartmentDao departmentDao;
+
+    @Resource
+    FacilityDao facilityDao;
+
+    private static String ROOT_FOLDER = "A0000000-0000-0000-0000-000000000000";
+    private static String ROOT_SHOW = "00000000-0000-0000-0000-000000000000";
+    private static String LAYER_NAME = "pass_1";
+    private static String JOB_NAME = "pipe-dev.cue-testuser_shell_v1";
+
+    @Before
+    public void testMode() {
+        jobLauncher.testMode = true;
+    }
+
+    public LayerDetail getLayer() {
+
+        JobSpec spec = jobLauncher.parse(new File("src/test/resources/conf/jobspec/jobspec.xml"));
+        JobDetail job =  spec.getJobs().get(0).detail;
+        job.groupId = ROOT_FOLDER;
+        job.showId = ROOT_SHOW;
+        job.logDir = JobLogUtil.getJobLogPath(job);
+        job.deptId = departmentDao.getDefaultDepartment().getId();
+        job.facilityId = facilityDao.getDefaultFacility().getId();
+        jobDao.insertJob(job);
+
+        LayerDetail lastLayer= null;
+
+        for (BuildableLayer buildableLayer: spec.getJobs().get(0).getBuildableLayers()) {
+
+            LayerDetail layer = buildableLayer.layerDetail;
+            FrameSet frameSet = new FrameSet(layer.range);
+            int num_frames = frameSet.size();
+            int chunk_size = layer.chunkSize;
+
+            layer.jobId = job.id;
+            layer.showId = ROOT_SHOW;
+            layer.totalFrameCount = num_frames / chunk_size;
+            if (num_frames % chunk_size > 0) { layer.totalFrameCount++; }
+
+            layerDao.insertLayerDetail(layer);
+            layerDao.insertLayerEnvironment(layer, buildableLayer.env);
+            lastLayer = layer;
+        }
+
+        return lastLayer;
+    }
+
+    public JobDetail getJob() {
+        return jobDao.findJobDetail(JOB_NAME);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testIsLayerComplete() {
+        layerDao.isLayerComplete(getLayer());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testIsLayerDispatchable() {
+        layerDao.isLayerDispatchable(getLayer());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertLayerDetail() {
+        LayerDetail layer = getLayer();
+        assertEquals(LAYER_NAME, layer.name);
+        assertEquals(layer.chunkSize, 1);
+        assertEquals(layer.dispatchOrder,2);
+        assertNotNull(layer.id);
+        assertNotNull(layer.jobId);
+        assertEquals(layer.showId,ROOT_SHOW);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetLayerDetail() {
+        LayerDetail layer = getLayer();
+        assertEquals(LAYER_NAME, layer.name);
+        assertEquals(layer.chunkSize, 1);
+        assertEquals(layer.dispatchOrder,2);
+        assertNotNull(layer.id);
+        assertNotNull(layer.jobId);
+        assertEquals(layer.showId,ROOT_SHOW);
+
+        LayerDetail l2 = layerDao.getLayerDetail(layer);
+        LayerDetail l3 = layerDao.getLayerDetail(layer.id);
+        assertEquals(l2, l3);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindLayerDetail() {
+        LayerDetail layer = getLayer();
+        layerDao.findLayer(getJob(), "pass_1");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetLayer() {
+        LayerDetail layer = getLayer();
+        layerDao.getLayer(layer.id);
+        layerDao.getLayerDetail(layer);
+        layerDao.getLayerDetail(layer.id);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindLayer() {
+        LayerDetail layer = getLayer();
+        layerDao.findLayer(getJob(), "pass_1");
+        layerDao.findLayerDetail(getJob(), "pass_1");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateLayerMinCores() {
+        LayerDetail layer = getLayer();
+        layerDao.updateLayerMinCores(layer, 200);
+        LayerDetail l2 = layerDao.findLayerDetail(getJob(), "pass_1");
+        assertEquals(l2.minimumCores,200);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateLayerThreadable() {
+        LayerDetail layer = getLayer();
+        layerDao.updateThreadable(layer, false);
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT b_threadable FROM layer WHERE pk_layer=?",
+                Integer.class, layer.getLayerId()));
+    }
+
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateLayerMinMemory() {
+        LayerDetail layer = getLayer();
+
+        /*
+         * Check to ensure going below Dispatcher.MEM_RESERVED_MIN is
+         * not allowed.
+         */
+        layerDao.updateLayerMinMemory(layer, 8096);
+        LayerDetail l2 = layerDao.findLayerDetail(getJob(), "pass_1");
+        assertEquals(l2.minimumMemory, Dispatcher.MEM_RESERVED_MIN);
+
+        /*
+         * Check regular operation.
+         */
+        layerDao.updateLayerMinMemory(layer, CueUtil.GB);
+        LayerDetail l3 = layerDao.findLayerDetail(getJob(), "pass_1");
+        assertEquals(l3.minimumMemory, CueUtil.GB);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateLayerTags() {
+        LayerDetail layer = getLayer();
+
+        HashSet<String> tags = new HashSet<String>();
+        tags.add("frickjack");
+        tags.add("pancake");
+
+        layerDao.updateLayerTags(layer, tags);
+        LayerDetail l2 = layerDao.findLayerDetail(getJob(), "pass_1");
+        assertEquals(StringUtils.join(l2.tags," | "), "frickjack | pancake");
+
+        tags.clear();
+        tags.add("frickjack");
+
+        layerDao.updateLayerTags(layer, tags);
+        l2 = layerDao.findLayerDetail(getJob(), "pass_1");
+        assertEquals(StringUtils.join(l2.tags," | "), "frickjack");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetFrameStateTotals() {
+        LayerDetail layer = getLayer();
+        layerDao.getFrameStateTotals(layer);
+        jobDao.getFrameStateTotals(layer);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetExecutionSummary() {
+        LayerDetail layer = getLayer();
+        layerDao.getExecutionSummary(layer);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetLayerEnvironment() {
+        LayerDetail layer = getLayer();
+        Map<String,String> map = layerDao.getLayerEnvironment(layer);
+        for (Map.Entry<String,String> e : map.entrySet()) {
+
+        }
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertLayerEnvironment() {
+        LayerDetail layer = getLayer();
+        layerDao.insertLayerEnvironment(layer, "CHAMBERS","123");
+        Map<String,String> env = layerDao.getLayerEnvironment(layer);
+        assertEquals(2,env.size());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertLayerEnvironmentMap() {
+        LayerDetail layer = getLayer();
+        Map<String,String> map = new HashMap<String,String>();
+        map.put("CHAMBERS","123");
+        map.put("OVER9000","123");
+
+        layerDao.insertLayerEnvironment(layer, map);
+        Map<String,String> env = layerDao.getLayerEnvironment(layer);
+        assertEquals(3,env.size());
+    }
+
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindPastSameNameMaxRSS() {
+        getLayer();
+        jobDao.updateState(getJob(), JobState.Finished);
+        assertEquals(JobState.Finished, getJob().state);
+
+        JobDetail lastJob = null;
+        lastJob = jobDao.findLastJob("pipe-dev.cue-testuser_shell_v1");
+        long maxRss = layerDao.findPastMaxRSS(lastJob, "pass_1");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindPastTimeStampMaxRSS() {
+        getLayer();
+        jobDao.updateState(getJob(), JobState.Finished);
+        assertEquals(JobState.Finished, getJob().state);
+
+        JobDetail lastJob = null;
+        lastJob = jobDao.findLastJob("pipe-dev.cue-testuser_shell_v1_2011_05_03_16_03");
+        long maxRss = layerDao.findPastMaxRSS(lastJob, "pass_1");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindPastNewVersionMaxRSS() {
+        getLayer();
+        jobDao.updateState(getJob(), JobState.Finished);
+        assertEquals(JobState.Finished, getJob().state);
+
+        JobDetail lastJob = null;
+        lastJob = jobDao.findLastJob("pipe-dev.cue-testuser_shell_v2");
+        long maxRss = layerDao.findPastMaxRSS(lastJob, "pass_1");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindPastNewVersionTimeStampMaxRSS() {
+        getLayer();
+        jobDao.updateState(getJob(), JobState.Finished);
+        assertEquals(JobState.Finished, getJob().state);
+
+        JobDetail lastJob = null;
+        lastJob = jobDao.findLastJob("pipe-dev.cue-testuser_shell_v2_2011_05_03_16_03");
+        long maxRss = layerDao.findPastMaxRSS(lastJob, "pass_1");
+    }
+
+    @Test(expected=org.springframework.dao.EmptyResultDataAccessException.class)
+    @Transactional
+    @Rollback(true)
+    public void testFindPastNewVersionFailMaxRSS() {
+        getLayer();
+        jobDao.updateState(getJob(), JobState.Finished);
+        assertEquals(JobState.Finished, getJob().state);
+
+        JobDetail lastJob = null;
+        lastJob = jobDao.findLastJob("pipe-dev.cue-testuser_shell_vfail_v2");
+        long maxRss = layerDao.findPastMaxRSS(lastJob, "pass_1");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateLayerMaxRSS() {
+        LayerDetail layer = getLayer();
+
+        layerDao.updateLayerMaxRSS(layer, 1000, true);
+        assertEquals(Long.valueOf(1000), jdbcTemplate.queryForObject(
+                "SELECT int_max_rss FROM layer_mem WHERE pk_layer=?",
+                Long.class, layer.getId()));
+
+        layerDao.updateLayerMaxRSS(layer, 999, true);
+        assertEquals(Long.valueOf(999), jdbcTemplate.queryForObject(
+                "SELECT int_max_rss FROM layer_mem WHERE pk_layer=?",
+                Long.class, layer.getId()));
+
+        layerDao.updateLayerMaxRSS(layer, 900, false);
+        assertEquals(Long.valueOf(999), jdbcTemplate.queryForObject(
+                "SELECT int_max_rss FROM layer_mem WHERE pk_layer=?",
+                Long.class, layer.getId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void updateTags() {
+        String tag = "dillweed";
+        LayerDetail layer = getLayer();
+        layerDao.updateTags(layer, tag, LayerType.Render);
+        assertEquals(tag,jdbcTemplate.queryForObject(
+                "SELECT str_tags FROM layer WHERE pk_layer=?", String.class, layer.getLayerId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void updateMinMemory() {
+        long mem = CueUtil.GB;
+        LayerDetail layer = getLayer();
+        layerDao.updateMinMemory(layer, mem, LayerType.Render);
+        assertEquals(Long.valueOf(mem), jdbcTemplate.queryForObject(
+                "SELECT int_mem_min FROM layer WHERE pk_layer=?",
+                Long.class, layer.getLayerId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void updateMinGpu() {
+        long gpu = CueUtil.GB;
+        LayerDetail layer = getLayer();
+        layerDao.updateMinGpu(layer, gpu, LayerType.Render);
+        assertEquals(Long.valueOf(gpu),jdbcTemplate.queryForObject(
+                "SELECT int_gpu_min FROM layer WHERE pk_layer=?",
+                Long.class, layer.getLayerId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void updateMinCores() {
+        int cores = CueUtil.ONE_CORE * 2;
+        LayerDetail layer = getLayer();
+        layerDao.updateMinCores(layer, cores, LayerType.Render);
+        assertEquals(Integer.valueOf(cores), jdbcTemplate.queryForObject(
+                "SELECT int_cores_min FROM layer WHERE pk_layer=?",
+                Integer.class, layer.getLayerId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void updateMaxCores() {
+        int cores = CueUtil.ONE_CORE * 2;
+        LayerDetail layer = getLayer();
+        layerDao.updateLayerMaxCores(layer, cores);
+        assertEquals(Integer.valueOf(cores), jdbcTemplate.queryForObject(
+                "SELECT int_cores_max FROM layer WHERE pk_layer=?",
+                Integer.class, layer.getLayerId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void isOptimizable() {
+        LayerDetail layer = getLayer();
+
+        assertFalse(layerDao.isOptimizable(layer, 5, 3600));
+
+        /*
+         * The succeeded count is good but the frames are too long
+         * Assert False
+         */
+        jdbcTemplate.update("UPDATE layer_stat SET int_succeeded_count = 5 WHERE pk_layer=?",
+                layer.getLayerId());
+
+        jdbcTemplate.update(
+                "UPDATE layer_usage SET layer_usage.int_core_time_success = 3600 * 6" +
+                "WHERE pk_layer=?", layer.getLayerId());
+
+        assertFalse(layerDao.isOptimizable(layer, 5, 3600));
+
+        /*
+         * Set the frame times lower, so now we meet the criteria
+         * Assert True
+         */
+        jdbcTemplate.update(
+                "UPDATE layer_usage SET layer_usage.int_core_time_success = 3500 * 5" +
+                "WHERE pk_layer=?", layer.getLayerId());
+
+        assertTrue(layerDao.isOptimizable(layer, 5, 3600));
+
+        /*
+         * Take the general tag away.  If a layer is not a general layer
+         * it cannot be optmiized.
+         * Assert False
+         */
+        jdbcTemplate.update(
+                "UPDATE layer SET str_tags=? WHERE pk_layer=?",
+                "desktop",layer.getLayerId());
+
+        assertFalse(layerDao.isOptimizable(layer, 5, 3600));
+
+        /*
+         * Layers that are already tagged util should return
+         * false as well.
+         *
+         * Assert False
+         */
+        jdbcTemplate.update(
+                "UPDATE layer SET str_tags=? WHERE pk_layer=?",
+                "general | util",layer.getLayerId());
+
+        assertFalse(layerDao.isOptimizable(layer, 5, 3600));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateUsage() {
+        LayerDetail layer = getLayer();
+
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT int_clock_time_success FROM layer_usage WHERE pk_layer=?",
+                Integer.class, layer.getId()));
+
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT int_core_time_success FROM layer_usage WHERE pk_layer=?",
+                Integer.class, layer.getId()));
+
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT int_frame_success_count FROM layer_usage WHERE pk_layer=?",
+                Integer.class, layer.getId()));
+
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT int_clock_time_fail FROM layer_usage WHERE pk_layer=?",
+                Integer.class, layer.getId()));
+
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT int_core_time_fail FROM layer_usage WHERE pk_layer=?",
+                Integer.class, layer.getId()));
+
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT int_frame_fail_count FROM layer_usage WHERE pk_layer=?",
+                Integer.class, layer.getId()));
+
+        /** 60 seconds of 100 core units **/
+        ResourceUsage usage = new ResourceUsage(60, 33);
+
+        assertTrue(usage.getClockTimeSeconds() > 0);
+        assertTrue(usage.getCoreTimeSeconds() > 0);
+
+        /**
+         * Successful frame
+         */
+        layerDao.updateUsage(layer, usage, 0);
+        assertEquals(Long.valueOf(usage.getClockTimeSeconds()), jdbcTemplate.queryForObject(
+                "SELECT int_clock_time_success FROM layer_usage WHERE pk_layer=?",
+                Long.class, layer.getId()));
+
+        assertEquals(Long.valueOf(usage.getCoreTimeSeconds()), jdbcTemplate.queryForObject(
+                "SELECT int_core_time_success FROM layer_usage WHERE pk_layer=?",
+                Long.class, layer.getId()));
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT int_frame_success_count FROM layer_usage WHERE pk_layer=?",
+                Integer.class, layer.getId()));
+
+        /**
+         * Failed frame
+         */
+        layerDao.updateUsage(layer, usage, 1);
+        assertEquals(Long.valueOf(usage.getClockTimeSeconds()), jdbcTemplate.queryForObject(
+                "SELECT int_clock_time_fail FROM layer_usage WHERE pk_layer=?",
+                Long.class, layer.getId()));
+
+        assertEquals(Long.valueOf(usage.getCoreTimeSeconds()), jdbcTemplate.queryForObject(
+                "SELECT int_core_time_fail FROM layer_usage WHERE pk_layer=?",
+                Long.class, layer.getId()));
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT int_frame_fail_count FROM layer_usage WHERE pk_layer=?",
+                Integer.class, layer.getId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void isLayerThreadable() {
+        LayerDetail layer = getLayer();
+        jdbcTemplate.update(
+                "UPDATE layer set b_threadable = 0 WHERE pk_layer=?",
+                layer.getId());
+
+        assertFalse(layerDao.isThreadable(layer));
+
+        jdbcTemplate.update(
+                "UPDATE layer set b_threadable = 1 WHERE pk_layer=?",
+                layer.getId());
+
+        assertTrue(layerDao.isThreadable(layer));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void enableMemoryOptimizer() {
+        LayerDetail layer = getLayer();
+        layerDao.enableMemoryOptimizer(layer, false);
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT b_optimize FROM layer WHERE pk_layer=?",
+                Integer.class, layer.getLayerId()));
+
+        layerDao.enableMemoryOptimizer(layer, true);
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT b_optimize FROM layer WHERE pk_layer=?",
+                Integer.class, layer.getLayerId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testBalanceMemory() {
+        LayerDetail layer = getLayer();
+        assertTrue(layerDao.balanceLayerMinMemory(layer, CueUtil.GB));
+        jdbcTemplate.update("UPDATE layer_mem SET int_max_rss=? WHERE pk_layer=?",
+                CueUtil.GB8, layer.getId());
+        assertFalse(layerDao.balanceLayerMinMemory(layer, CueUtil.MB512));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertLayerOutput() {
+        LayerDetail layer = getLayer();
+        layerDao.insertLayerOutput(layer, "filespec1");
+        layerDao.insertLayerOutput(layer, "filespec2");
+        layerDao.insertLayerOutput(layer, "filespec3");
+        assertEquals(3, layerDao.getLayerOutputs(layer).size());
+    }
+}
+
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/MaintenanceDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/MaintenanceDaoTests.java
@@ -1,0 +1,70 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import static org.junit.Assert.*;
+
+import javax.annotation.Resource;
+
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.MaintenanceTask;
+import com.imageworks.spcue.dao.MaintenanceDao;
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class MaintenanceDaoTests extends AbstractTransactionalJUnit4SpringContextTests  {
+
+    @Resource
+    MaintenanceDao maintenanceDao;
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testSetUpHostsToDown() {
+        maintenanceDao.setUpHostsToDown();
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testLockHistoricalTask() {
+        assertTrue(maintenanceDao.lockTask(MaintenanceTask.LOCK_HISTORICAL_TRANSFER));
+        assertFalse(maintenanceDao.lockTask(MaintenanceTask.LOCK_HISTORICAL_TRANSFER));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUnlockHistoricalTask() {
+        assertTrue(maintenanceDao.lockTask(MaintenanceTask.LOCK_HISTORICAL_TRANSFER));
+        maintenanceDao.unlockTask(MaintenanceTask.LOCK_HISTORICAL_TRANSFER);
+    }
+}
+
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/MatcherDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/MatcherDaoTests.java
@@ -1,0 +1,135 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import javax.annotation.Resource;
+
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.FilterDetail;
+import com.imageworks.spcue.MatcherDetail;
+import com.imageworks.spcue.Show;
+import com.imageworks.spcue.CueIce.FilterType;
+import com.imageworks.spcue.CueIce.MatchSubject;
+import com.imageworks.spcue.CueIce.MatchType;
+import com.imageworks.spcue.dao.FilterDao;
+import com.imageworks.spcue.dao.GroupDao;
+import com.imageworks.spcue.dao.MatcherDao;
+import com.imageworks.spcue.dao.ShowDao;
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class MatcherDaoTests extends AbstractTransactionalJUnit4SpringContextTests  {
+
+    @Resource
+    MatcherDao matcherDao;
+
+    @Resource
+    FilterDao filterDao;
+
+    @Resource
+    ShowDao showDao;
+
+    @Resource
+    GroupDao groupDao;
+
+    private static String FILTER_NAME = "test_filter";
+
+    public Show getShow() {
+        return showDao.getShowDetail("00000000-0000-0000-0000-000000000000");
+    }
+
+    public MatcherDetail createMatcher() {
+        FilterDetail filter = createFilter();
+        MatcherDetail matcher = new MatcherDetail();
+        matcher.filterId = filter.id;
+        matcher.name = null;
+        matcher.showId = getShow().getId();
+        matcher.subject = MatchSubject.JobName;
+        matcher.type = MatchType.Contains;
+        matcher.value = "testuser";
+        matcherDao.insertMatcher(matcher);
+        return matcher;
+    }
+
+    public FilterDetail createFilter() {
+        FilterDetail filter = new FilterDetail();
+        filter.name = FILTER_NAME;
+        filter.showId = "00000000-0000-0000-0000-000000000000";
+        filter.type = FilterType.MatchAny;
+        filter.enabled = true;
+        filterDao.insertFilter(filter);
+        return filter;
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertMatcher() {
+        createMatcher();
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testDeleteMatcher() {
+        MatcherDetail matcher = createMatcher();
+        matcherDao.deleteMatcher(matcher);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateMatcher() {
+        MatcherDetail matcher = createMatcher();
+        matcher.subject = MatchSubject.User;
+        matcher.value = "testuser";
+        matcher.type = MatchType.Is;
+        matcherDao.updateMatcher(matcher);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetMatcher() {
+        MatcherDetail matcher = createMatcher();
+        matcherDao.getMatcher(matcher);
+        matcherDao.getMatcher(matcher.getMatcherId());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetMatchers() {
+        MatcherDetail matcher = createMatcher();
+        matcherDao.getMatchers(matcher);
+    }
+
+}
+
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/NestedWhiteboardDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/NestedWhiteboardDaoTests.java
@@ -1,0 +1,68 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import javax.annotation.Resource;
+
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.ShowDetail;
+import com.imageworks.spcue.CueClientIce.NestedHost;
+import com.imageworks.spcue.dao.NestedWhiteboardDao;
+import com.imageworks.spcue.dao.ShowDao;
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class NestedWhiteboardDaoTests extends AbstractTransactionalJUnit4SpringContextTests {
+
+    @Resource
+    NestedWhiteboardDao nestedWhiteboardDao;
+
+    @Resource
+    ShowDao showDao;
+
+    public ShowDetail getShow() {
+        return showDao.findShowDetail("pipe");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetNestedJobWhiteboard() {
+        nestedWhiteboardDao.getJobWhiteboard(getShow());
+        nestedWhiteboardDao.getJobWhiteboard(getShow());
+        nestedWhiteboardDao.getJobWhiteboard(getShow());
+        nestedWhiteboardDao.getJobWhiteboard(getShow());
+        nestedWhiteboardDao.getJobWhiteboard(getShow());
+    }
+}
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/OwnerDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/OwnerDaoTests.java
@@ -1,0 +1,126 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import static org.junit.Assert.*;
+
+import javax.annotation.Resource;
+
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.Owner;
+import com.imageworks.spcue.Show;
+import com.imageworks.spcue.dao.OwnerDao;
+import com.imageworks.spcue.service.AdminManager;
+import com.imageworks.spcue.service.HostManager;
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class OwnerDaoTests  extends AbstractTransactionalJUnit4SpringContextTests {
+
+    @Resource
+    OwnerDao ownerDao;
+
+    @Resource
+    AdminManager adminManager;
+
+    @Resource
+    HostManager hostManager;
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertOwner() {
+        Show show = adminManager.findShowDetail("pipe");
+        Owner o = new Owner();
+        o.name = "spongebob";
+        ownerDao.insertOwner(o, show);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testIsOwner() {
+        Show show = adminManager.findShowDetail("pipe");
+        Owner o = new Owner();
+        o.name = "spongebob";
+        ownerDao.insertOwner(o, show);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetOwner() {
+        Show show = adminManager.findShowDetail("pipe");
+        Owner o = new Owner();
+        o.name = "spongebob";
+        ownerDao.insertOwner(o, show);
+
+        assertEquals(o, ownerDao.findOwner("spongebob"));
+        assertEquals(o, ownerDao.getOwner(o.id));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testDeleteOwner() {
+        Show show = adminManager.findShowDetail("pipe");
+        Owner o = new Owner();
+        o.name = "spongebob";
+        ownerDao.insertOwner(o, show);
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM owner WHERE pk_owner=?",
+                Integer.class, o.id));
+
+        ownerDao.deleteOwner(o);
+
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM owner WHERE pk_owner=?",
+                Integer.class, o.id));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateShow() {
+        Show show = adminManager.findShowDetail("pipe");
+        Owner o = new Owner();
+        o.name = "spongebob";
+        ownerDao.insertOwner(o, show);
+
+        Show newShow = adminManager.findShowDetail("edu");
+
+        ownerDao.updateShow(o, newShow);
+
+        assertEquals(newShow.getShowId(), jdbcTemplate.queryForObject(
+                "SELECT pk_show FROM owner WHERE pk_owner=?",
+                String.class, o.id));
+    }
+}
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/PointDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/PointDaoTests.java
@@ -1,0 +1,165 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import java.io.File;
+
+import javax.annotation.Resource;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.Department;
+import com.imageworks.spcue.JobDetail;
+import com.imageworks.spcue.Point;
+import com.imageworks.spcue.Show;
+import com.imageworks.spcue.ShowDetail;
+import com.imageworks.spcue.dao.DepartmentDao;
+import com.imageworks.spcue.dao.PointDao;
+import com.imageworks.spcue.service.AdminManager;
+import com.imageworks.spcue.service.JobLauncher;
+import com.imageworks.spcue.service.JobManager;
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class PointDaoTests extends AbstractTransactionalJUnit4SpringContextTests  {
+
+    @Resource
+    DepartmentDao departmentDao;
+
+    @Resource
+    AdminManager adminManager;
+
+    @Resource
+    JobManager jobManager;
+
+    @Resource
+    JobLauncher jobLauncher;
+
+    @Resource
+    PointDao pointDao;
+
+    public JobDetail launchJob() {
+        jobLauncher.testMode = true;
+        jobLauncher.launch(new File("src/test/resources/conf/jobspec/jobspec.xml"));
+        return jobManager.findJobDetail("pipe-dev.cue-testuser_shell_v1");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void insertDepartmentConfig() {
+        ShowDetail show = new ShowDetail();
+        show.name = "testtest";
+        adminManager.createShow(show);
+        Department dept = departmentDao.findDepartment("Lighting");
+        Point d = pointDao.insertPointConf(show, dept);
+
+        assertEquals(show.id, jdbcTemplate.queryForObject(
+                "SELECT pk_show FROM point WHERE pk_point=?",
+                String.class, d.getPointId()));
+
+        assertEquals(dept.getDepartmentId(), jdbcTemplate.queryForObject(
+                "SELECT pk_dept FROM point WHERE pk_point=?",
+                String.class, d.getPointId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void departmentConfigExists() {
+        ShowDetail show = new ShowDetail();
+        show.name = "testtest";
+        adminManager.createShow(show);
+
+        assertTrue(pointDao.pointConfExists(show,
+                departmentDao.getDefaultDepartment()));
+
+        assertFalse(pointDao.pointConfExists(show,
+                departmentDao.findDepartment("Lighting")));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void updateEnableTiManaged() {
+        ShowDetail show = new ShowDetail();
+        show.name = "testtest";
+        adminManager.createShow(show);
+
+        Point config = pointDao.getPointConfigDetail(show,
+                departmentDao.getDefaultDepartment());
+
+        //pointDao.updateEnableManaged(config, "Lighting", 10);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void getDepartmentConfig() {
+        ShowDetail show = new ShowDetail();
+        show.name = "testtest";
+        adminManager.createShow(show);
+
+        /* Tests both overlodaed methods */
+        Point configA = pointDao.getPointConfigDetail(show,
+                departmentDao.getDefaultDepartment());
+
+        Point configB = pointDao.getPointConfDetail(
+                configA.getPointId());
+
+        assertEquals(configA.getPointId(), configB.getPointId());
+        assertEquals(configA.getDepartmentId(), configB.getDepartmentId());
+        assertEquals(configA.getShowId(), configB.getShowId());
+    }
+
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testIsOverMinCores() {
+
+        JobDetail job = launchJob();
+
+        Point pointConfig = pointDao.getPointConfigDetail(job,
+                departmentDao.getDepartment(job.getDepartmentId()));
+
+        assertFalse(pointDao.isOverMinCores(job));
+
+        // Now update some values so it returns true.
+        jdbcTemplate.update("UPDATE point SET int_cores = int_min_cores + 2000000 WHERE pk_point=?",
+                pointConfig.getId());
+
+        logger.info(jdbcTemplate.queryForObject("SELECT int_min_cores from point where pk_point=?",
+                Integer.class, pointConfig.getId()));
+
+        assertTrue(pointDao.isOverMinCores(job));
+    }
+
+}
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/ProcDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/ProcDaoTests.java
@@ -1,0 +1,842 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import javax.annotation.Resource;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.DispatchFrame;
+import com.imageworks.spcue.DispatchHost;
+import com.imageworks.spcue.FrameDetail;
+import com.imageworks.spcue.JobDetail;
+import com.imageworks.spcue.Layer;
+import com.imageworks.spcue.VirtualProc;
+import com.imageworks.spcue.dao.AllocationDao;
+import com.imageworks.spcue.dao.DispatcherDao;
+import com.imageworks.spcue.dao.FacilityDao;
+import com.imageworks.spcue.dao.FrameDao;
+import com.imageworks.spcue.dao.HostDao;
+import com.imageworks.spcue.dao.LayerDao;
+import com.imageworks.spcue.dao.ProcDao;
+import com.imageworks.spcue.dao.criteria.Direction;
+import com.imageworks.spcue.dao.criteria.FrameSearch;
+import com.imageworks.spcue.dao.criteria.ProcSearch;
+import com.imageworks.spcue.dao.criteria.Sort;
+import com.imageworks.spcue.dispatcher.DispatchSupport;
+import com.imageworks.spcue.dispatcher.Dispatcher;
+import com.imageworks.spcue.dispatcher.ResourceReservationFailureException;
+import com.imageworks.spcue.grpc.host.HardwareState;
+import com.imageworks.spcue.grpc.report.RenderHost;
+import com.imageworks.spcue.service.AdminManager;
+import com.imageworks.spcue.service.HostManager;
+import com.imageworks.spcue.service.JobLauncher;
+import com.imageworks.spcue.service.JobManager;
+import com.imageworks.spcue.util.CueUtil;
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class ProcDaoTests extends AbstractTransactionalJUnit4SpringContextTests  {
+
+    @Resource
+    ProcDao procDao;
+
+    @Resource
+    HostDao hostDao;
+
+    @Resource
+    JobManager jobManager;
+
+    @Resource
+    JobLauncher jobLauncher;
+
+    @Resource
+    FrameDao frameDao;
+
+    @Resource
+    LayerDao layerDao;
+
+    @Resource
+    AllocationDao allocationDao;
+
+    @Resource
+    FacilityDao facilityDao;
+
+    @Resource
+    DispatcherDao dispatcherDao;
+
+    @Resource
+    HostManager hostManager;
+
+    @Resource
+    DispatchSupport dispatchSupport;
+
+    @Resource
+    AdminManager adminManager;
+
+    @Resource
+    Dispatcher dispatcher;
+
+    private static String PK_ALLOC = "00000000-0000-0000-0000-000000000000";
+
+    public DispatchHost createHost() {
+
+        RenderHost host = RenderHost.newBuilder()
+                .setName("beta")
+                .setBootTime(1192369572)
+                .setFreeMcp(76020)
+                .setFreeMem(53500)
+                .setFreeSwap(20760)
+                .setLoad(1)
+                .setTotalMcp(195430)
+                .setTotalMem((int) CueUtil.GB32)
+                .setTotalSwap(20960)
+                .setNimbyEnabled(false)
+                .setNumProcs(8)
+                .setCoresPerProc(100)
+                .setState(HardwareState.UP)
+                .setFacility("spi")
+                .build();
+
+        DispatchHost dh = hostManager.createHost(host);
+        hostManager.setAllocation(dh,
+                adminManager.findAllocationDetail("spi", "general"));
+
+        return hostDao.findDispatchHost("beta");
+    }
+
+    public JobDetail launchJob() {
+        jobLauncher.launch(new File("src/test/resources/conf/jobspec/jobspec.xml"));
+        return jobManager.findJobDetail("pipe-dev.cue-testuser_shell_v1");
+    }
+
+    @Before
+    public void setDispatcherTestMode() {
+        dispatcher.setTestMode(true);
+        jobLauncher.testMode = true;
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testDontVerifyRunningProc() {
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+        FrameDetail fd = frameDao.findFrameDetail(job, "0001-pass_1_preprocess");
+        DispatchFrame frame = frameDao.getDispatchFrame(fd.getId());
+        VirtualProc proc = VirtualProc.build(host, frame);
+        dispatcher.dispatch(frame, proc);
+
+        // Confirm was have a running frame.
+        assertEquals("Running", jdbcTemplate.queryForObject(
+                "SELECT str_state FROM frame WHERE pk_frame=?",
+                String.class, frame.id));
+
+        assertTrue(procDao.verifyRunningProc(proc.getId(), frame.getId()));
+        jobManager.shutdownJob(job);
+
+       int result =  jdbcTemplate.update(
+                "UPDATE job SET ts_stopped = " +
+                "systimestamp - interval '10' minute " +
+                "WHERE pk_job=?", job.id);
+
+        assertEquals(1, result);
+        assertFalse(procDao.verifyRunningProc(proc.getId(), frame.getId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertVirtualProc() {
+
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1");
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = PK_ALLOC;
+        proc.coresReserved = 100;
+        proc.hostId = host.id;
+        proc.hostName = host.name;
+        proc.jobId = job.id;
+        proc.frameId = frame.id;
+        proc.layerId = frame.layerId;
+        proc.showId = frame.showId;
+
+        procDao.insertVirtualProc(proc);
+        procDao.verifyRunningProc(proc.getId(), frame.getId());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testDeleteVirtualProc() {
+
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1");
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = PK_ALLOC;
+        proc.coresReserved = 100;
+        proc.hostId = host.id;
+        proc.hostName = host.name;
+        proc.jobId = job.id;
+        proc.frameId = frame.id;
+        proc.layerId = frame.layerId;
+        proc.showId = frame.showId;
+
+        procDao.insertVirtualProc(proc);
+        procDao.verifyRunningProc(proc.getId(), frame.getId());
+        procDao.deleteVirtualProc(proc);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testClearVirtualProcAssignment() {
+
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1");
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = PK_ALLOC;
+        proc.coresReserved = 100;
+        proc.hostId = host.id;
+        proc.hostName = host.name;
+        proc.jobId = job.id;
+        proc.frameId = frame.id;
+        proc.layerId = frame.layerId;
+        proc.showId = frame.showId;
+
+        procDao.insertVirtualProc(proc);
+        procDao.verifyRunningProc(proc.getId(), frame.getId());
+        procDao.clearVirtualProcAssignment(proc);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testClearVirtualProcAssignmentByFrame() {
+
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1");
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = PK_ALLOC;
+        proc.coresReserved = 100;
+        proc.hostId = host.id;
+        proc.hostName = host.name;
+        proc.jobId = job.id;
+        proc.frameId = frame.id;
+        proc.layerId = frame.layerId;
+        proc.showId = frame.showId;
+
+        procDao.insertVirtualProc(proc);
+        procDao.verifyRunningProc(proc.getId(), frame.getId());
+        assertTrue(procDao.clearVirtualProcAssignment(frame));
+    }
+
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateVirtualProcAssignment() {
+
+        DispatchHost host = createHost();
+
+        JobDetail job = launchJob();
+        FrameDetail frame1 = frameDao.findFrameDetail(job, "0001-pass_1");
+        FrameDetail frame2 = frameDao.findFrameDetail(job, "0002-pass_1");
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = PK_ALLOC;
+        proc.coresReserved = 100;
+        proc.hostId = host.id;
+        proc.hostName = host.name;
+        proc.jobId = job.id;
+        proc.frameId = frame1.id;
+        proc.layerId = frame1.layerId;
+        proc.showId = frame1.showId;
+
+        procDao.insertVirtualProc(proc);
+        procDao.verifyRunningProc(proc.getId(), frame1.getId());
+
+        proc.frameId = frame2.id;
+
+        procDao.updateVirtualProcAssignment(proc);
+        procDao.verifyRunningProc(proc.getId(), frame2.getId());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateProcMemoryUsage() {
+
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1");
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = PK_ALLOC;
+        proc.coresReserved = 100;
+        proc.hostId = host.id;
+        proc.hostName = host.name;
+        proc.jobId = job.id;
+        proc.frameId = frame.id;
+        proc.layerId = frame.layerId;
+        proc.showId = frame.showId;
+
+        procDao.insertVirtualProc(proc);
+        procDao.verifyRunningProc(proc.getId(), frame.getId());
+
+        procDao.updateProcMemoryUsage(frame, 100, 100, 1000, 1000);
+
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetVirtualProc() {
+        DispatchHost host = createHost();
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM host WHERE pk_host=?",
+                Integer.class, host.id));
+
+        JobDetail job = launchJob();
+        FrameDetail fd = frameDao.findFrameDetail(job, "0001-pass_1_preprocess");
+
+        DispatchFrame frame = frameDao.getDispatchFrame(fd.getId());
+        VirtualProc proc = VirtualProc.build(host, frame);
+        dispatcher.dispatch(frame, proc);
+
+        assertTrue(procDao.verifyRunningProc(proc.getId(), frame.getId()));
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM proc WHERE pk_proc=?",
+                Integer.class, proc.id));
+
+
+        VirtualProc verifyProc = procDao.getVirtualProc(proc.getId());
+        assertEquals(host.allocationId, verifyProc.allocationId);
+        assertEquals(proc.coresReserved, verifyProc.coresReserved);
+        assertEquals(proc.frameId, verifyProc.frameId);
+        assertEquals(proc.hostId, verifyProc.hostId);
+        assertEquals(proc.id, verifyProc.id);
+        assertEquals(proc.jobId, verifyProc.jobId);
+        assertEquals(proc.layerId, verifyProc.layerId);
+        assertEquals(proc.showId, verifyProc.showId);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindVirtualProc() {
+
+        DispatchHost host = createHost();
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM host WHERE pk_host=?",
+                Integer.class, host.id));
+
+        JobDetail job = launchJob();
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1");
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = PK_ALLOC;
+        proc.coresReserved = 100;
+        proc.hostId = host.id;
+        proc.hostName = host.name;
+        proc.jobId = job.id;
+        proc.frameId = frame.id;
+        proc.layerId = frame.layerId;
+        proc.showId = frame.showId;
+        procDao.insertVirtualProc(proc);
+
+        procDao.findVirtualProc(frame);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindVirtualProcs() {
+
+        DispatchHost host = createHost();
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM host WHERE pk_host=?",
+                Integer.class, host.id));
+
+        JobDetail job = launchJob();
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1");
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = PK_ALLOC;
+        proc.coresReserved = 100;
+        proc.hostId = host.id;
+        proc.hostName = host.name;
+        proc.jobId = job.id;
+        proc.frameId = frame.id;
+        proc.layerId = frame.layerId;
+        proc.showId = frame.showId;
+        procDao.insertVirtualProc(proc);
+
+        assertEquals(1, procDao.findVirtualProcs(HardwareState.UP).size());
+        assertEquals(1, procDao.findVirtualProcs(host).size());
+        assertEquals(1, procDao.findVirtualProcs(job).size());
+        assertEquals(1, procDao.findVirtualProcs(frame).size());
+        assertEquals(1, procDao.findVirtualProcs(new FrameSearch(job)).size());
+        assertEquals(1, procDao.findVirtualProcs(new FrameSearch((Layer) frame)).size());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindOrphanedVirtualProcs() {
+        DispatchHost host = createHost();
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM host WHERE pk_host=?",
+                Integer.class, host.id));
+
+        JobDetail job = launchJob();
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1");
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = PK_ALLOC;
+        proc.coresReserved = 100;
+        proc.hostId = host.id;
+        proc.hostName = host.name;
+        proc.jobId = job.id;
+        proc.frameId = frame.id;
+        proc.layerId = frame.layerId;
+        proc.showId = frame.showId;
+        procDao.insertVirtualProc(proc);
+
+        assertEquals(0, procDao.findOrphanedVirtualProcs().size());
+
+        /**
+        * This is destructive to running jobs
+        */
+        jdbcTemplate.update(
+        "UPDATE proc SET ts_ping = (systimestamp - interval '30' day)");
+
+        assertEquals(1, procDao.findOrphanedVirtualProcs().size());
+        assertTrue(procDao.isOrphan(proc));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUnbookProc() {
+
+        DispatchHost host = createHost();
+
+        JobDetail job = launchJob();
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1");
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = PK_ALLOC;
+        proc.coresReserved = 100;
+        proc.hostId = host.id;
+        proc.hostName = host.name;
+        proc.jobId = job.id;
+        proc.frameId = frame.id;
+        proc.layerId = frame.layerId;
+        proc.showId = frame.showId;
+        procDao.insertVirtualProc(proc);
+
+        procDao.unbookProc(proc);
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT b_unbooked FROM proc WHERE pk_proc=?",
+                Integer.class, proc.id));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUnbookVirtualProcs() {
+
+        DispatchHost host = createHost();
+
+        JobDetail job = launchJob();
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1");
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = PK_ALLOC;
+        proc.coresReserved = 100;
+        proc.hostId = host.id;
+        proc.hostName = host.name;
+        proc.jobId = job.id;
+        proc.frameId = frame.id;
+        proc.layerId = frame.layerId;
+        proc.showId = frame.showId;
+        procDao.insertVirtualProc(proc);
+
+
+        List<VirtualProc> procs = new ArrayList<VirtualProc>();
+        procs.add(proc);
+
+        procDao.unbookVirtualProcs(procs);
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT b_unbooked FROM proc WHERE pk_proc=?",
+                Integer.class, proc.id));
+    }
+
+
+    @Test(expected=ResourceReservationFailureException.class)
+    @Transactional
+    @Rollback(true)
+    public void testIncreaseReservedMemoryFail() {
+
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1");
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = PK_ALLOC;
+        proc.coresReserved = 100;
+        proc.hostId = host.id;
+        proc.hostName = host.name;
+        proc.jobId = job.id;
+        proc.frameId = frame.id;
+        proc.layerId = frame.layerId;
+        proc.showId = frame.showId;
+        procDao.insertVirtualProc(proc);
+
+        procDao.increaseReservedMemory(proc, 8173264l * 8);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testIncreaseReservedMemory() {
+
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1");
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = PK_ALLOC;
+        proc.coresReserved = 100;
+        proc.hostId = host.id;
+        proc.hostName = host.name;
+        proc.jobId = job.id;
+        proc.frameId = frame.id;
+        proc.layerId = frame.layerId;
+        proc.showId = frame.showId;
+        procDao.insertVirtualProc(proc);
+
+        procDao.increaseReservedMemory(proc, 3145728);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindReservedMemoryOffender() {
+        DispatchHost host = createHost();
+
+
+        jobLauncher.launch(new File("src/test/resources/conf/jobspec/jobspec_dispatch_test.xml"));
+        JobDetail job = jobManager.findJobDetail("pipe-dev.cue-testuser_shell_dispatch_test_v1");
+        jobManager.setJobPaused(job, false);
+
+        int i = 1;
+        List<DispatchFrame> frames  = dispatcherDao.findNextDispatchFrames(job, host, 6);
+        assertEquals(6, frames.size());
+
+        for (DispatchFrame frame: frames) {
+
+            VirtualProc proc = VirtualProc.build(host, frame);
+            frame.minMemory = Dispatcher.MEM_RESERVED_DEFAULT;
+            dispatcher.dispatch(frame, proc);
+
+            // Increase the memory usage as frames are added
+            procDao.updateProcMemoryUsage(frame,
+                    1000*i, 1000*i, 1000*i, 1000*i);
+            i++;
+        }
+
+        // Now compare the last frame which has the highest memory
+        // usage to the what is returned by getWorstMemoryOffender
+        VirtualProc offender = procDao.getWorstMemoryOffender(host);
+
+        FrameDetail f = frameDao.getFrameDetail(frames.get(5));
+        FrameDetail o = frameDao.getFrameDetail(offender);
+
+        assertEquals(f.getName(), o.getName());
+        assertEquals(f.id, o.getFrameId());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetReservedMemory() {
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+
+        FrameDetail frameDetail = frameDao.findFrameDetail(job, "0001-pass_1");
+        DispatchFrame frame = frameDao.getDispatchFrame(frameDetail.id);
+
+        VirtualProc proc = VirtualProc.build(host, frame);
+        proc.frameId = frame.id;
+        procDao.insertVirtualProc(proc);
+
+        VirtualProc _proc = procDao.findVirtualProc(frame);
+        assertEquals(Long.valueOf(Dispatcher.MEM_RESERVED_DEFAULT), jdbcTemplate.queryForObject(
+                        "SELECT int_mem_reserved FROM proc WHERE pk_proc=?",
+                        Long.class, _proc.id));
+        assertEquals(Dispatcher.MEM_RESERVED_DEFAULT,
+                procDao.getReservedMemory(_proc));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetReservedGpu() {
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+
+        FrameDetail frameDetail = frameDao.findFrameDetail(job, "0001-pass_1");
+        DispatchFrame frame = frameDao.getDispatchFrame(frameDetail.id);
+
+        VirtualProc proc = VirtualProc.build(host, frame);
+        proc.frameId = frame.id;
+        procDao.insertVirtualProc(proc);
+
+        VirtualProc _proc = procDao.findVirtualProc(frame);
+        assertEquals(Long.valueOf(Dispatcher.GPU_RESERVED_DEFAULT), jdbcTemplate.queryForObject(
+                        "SELECT int_gpu_reserved FROM proc WHERE pk_proc=?",
+                        Long.class, _proc.id));
+        assertEquals(Dispatcher.GPU_RESERVED_DEFAULT,
+                procDao.getReservedGpu(_proc));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testBalanceUnderUtilizedProcs() {
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+
+        FrameDetail frameDetail1 = frameDao.findFrameDetail(job, "0001-pass_1");
+        DispatchFrame frame1 = frameDao.getDispatchFrame(frameDetail1.id);
+
+        VirtualProc proc1 = VirtualProc.build(host, frame1);
+        proc1.frameId = frame1.id;
+        procDao.insertVirtualProc(proc1);
+
+        procDao.updateProcMemoryUsage(frame1, 250000, 250000, 250000, 250000);
+        layerDao.updateLayerMaxRSS(frame1, 250000, true);
+
+        FrameDetail frameDetail2 = frameDao.findFrameDetail(job, "0002-pass_1");
+        DispatchFrame frame2 = frameDao.getDispatchFrame(frameDetail2.id);
+
+        VirtualProc proc2 = VirtualProc.build(host, frame2);
+        proc2.frameId = frame2.id;
+        procDao.insertVirtualProc(proc2);
+
+        procDao.updateProcMemoryUsage(frame2, 255000, 255000,255000, 255000);
+        layerDao.updateLayerMaxRSS(frame2, 255000, true);
+
+        FrameDetail frameDetail3 = frameDao.findFrameDetail(job, "0003-pass_1");
+        DispatchFrame frame3 = frameDao.getDispatchFrame(frameDetail3.id);
+
+        VirtualProc proc3 = VirtualProc.build(host, frame3);
+        proc3.frameId = frame3.id;
+        procDao.insertVirtualProc(proc3);
+
+        procDao.updateProcMemoryUsage(frame3, 3145728, 3145728,3145728, 3145728);
+        layerDao.updateLayerMaxRSS(frame3,300000, true);
+
+        procDao.balanceUnderUtilizedProcs(proc3, 100000);
+        procDao.increaseReservedMemory(proc3, Dispatcher.MEM_RESERVED_DEFAULT + 100000);
+
+        // Check the target proc
+        VirtualProc targetProc = procDao.getVirtualProc(proc3.getId());
+        assertEquals( Dispatcher.MEM_RESERVED_DEFAULT+ 100000, targetProc.memoryReserved);
+
+        // Check other procs
+        VirtualProc firstProc = procDao.getVirtualProc(proc1.getId());
+        assertEquals( Dispatcher.MEM_RESERVED_DEFAULT - 50000 -1 , firstProc.memoryReserved);
+
+        VirtualProc secondProc = procDao.getVirtualProc(proc2.getId());
+        assertEquals(Dispatcher.MEM_RESERVED_DEFAULT - 50000 -1, secondProc.memoryReserved);
+
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetCurrentShowId() {
+
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+
+        FrameDetail frameDetail = frameDao.findFrameDetail(job, "0001-pass_1_preprocess");
+        DispatchFrame frame = frameDao.getDispatchFrame(frameDetail.id);
+
+        VirtualProc proc = VirtualProc.build(host, frame);
+        proc.frameId = frame.id;
+        procDao.insertVirtualProc(proc);
+
+        assertEquals(job.getShowId(), procDao.getCurrentShowId(proc));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetCurrentJobId() {
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+
+        FrameDetail frameDetail = frameDao.findFrameDetail(job, "0001-pass_1_preprocess");
+        DispatchFrame frame = frameDao.getDispatchFrame(frameDetail.id);
+
+        VirtualProc proc = VirtualProc.build(host, frame);
+        proc.frameId = frame.id;
+        procDao.insertVirtualProc(proc);
+
+        assertEquals(job.getJobId(), procDao.getCurrentJobId(proc));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetCurrentLayerId() {
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+
+        FrameDetail frameDetail = frameDao.findFrameDetail(job, "0001-pass_1_preprocess");
+        DispatchFrame frame = frameDao.getDispatchFrame(frameDetail.id);
+
+        VirtualProc proc = VirtualProc.build(host, frame);
+        proc.frameId = frame.id;
+        procDao.insertVirtualProc(proc);
+
+        assertEquals(frame.getLayerId(), procDao.getCurrentLayerId(proc));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetCurrentFrameId() {
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+
+        FrameDetail frameDetail = frameDao.findFrameDetail(job, "0001-pass_1_preprocess");
+        DispatchFrame frame = frameDao.getDispatchFrame(frameDetail.id);
+
+        VirtualProc proc = VirtualProc.build(host, frame);
+        proc.frameId = frame.id;
+        procDao.insertVirtualProc(proc);
+
+        assertEquals(frame.getFrameId(), procDao.getCurrentFrameId(proc));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void getProcsBySearch() {
+        DispatchHost host = createHost();
+
+        jobLauncher.launch(new File("src/test/resources/conf/jobspec/jobspec_dispatch_test.xml"));
+        JobDetail job = jobManager.findJobDetail("pipe-dev.cue-testuser_shell_dispatch_test_v1");
+
+        /*
+         * Book 5 procs.
+         */
+        for (int i=1; i<6; i++) {
+            FrameDetail f = frameDao.findFrameDetail(job, String.format("%04d-pass_1",i));
+            VirtualProc proc = new VirtualProc();
+            proc.allocationId = null;
+            proc.coresReserved = 100;
+            proc.hostId = host.id;
+            proc.hostName = host.name;
+            proc.jobId = job.id;
+            proc.frameId = f.id;
+            proc.layerId = f.layerId;
+            proc.showId = f.showId;
+            procDao.insertVirtualProc(proc);
+        }
+
+        ProcSearch r;
+
+        /*
+         * Search for all 5 running procs
+         */
+        r = new ProcSearch();
+        r.addSort(new Sort("proc.ts_booked",Direction.ASC));
+        r.getCriteria().shows.add("pipe");
+        assertEquals(5, procDao.findVirtualProcs(r).size());
+
+        /*
+         * Limit the result to 1 result.
+         */
+        r = new ProcSearch();
+        r.getCriteria().shows.add("pipe");
+        r.getCriteria().maxResults = new int[] { 1 };
+        assertEquals(1, procDao.findVirtualProcs(r).size());
+
+        /*
+         * Change the first result to 1, which should limt
+         * the result to 4.
+         */
+        r = new ProcSearch();
+        r.getCriteria().shows.add("pipe");
+        r.getCriteria().firstResult = 2;
+        r.addSort(new Sort("proc.ts_booked",Direction.ASC));
+        assertEquals(4, procDao.findVirtualProcs(r).size());
+
+        /*
+         * Now try to do the eqivalent of a limit/offset
+         */
+        r = new ProcSearch();
+        r.getCriteria().shows.add("pipe");
+        r.getCriteria().firstResult = 3;
+        r.getCriteria().maxResults = new int[] { 2 };
+        assertEquals(2, procDao.findVirtualProcs(r).size());
+
+    }
+}
+
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/ServiceDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/ServiceDaoTests.java
@@ -1,0 +1,205 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import static org.junit.Assert.*;
+
+import javax.annotation.Resource;
+
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.google.common.collect.Sets;
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.Service;
+import com.imageworks.spcue.ServiceOverride;
+import com.imageworks.spcue.dao.ServiceDao;
+import com.imageworks.spcue.util.CueUtil;
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class ServiceDaoTests extends AbstractTransactionalJUnit4SpringContextTests  {
+
+    @Resource
+    ServiceDao serviceDao;
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetService() {
+        Service s1 = serviceDao.get("default");
+        Service s2 = serviceDao.get("AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAA0");
+        assertEquals(s1, s2);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertService() {
+        Service s = new Service();
+        s.name = "dillweed";
+        s.minCores = 100;
+        s.minMemory = CueUtil.GB4;
+        s.minGpu = CueUtil.GB;
+        s.threadable = false;
+        s.tags.addAll(Sets.newHashSet(new String[] { "general"}));
+
+        serviceDao.insert(s);
+        assertEquals(s, serviceDao.get("dillweed"));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateService() {
+        Service s = new Service();
+        s.name = "dillweed";
+        s.minCores = 100;
+        s.minMemory = CueUtil.GB4;
+        s.minGpu = CueUtil.GB;
+        s.threadable = false;
+        s.tags.addAll(Sets.newHashSet(new String[] { "general"}));
+
+        serviceDao.insert(s);
+        assertEquals(s, serviceDao.get("dillweed"));
+
+        s.name = "smacktest";
+        s.minCores = 200;
+        s.minMemory = CueUtil.GB8;
+        s.minGpu = CueUtil.GB2;
+        s.threadable = true;
+        s.tags = Sets.newLinkedHashSet();
+        s.tags.add("linux");
+
+        serviceDao.update(s);
+        Service s1 =  serviceDao.get(s.getId());
+
+        assertEquals(s.name, s1.name);
+        assertEquals(s.minCores, s1.minCores);
+        assertEquals(s.minMemory, s1.minMemory);
+        assertEquals(s.threadable, s1.threadable);
+        assertEquals(s.tags.toArray()[0], s1.tags.toArray()[0]);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testDeleteService() {
+        Service s = new Service();
+        s.name = "dillweed";
+        s.minCores = 100;
+        s.minMemory = CueUtil.GB4;
+        s.minGpu = CueUtil.GB;
+        s.threadable = false;
+        s.tags.addAll(Sets.newHashSet(new String[] { "general"}));
+
+        serviceDao.insert(s);
+        assertEquals(s, serviceDao.get("dillweed"));
+
+        serviceDao.delete(s);
+
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT COUNT(1) FROM service WHERE pk_service=?",
+                Integer.class, s.getId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertServiceOverride() {
+        ServiceOverride s = new ServiceOverride();
+        s.name = "dillweed";
+        s.minCores = 100;
+        s.minMemory = CueUtil.GB4;
+        s.minGpu = CueUtil.GB;
+        s.threadable = false;
+        s.tags.addAll(Sets.newHashSet(new String[] { "general"}));
+        s.showId = "00000000-0000-0000-0000-000000000000";
+
+        serviceDao.insert(s);
+        assertEquals(s, serviceDao.getOverride("dillweed"));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateServiceOverride() {
+        ServiceOverride s = new ServiceOverride();
+        s.name = "dillweed";
+        s.minCores = 100;
+        s.minMemory = CueUtil.GB4;
+        s.minGpu = CueUtil.GB2;
+        s.threadable = false;
+        s.tags.addAll(Sets.newHashSet(new String[] { "general"}));
+        s.showId = "00000000-0000-0000-0000-000000000000";
+
+        serviceDao.insert(s);
+        assertEquals(s, serviceDao.getOverride("dillweed"));
+        assertEquals(s, serviceDao.getOverride("dillweed", s.showId));
+
+        s.name = "smacktest";
+        s.minCores = 200;
+        s.minMemory = CueUtil.GB8;
+        s.minGpu = CueUtil.GB4;
+        s.threadable = true;
+        s.tags = Sets.newLinkedHashSet();
+        s.tags.add("linux");
+
+        serviceDao.update(s);
+        Service s1 =  serviceDao.getOverride(s.getId());
+
+        assertEquals(s.name, s1.name);
+        assertEquals(s.minCores, s1.minCores);
+        assertEquals(s.minMemory, s1.minMemory);
+        assertEquals(s.minGpu, s1.minGpu);
+        assertEquals(s.threadable, s1.threadable);
+        assertEquals(s.tags.toArray()[0], s1.tags.toArray()[0]);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testDeleteServiceOverride() {
+        ServiceOverride s = new ServiceOverride();
+        s.name = "dillweed";
+        s.minCores = 100;
+        s.minMemory = CueUtil.GB4;
+        s.minGpu = CueUtil.GB;
+        s.threadable = false;
+        s.tags.addAll(Sets.newHashSet(new String[] { "general"}));
+        s.showId = "00000000-0000-0000-0000-000000000000";
+
+        serviceDao.insert(s);
+        assertEquals(s, serviceDao.getOverride("dillweed"));
+        assertEquals(s, serviceDao.getOverride("dillweed", s.showId));
+        serviceDao.delete(s);
+
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT COUNT(1) FROM show_service WHERE pk_show_service=?",
+                Integer.class, s.getId()));
+    }
+}
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/ShowDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/ShowDaoTests.java
@@ -1,0 +1,237 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import javax.annotation.Resource;
+
+import org.junit.Test;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.DispatchHost;
+import com.imageworks.spcue.ShowDetail;
+import com.imageworks.spcue.dao.ShowDao;
+import com.imageworks.spcue.grpc.host.HardwareState;
+import com.imageworks.spcue.grpc.report.RenderHost;
+import com.imageworks.spcue.service.AdminManager;
+import com.imageworks.spcue.service.HostManager;
+import com.imageworks.spcue.util.CueUtil;
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class ShowDaoTests extends AbstractTransactionalJUnit4SpringContextTests  {
+
+    @Resource
+    ShowDao showDao;
+
+    @Resource
+    HostManager hostManager;
+
+    @Resource
+    AdminManager adminManager;
+
+    private static String SHOW_ID = "00000000-0000-0000-0000-000000000000";
+    private static String SHOW_NAME= "pipe";
+
+    public DispatchHost createHost() {
+
+        RenderHost host = RenderHost.newBuilder()
+                .setName("test_host")
+                .setBootTime(1192369572)
+                .setFreeMcp(76020)
+                .setFreeMem(53500)
+                .setFreeSwap(20760)
+                .setLoad(1)
+                .setTotalMcp(195430)
+                .setTotalMem((int) CueUtil.GB16)
+                .setTotalSwap((int) CueUtil.GB16)
+                .setNimbyEnabled(false)
+                .setNumProcs(2)
+                .setCoresPerProc(100)
+                .addTags("general")
+                .setState(HardwareState.UP)
+                .setFacility("spi")
+                .putAttributes("freeGpu", String.format("%d", CueUtil.MB512))
+                .putAttributes("totalGpu", String.format("%d", CueUtil.MB512))
+                .build();
+
+        DispatchHost dh = hostManager.createHost(host);
+        hostManager.setAllocation(dh,
+                adminManager.findAllocationDetail("spi", "general"));
+
+        return dh;
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindShowDetail() {
+        ShowDetail show = showDao.findShowDetail(SHOW_NAME);
+        assertEquals(SHOW_ID, show.id);
+        assertEquals(SHOW_NAME,show.name);
+        assertFalse(show.paused);
+    }
+
+    @Test(expected=EmptyResultDataAccessException.class)
+    @Transactional
+    @Rollback(true)
+    public void testFindShowDetailByHost() {
+        //TODO: Add code to setup a host and make the sow
+        // prefer the host, then check result again.
+        showDao.getShowDetail(createHost());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetShowDetail() {
+        ShowDetail show = showDao.getShowDetail(SHOW_ID);
+        assertEquals(SHOW_ID, show.id);
+        assertEquals(SHOW_NAME,show.name);
+        assertFalse(show.paused);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertShow() {
+        ShowDetail show = new ShowDetail();
+        show.name = "uber";
+        showDao.insertShow(show);
+
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM show where str_name=?",
+                Integer.class, show.name));
+
+        ShowDetail newShow = showDao.findShowDetail(show.name);
+        assertEquals(newShow.id, show.id);
+        assertEquals(newShow.name,show.name);
+        assertFalse(show.paused);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testShowExists() {
+        assertFalse(showDao.showExists("uber"));
+        assertTrue(showDao.showExists("pipe"));
+        assertTrue(showDao.showExists("fx"));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateShowDefaultMinCores() {
+        ShowDetail show = showDao.findShowDetail(SHOW_NAME);
+        showDao.updateShowDefaultMinCores(show, 100);
+        assertTrue(jdbcTemplate.queryForObject(
+                "SELECT int_default_min_cores FROM show WHERE pk_show=?",
+                Integer.class, show.id) == 100);
+
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateShowDefaultMaxCores() {
+        ShowDetail show = showDao.findShowDetail(SHOW_NAME);
+        showDao.updateShowDefaultMaxCores(show, 1000);
+        assertTrue(jdbcTemplate.queryForObject(
+                "SELECT int_default_max_cores FROM show WHERE pk_show=?",
+                Integer.class, show.id) == 1000);
+
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateShowCommentEmail() {
+        ShowDetail show = showDao.findShowDetail(SHOW_NAME);
+        showDao.updateShowCommentEmail(show, new String[] {"test@imageworks.com"});
+        String email = jdbcTemplate.queryForObject(
+                "SELECT str_comment_email FROM show WHERE pk_show=?",
+                String.class, show.id);
+        assertEquals("test@imageworks.com", email);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateBookingEnabled() {
+        ShowDetail show = showDao.findShowDetail(SHOW_NAME);
+        showDao.updateBookingEnabled(show,false);
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT b_booking_enabled FROM show WHERE pk_show=?",
+                Integer.class, show.id));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateActive() {
+        ShowDetail show = showDao.findShowDetail(SHOW_NAME);
+        showDao.updateActive(show, false);
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT b_active FROM show WHERE pk_show=?",
+                Integer.class, show.id));
+        showDao.updateActive(show, true);
+        assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
+                "SELECT b_active FROM show WHERE pk_show=?",
+                Integer.class, show.id));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateFrameCounters() {
+        ShowDetail show = showDao.findShowDetail(SHOW_NAME);
+        int frameSuccess =  jdbcTemplate.queryForObject(
+                "SELECT int_frame_success_count FROM show WHERE pk_show=?",
+                Integer.class, show.id);
+        showDao.updateFrameCounters(show, 0);
+        int frameSucces2 =  jdbcTemplate.queryForObject(
+                "SELECT int_frame_success_count FROM show WHERE pk_show=?",
+                Integer.class, show.id);
+        assertEquals(frameSuccess + 1,frameSucces2);
+
+        int frameFail=  jdbcTemplate.queryForObject(
+                "SELECT int_frame_fail_count FROM show WHERE pk_show=?",
+                Integer.class, show.id);
+        showDao.updateFrameCounters(show, 1);
+        int frameFail2 =  jdbcTemplate.queryForObject(
+                "SELECT int_frame_fail_count FROM show WHERE pk_show=?",
+                Integer.class, show.id);
+        assertEquals(frameFail+ 1,frameFail2);
+    }
+}
+
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/SubscriptionDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/SubscriptionDaoTests.java
@@ -1,0 +1,254 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import static org.junit.Assert.*;
+
+import javax.annotation.Resource;
+
+import com.imageworks.spcue.AllocationEntity;
+import com.imageworks.spcue.FacilityInterface;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.AllocationInterface;
+import com.imageworks.spcue.Show;
+import com.imageworks.spcue.SubscriptionDetail;
+import com.imageworks.spcue.dao.AllocationDao;
+import com.imageworks.spcue.dao.FacilityDao;
+import com.imageworks.spcue.dao.ShowDao;
+import com.imageworks.spcue.dao.SubscriptionDao;
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class SubscriptionDaoTests extends AbstractTransactionalJUnit4SpringContextTests  {
+
+    @Resource
+    AllocationDao allocDao;
+
+    @Resource
+    SubscriptionDao subscriptionDao;
+
+    @Resource
+    AllocationDao allocationDao;
+
+    @Resource
+    ShowDao showDao;
+
+    @Resource
+    FacilityDao facilityDao;
+
+    public static final String SUB_NAME = "test.pipe";
+    public static final String ALLOC_NAME = "test";
+
+    private AllocationEntity alloc;
+
+    public Show getShow() {
+        return showDao.getShowDetail("00000000-0000-0000-0000-000000000000");
+    }
+
+    public SubscriptionDetail buildSubscription(Show t, AllocationInterface a) {
+        SubscriptionDetail s = new SubscriptionDetail();
+        s.allocationId = a.getId();
+        s.showId = t.getId();
+        s.burst = 500;
+        s.size = 100;
+        return s;
+    }
+
+    public AllocationEntity buildAllocation() {
+        AllocationEntity a = new AllocationEntity();
+        a.tag = "test";
+        a.name = ALLOC_NAME;
+        a.facilityId = facilityDao.getDefaultFacility().getFacilityId();
+        return a;
+    }
+
+    @Before
+    public void before() {
+        alloc =  new AllocationEntity();
+        alloc.name = ALLOC_NAME;
+        alloc.tag = "test";
+        allocationDao.insertAllocation(
+                facilityDao.getDefaultFacility(), alloc);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testHasRunningProcs() {
+        SubscriptionDetail s = buildSubscription(getShow(), alloc);
+        subscriptionDao.insertSubscription(s);
+        assertFalse(subscriptionDao.hasRunningProcs(s));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testIsShowOverSize() {
+
+        SubscriptionDetail sub = buildSubscription(getShow(), alloc);
+        subscriptionDao.insertSubscription(sub);
+
+        assertFalse(this.subscriptionDao.isShowOverSize(getShow(), alloc));
+
+        jdbcTemplate.update(
+                "UPDATE subscription SET int_cores = ? WHERE pk_subscription = ?",
+                100, sub.getSubscriptionId());
+
+        assertFalse(subscriptionDao.isShowOverSize(getShow(), alloc));
+
+        jdbcTemplate.update(
+                "UPDATE subscription SET int_cores = ? WHERE pk_subscription = ?",
+                101, sub.getSubscriptionId());
+
+        assertEquals(true, subscriptionDao.isShowOverSize(getShow(), alloc));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testIsShowAtOrOverSize() {
+
+        SubscriptionDetail sub = buildSubscription(getShow(), alloc);
+        subscriptionDao.insertSubscription(sub);
+        assertFalse(this.subscriptionDao.isShowAtOrOverSize(getShow(), alloc));
+
+        jdbcTemplate.update(
+                "UPDATE subscription SET int_cores = ? WHERE pk_subscription = ?",
+                100, sub.getSubscriptionId());
+
+        assertTrue(subscriptionDao.isShowAtOrOverSize(getShow(), alloc));
+
+        jdbcTemplate.update(
+                "UPDATE subscription SET int_cores = ? WHERE pk_subscription = ?",
+                200, sub.getSubscriptionId());
+
+        assertTrue(subscriptionDao.isShowAtOrOverSize(getShow(), alloc));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testIsShowOverBurst() {
+        subscriptionDao.insertSubscription(buildSubscription(getShow(), alloc));
+
+        // Burst is 500 so 600 would be over burst.
+        assertTrue(subscriptionDao.isShowOverBurst(getShow(), alloc, 600));
+
+        // Burst is 500 so 300 would be under burst.
+        assertFalse(subscriptionDao.isShowOverBurst(getShow(), alloc, 300));
+    }
+
+    @Test(expected=org.springframework.jdbc.UncategorizedSQLException.class)
+    @Transactional
+    @Rollback(true)
+    public void testIsShowAtOrOverBurst() {
+
+        SubscriptionDetail sub = buildSubscription(getShow(), alloc);
+        subscriptionDao.insertSubscription(sub);
+        assertFalse(subscriptionDao.isShowAtOrOverBurst(getShow(), alloc));
+
+        jdbcTemplate.update(
+                "UPDATE subscription SET int_cores = ? WHERE pk_subscription = ?",
+                500, sub.getSubscriptionId());
+
+        assertTrue(subscriptionDao.isShowAtOrOverBurst(getShow(), alloc));
+
+        jdbcTemplate.update(
+                "UPDATE subscription SET int_cores = ? WHERE pk_subscription = ?",
+                501, sub.getSubscriptionId());
+
+        assertTrue(subscriptionDao.isShowAtOrOverBurst(getShow(), alloc));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetSubscriptionDetail() {
+
+        FacilityInterface f = facilityDao.getDefaultFacility();
+
+        SubscriptionDetail s = buildSubscription(getShow(), alloc);
+        subscriptionDao.insertSubscription(s);
+        assertNotNull(s.id);
+        assertNotNull(s.getId());
+
+        SubscriptionDetail s1 =  subscriptionDao.getSubscriptionDetail(
+                s.getSubscriptionId());
+
+        assertEquals(alloc.getName() + ".pipe", s1.name);
+        assertEquals(s.burst, s1.burst);
+        assertEquals(s.id, s1.id);
+        assertEquals(s.size, s1.size);
+        assertEquals(s.allocationId, s1.allocationId);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testInsertSubscription() {
+        SubscriptionDetail s = buildSubscription(getShow(), alloc);
+        subscriptionDao.insertSubscription(s);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testDeleteSubscription() {
+        SubscriptionDetail s = buildSubscription(getShow(), alloc);
+        subscriptionDao.insertSubscription(s);
+        subscriptionDao.deleteSubscription(s);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateSubscriptionSize() {
+        SubscriptionDetail s = buildSubscription(getShow(), alloc);
+        subscriptionDao.insertSubscription(s);
+        subscriptionDao.updateSubscriptionSize(s, 100);
+        assertEquals(Integer.valueOf(100), jdbcTemplate.queryForObject(
+                "SELECT int_size FROM subscription WHERE pk_subscription=?",
+                Integer.class, s.getId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testUpdateSubscriptionBurst() {
+        SubscriptionDetail s = buildSubscription(getShow(), alloc);
+        subscriptionDao.insertSubscription(s);
+        subscriptionDao.updateSubscriptionBurst(s, 100);
+        assertEquals(Integer.valueOf(100), jdbcTemplate.queryForObject(
+                "SELECT int_burst FROM subscription WHERE pk_subscription=?",
+                Integer.class, s.getId()));
+    }
+}
+
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/TaskDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/TaskDaoTests.java
@@ -1,0 +1,283 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+
+import javax.annotation.Resource;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.JobDetail;
+import com.imageworks.spcue.Point;
+import com.imageworks.spcue.TaskDetail;
+import com.imageworks.spcue.dao.DepartmentDao;
+import com.imageworks.spcue.dao.PointDao;
+import com.imageworks.spcue.dao.ShowDao;
+import com.imageworks.spcue.dao.TaskDao;
+import com.imageworks.spcue.service.JobLauncher;
+import com.imageworks.spcue.service.JobManager;
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class TaskDaoTests extends AbstractTransactionalJUnit4SpringContextTests {
+
+    @Resource
+    ShowDao showDao;
+
+    @Resource
+    DepartmentDao departmentDao;
+
+    @Resource
+    TaskDao taskDao;
+
+    @Resource
+    PointDao pointDao;
+
+    @Resource
+    JobManager jobManager;
+
+    @Resource
+    JobLauncher jobLauncher;
+
+    @Before
+    public void testMode() {
+        jobLauncher.testMode = true;
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void insertTask() {
+        jobLauncher.launch(new File("src/test/resources/conf/jobspec/jobspec.xml"));
+        JobDetail job = jobManager.findJobDetail("pipe-dev.cue-testuser_shell_v1");
+
+        String dept = jdbcTemplate.queryForObject(
+                "SELECT pk_dept FROM job WHERE pk_job=?", String.class, job.getJobId());
+
+        // Add in a new task, the job should switch to using this task.
+        Point p = pointDao.getPointConfigDetail(
+                showDao.findShowDetail("pipe"),
+                departmentDao.getDepartment(dept));
+
+        TaskDetail t = new TaskDetail(p, "dev.foo", 100);
+        taskDao.insertTask(t);
+
+        t = taskDao.getTaskDetail(t.id);
+        taskDao.deleteTask(t);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void deleteTask() {
+        Point p = pointDao.getPointConfigDetail(
+                showDao.findShowDetail("pipe"),
+                departmentDao.getDefaultDepartment());
+        TaskDetail t = new TaskDetail(p, "dev.cue", 100);
+        taskDao.insertTask(t);
+        taskDao.deleteTask(t);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void deleteTasksByShowAndDepartment() {
+
+        Point p = pointDao.getPointConfigDetail(
+                showDao.findShowDetail("pipe"),
+                departmentDao.getDefaultDepartment());
+
+        int task_count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM task WHERE pk_point=?",
+                Integer.class, p.getPointId());
+
+        TaskDetail t = new TaskDetail(p, "dev.cue");
+        taskDao.insertTask(t);
+
+        assertEquals(Integer.valueOf(task_count + 1), jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM task WHERE pk_point=?",
+                Integer.class, p.getPointId()));
+
+        taskDao.deleteTasks(p);
+
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM task WHERE pk_point=?",
+                Integer.class, p.getPointId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void deleteTasksByDepartmentConfig() {
+
+        Point p = pointDao.getPointConfigDetail(
+                showDao.findShowDetail("pipe"),
+                departmentDao.getDefaultDepartment());
+
+        TaskDetail t = new TaskDetail(p,
+                "dev.cue");
+        t.minCoreUnits = 100;
+        taskDao.insertTask(t);
+
+        taskDao.deleteTasks(p);
+
+        /**
+         * This is always
+         */
+        assertEquals(Integer.valueOf(0), jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM task WHERE pk_point=?",
+                Integer.class, p.getPointId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void getTaskDetail() {
+
+        Point p = pointDao.getPointConfigDetail(
+                showDao.findShowDetail("pipe"),
+                departmentDao.getDefaultDepartment());
+
+        TaskDetail t = new TaskDetail(p, "dev.cue");
+
+        taskDao.insertTask(t);
+        TaskDetail newTask = taskDao.getTaskDetail(t.getTaskId());
+        assertEquals(newTask.id,t.id);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void getTaskDetailByDept() {
+        Point p = pointDao.getPointConfigDetail(
+                showDao.findShowDetail("pipe"),
+                departmentDao.getDefaultDepartment());
+
+        TaskDetail t = new TaskDetail(p, "dev.cue");
+
+        taskDao.insertTask(t);
+        TaskDetail newTask = taskDao.getTaskDetail(departmentDao.getDefaultDepartment(), "dev.cue");
+        assertEquals(newTask.id,t.id);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void updateTaskMinProcs() {
+
+        Point p = pointDao.getPointConfigDetail(
+                showDao.findShowDetail("pipe"),
+                departmentDao.getDefaultDepartment());
+
+        TaskDetail t = new TaskDetail(p, "dev.cue");
+        t.minCoreUnits = 100;
+        taskDao.insertTask(t);
+        TaskDetail newTask = taskDao.getTaskDetail(t.getTaskId());
+        taskDao.updateTaskMinCores(newTask, 100);
+        assertEquals(Integer.valueOf(100), jdbcTemplate.queryForObject(
+                "SELECT int_min_cores FROM task WHERE pk_task=?",
+                Integer.class, newTask.getTaskId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void adjustTaskMinProcs() {
+
+        Point p = pointDao.getPointConfigDetail(
+                showDao.findShowDetail("pipe"),
+                departmentDao.getDefaultDepartment());
+
+        TaskDetail t = new TaskDetail(p,"dev.cue");
+        t.minCoreUnits = 10;
+        taskDao.insertTask(t);
+        TaskDetail newTask = taskDao.getTaskDetail(t.getTaskId());
+        taskDao.updateTaskMinCores(newTask, 100);
+        assertEquals(Integer.valueOf(100), jdbcTemplate.queryForObject(
+                "SELECT int_min_cores FROM task WHERE pk_task=?",
+                Integer.class, newTask.getTaskId()));
+
+        taskDao.adjustTaskMinCores(t, 105);
+
+        assertEquals(Integer.valueOf(100), jdbcTemplate.queryForObject(
+                "SELECT int_min_cores FROM task WHERE pk_task=?",
+                Integer.class, newTask.getTaskId()));
+        assertEquals(Integer.valueOf(5), jdbcTemplate.queryForObject(
+                "SELECT int_adjust_cores FROM task WHERE pk_task=?",
+                Integer.class, newTask.getTaskId()));
+
+        taskDao.adjustTaskMinCores(t, 50);
+
+        assertEquals(Integer.valueOf(100), jdbcTemplate.queryForObject(
+                "SELECT int_min_cores FROM task WHERE pk_task=?",
+                Integer.class, newTask.getTaskId()));
+        assertEquals(Integer.valueOf(-50), jdbcTemplate.queryForObject(
+                "SELECT int_adjust_cores FROM task WHERE pk_task=?",
+                Integer.class, newTask.getTaskId()));
+    }
+
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void mergeTask() {
+
+        Point p = pointDao.getPointConfigDetail(
+                showDao.findShowDetail("pipe"),
+                departmentDao.getDefaultDepartment());
+
+        TaskDetail t = new TaskDetail(p, "dev.cue");
+        taskDao.insertTask(t);
+
+        assertEquals(Integer.valueOf(100), jdbcTemplate.queryForObject(
+                "SELECT int_min_cores FROM task WHERE pk_task=?",
+                Integer.class, t.getTaskId()));
+
+        TaskDetail newTask = taskDao.getTaskDetail(t.getTaskId());
+        newTask.minCoreUnits = 200;
+        taskDao.mergeTask(newTask);
+
+        assertEquals(Integer.valueOf(200), jdbcTemplate.queryForObject(
+                "SELECT int_min_cores FROM task WHERE pk_task=?",
+                Integer.class, newTask.getTaskId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void isJobManaged() {
+        jobLauncher.launch(new File("src/test/resources/conf/jobspec/jobspec.xml"));
+        JobDetail job = jobManager.findJobDetail("pipe-dev.cue-testuser_shell_v1");
+        assertFalse(taskDao.isManaged(job));
+    }
+}
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/TrackitDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/TrackitDaoTests.java
@@ -1,0 +1,53 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import javax.annotation.Resource;
+
+import org.junit.Test;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.TrackitTaskDetail;
+import com.imageworks.spcue.dao.TrackitDao;
+
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+public class TrackitDaoTests extends AbstractTransactionalJUnit4SpringContextTests  {
+
+    @Resource
+    TrackitDao trackitDao;
+
+    @Test
+    public void testDummyTest() { assertTrue(0 == 0); }
+
+    // TODO: Make TrackIt Dependency optional
+    // @Test
+    // public void testGetTasks() {
+    //     List<TrackitTaskDetail> result = trackitDao.getTasks("clo","Lighting");
+    //     assertTrue(result.size() > 0);
+    // }
+}
+

--- a/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/WhiteboardDaoTests.java
+++ b/cue3bot/src/test/java/com/imageworks/spcue/test/dao/postgres/WhiteboardDaoTests.java
@@ -1,0 +1,1173 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import static org.junit.Assert.*;
+
+import javax.annotation.Resource;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.ActionDetail;
+
+import com.imageworks.spcue.AllocationEntity;
+import com.imageworks.spcue.CommentDetail;
+import com.imageworks.spcue.Deed;
+import com.imageworks.spcue.Department;
+import com.imageworks.spcue.DispatchFrame;
+import com.imageworks.spcue.DispatchHost;
+import com.imageworks.spcue.FilterDetail;
+import com.imageworks.spcue.Frame;
+import com.imageworks.spcue.FrameDetail;
+import com.imageworks.spcue.HostDetail;
+import com.imageworks.spcue.Job;
+import com.imageworks.spcue.JobDetail;
+import com.imageworks.spcue.Layer;
+import com.imageworks.spcue.LightweightDependency;
+import com.imageworks.spcue.LocalHostAssignment;
+import com.imageworks.spcue.MatcherDetail;
+import com.imageworks.spcue.Owner;
+import com.imageworks.spcue.Point;
+import com.imageworks.spcue.ServiceOverride;
+import com.imageworks.spcue.Show;
+import com.imageworks.spcue.ShowDetail;
+import com.imageworks.spcue.Source;
+import com.imageworks.spcue.TaskDetail;
+import com.imageworks.spcue.VirtualProc;
+import com.imageworks.spcue.CueClientIce.Host;
+import com.imageworks.spcue.CueClientIce.HostSearchCriteria;
+import com.imageworks.spcue.CueClientIce.JobSearchCriteria;
+
+import com.imageworks.spcue.dao.*;
+import com.imageworks.spcue.dao.criteria.FrameSearch;
+import com.imageworks.spcue.dao.criteria.HostSearch;
+import com.imageworks.spcue.dao.criteria.JobSearch;
+import com.imageworks.spcue.dao.criteria.ProcSearch;
+import com.imageworks.spcue.dispatcher.DispatchSupport;
+import com.imageworks.spcue.dispatcher.Dispatcher;
+import com.imageworks.spcue.service.BookingManager;
+import com.imageworks.spcue.service.CommentManager;
+import com.imageworks.spcue.service.DependManager;
+import com.imageworks.spcue.service.HostManager;
+import com.imageworks.spcue.service.JobLauncher;
+import com.imageworks.spcue.service.JobManager;
+import com.imageworks.spcue.service.DepartmentManager;
+import com.imageworks.spcue.service.OwnerManager;
+import com.imageworks.spcue.service.ServiceManager;
+import com.imageworks.spcue.util.CueUtil;
+import com.imageworks.spcue.CueIce.ActionType;
+import com.imageworks.spcue.CueIce.ActionValueType;
+import com.imageworks.spcue.CueIce.FilterType;
+import com.imageworks.spcue.CueIce.FrameState;
+import com.imageworks.spcue.CueIce.LockState;
+import com.imageworks.spcue.CueIce.MatchSubject;
+import com.imageworks.spcue.CueIce.MatchType;
+import com.imageworks.spcue.grpc.host.HardwareState;
+import com.imageworks.spcue.grpc.report.RenderHost;
+
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+@TransactionConfiguration(transactionManager="transactionManager")
+public class WhiteboardDaoTests extends AbstractTransactionalJUnit4SpringContextTests  {
+
+    @Resource
+    AllocationDao allocationDao;
+
+    @Resource
+    HostDao hostDao;
+
+    @Resource
+    WhiteboardDao whiteboardDao;
+
+    @Resource
+    ShowDao showDao;
+
+    @Resource
+    FilterDao filterDao;
+
+    @Resource
+    ProcDao procDao;
+
+    @Resource
+    MatcherDao matcherDao;
+
+    @Resource
+    ActionDao actionDao;
+
+    @Resource
+    JobManager jobManager;
+
+    @Resource
+    JobLauncher jobLauncher;
+
+    @Resource
+    GroupDao groupDao;
+
+    @Resource
+    LayerDao layerDao;
+
+    @Resource
+    JobDao jobDao;
+
+    @Resource
+    DepartmentDao departmentDao;
+
+    @Resource
+    DependManager dependManager;
+
+    @Resource
+    FrameDao frameDao;
+
+    @Resource
+    PointDao pointDao;
+
+    @Resource
+    HostManager hostManager;
+
+    @Resource
+    CommentManager commentManager;
+
+    @Resource
+    DepartmentManager departmentManager;
+
+    @Resource
+    Dispatcher dispatcher;
+
+    @Resource
+    DispatchSupport dispatchSupport;
+
+    @Resource
+    OwnerManager ownerManager;
+
+    @Resource
+    BookingManager bookingManager;
+
+    @Resource
+    ServiceManager serviceManager;
+
+    private static final String HOST = "testest";
+    private static final String SHOW = "pipe";
+
+    @Before
+    public void testMode() {
+        jobLauncher.testMode = true;
+    }
+
+    public ShowDetail getShow() {
+        return showDao.findShowDetail(SHOW);
+    }
+
+    public FilterDetail createFilter() {
+        FilterDetail filter = new FilterDetail();
+        filter.name = "Default";
+        filter.showId = getShow().id;
+        filter.type = FilterType.MatchAny;
+        filter.enabled = true;
+        filterDao.insertFilter(filter);
+        return filter;
+    }
+
+    public MatcherDetail createMatcher(FilterDetail f) {
+        MatcherDetail matcher = new MatcherDetail();
+        matcher.filterId = f.id;
+        matcher.name = null;
+        matcher.showId = getShow().getId();
+        matcher.subject = MatchSubject.JobName;
+        matcher.type = MatchType.Contains;
+        matcher.value = "testuser";
+        matcherDao.insertMatcher(matcher);
+        return matcher;
+    }
+
+    public ActionDetail createAction(FilterDetail f) {
+        ActionDetail a1 = new ActionDetail();
+        a1.type = ActionType.PauseJob;
+        a1.filterId = f.getFilterId();
+        a1.booleanValue = true;
+        a1.name = null;
+        a1.valueType = ActionValueType.BooleanType;
+        actionDao.createAction(a1);
+        return a1;
+    }
+
+    public RenderHost getRenderHost() {
+
+        RenderHost host = RenderHost.newBuilder()
+                .setName(HOST)
+                .setBootTime(1192369572)
+                .setFreeMcp(7602)
+                .setFreeMem((int) Dispatcher.MEM_RESERVED_MIN * 4)
+                .setFreeSwap(2076)
+                .setLoad(1)
+                .setTotalMcp(19543)
+                .setTotalMem((int) Dispatcher.MEM_RESERVED_MIN * 4)
+                .setTotalSwap(2096)
+                .setNimbyEnabled(true)
+                .setNumProcs(2)
+                .setCoresPerProc(400)
+                .setState(HardwareState.DOWN)
+                .setFacility("spi")
+                .putAttributes("freeGpu", String.format("%d", CueUtil.MB512))
+                .putAttributes("totalGpu", String.format("%d", CueUtil.MB512))
+                .build();
+        return host;
+    }
+
+    public JobDetail launchJob() {
+        jobLauncher.testMode = true;
+        jobLauncher.launch(new File("src/test/resources/conf/jobspec/jobspec.xml"));
+        return jobManager.findJobDetail("pipe-dev.cue-testuser_shell_v1");
+    }
+
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void getService() {
+        whiteboardDao.getService("arnold");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void getServices() {
+        whiteboardDao.getDefaultServices();
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void getServiceOverride() {
+
+        Show show = getShow();
+        ServiceOverride s = new ServiceOverride();
+        s.name = "test";
+        s.minCores = 100;
+        s.minMemory = 320000;
+        s.tags.add("general");
+        s.threadable = false;
+        s.showId = show.getId();
+
+        serviceManager.createService(s);
+        whiteboardDao.getServiceOverride(getShow(), "test");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void getServiceOverrides() {
+        whiteboardDao.getServiceOverrides(getShow());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetDepend() {
+
+        List<LightweightDependency> depends = dependManager.getWhatDependsOn(launchJob());
+        for (LightweightDependency depend: depends) {
+            whiteboardDao.getDepend(depend);
+        }
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetDependById() {
+
+        List<LightweightDependency> depends = dependManager.getWhatDependsOn(launchJob());
+        for (LightweightDependency depend: depends) {
+            whiteboardDao.getDepend(depend);
+            whiteboardDao.getDepend(depend.id);
+        }
+    }
+
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetWhatDependsOnThis() {
+        JobDetail job = launchJob();
+        assertEquals(1,whiteboardDao.getWhatDependsOnThis(job).size());
+
+        Layer layer1 = layerDao.findLayer(job, "pass_1");
+        assertEquals(0, whiteboardDao.getWhatDependsOnThis(layer1).size());
+
+        Layer layer2 = layerDao.findLayer(job, "pass_1_preprocess");
+        assertEquals(1, whiteboardDao.getWhatDependsOnThis(layer2).size());
+
+        Frame frame = frameDao.findFrame(job, "0001-pass_1");
+        assertEquals(0, whiteboardDao.getWhatDependsOnThis(frame).size());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetWhatThisDependsOn() {
+        JobDetail job = launchJob();
+        assertEquals(0, whiteboardDao.getWhatThisDependsOn(job).size());
+
+        Layer layer1 = layerDao.findLayer(job, "pass_1");
+        assertEquals(1, whiteboardDao.getWhatThisDependsOn(layer1).size());
+
+        Layer layer2 = layerDao.findLayer(job, "pass_1_preprocess");
+        assertEquals(0, whiteboardDao.getWhatThisDependsOn(layer2).size());
+
+        Frame frame = frameDao.findFrame(job, "0001-pass_1");
+        assertEquals(1, whiteboardDao.getWhatThisDependsOn(frame).size());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetDepends() {
+        JobDetail job = launchJob();
+        assertEquals(1,whiteboardDao.getDepends(job).size());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetCommentsOnJob() {
+        JobDetail job = launchJob();
+        assertEquals(0,whiteboardDao.getComments(job).size());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetCommentsOnHost() {
+
+        RenderHost host = getRenderHost();
+        DispatchHost hd = hostManager.createHost(host);
+        hostDao.updateHostLock(hd, LockState.Locked, new Source("TEST"));
+
+        CommentDetail c = new CommentDetail();
+        c.message = "you suck";
+        c.subject = "a useful message";
+        c.user = "testuser";
+        c.timestamp = null;
+
+        commentManager.addComment(hd, c);
+        assertEquals(1,whiteboardDao.getComments(hd).size());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindFilter() {
+        createFilter();
+        whiteboardDao.findFilter(getShow(), "Default");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetFilter() {
+        whiteboardDao.getFilter(createFilter());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetMatchers() {
+        FilterDetail f = createFilter();
+        createMatcher(f);
+        whiteboardDao.getMatchers(f);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetMatcher() {
+        FilterDetail f = createFilter();
+        MatcherDetail m = createMatcher(f);
+        whiteboardDao.getMatcher(m);
+     }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetActions() {
+        FilterDetail f = createFilter();
+        createAction(f);
+        whiteboardDao.getActions(f);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetAction() {
+        FilterDetail f = createFilter();
+        whiteboardDao.getAction(createAction(f));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetFilters() {
+        createFilter();
+        whiteboardDao.getFilters(getShow());
+   }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetFramesByFrameSearch() {
+        Job job = launchJob();
+        FrameSearch r = new FrameSearch(job);
+        r.getCriteria().page = 1;
+        r.getCriteria().limit = 5;
+        r.getCriteria().layers.add("pass_1");
+        assertEquals(5, whiteboardDao.getFrames(r).size());
+        for (com.imageworks.spcue.CueClientIce.Frame f: whiteboardDao.getFrames(r)) {
+            assertEquals(f.data.layerName,"pass_1");
+        }
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetLayers() {
+        JobDetail job = launchJob();
+        whiteboardDao.getLayers(job);
+
+        RenderHost host = getRenderHost();
+        DispatchHost hd = hostManager.createHost(host);
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1_preprocess");
+
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = null;
+        proc.coresReserved = 100;
+        proc.hostId = hd.id;
+        proc.hostName = host.getName();
+        proc.jobId = job.id;
+        proc.frameId = frame.id;
+        proc.layerId = frame.layerId;
+        proc.showId = frame.showId;
+
+        DispatchFrame dframe = frameDao.getDispatchFrame(frame.getId());
+        dispatcher.setTestMode(true);
+        dispatcher.dispatch(dframe, proc);
+
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        dframe = frameDao.getDispatchFrame(frame.getId());
+
+        assertTrue(dispatchSupport.stopFrame(dframe, FrameState.Succeeded, 0));
+        dispatchSupport.updateUsageCounters(frame, 0);
+        whiteboardDao.getLayers(job);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testStopFrameUpdatesLayerMaxRSS() {
+        long max_rss = 123456L;
+
+        JobDetail job = launchJob();
+        whiteboardDao.getLayers(job);
+
+        RenderHost host = getRenderHost();
+        DispatchHost hd = hostManager.createHost(host);
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1_preprocess");
+
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = null;
+        proc.coresReserved = 100;
+        proc.hostId = hd.id;
+        proc.hostName = host.getName();
+        proc.jobId = job.id;
+        proc.frameId = frame.id;
+        proc.layerId = frame.layerId;
+        proc.showId = frame.showId;
+
+        DispatchFrame dframe = frameDao.getDispatchFrame(frame.getId());
+        dispatcher.setTestMode(true);
+        dispatcher.dispatch(dframe, proc);
+
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        dframe = frameDao.getDispatchFrame(frame.getId());
+
+        // Note use of 4-arg stopFrame here to update max rss.
+        assertTrue(dispatchSupport.stopFrame(dframe, FrameState.Succeeded, 0, max_rss));
+        dispatchSupport.updateUsageCounters(frame, 0);
+        com.imageworks.spcue.CueClientIce.Layer layer = whiteboardDao.getLayer(frame.layerId);
+        assertEquals(max_rss, layer.stats.maxRss);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testStopFrameUpdatesJobMaxRSS() {
+        long max_rss = 123456L;
+
+        JobDetail job = launchJob();
+        whiteboardDao.getLayers(job);
+
+        RenderHost host = getRenderHost();
+        DispatchHost hd = hostManager.createHost(host);
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1_preprocess");
+
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = null;
+        proc.coresReserved = 100;
+        proc.hostId = hd.id;
+        proc.hostName = host.getName();
+        proc.jobId = job.id;
+        proc.frameId = frame.id;
+        proc.layerId = frame.layerId;
+        proc.showId = frame.showId;
+
+        DispatchFrame dframe = frameDao.getDispatchFrame(frame.getId());
+        dispatcher.setTestMode(true);
+        dispatcher.dispatch(dframe, proc);
+
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        dframe = frameDao.getDispatchFrame(frame.getId());
+
+        // Note use of 4-arg stopFrame here to update max rss.
+        assertTrue(dispatchSupport.stopFrame(dframe, FrameState.Succeeded, 0, max_rss));
+        dispatchSupport.updateUsageCounters(frame, 0);
+        com.imageworks.spcue.CueClientIce.Job ice_job = whiteboardDao.getJob(job.id);
+        assertEquals(max_rss, ice_job.stats.maxRss);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetJobs() {
+        launchJob();
+        JobSearchCriteria r = JobSearch.criteriaFactory();
+        r.shows.add("pipe");
+        whiteboardDao.getJobs(new JobSearch(r));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetJobNames() {
+        launchJob();
+        JobSearchCriteria r = JobSearch.criteriaFactory();
+        r.shows.add("pipe");
+        whiteboardDao.getJobNames(new JobSearch(r));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetUpdatedFrames() {
+        final JobDetail job = launchJob();
+        List<Job> jobs = new ArrayList<Job>();
+
+        jobs.add(new Job() {
+            public String getJobId() { return job.getId(); }
+            public String getShowId() { return null; }
+            public String getId() { return job.getId(); }
+            public String getName() { return null; }
+            public String getFacilityId() { throw new RuntimeException("not implemented"); }
+        });
+
+        whiteboardDao.getUpdatedFrames(job, new ArrayList<Layer>(),
+                (int) (System.currentTimeMillis() / 1000));
+
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    @Transactional
+    @Rollback(true)
+    public void testGetUpdatedFramesFailure() {
+        final JobDetail job = launchJob();
+        List<Job> jobs = new ArrayList<Job>();
+
+        jobs.add(new Job() {
+            public String getJobId() { return job.getId(); }
+            public String getShowId() { return null; }
+            public String getId() { return job.getId(); }
+            public String getName() { return null; }
+            public String getFacilityId() { throw new RuntimeException("not implemented"); }
+        });
+
+        // this one should fail
+        whiteboardDao.getUpdatedFrames(job, new ArrayList<Layer>(),
+                (int) (System.currentTimeMillis() / 1000 - 1000000));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindJob() {
+        JobDetail job = launchJob();
+        whiteboardDao.findJob(job.name);
+     }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetJob() {
+        JobDetail job = launchJob();
+        whiteboardDao.getJob(job.id);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetSubscriptionByID() {
+        whiteboardDao.getSubscription("00000000-0000-0000-0000-000000000001");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void findFindSubscription() {
+        whiteboardDao.findSubscription("pipe", "spi.general");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetSubscriptions() {
+        whiteboardDao.getSubscriptions(getShow());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetSubscriptionsByAllocation() {
+        whiteboardDao.getSubscriptions(
+                allocationDao.findAllocationEntity("spi", "general"));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetShow() {
+        whiteboardDao.getShow(getShow().id);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindShow() {
+        whiteboardDao.findShow(getShow().name);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetShows() {
+        whiteboardDao.getShows();
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetActiveShows() {
+        whiteboardDao.getActiveShows();
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindHost() {
+
+        try {
+            HostDetail h = hostManager.findHostDetail(HOST);
+            hostManager.deleteHost(h);
+        } catch (Exception e) { }
+
+        RenderHost host = getRenderHost();
+        DispatchHost hd = hostManager.createHost(host);
+        hostDao.updateHostLock(hd, LockState.Locked, new Source("TEST"));
+        Host h = whiteboardDao.findHost(host.getName());
+        assertEquals(host.getName(), h.data.name);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetHosts() {
+        RenderHost host = getRenderHost();
+        DispatchHost hd = hostManager.createHost(host);
+
+        HostSearchCriteria h = HostSearch.criteriaFactory();
+        h.hosts.add(HOST);
+        assertEquals(1, whiteboardDao.getHosts(new HostSearch(h)).size());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetHostsByAllocation() {
+        RenderHost host = getRenderHost();
+        AllocationEntity alloc = allocationDao.getAllocationEntity("00000000-0000-0000-0000-000000000006");
+        DispatchHost hd = hostManager.createHost(host, alloc);
+
+        HostSearchCriteria h = HostSearch.criteriaFactory();
+        h.allocs.add(alloc.getName());
+        assertEquals(1, whiteboardDao.getHosts(new HostSearch(h)).size());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetAllocation() {
+        whiteboardDao.getAllocation("00000000-0000-0000-0000-000000000000");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindAllocation() {
+        whiteboardDao.findAllocation("spi.general");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetAllocations() {
+        whiteboardDao.getAllocations();
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetRootGroup() {
+        whiteboardDao.getRootGroup(getShow());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetGroup() {
+        whiteboardDao.getGroup("A0000000-0000-0000-0000-000000000000");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetGroups() {
+        whiteboardDao.getGroups(getShow());
+        whiteboardDao.getGroup(groupDao.getRootGroupId(getShow()));
+        whiteboardDao.getGroups(groupDao.getRootGroupDetail(getShow()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindGroup() {
+        whiteboardDao.findGroup("pipe", "pipe");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindFrame() {
+        JobDetail job = launchJob();
+        whiteboardDao.findFrame(job.name, "pass_1", 1);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindFilterByName() {
+        createFilter();
+        whiteboardDao.findFilter("pipe", "Default");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFindLayer() {
+        JobDetail job = launchJob();
+        whiteboardDao.findLayer(job.name, "pass_1");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetDepartment() {
+        Show show = showDao.findShowDetail("pipe");
+        Department dept = departmentDao.getDefaultDepartment();
+
+        com.imageworks.spcue.CueClientIce.Department d =
+            whiteboardDao.getDepartment(show, dept.getName());
+
+        assertEquals("pipe.Unknown", d.data.name);
+        assertEquals("Unknown",d.data.dept);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetDepartments() {
+        Show show = showDao.findShowDetail("pipe");
+        whiteboardDao.getDepartments(show);
+    }
+
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetDepartmentNames() {
+        assertTrue(whiteboardDao.getDepartmentNames().size() > 0);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetTasks() {
+        whiteboardDao.getTasks(showDao.findShowDetail("pipe"),
+                departmentDao.getDefaultDepartment());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGetTask() {
+        Point p = pointDao.getPointConfigDetail(
+                showDao.findShowDetail("pipe"),
+                departmentDao.getDefaultDepartment());
+
+        TaskDetail t = new TaskDetail(p,"dev.cue");
+        departmentManager.createTask(t);
+
+        whiteboardDao.getTask(showDao.findShowDetail("pipe"),
+                departmentDao.getDefaultDepartment(), "dev.cue");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void getFrame() {
+        JobDetail job = launchJob();
+        Frame frame = frameDao.findFrame(job, "0001-pass_1_preprocess");
+        assertEquals(1, whiteboardDao.getFrame(frame.getFrameId()).data.number);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void getLayer() {
+        JobDetail job = launchJob();
+        Layer layer = layerDao.findLayer(job, "pass_1");
+        assertEquals(layer.getName(),whiteboardDao.getLayer(layer.getLayerId()).data.name);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void getHost() {
+
+        RenderHost host = getRenderHost();
+        DispatchHost hd = hostManager.createHost(host);
+
+        JobDetail job = launchJob();
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1_preprocess");
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = null;
+        proc.coresReserved = 100;
+        proc.hostId = hd.id;
+        proc.hostName = host.getName();
+        proc.jobId = job.id;
+        proc.frameId = frame.id;
+        proc.layerId = frame.layerId;
+        proc.showId = frame.showId;
+
+        procDao.insertVirtualProc(proc);
+        assertEquals(hd.getName(), whiteboardDao.getHost(proc.getHostId()).data.name);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void getProcs() {
+        RenderHost host = getRenderHost();
+        DispatchHost hd = hostManager.createHost(host);
+        JobDetail job = launchJob();
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1_preprocess");
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = null;
+        proc.coresReserved = 100;
+        proc.hostId = hd.id;
+        proc.hostName = host.getName();
+        proc.jobId = job.id;
+        proc.frameId = frame.id;
+        proc.layerId = frame.layerId;
+        proc.showId = frame.showId;
+
+        procDao.insertVirtualProc(proc);
+        assertEquals(1,whiteboardDao.getProcs(proc).size());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void getProcsBySearch() {
+        RenderHost host = getRenderHost();
+        DispatchHost hd = hostManager.createHost(host);
+
+        jobLauncher.launch(new File("src/test/resources/conf/jobspec/jobspec_dispatch_test.xml"));
+        JobDetail job = jobManager.findJobDetail("pipe-dev.cue-testuser_shell_dispatch_test_v1");
+
+        /*
+         * Book 5 procs.
+         */
+        for (int i=1; i<6; i++) {
+            FrameDetail f = frameDao.findFrameDetail(job, String.format("%04d-pass_1",i));
+            VirtualProc proc = new VirtualProc();
+            proc.allocationId = null;
+            proc.coresReserved = 100;
+            proc.hostId = hd.id;
+            proc.hostName = host.getName();
+            proc.jobId = job.id;
+            proc.frameId = f.id;
+            proc.layerId = f.layerId;
+            proc.showId = f.showId;
+            procDao.insertVirtualProc(proc);
+        }
+
+        ProcSearch r;
+
+        /*
+         * Search for all 5 running procs
+         */
+        r = new ProcSearch();
+        r.getCriteria().shows.add("pipe");
+        assertEquals(5, whiteboardDao.getProcs(r).size());
+
+        /*
+         * Limit the result to 1 result.
+         */
+        r = new ProcSearch();
+        r.getCriteria().shows.add("pipe");
+        r.getCriteria().maxResults = new int[] { 1 };
+        assertEquals(1, whiteboardDao.getProcs(r).size());
+
+        /*
+         * Change the first result to 1, which should limit
+         * the result to 4.
+         */
+        r = new ProcSearch();
+        r.getCriteria().shows.add("pipe");
+        r.getCriteria().firstResult = 2;
+        assertEquals(4, whiteboardDao.getProcs(r).size());
+
+        /*
+         * Now try to do the equivalent of a limit/offset
+         */
+        r = new ProcSearch();
+        r.getCriteria().shows.add("pipe");
+        r.getCriteria().firstResult = 3;
+        r.getCriteria().maxResults = new int[] { 2 };
+        assertEquals(2, whiteboardDao.getProcs(r).size());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void getOwner() {
+        ownerManager.createOwner("spongebob",
+                showDao.findShowDetail("pipe"));
+        whiteboardDao.getOwner("spongebob");
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void getOwnersByShow() {
+        RenderHost host = getRenderHost();
+        DispatchHost hd = hostManager.createHost(host);
+
+        Owner owner = ownerManager.createOwner("spongebob",
+                showDao.findShowDetail("pipe"));
+
+        ownerManager.takeOwnership(owner, hd);
+
+        assertTrue(whiteboardDao.getOwners(
+                showDao.findShowDetail("pipe")).size() != 0);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void getDeedsByShow() {
+
+        RenderHost host = getRenderHost();
+        DispatchHost hd = hostManager.createHost(host);
+
+        Owner owner = ownerManager.createOwner("spongebob",
+                showDao.findShowDetail("pipe"));
+
+        ownerManager.takeOwnership(owner, hd);
+        assertTrue(whiteboardDao.getDeeds(
+                showDao.findShowDetail("pipe")).size() != 0);
+
+        assertTrue(whiteboardDao.getDeeds(
+                showDao.findShowDetail("pipe")).size() != 0);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void getDeedsByOwner() {
+
+        RenderHost host = getRenderHost();
+        DispatchHost hd = hostManager.createHost(host);
+
+        Owner owner = ownerManager.createOwner("spongebob",
+                showDao.findShowDetail("pipe"));
+
+        ownerManager.takeOwnership(owner, hd);
+        assertTrue(whiteboardDao.getDeeds(
+                owner).size() != 0);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void getHostsByOwner() {
+
+        RenderHost host = getRenderHost();
+        DispatchHost hd = hostManager.createHost(host);
+
+        Owner owner = ownerManager.createOwner("spongebob",
+                showDao.findShowDetail("pipe"));
+        ownerManager.takeOwnership(owner, hd);
+
+        assertEquals(1, whiteboardDao.getHosts(owner).size());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void getOwnerFromDeed() {
+
+        RenderHost host = getRenderHost();
+        DispatchHost hd = hostManager.createHost(host);
+
+        Owner owner = ownerManager.createOwner("spongebob",
+                showDao.findShowDetail("pipe"));
+        Deed deed = ownerManager.takeOwnership(owner, hd);
+
+        com.imageworks.spcue.CueClientIce.Owner o2 =
+            whiteboardDao.getOwner(deed);
+
+        assertEquals(owner.getName(), o2.name);
+        assertEquals(1, o2.hostCount);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void getOwnerFromHost() {
+
+        RenderHost host = getRenderHost();
+        DispatchHost hd = hostManager.createHost(host);
+
+        Owner owner = ownerManager.createOwner("spongebob",
+                showDao.findShowDetail("pipe"));
+        ownerManager.takeOwnership(owner, hd);
+
+        com.imageworks.spcue.CueClientIce.Owner o2 =
+            whiteboardDao.getOwner(hd);
+
+        assertEquals(owner.getName(), o2.name);
+        assertEquals(1, o2.hostCount);
+    }
+
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void getRenderPartition() {
+
+        RenderHost host = getRenderHost();
+        DispatchHost hd = hostManager.createHost(host);
+
+        jobLauncher.launch(new File("src/test/resources/conf/jobspec/jobspec_dispatch_test.xml"));
+        JobDetail job = jobManager.findJobDetail("pipe-dev.cue-testuser_shell_dispatch_test_v1");
+
+        LocalHostAssignment lba = new LocalHostAssignment(800, 8, CueUtil.GB8, 1);
+        bookingManager.createLocalHostAssignment(hd, job, lba);
+
+        whiteboardDao.getRenderPartition(lba);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void getRenderPartitionsByHost() {
+
+        RenderHost host = getRenderHost();
+        DispatchHost hd = hostManager.createHost(host);
+
+        jobLauncher.launch(new File("src/test/resources/conf/jobspec/jobspec_dispatch_test.xml"));
+        JobDetail job = jobManager.findJobDetail("pipe-dev.cue-testuser_shell_dispatch_test_v1");
+
+        LocalHostAssignment lba = new LocalHostAssignment(800, 8, CueUtil.GB8, 1);
+        bookingManager.createLocalHostAssignment(hd, job, lba);
+
+        assertEquals(1, whiteboardDao.getRenderPartitions(hd).size());
+
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void getFacility() {
+        whiteboardDao.getFacilities();
+        whiteboardDao.getFacility("spi");
+    }
+}
+
+


### PR DESCRIPTION
Similar to https://github.com/imageworks/cue3/pull/10, create Postgres versions of all the DAO test classes.

These are copies of their Oracle counterparts with only the `package` line changed, so they won't work yet. This change is just intended to make it easier to see what has actually changed from Oracle world once I send the change that actually implements tests.