### PR TITLE
Adding missing wrapper function for RegisterOutputPath

### DIFF
--- a/cuebot/README.md
+++ b/cuebot/README.md
@@ -41,4 +41,3 @@ NOTE: Only OpenCue developers will need to do this setup. If you just want to us
 
 View > Tool Windows > Gradle. Refresh the Gradle project and run the build task, which will
 run compilation and tests.
-

--- a/pycue/opencue/wrappers/layer.py
+++ b/pycue/opencue/wrappers/layer.py
@@ -204,6 +204,15 @@ class Layer(object):
     #     @param kill: wheather or not to kill the frames as well"""
     #     self.proxy.unbookProcs([a.proxy for a in subs], number, kill)
 
+    def registerOutputPath(self, outputPath):
+        """Register an output with the given layer. The output paths are sent in the opencue email.
+        @type outputPath: str
+        @param outputPath: Output path to register
+        """
+        self.stub.RegisterOutputPath(
+            job_pb2.LayerRegisterOutputPathRequest(layer=self.data, spec=outputPath),
+            timeout=Cuebot.Timeout)
+
     def reorderFrames(self, range, order):
         """Reorders the specified frame range on this layer.
         @type  range: string

--- a/pycue/tests/wrappers/layer_test.py
+++ b/pycue/tests/wrappers/layer_test.py
@@ -317,6 +317,20 @@ class LayerTests(unittest.TestCase):
             timeout=mock.ANY)
         self.assertEqual(depend.id(), dependId)
 
+    def testRegisterOutputPath(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.RegisterOutputPath.return_value = job_pb2.LayerRegisterOutputPathResponse()
+        getStubMock.return_value = stubMock
+
+        outputPath = '/test/output/path'
+        layer = opencue.wrappers.layer.Layer(
+            job_pb2.Layer(name=TEST_LAYER_NAME))
+        layer.registerOutputPath(outputPath)
+
+        stubMock.RegisterOutputPath.assert_called_with(
+            job_pb2.LayerRegisterOutputPathRequest(layer=layer.data, spec=outputPath),
+            timeout=mock.ANY)
+
     def testReorderFrames(self, getStubMock):
         stubMock = mock.Mock()
         stubMock.ReorderFrames.return_value = job_pb2.LayerReorderFramesResponse()


### PR DESCRIPTION
The protos defined the RegisterOutputPath function but it was not exposed in the Layer pycue wrapper.