### PR TITLE
close and delete grpc channel when quitting

### DIFF
--- a/pycue/Cue3/cuebot.py
+++ b/pycue/Cue3/cuebot.py
@@ -153,10 +153,18 @@ class Cuebot:
             except Exception:
                 logger.warning('Could not establish grpc channel with {}.'.format(connect_str))
                 continue
-            atexit.register(Cuebot.RpcChannel.close)
+            atexit.register(Cuebot.closeChannel)
             return None
         raise CueException('No grpc connection could be established. ' +
                            'Please check configured cuebot hosts.')
+
+    @staticmethod
+    def closeChannel():
+        """Close the gRPC channel, delete it and reset it to None."""
+        if Cuebot.RpcChannel is not None:
+            Cuebot.RpcChannel.close()
+            del Cuebot.RpcChannel
+            Cuebot.RpcChannel = None
 
     @staticmethod
     def setFacility(facility):


### PR DESCRIPTION
We need to close and delete the grpc channel object when quitting from pycue to stop the `Exception AttributeError: "'NoneType' object has no attribute 'fork_unregister_channel'" in <bound method Channel.__del__ of <grpc._channel.Channel object at 0x1045072d0>> ignored` error message from surfacing in the shell.