### PR TITLE
Ensure ElementTree.SubElement receives a str #368

### DIFF
--- a/pyoutline/outline/backend/cue.py
+++ b/pyoutline/outline/backend/cue.py
@@ -345,7 +345,7 @@ def build_dependencies(ol, layer, all_depends):
 
         depend = Et.SubElement(all_depends, "depend",
                                type=dep.get_type(),
-                               anyframe=str(dep.is_any_frame()))
+                               anyframe=bool_to_str(dep.is_any_frame()))
 
         if dep.get_type() == DependType.LayerOnSimFrame:
 


### PR DESCRIPTION
Fix for job submit error on jobs with dependencies:
```bash
Failed to parse job spec XML, org.jdom.input.JDOMParseException: Error on line 1: Attribute value "b'False'" of type NMTOKEN must be a name token.
```

Resulting in bad 'anyframe' value:
```xml
<depends>
  <depend anyframe="b'False'" type="LAYER_ON_LAYER">
    <depjob>b858be71-6467-4e00-997a-824b32fb0e0c</depjob
    <deplayer>MyTaskNameTwoB</deplayer>
    <onjob>b858be71-6467-4e00-997a-824b32fb0e0c</onjob>
    <onlayer>MyTaskNameOneA</onlayer>
  </depend>
</depends>
```