### PR TITLE
Some small cuebot bug fixes

### DIFF
--- a/cue3bot/src/main/java/com/imageworks/spcue/dao/criteria/postgres/Criteria.java
+++ b/cue3bot/src/main/java/com/imageworks/spcue/dao/criteria/postgres/Criteria.java
@@ -200,7 +200,7 @@ public abstract class Criteria implements CriteriaInterface {
         StringBuilder sb = new StringBuilder(1024);
         sb.append("(");
         for (String w: s) {
-            sb.append(String.format("REGEXP_LIKE(%s,?)", col));
+            sb.append(String.format("%s ~ ?", col));
             sb.append(" OR ");
             values.add(w);
         }

--- a/cue3bot/src/main/java/com/imageworks/spcue/dao/criteria/postgres/JobSearch.java
+++ b/cue3bot/src/main/java/com/imageworks/spcue/dao/criteria/postgres/JobSearch.java
@@ -55,7 +55,7 @@ public final class JobSearch extends Criteria implements JobSearchInterface {
         addPhrase("show.str_name", criteria.getShowsList());
         addPhrase("job.str_user", criteria.getUsersList());
         if (!criteria.getIncludeFinished()) {
-            addPhrase("job.str_state", "Pending");
+            addPhrase("job.str_state", "PENDING");
         }
     }
 }

--- a/cue3bot/src/main/java/com/imageworks/spcue/dao/postgres/WhiteboardDaoJdbc.java
+++ b/cue3bot/src/main/java/com/imageworks/spcue/dao/postgres/WhiteboardDaoJdbc.java
@@ -1089,7 +1089,8 @@ public class WhiteboardDaoJdbc extends JdbcDaoSupport implements WhiteboardDao {
             new RowMapper<Job>() {
                 public Job mapRow(ResultSet rs, int rowNum) throws SQLException {
                     Job.Builder jobBuilder = Job.newBuilder()
-                            .setLogDir(SqlUtil.getString(rs,"str_log_dir"))
+                            .setId(SqlUtil.getString(rs, "pk_job"))
+                            .setLogDir(SqlUtil.getString(rs, "str_log_dir"))
                             .setMaxCores(Convert.coreUnitsToCores(rs.getInt("int_max_cores")))
                             .setMinCores(Convert.coreUnitsToCores(rs.getInt("int_min_cores")))
                             .setName(SqlUtil.getString(rs,"str_name"))


### PR DESCRIPTION
* Criteria.java
Postgres does not support REGEX_LIKE.

* JobSearch.java
Constants should be uppercase by grpc conventions.

* WhiteboardDaoJdbc.java
Making sure that the id parameter is added to job mapper. Jobs were being returned missing their id value.