### PR TITLE
Update HostSearch to return wrapped objects instead of Response class.

### DIFF
--- a/pycue/opencue/api.py
+++ b/pycue/opencue/api.py
@@ -469,8 +469,7 @@ def getHosts(**options):
     @rtype:  List<Host>
     @return: a list of hosts
     """
-    hostSeq = search.HostSearch.byOptions(**options).hosts
-    return [Host(h) for h in hostSeq.hosts]
+    return search.HostSearch.byOptions(**options)
 
 
 @util.grpcExceptionParser

--- a/pycue/opencue/search.py
+++ b/pycue/opencue/search.py
@@ -56,6 +56,7 @@ import six
 from opencue.compiled_proto import criterion_pb2
 from opencue.compiled_proto import host_pb2
 from opencue.compiled_proto import job_pb2
+import opencue.wrappers.host
 from .cuebot import Cuebot
 
 logger = logging.getLogger("opencue")
@@ -134,8 +135,9 @@ class HostSearch(BaseSearch):
     @classmethod
     def byOptions(cls, **options):
         criteria = cls.criteriaFromOptions(**options)
-        return Cuebot.getStub('host').GetHosts(
-            host_pb2.HostGetHostsRequest(r=criteria), timeout=Cuebot.Timeout)
+        return [
+            opencue.wrappers.host.Host(host) for host in Cuebot.getStub('host').GetHosts(
+                host_pb2.HostGetHostsRequest(r=criteria), timeout=Cuebot.Timeout).hosts.hosts]
 
     @classmethod
     def byName(cls, val):

--- a/pycue/tests/search_test.py
+++ b/pycue/tests/search_test.py
@@ -48,6 +48,7 @@ class JobSearchTests(unittest.TestCase):
 
     def testBaseSearchHost(self, getStubMock):
         stubMock = mock.Mock()
+        stubMock.GetHosts.return_value = host_pb2.HostGetHostsResponse()
         getStubMock.return_value = stubMock
 
         hostSearch = opencue.search.HostSearch(substr=['unittest_host'])


### PR DESCRIPTION
Fixes #371 

Bring `HostSearch` in line with our current policy of converting gRPC responses to wrapper classes as soon as possible on reception.

Host searching is used in two places:

1. CueAdmin, when using the `-host` flag. This code appears to already have expected wrapped classes (see bug report in linked bug). Unit tests were passing because the mocked response from `HostSearch` assumed this as well.
1. CueGUI, in the Monitor Hosts panel. In this case the search was happening by way of `opencue.api.getHosts`, which was wrapping the response itself. This downstream wrapping is no longer needed.
