### PR TITLE
Clean up to PyCue and RQD packaging.

### DIFF
--- a/pycue/.gitignore
+++ b/pycue/.gitignore
@@ -1,0 +1,3 @@
+/build/
+/dist/
+/pycue.egg-info/

--- a/pycue/setup.py
+++ b/pycue/setup.py
@@ -18,8 +18,15 @@ from setuptools import setup
 
 pycue_dir = os.path.abspath(os.path.dirname(__file__))
 
-with open(os.path.join(pycue_dir, 'VERSION')) as fp:
-    version = fp.read().strip()
+version = 'unknown'
+possible_version_paths = [
+    os.path.join(pycue_dir, 'VERSION'),
+    os.path.join(os.path.dirname(pycue_dir), 'VERSION'),
+]
+for possible_version_path in possible_version_paths:
+    if os.path.exists(possible_version_path):
+        with open(possible_version_path) as fp:
+            version = fp.read().strip()
 
 with open(os.path.join(pycue_dir, 'README.md')) as fp:
     long_description = fp.read()

--- a/rqd/.gitignore
+++ b/rqd/.gitignore
@@ -1,3 +1,3 @@
-/venv
-*.pyc
-/src/slice/
+/build/
+/dist/
+/rqd.egg-info/

--- a/rqd/setup.py
+++ b/rqd/setup.py
@@ -17,8 +17,15 @@ from setuptools import setup
 
 rqd_dir = os.path.abspath(os.path.dirname(__file__))
 
-with open(os.path.join(rqd_dir, 'VERSION')) as fp:
-    version = fp.read().strip()
+version = 'unknown'
+possible_version_paths = [
+    os.path.join(rqd_dir, 'VERSION'),
+    os.path.join(os.path.dirname(rqd_dir), 'VERSION'),
+]
+for possible_version_path in possible_version_paths:
+    if os.path.exists(possible_version_path):
+        with open(possible_version_path) as fp:
+            version = fp.read().strip()
 
 with open(os.path.join(rqd_dir, 'README.md')) as fp:
     long_description = fp.read()


### PR DESCRIPTION
- Ignore some artifacts left over when you run `setup.py`.
- Update the `VERSION` finding code. That file can exist either in the top-level directory (if installing from source) or the component-level directory (if installing from a published artifact).