### PR TITLE
Migrate Criterion usage to GRPC.

### DIFF
--- a/cue3bot/src/main/java/com/imageworks/spcue/dao/criteria/ProcSearchInterface.java
+++ b/cue3bot/src/main/java/com/imageworks/spcue/dao/criteria/ProcSearchInterface.java
@@ -19,10 +19,12 @@ package com.imageworks.spcue.dao.criteria;
 
 import java.util.List;
 
-import com.imageworks.common.SpiIce.IntegerSearchCriterion;
 import com.imageworks.spcue.GroupInterface;
 import com.imageworks.spcue.HostInterface;
 import com.imageworks.spcue.JobInterface;
+import com.imageworks.spcue.grpc.criterion.GreaterThanIntegerSearchCriterion;
+import com.imageworks.spcue.grpc.criterion.InRangeIntegerSearchCriterion;
+import com.imageworks.spcue.grpc.criterion.LessThanIntegerSearchCriterion;
 import com.imageworks.spcue.grpc.host.ProcSearchCriteria;
 
 public interface ProcSearchInterface extends CriteriaInterface {
@@ -30,7 +32,9 @@ public interface ProcSearchInterface extends CriteriaInterface {
     void setCriteria(ProcSearchCriteria criteria);
     void notJobs(List<JobInterface> jobs);
     void notGroups(List<GroupInterface> groups);
-    void filterByDurationRange(IntegerSearchCriterion criterion);
+    void filterByDurationRange(LessThanIntegerSearchCriterion criterion);
+    void filterByDurationRange(GreaterThanIntegerSearchCriterion criterion);
+    void filterByDurationRange(InRangeIntegerSearchCriterion criterion);
     void filterByHost(HostInterface host);
     void sortByHostName();
     void sortByDispatchedTime();

--- a/cue3bot/src/main/java/com/imageworks/spcue/dao/criteria/oracle/Criteria.java
+++ b/cue3bot/src/main/java/com/imageworks/spcue/dao/criteria/oracle/Criteria.java
@@ -26,20 +26,17 @@ import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
 
-import com.imageworks.common.SpiIce.EqualsFloatSearchCriterion;
-import com.imageworks.common.SpiIce.EqualsIntegerSearchCriterion;
-import com.imageworks.common.SpiIce.FloatSearchCriterion;
-import com.imageworks.common.SpiIce.GreaterThanFloatSearchCriterion;
-import com.imageworks.common.SpiIce.GreaterThanIntegerSearchCriterion;
-import com.imageworks.common.SpiIce.InRangeFloatSearchCriterion;
-import com.imageworks.common.SpiIce.InRangeIntegerSearchCriterion;
-import com.imageworks.common.SpiIce.IntegerSearchCriterion;
-import com.imageworks.common.SpiIce.LessThanFloatSearchCriterion;
-import com.imageworks.common.SpiIce.LessThanIntegerSearchCriterion;
-import com.imageworks.spcue.dao.criteria.CriteriaException;
 import com.imageworks.spcue.dao.criteria.CriteriaInterface;
 import com.imageworks.spcue.dao.criteria.Phrase;
 import com.imageworks.spcue.dao.criteria.Sort;
+import com.imageworks.spcue.grpc.criterion.EqualsFloatSearchCriterion;
+import com.imageworks.spcue.grpc.criterion.EqualsIntegerSearchCriterion;
+import com.imageworks.spcue.grpc.criterion.GreaterThanFloatSearchCriterion;
+import com.imageworks.spcue.grpc.criterion.GreaterThanIntegerSearchCriterion;
+import com.imageworks.spcue.grpc.criterion.InRangeFloatSearchCriterion;
+import com.imageworks.spcue.grpc.criterion.InRangeIntegerSearchCriterion;
+import com.imageworks.spcue.grpc.criterion.LessThanFloatSearchCriterion;
+import com.imageworks.spcue.grpc.criterion.LessThanIntegerSearchCriterion;
 
 public abstract class Criteria implements CriteriaInterface {
 
@@ -243,66 +240,62 @@ public abstract class Criteria implements CriteriaInterface {
         chunks.add(sb);
     }
 
-    void addRangePhrase(String col, IntegerSearchCriterion e) {
+    void addRangePhrase(String col, EqualsIntegerSearchCriterion criterion) {
         StringBuilder sb = new StringBuilder(128);
-        final Class<? extends IntegerSearchCriterion> c = e.getClass();
-        if (c == EqualsIntegerSearchCriterion.class) {
-            EqualsIntegerSearchCriterion r = (EqualsIntegerSearchCriterion) e;
-            values.add(r.value);
-            sb.append(" " + col + " = ?");
-        }
-        else if (c == LessThanIntegerSearchCriterion.class) {
-            LessThanIntegerSearchCriterion r = (LessThanIntegerSearchCriterion) e;
-            values.add(r.value);
-            sb.append(" " + col + "<=? ");
-        }
-        else if (c == GreaterThanIntegerSearchCriterion.class) {
-            GreaterThanIntegerSearchCriterion r = (GreaterThanIntegerSearchCriterion) e;
-            values.add(r.value);
-            sb.append(" " + col + " >= ? ");
-        }
-        else if (c == InRangeIntegerSearchCriterion.class) {
-            InRangeIntegerSearchCriterion r = (InRangeIntegerSearchCriterion) e;
-            values.add(r.min);
-            values.add(r.max);
-            sb.append(" (" + col +" >= ? AND " + col + " <= ?) ");
-        }
-        else {
-            throw new CriteriaException("Invalid criteria class used for memory range search: "
-                    + e.getClass().getCanonicalName());
-        }
+        sb.append(" " + col + " = ?");
         chunks.add(sb);
+        values.add(criterion.getValue());
     }
 
-    void addRangePhrase(String col, FloatSearchCriterion e) {
+    void addRangePhrase(String col, LessThanIntegerSearchCriterion criterion) {
         StringBuilder sb = new StringBuilder(128);
-        final Class<? extends FloatSearchCriterion> c = e.getClass();
-        if (c == EqualsFloatSearchCriterion.class) {
-            EqualsFloatSearchCriterion r = (EqualsFloatSearchCriterion) e;
-            values.add(r.value);
-            sb.append(" " + col + " = ?");
-        }
-        else if (c == LessThanFloatSearchCriterion.class) {
-            LessThanFloatSearchCriterion r = (LessThanFloatSearchCriterion) e;
-            values.add(r.value);
-            sb.append(" " + col + "<=? ");
-        }
-        else if (c == GreaterThanFloatSearchCriterion.class) {
-            GreaterThanFloatSearchCriterion r = (GreaterThanFloatSearchCriterion) e;
-            values.add(r.value);
-            sb.append(" " + col + " >= ? ");
-        }
-        else if (c == InRangeFloatSearchCriterion.class) {
-            InRangeFloatSearchCriterion r = (InRangeFloatSearchCriterion) e;
-            values.add(r.min);
-            values.add(r.max);
-            sb.append(" (" + col +" >= ? AND " + col + " <= ?) ");
-        }
-        else {
-            throw new CriteriaException("Invalid criteria class used for memory range search: "
-                    + e.getClass().getCanonicalName());
-        }
+        sb.append(" " + col + "<=? ");
         chunks.add(sb);
+        values.add(criterion.getValue());
+    }
+
+    void addRangePhrase(String col, GreaterThanIntegerSearchCriterion criterion) {
+        StringBuilder sb = new StringBuilder(128);
+        sb.append(" " + col + " >= ? ");
+        chunks.add(sb);
+        values.add(criterion.getValue());
+    }
+
+    void addRangePhrase(String col, InRangeIntegerSearchCriterion criterion) {
+        StringBuilder sb = new StringBuilder(128);
+        sb.append(" " + col + " >= ? ");
+        chunks.add(sb);
+        values.add(criterion.getMin());
+        values.add(criterion.getMax());
+    }
+
+    void addRangePhrase(String col, EqualsFloatSearchCriterion criterion) {
+        StringBuilder sb = new StringBuilder(128);
+        sb.append(" " + col + " = ?");
+        chunks.add(sb);
+        values.add(criterion.getValue());
+    }
+
+    void addRangePhrase(String col, LessThanFloatSearchCriterion criterion) {
+        StringBuilder sb = new StringBuilder(128);
+        sb.append(" " + col + " <= ? ");
+        chunks.add(sb);
+        values.add(criterion.getValue());
+    }
+
+    void addRangePhrase(String col, GreaterThanFloatSearchCriterion criterion) {
+        StringBuilder sb = new StringBuilder(128);
+        sb.append(" " + col + " >= ? ");
+        chunks.add(sb);
+        values.add(criterion.getValue());
+    }
+
+    void addRangePhrase(String col, InRangeFloatSearchCriterion criterion) {
+        StringBuilder sb = new StringBuilder(128);
+        sb.append(" " + col + " >= ? ");
+        chunks.add(sb);
+        values.add(criterion.getMin());
+        values.add(criterion.getMax());
     }
 
     boolean isValid(String v) {

--- a/cue3bot/src/main/java/com/imageworks/spcue/dao/criteria/postgres/Criteria.java
+++ b/cue3bot/src/main/java/com/imageworks/spcue/dao/criteria/postgres/Criteria.java
@@ -26,20 +26,17 @@ import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
 
-import com.imageworks.common.SpiIce.EqualsFloatSearchCriterion;
-import com.imageworks.common.SpiIce.EqualsIntegerSearchCriterion;
-import com.imageworks.common.SpiIce.FloatSearchCriterion;
-import com.imageworks.common.SpiIce.GreaterThanFloatSearchCriterion;
-import com.imageworks.common.SpiIce.GreaterThanIntegerSearchCriterion;
-import com.imageworks.common.SpiIce.InRangeFloatSearchCriterion;
-import com.imageworks.common.SpiIce.InRangeIntegerSearchCriterion;
-import com.imageworks.common.SpiIce.IntegerSearchCriterion;
-import com.imageworks.common.SpiIce.LessThanFloatSearchCriterion;
-import com.imageworks.common.SpiIce.LessThanIntegerSearchCriterion;
-import com.imageworks.spcue.dao.criteria.CriteriaException;
 import com.imageworks.spcue.dao.criteria.CriteriaInterface;
 import com.imageworks.spcue.dao.criteria.Phrase;
 import com.imageworks.spcue.dao.criteria.Sort;
+import com.imageworks.spcue.grpc.criterion.EqualsFloatSearchCriterion;
+import com.imageworks.spcue.grpc.criterion.EqualsIntegerSearchCriterion;
+import com.imageworks.spcue.grpc.criterion.GreaterThanFloatSearchCriterion;
+import com.imageworks.spcue.grpc.criterion.GreaterThanIntegerSearchCriterion;
+import com.imageworks.spcue.grpc.criterion.InRangeFloatSearchCriterion;
+import com.imageworks.spcue.grpc.criterion.InRangeIntegerSearchCriterion;
+import com.imageworks.spcue.grpc.criterion.LessThanFloatSearchCriterion;
+import com.imageworks.spcue.grpc.criterion.LessThanIntegerSearchCriterion;
 
 public abstract class Criteria implements CriteriaInterface {
 
@@ -250,66 +247,62 @@ public abstract class Criteria implements CriteriaInterface {
         chunks.add(sb);
     }
 
-    void addRangePhrase(String col, IntegerSearchCriterion e) {
+    void addRangePhrase(String col, EqualsIntegerSearchCriterion criterion) {
         StringBuilder sb = new StringBuilder(128);
-        final Class<? extends IntegerSearchCriterion> c = e.getClass();
-        if (c == EqualsIntegerSearchCriterion.class) {
-            EqualsIntegerSearchCriterion r = (EqualsIntegerSearchCriterion) e;
-            values.add(r.value);
-            sb.append(" " + col + " = ?");
-        }
-        else if (c == LessThanIntegerSearchCriterion.class) {
-            LessThanIntegerSearchCriterion r = (LessThanIntegerSearchCriterion) e;
-            values.add(r.value);
-            sb.append(" " + col + "<=? ");
-        }
-        else if (c == GreaterThanIntegerSearchCriterion.class) {
-            GreaterThanIntegerSearchCriterion r = (GreaterThanIntegerSearchCriterion) e;
-            values.add(r.value);
-            sb.append(" " + col + " >= ? ");
-        }
-        else if (c == InRangeIntegerSearchCriterion.class) {
-            InRangeIntegerSearchCriterion r = (InRangeIntegerSearchCriterion) e;
-            values.add(r.min);
-            values.add(r.max);
-            sb.append(" (" + col +" >= ? AND " + col + " <= ?) ");
-        }
-        else {
-            throw new CriteriaException("Invalid criteria class used for memory range search: "
-                    + e.getClass().getCanonicalName());
-        }
+        sb.append(" " + col + " = ?");
         chunks.add(sb);
+        values.add(criterion.getValue());
     }
 
-    void addRangePhrase(String col, FloatSearchCriterion e) {
+    void addRangePhrase(String col, LessThanIntegerSearchCriterion criterion) {
         StringBuilder sb = new StringBuilder(128);
-        final Class<? extends FloatSearchCriterion> c = e.getClass();
-        if (c == EqualsFloatSearchCriterion.class) {
-            EqualsFloatSearchCriterion r = (EqualsFloatSearchCriterion) e;
-            values.add(r.value);
-            sb.append(" " + col + " = ?");
-        }
-        else if (c == LessThanFloatSearchCriterion.class) {
-            LessThanFloatSearchCriterion r = (LessThanFloatSearchCriterion) e;
-            values.add(r.value);
-            sb.append(" " + col + "<=? ");
-        }
-        else if (c == GreaterThanFloatSearchCriterion.class) {
-            GreaterThanFloatSearchCriterion r = (GreaterThanFloatSearchCriterion) e;
-            values.add(r.value);
-            sb.append(" " + col + " >= ? ");
-        }
-        else if (c == InRangeFloatSearchCriterion.class) {
-            InRangeFloatSearchCriterion r = (InRangeFloatSearchCriterion) e;
-            values.add(r.min);
-            values.add(r.max);
-            sb.append(" (" + col +" >= ? AND " + col + " <= ?) ");
-        }
-        else {
-            throw new CriteriaException("Invalid criteria class used for memory range search: "
-                    + e.getClass().getCanonicalName());
-        }
+        sb.append(" " + col + "<=? ");
         chunks.add(sb);
+        values.add(criterion.getValue());
+    }
+
+    void addRangePhrase(String col, GreaterThanIntegerSearchCriterion criterion) {
+        StringBuilder sb = new StringBuilder(128);
+        sb.append(" " + col + " >= ? ");
+        chunks.add(sb);
+        values.add(criterion.getValue());
+    }
+
+    void addRangePhrase(String col, InRangeIntegerSearchCriterion criterion) {
+        StringBuilder sb = new StringBuilder(128);
+        sb.append(" " + col + " >= ? ");
+        chunks.add(sb);
+        values.add(criterion.getMin());
+        values.add(criterion.getMax());
+    }
+
+    void addRangePhrase(String col, EqualsFloatSearchCriterion criterion) {
+        StringBuilder sb = new StringBuilder(128);
+        sb.append(" " + col + " = ?");
+        chunks.add(sb);
+        values.add(criterion.getValue());
+    }
+
+    void addRangePhrase(String col, LessThanFloatSearchCriterion criterion) {
+        StringBuilder sb = new StringBuilder(128);
+        sb.append(" " + col + " <= ? ");
+        chunks.add(sb);
+        values.add(criterion.getValue());
+    }
+
+    void addRangePhrase(String col, GreaterThanFloatSearchCriterion criterion) {
+        StringBuilder sb = new StringBuilder(128);
+        sb.append(" " + col + " >= ? ");
+        chunks.add(sb);
+        values.add(criterion.getValue());
+    }
+
+    void addRangePhrase(String col, InRangeFloatSearchCriterion criterion) {
+        StringBuilder sb = new StringBuilder(128);
+        sb.append(" " + col + " >= ? ");
+        chunks.add(sb);
+        values.add(criterion.getMin());
+        values.add(criterion.getMax());
     }
 
     boolean isValid(String v) {

--- a/cue3bot/src/main/java/com/imageworks/spcue/dao/criteria/postgres/ProcSearch.java
+++ b/cue3bot/src/main/java/com/imageworks/spcue/dao/criteria/postgres/ProcSearch.java
@@ -21,17 +21,15 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import com.imageworks.common.SpiIce.GreaterThanIntegerSearchCriterion;
-import com.imageworks.common.SpiIce.InRangeIntegerSearchCriterion;
-import com.imageworks.common.SpiIce.IntegerSearchCriterion;
-import com.imageworks.common.SpiIce.LessThanIntegerSearchCriterion;
 import com.imageworks.spcue.GroupInterface;
 import com.imageworks.spcue.HostInterface;
 import com.imageworks.spcue.JobInterface;
-import com.imageworks.spcue.dao.criteria.CriteriaException;
 import com.imageworks.spcue.dao.criteria.Phrase;
 import com.imageworks.spcue.dao.criteria.ProcSearchInterface;
 import com.imageworks.spcue.dao.criteria.Sort;
+import com.imageworks.spcue.grpc.criterion.GreaterThanIntegerSearchCriterion;
+import com.imageworks.spcue.grpc.criterion.InRangeIntegerSearchCriterion;
+import com.imageworks.spcue.grpc.criterion.LessThanIntegerSearchCriterion;
 import com.imageworks.spcue.grpc.host.ProcSearchCriteria;
 
 public class ProcSearch extends Criteria implements ProcSearchInterface {
@@ -64,31 +62,26 @@ public class ProcSearch extends Criteria implements ProcSearchInterface {
         }
     }
 
-    public void filterByDurationRange(IntegerSearchCriterion criterion) {
+    public void filterByDurationRange(LessThanIntegerSearchCriterion criterion) {
         StringBuilder sb = new StringBuilder(128);
-        final Class<? extends IntegerSearchCriterion> c = criterion.getClass();
-
-        if (c == LessThanIntegerSearchCriterion.class) {
-            LessThanIntegerSearchCriterion r = (LessThanIntegerSearchCriterion) criterion;
-            values.add(r.value);
-            sb.append(" (find_duration(proc.ts_dispatched, null) <= ?) ");
-        }
-        else if (c == GreaterThanIntegerSearchCriterion.class) {
-            GreaterThanIntegerSearchCriterion r = (GreaterThanIntegerSearchCriterion) criterion;
-            values.add(r.value);
-            sb.append(" (find_duration(proc.ts_dispatched, null) >= ?) ");
-        }
-        else if (c == InRangeIntegerSearchCriterion.class) {
-            InRangeIntegerSearchCriterion r = (InRangeIntegerSearchCriterion) criterion;
-            values.add(r.min);
-            values.add(r.max);
-            sb.append(" (find_duration(proc.ts_dispatched, null) BETWEEN ? AND ? )");
-        }
-        else {
-            throw new CriteriaException("Invalid criteria class used for duration range search: "
-                    + criterion.getClass().getCanonicalName());
-        }
+        sb.append(" (find_duration(proc.ts_dispatched, null) <= ?) ");
         chunks.add(sb);
+        values.add(criterion.getValue());
+    }
+
+    public void filterByDurationRange(GreaterThanIntegerSearchCriterion criterion) {
+        StringBuilder sb = new StringBuilder(128);
+        sb.append(" (find_duration(proc.ts_dispatched, null) >= ?) ");
+        chunks.add(sb);
+        values.add(criterion.getValue());
+    }
+
+    public void filterByDurationRange(InRangeIntegerSearchCriterion criterion) {
+        StringBuilder sb = new StringBuilder(128);
+        sb.append(" (find_duration(proc.ts_dispatched, null) BETWEEN ? AND ? )");
+        chunks.add(sb);
+        values.add(criterion.getMin());
+        values.add(criterion.getMax());
     }
 
     public void filterByHost(HostInterface host) {
@@ -118,14 +111,12 @@ public class ProcSearch extends Criteria implements ProcSearchInterface {
         addPhrase("show.str_name", criteria.getShowsList());
         addPhrase("alloc.str_name", criteria.getAllocsList());
 
-        // TODO(gdenton) Reimplement the Criterion objects in grpc (b/119788753)
-        // if (criteria.getMemoryRangeCount() > 0) {
-        //     addRangePhrase("proc.int_mem_reserved", criteria.getMemoryRange(0));
-        // }
-        //
-        // if (criteria.getDurationRangeCount() > 0) {
-        //     addDurationRange(criteria.getDurationRange(0));
-        // }
+        if (criteria.getMemoryRangeCount() > 0) {
+            addRangePhrase("proc.int_mem_reserved", criteria.getMemoryRange(0));
+        }
+        if (criteria.getDurationRangeCount() > 0) {
+            filterByDurationRange(criteria.getDurationRange(0));
+        }
 
         setFirstResult(criteria.getFirstResult());
         if (criteria.getMaxResultsCount() > 0) {

--- a/cue3bot/src/main/proto/criterion.proto
+++ b/cue3bot/src/main/proto/criterion.proto
@@ -7,6 +7,14 @@ option java_multiple_files = true;
 
 // -------- Primary Message Types --------]
 
+message EqualsFloatSearchCriterion {
+    float value = 1;
+}
+
+message EqualsIntegerSearchCriterion {
+    int32 value = 1;
+}
+
 message GreaterThanFloatSearchCriterion {
     float value = 1;
 }

--- a/cue3bot/src/main/proto/host.proto
+++ b/cue3bot/src/main/proto/host.proto
@@ -6,6 +6,7 @@ option java_package = "com.imageworks.spcue.grpc.host";
 option java_multiple_files = true;
 
 import "comment.proto";
+import "criterion.proto";
 import "job.proto";
 import "renderPartition.proto";
 
@@ -393,11 +394,11 @@ message ProcSearchCriteria {
     // An array of allocation names to match.
     repeated string allocs = 5;
 
-    // A range of memory usage.  Ranges should be in the format "x-y"  Values are in KB.
-    repeated string memory_range = 6;
+    // A range of memory usage. Values are in KB.
+    repeated criterion.InRangeIntegerSearchCriterion memory_range = 6;
 
-    // A duration range.  Ranges should be in the format "x-y". Values are in seconds.
-    repeated string duration_range = 7;
+    // A duration range. Values are in seconds.
+    repeated criterion.InRangeIntegerSearchCriterion duration_range = 7;
 
     //The maximum number of results.
     repeated int32 max_results = 8;


### PR DESCRIPTION
Some of the other `*SearchCriteria` classes use strings where they should probably use `*SearchCriterion` instead, but I chose to leave those be for now - no need to fix things that aren't broken.