### PR TITLE
Clean up PyCue config yaml setup.

### DIFF
--- a/pycue/opencue/cuebot.py
+++ b/pycue/opencue/cuebot.py
@@ -52,14 +52,13 @@ __all__ = ["Cuebot"]
 
 logger = logging.getLogger("opencue")
 
+default_config = os.path.join(os.path.dirname(__file__), 'default.yaml')
+config = yaml.load(open(default_config).read())
+
 # check for facility specific configurations.
 fcnf = os.environ.get('OPENCUE_CONF', '')
-
 if os.path.exists(fcnf):
-    config = yaml.load(open(fcnf).read())
-else:
-    default_config = os.path.join(os.path.dirname(__file__), 'default.yaml')
-    config = yaml.load(open(default_config).read())
+    config.update(yaml.load(open(fcnf).read()))
 
 
 class Cuebot:
@@ -144,8 +143,10 @@ class Cuebot:
         """Sets the gRPC channel connection"""
         # gRPC must specify a single host.
         for host in Cuebot.Hosts:
-            hostname = host.split(':')[0]
-            connect_str = '%s:%s' % (hostname, config.get('cuebot.grpc_port', 8443))
+            if ':' in host:
+                connect_str = host
+            else:
+                connect_str = '%s:%s' % (host, config.get('cuebot.grpc_port', 8443))
             logger.debug('connecting to gRPC at %s', connect_str)
             # TODO(cipriano) Configure gRPC TLS.
             try:

--- a/pycue/opencue/default.yaml
+++ b/pycue/opencue/default.yaml
@@ -1,11 +1,10 @@
-# Default pycue config file
+# Default PyCue config file
 
 # Logger
 logger.format: "%(levelname)-9s %(module)-10s %(message)s"
 logger.level: WARNING
 
 # Cuebot Network Settings
-cuebot.port: 9019
 cuebot.protocol: tcp
 cuebot.grpc_port: 8443
 cuebot.timeout: 10000
@@ -13,12 +12,9 @@ cuebot.timeout: 10000
 cuebot.facility_default: lax
 cuebot.facility:
     dev:
-        - cuetest02-vm.spimageworks.com:9019
+        - cuetest02-vm.example.com:8443
     lax:
-        - cuebot1.spimageworks.com:9019
-        - cuebot2.spimageworks.com:9019
-        - cuebot3.spimageworks.com:9019
-    maa:
-        - cuebot1-vm.maa.spimageworks.com:9019
-        - cuebot2-vm.maa.spimageworks.com:9019
+        - cuebot1.example.com:8443
+        - cuebot2.example.com:8443
+        - cuebot3.example.com:8443
 


### PR DESCRIPTION
Fixes https://github.com/imageworks/OpenCue/issues/60

- Clean up default.yaml
- If custom yaml values are defined, merge them with the defaults. This way users don't have to override every single value - things like ports they probably won't care about.
- Change the pycue code to make use of the port numbers from the config yaml - those old ICE ports weren't being used so I repurposed them to be the GRPC ports