### PR TITLE
Cuebot bug fixes

### DIFF
--- a/cue3bot/src/main/java/com/imageworks/spcue/servant/ManageJob.java
+++ b/cue3bot/src/main/java/com/imageworks/spcue/servant/ManageJob.java
@@ -116,6 +116,7 @@ import com.imageworks.spcue.grpc.job.JobRetryFramesResponse;
 import com.imageworks.spcue.grpc.job.JobRunFiltersRequest;
 import com.imageworks.spcue.grpc.job.JobRunFiltersResponse;
 import com.imageworks.spcue.grpc.job.JobSearchCriteria;
+import com.imageworks.spcue.grpc.job.JobSeq;
 import com.imageworks.spcue.grpc.job.JobSetAutoEatRequest;
 import com.imageworks.spcue.grpc.job.JobSetAutoEatResponse;
 import com.imageworks.spcue.grpc.job.JobSetGroupRequest;
@@ -246,14 +247,13 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
                                   StreamObserver<JobLaunchSpecAndWaitResponse> responseObserver) {
         JobSpec spec = jobLauncher.parse(request.getSpec());
         jobLauncher.launch(spec);
-        JobSearchCriteria r = JobSearchInterface.criteriaFactory();
-        JobSearchCriteria.Builder builder = r.toBuilder();
-        for (BuildableJob job: spec.getJobs()) {
-            builder.addIds((job.detail.id)).build();
+        JobSeq.Builder jobSeqBuilder = JobSeq.newBuilder();
+        for (BuildableJob j: spec.getJobs()) {
+            jobSeqBuilder.addJobs(whiteboard.findJob(j.detail.name));
         }
-        r = builder.build();
+
         responseObserver.onNext(JobLaunchSpecAndWaitResponse.newBuilder()
-                .setJobs(whiteboard.getJobs(jobSearchFactory.create(r)))
+                .setJobs(jobSeqBuilder.build())
                 .build());
         responseObserver.onCompleted();
     }

--- a/cue3bot/src/main/java/com/imageworks/spcue/servant/ManageService.java
+++ b/cue3bot/src/main/java/com/imageworks/spcue/servant/ManageService.java
@@ -102,6 +102,14 @@ public class ManageService extends ServiceInterfaceGrpc.ServiceInterfaceImplBase
         this.serviceManager = serviceManager;
     }
 
+    public Whiteboard getWhiteboard() {
+        return whiteboard;
+    }
+
+    public void setWhiteboard(Whiteboard whiteboard) {
+        this.whiteboard = whiteboard;
+    }
+
     private ServiceEntity toServiceEntity(Service service) {
         ServiceEntity entity = new ServiceEntity();
         entity.id = service.getId();

--- a/cue3bot/src/main/resources/conf/spring/applicationContext-grpc.xml
+++ b/cue3bot/src/main/resources/conf/spring/applicationContext-grpc.xml
@@ -159,6 +159,7 @@
 
     <bean scope="prototype" id="manageService" class="com.imageworks.spcue.servant.ManageService">
         <property name="serviceManager" ref="serviceManager" />
+        <property name="whiteboard" ref="whiteboard" />
     </bean>
 
     <bean scope="prototype" id="manageServiceOverride" class="com.imageworks.spcue.servant.ManageServiceOverride">


### PR DESCRIPTION
ManageService bean was missing whiteboard, causing problems when trying to retrieve services.
LaunchSpecAndWait was returning an empty list of jobs due to the ids never being populated. Instead return the job objects by looking them up by name.