### PR TITLE
Set a default value for pyoutline sessions.

### DIFF
--- a/pyoutline/etc/outline.cfg
+++ b/pyoutline/etc/outline.cfg
@@ -1,6 +1,6 @@
 [outline]
 home =
-session_dir =
+session_dir = {HOME}/.opencue/sessions
 wrapper_dir = %(home)s/wrappers
 user_dir =
 bin_dir = %(home)s/bin

--- a/pyoutline/src/outline/session.py
+++ b/pyoutline/src/outline/session.py
@@ -99,8 +99,10 @@ class Session(object):
             # The base dir is where we copy the outline and
             # store session data.
             base_path = config.get("outline", "session_dir")
-            base_path = base_path % {"SHOW": util.get_show(),
-                                     "SHOT": util.get_shot()}
+            base_path = base_path.format(
+                HOME=os.path.expanduser("~"),
+                SHOW=util.get_show(),
+                SHOT=util.get_shot())
             base_path =  os.path.join(base_path, self.__name)
 
             # If the base dir doesn't exist, create it.  Be sure


### PR DESCRIPTION
The `%()s` style of string formatting is also used by the config parser so they conflict.

We'll need to update the rest of the config values to follow a similar format but there's no point doing this until we do the larger scale config cleanup.