### PR TITLE
Add Blender as an option to cuesubmit

### DIFF
--- a/cuesubmit/cuesubmit/Constants.py
+++ b/cuesubmit/cuesubmit/Constants.py
@@ -31,8 +31,8 @@ NUKE_RENDER_CMD = config.get('NUKE_RENDER_CMD', 'nuke')
 BLENDER_RENDER_CMD = config.get('BLENDER_RENDER_CMD', 'blender')
 FRAME_TOKEN = config.get('FRAME_TOKEN', '#IFRAME#')
 
-BLENDER_FORMATS = ['AVIJPEG', 'AVIRAW', 'BMP', 'CINEON', 'DPX', 'EXR', 'HDR', 'IRIS', 'IRIZ', 'JP2',
-                   'JPEG', 'MPEG', 'MULTILAYER', 'PNG', 'RAWTGA', 'TGA', 'TIFF']
+BLENDER_FORMATS = ['', 'AVIJPEG', 'AVIRAW', 'BMP', 'CINEON', 'DPX', 'EXR', 'HDR', 'IRIS', 'IRIZ',
+                   'JP2', 'JPEG', 'MPEG', 'MULTILAYER', 'PNG', 'RAWTGA', 'TGA', 'TIFF']
 BLENDER_OUTPUT_OPTIONS_URL = \
   'https://docs.blender.org/manual/en/latest/advanced/command_line/arguments.html#render-options'
 

--- a/cuesubmit/cuesubmit/Constants.py
+++ b/cuesubmit/cuesubmit/Constants.py
@@ -28,6 +28,12 @@ SUBMIT_APP_WINDOW_TITLE = config.get('SUBMIT_APP_WINDOW_TITLE', 'OpenCue Submit'
 
 MAYA_RENDER_CMD = config.get('MAYA_RENDER_CMD', 'Render')
 NUKE_RENDER_CMD = config.get('NUKE_RENDER_CMD', 'nuke')
+BLENDER_RENDER_CMD = config.get('BLENDER_RENDER_CMD', 'blender')
 FRAME_TOKEN = config.get('FRAME_TOKEN', '#IFRAME#')
+
+BLENDER_FORMATS = ['AVIJPEG', 'AVIRAW', 'BMP', 'CINEON', 'DPX', 'EXR', 'HDR', 'IRIS', 'IRIZ', 'JP2',
+                   'JPEG', 'MPEG', 'MULTILAYER', 'PNG', 'RAWTGA', 'TGA', 'TIFF']
+BLENDER_OUTPUT_OPTIONS_URL = \
+  'https://docs.blender.org/manual/en/latest/advanced/command_line/arguments.html#render-options'
 
 DIR_PATH = os.path.dirname(__file__)

--- a/cuesubmit/cuesubmit/JobTypes.py
+++ b/cuesubmit/cuesubmit/JobTypes.py
@@ -25,11 +25,13 @@ class JobTypes(object):
     SHELL = 'Shell'
     MAYA = 'Maya'
     NUKE = 'Nuke'
+    BLENDER = 'Blender'
 
     SETTINGS_MAP = {
         SHELL: SettingsWidgets.ShellSettings,
         MAYA: SettingsWidgets.BaseMayaSettings,
-        NUKE: SettingsWidgets.BaseNukeSettings
+        NUKE: SettingsWidgets.BaseNukeSettings,
+        BLENDER: SettingsWidgets.BaseBlenderSettings
     }
 
     def __init__(self):
@@ -43,4 +45,4 @@ class JobTypes(object):
     @classmethod
     def types(cls):
         """return a list of types available."""
-        return [cls.SHELL, cls.MAYA, cls.NUKE]
+        return [cls.SHELL, cls.MAYA, cls.NUKE, cls.BLENDER]

--- a/cuesubmit/cuesubmit/JobTypes.py
+++ b/cuesubmit/cuesubmit/JobTypes.py
@@ -31,7 +31,7 @@ class JobTypes(object):
         SHELL: SettingsWidgets.ShellSettings,
         MAYA: SettingsWidgets.BaseMayaSettings,
         NUKE: SettingsWidgets.BaseNukeSettings,
-        BLENDER: SettingsWidgets.BaseBlenderSettings
+        BLENDER: SettingsWidgets.BaseBlenderSettings,
     }
 
     def __init__(self):

--- a/cuesubmit/cuesubmit/Submission.py
+++ b/cuesubmit/cuesubmit/Submission.py
@@ -47,6 +47,23 @@ def buildNukeCmd(layerData):
     renderCommand += '-x {}'.format(nukeFile)
     return renderCommand
 
+def buildBlenderCmd(layerData):
+    """From a layer, build a Blender render command."""
+    blenderFile = layerData.cmd.get('blenderFile')
+    outputPath = layerData.cmd.get('outputPath')
+    outputFormat = layerData.cmd.get('outputFormat')
+    if not blenderFile:
+        raise ValueError('No Blender file provided. Cannot submit job.')
+    
+    renderCommand = '{renderCmd} -b -noaudio {blenderFile} -f {frameToken}'.format(
+        renderCmd=Constants.BLENDER_RENDER_CMD, blenderFile=blenderFile,
+        frameToken=Constants.FRAME_TOKEN)
+    if outputPath:
+        renderCommand += ' -o {}'.format(outputPath)
+    if outputFormat:
+        renderCommand += ' -F {}'.format(outputFormat)
+    return renderCommand
+
 
 def buildLayer(layerData, command, lastLayer=None):
     """Create a PyOutline Layer for the given layerData.
@@ -84,6 +101,10 @@ def buildNukeLayer(layerData, lastLayer):
     return buildLayer(layerData, nukeCmd, lastLayer)
 
 
+def buildBlenderLayer(layerData, lastLayer):
+    blenderCmd = buildBlenderCmd(layerData)
+    return buildLayer(layerData, blenderCmd, lastLayer)
+
 def buildShellLayer(layerData, lastLayer):
     return buildLayer(layerData, layerData.cmd['commandTextBox'], lastLayer)
 
@@ -100,6 +121,8 @@ def submitJob(jobData):
             layer = buildShellLayer(layerData, lastLayer)
         elif layerData.layerType == JobTypes.JobTypes.NUKE:
             layer = buildNukeLayer(layerData, lastLayer)
+        elif layerData.layerType == JobTypes.JobTypes.BLENDER:
+            layer = buildBlenderLayer(layerData, lastLayer)
         else:
             raise ValueError('unrecognized layer type %s' % layerData.layerType)
         outline.add_layer(layer)

--- a/cuesubmit/cuesubmit/ui/SettingsWidgets.py
+++ b/cuesubmit/cuesubmit/ui/SettingsWidgets.py
@@ -160,12 +160,12 @@ class BaseBlenderSettings(BaseSettingsWidget):
         super(BaseBlenderSettings, self).__init__(parent=parent)
         self.fileInput = Widgets.CueLabelLineEdit('Blender File:')
         self.outputPath = Widgets.CueLabelLineEdit(
-            'Output Path:',
+            'Output Path (Optional):',
             tooltip='Optionally set the rendered output format. '
                     'See the "-o" flag of {} for more info.'.format(
                             Constants.BLENDER_OUTPUT_OPTIONS_URL))
         self.outputSelector = Widgets.CueSelectPulldown(
-            'Output Format (Optional)', options=Constants.BLENDER_FORMATS)
+            'Output Format', options=Constants.BLENDER_FORMATS)
         self.outputLayout = QtWidgets.QHBoxLayout()
         self.setupUi()
         self.setupConnections()

--- a/cuesubmit/cuesubmit/ui/SettingsWidgets.py
+++ b/cuesubmit/cuesubmit/ui/SettingsWidgets.py
@@ -96,7 +96,7 @@ class InNukeSettings(BaseSettingsWidget):
 
     def setCommandData(self, commandData):
         self.fileInput.setText(commandData.get('nukeFile', ''))
-        self.cameraSelector.setChecked(commandData.get('camera', '').split(','))
+        self.writeNodeSelector.setChecked(commandData.get('writeNodes', '').split(','))
 
     def getCommandData(self):
         return {
@@ -165,7 +165,7 @@ class BaseBlenderSettings(BaseSettingsWidget):
                     'See the "-o" flag of {} for more info.'.format(
                             Constants.BLENDER_OUTPUT_OPTIONS_URL))
         self.outputSelector = Widgets.CueSelectPulldown(
-            'Output Format', options=Constants.BLENDER_FORMATS)
+            'Output Format', options=Constants.BLENDER_FORMATS, multiselect=False)
         self.outputLayout = QtWidgets.QHBoxLayout()
         self.setupUi()
         self.setupConnections()
@@ -178,9 +178,12 @@ class BaseBlenderSettings(BaseSettingsWidget):
     
     def setupConnections(self):
         self.fileInput.lineEdit.textChanged.connect(self.dataChanged.emit)
-    
+        self.outputPath.lineEdit.textChanged.connect(self.dataChanged.emit)
+      
     def setCommandData(self, commandData):
         self.fileInput.setText(commandData.get('nukeFile', ''))
+        self.outputPath.setText(commandData.get('outputPath', ''))
+        self.outputSelector.setChecked(commandData.get('outputFormat', ''))
     
     def getCommandData(self):
         return {

--- a/cuesubmit/cuesubmit/ui/SettingsWidgets.py
+++ b/cuesubmit/cuesubmit/ui/SettingsWidgets.py
@@ -1,6 +1,7 @@
 
 from PySide2 import QtCore, QtWidgets
 
+from cuesubmit import Constants
 from cuesubmit.ui import Command
 from cuesubmit.ui import Widgets
 
@@ -150,3 +151,40 @@ class ShellSettings(BaseSettingsWidget):
 
     def setCommandData(self, commandData):
         self.commandTextBox.setText(commandData.get('commandTextBox', ''))
+
+
+class BaseBlenderSettings(BaseSettingsWidget):
+    """Standard Blender settings widget to be used from outside Blender."""
+
+    def __init__(self, parent=None, *args, **kwargs):
+        super(BaseBlenderSettings, self).__init__(parent=parent)
+        self.fileInput = Widgets.CueLabelLineEdit('Blender File:')
+        self.outputPath = Widgets.CueLabelLineEdit(
+            'Output Path:',
+            tooltip='Optionally set the rendered output format. '
+                    'See the "-o" flag of {} for more info.'.format(
+                            Constants.BLENDER_OUTPUT_OPTIONS_URL))
+        self.outputSelector = Widgets.CueSelectPulldown(
+            'Output Format (Optional)', options=Constants.BLENDER_FORMATS)
+        self.outputLayout = QtWidgets.QHBoxLayout()
+        self.setupUi()
+        self.setupConnections()
+    
+    def setupUi(self):
+        self.mainLayout.addWidget(self.fileInput)
+        self.mainLayout.addLayout(self.outputLayout)
+        self.outputLayout.addWidget(self.outputPath)
+        self.outputLayout.addWidget(self.outputSelector)
+    
+    def setupConnections(self):
+        self.fileInput.lineEdit.textChanged.connect(self.dataChanged.emit)
+    
+    def setCommandData(self, commandData):
+        self.fileInput.setText(commandData.get('nukeFile', ''))
+    
+    def getCommandData(self):
+        return {
+            'blenderFile': self.fileInput.text(),
+            'outputPath': self.outputPath.text(),
+            'outputFormat': self.outputSelector.text()
+        }


### PR DESCRIPTION
Basic solution for #312.

This adds "Blender" as an option in the cuesubmit job types dropdown. It does not include a dedicated Blender plugin.  Available options include, setting blender file name, setting output name and format.

![Screen Shot 2019-07-17 at 5 39 41 PM](https://user-images.githubusercontent.com/2965608/61421008-fdae8580-a8b9-11e9-8e48-91e6c2353eb2.png)
