### PR TITLE
Build pipeline improvements

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,13 +36,11 @@ jobs:
       displayName: 'Cuebot'
       artifactPath: '/opt/opencue/cuebot-$(setBuildId.buildId)-all.jar'
 
-  - bash: |
-      docker build -t opencue/rqd:$(setBuildId.buildId) -f rqd/Dockerfile .
-      container_id=$(docker create opencue/rqd:$(setBuildId.buildId))
-      docker cp $container_id:/opt/opencue/rqd-$(setBuildId.buildId)-all.tar.gz "$(ARTIFACT_DIRECTORY)/"
-      docker rm $container_id
-    name: rqd
-    displayName: Build and Test RQD
+  - template: ci/templates/build_docker.yml
+    parameters:
+      imageName: 'rqd'
+      displayName: 'RQD'
+      artifactPath: '/opt/opencue/rqd-$(setBuildId.buildId)-all.tar.gz'
 
   - bash: |
       docker build -t opencue/pycue:$(setBuildId.buildId) -f pycue/Dockerfile .

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,7 @@ jobs:
       branch_name=${SYSTEM_PULLREQUEST_SOURCEBRANCH:-$BUILD_SOURCEBRANCHNAME}
       build_image_id="opencuebuild/cuebot:$(setBuildId.buildId)"
       branch_image_id="opencuebuild/cuebot:${branch_name}"
+      docker pull centos:7
       docker pull $branch_image_id && docker tag $branch_image_id $build_image_id || true
       docker build -t $build_image_id -f cuebot/Dockerfile .
       docker tag $build_image_id $branch_image_id

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,20 +30,11 @@ jobs:
     name: createArtifactDirectory
     displayName: Create Artifact Directory
 
-  - bash: |
-      branch_name=${SYSTEM_PULLREQUEST_SOURCEBRANCH:-$BUILD_SOURCEBRANCHNAME}
-      build_image_id="opencuebuild/cuebot:$(setBuildId.buildId)"
-      branch_image_id="opencuebuild/cuebot:${branch_name}"
-      docker pull $branch_image_id || true
-      docker build --cache-from $branch_image_id -t $build_image_id -f cuebot/Dockerfile .
-      docker tag $build_image_id $branch_image_id
-      docker push $build_image_id
-      docker push $branch_image_id
-      container_id=$(docker create ${build_image_id})
-      docker cp $container_id:/opt/opencue/cuebot-$(setBuildId.buildId)-all.jar "$(ARTIFACT_DIRECTORY)/"
-      docker rm $container_id
-    name: cuebot
-    displayName: Build and Test Cuebot
+  - template: ci/templates/build_docker.yml
+    parameters:
+      imageName: 'cuebot'
+      displayName: 'Cuebot'
+      artifactPath: '/opt/opencue/cuebot-$(setBuildId.buildId)-all.jar'
 
   - bash: |
       docker build -t opencue/rqd:$(setBuildId.buildId) -f rqd/Dockerfile .

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,7 @@ jobs:
     vmImage: 'ubuntu-16.04'
   steps:
   - bash: |
+      set -e
       ci/generate_version_number.sh > VERSION
       echo "##vso[task.setvariable variable=buildId;isOutput=true]$(cat ./VERSION)"
     name: setBuildId

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,45 +43,35 @@ jobs:
       displayName: 'RQD'
       artifactPath: '/opt/opencue/rqd-$(setBuildId.buildId)-all.tar.gz'
 
-  - bash: |
-      docker build -t opencue/pycue:$(setBuildId.buildId) -f pycue/Dockerfile .
-      container_id=$(docker create opencue/pycue:$(setBuildId.buildId))
-      docker cp $container_id:/opt/opencue/pycue-$(setBuildId.buildId)-all.tar.gz "$(ARTIFACT_DIRECTORY)/"
-      docker rm $container_id
-    name: pycue
-    displayName: Build and Test PyCue
+  - template: ci/templates/build_docker.yml
+    parameters:
+      imageName: 'pycue'
+      displayName: 'PyCue'
+      artifactPath: '/opt/opencue/pycue-$(setBuildId.buildId)-all.tar.gz'
 
-  - bash: |
-      docker build -t opencue/pyoutline:$(setBuildId.buildId) -f pyoutline/Dockerfile .
-      container_id=$(docker create opencue/pyoutline:$(setBuildId.buildId))
-      docker cp $container_id:/opt/opencue/pyoutline-$(setBuildId.buildId)-all.tar.gz "$(ARTIFACT_DIRECTORY)/"
-      docker rm $container_id
-    name: pyoutline
-    displayName: Build and Test PyOutline
+  - template: ci/templates/build_docker.yml
+      parameters:
+        imageName: 'pyoutline'
+        displayName: 'PyOutline'
+        artifactPath: '/opt/opencue/pyoutline-$(setBuildId.buildId)-all.tar.gz'
 
-  - bash: |
-      docker build -t opencue/cuegui:$(setBuildId.buildId) -f cuegui/Dockerfile .
-      container_id=$(docker create opencue/cuegui:$(setBuildId.buildId))
-      docker cp $container_id:/opt/opencue/cuegui-$(setBuildId.buildId)-all.tar.gz "$(ARTIFACT_DIRECTORY)/"
-      docker rm $container_id
-    name: cuegui
-    displayName: Build and Test CueGUI
+  - template: ci/templates/build_docker.yml
+      parameters:
+        imageName: 'cuegui'
+        displayName: 'CueGUI'
+        artifactPath: '/opt/opencue/cuegui-$(setBuildId.buildId)-all.tar.gz'
 
-  - bash: |
-      docker build -t opencue/cuesubmit:$(setBuildId.buildId) -f cuesubmit/Dockerfile .
-      container_id=$(docker create opencue/cuesubmit:$(setBuildId.buildId))
-      docker cp $container_id:/opt/opencue/cuesubmit-$(setBuildId.buildId)-all.tar.gz "$(ARTIFACT_DIRECTORY)/"
-      docker rm $container_id
-    name: cuesubmit
-    displayName: Build and Test CueSubmit
+  - template: ci/templates/build_docker.yml
+      parameters:
+        imageName: 'cuesubmit'
+        displayName: 'CueSubmit'
+        artifactPath: '/opt/opencue/cuesubmit-$(setBuildId.buildId)-all.tar.gz'
 
-  - bash: |
-      docker build -t opencue/cueadmin:$(setBuildId.buildId) -f cueadmin/Dockerfile .
-      container_id=$(docker create opencue/cueadmin:$(setBuildId.buildId))
-      docker cp $container_id:/opt/opencue/cueadmin-$(setBuildId.buildId)-all.tar.gz "$(ARTIFACT_DIRECTORY)/"
-      docker rm $container_id
-    name: cueadmin
-    displayName: Build and Test CueAdmin
+  - template: ci/templates/build_docker.yml
+      parameters:
+        imageName: 'cueadmin'
+        displayName: 'CueAdmin'
+        artifactPath: '/opt/opencue/cueadmin-$(setBuildId.buildId)-all.tar.gz'
 
   - bash: ci/extract_artifacts.sh $(setBuildId.buildId) ./$(ARTIFACT_DIRECTORY)
     name: extractArtifacts

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,11 +35,11 @@ jobs:
       build_image_id="opencuebuild/cuebot:$(setBuildId.buildId)"
       branch_image_id="opencuebuild/cuebot:${branch_name}"
       docker pull $branch_image_id || true
-      docker build -t $image_id -f cuebot/Dockerfile .
-      docker tag $image_id $branch_image_id
-      docker push $image_id
+      docker build -t $build_image_id -f cuebot/Dockerfile .
+      docker tag $build_image_id $branch_image_id
+      docker push $build_image_id
       docker push $branch_image_id
-      container_id=$(docker create ${image_id})
+      container_id=$(docker create ${build_image_id})
       docker cp $container_id:/opt/opencue/cuebot-$(setBuildId.buildId)-all.jar "$(ARTIFACT_DIRECTORY)/"
       docker rm $container_id
     name: cuebot

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ jobs:
       branch_name=${SYSTEM_PULLREQUEST_SOURCEBRANCH:-$BUILD_SOURCEBRANCHNAME}
       build_image_id="opencuebuild/cuebot:$(setBuildId.buildId)"
       branch_image_id="opencuebuild/cuebot:${branch_name}"
-      docker pull $branch_image_id || true
+      docker pull $branch_image_id && docker tag $branch_image_id $build_image_id || true
       docker build -t $build_image_id -f cuebot/Dockerfile .
       docker tag $build_image_id $branch_image_id
       docker push $build_image_id

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,8 +31,9 @@ jobs:
     displayName: Create Artifact Directory
 
   - bash: |
+      branch_name=${SYSTEM_PULLREQUEST_SOURCEBRANCH:-$BUILD_SOURCEBRANCHNAME}
       build_image_id="opencuebuild/cuebot:$(setBuildId.buildId)"
-      branch_image_id="opencuebuild/cuebot:$(Build.SourceBranchName)"
+      branch_image_id="opencuebuild/cuebot:${branch_name}"
       echo $branch_image_id
       echo "FOO"
       exit 1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,10 +50,10 @@ jobs:
       artifactPath: '/opt/opencue/pycue-$(setBuildId.buildId)-all.tar.gz'
 
   - template: ci/templates/build_docker.yml
-      parameters:
-        imageName: 'pyoutline'
-        displayName: 'PyOutline'
-        artifactPath: '/opt/opencue/pyoutline-$(setBuildId.buildId)-all.tar.gz'
+    parameters:
+      imageName: 'pyoutline'
+      displayName: 'PyOutline'
+      artifactPath: '/opt/opencue/pyoutline-$(setBuildId.buildId)-all.tar.gz'
 
   - template: ci/templates/build_docker.yml
       parameters:
@@ -62,16 +62,16 @@ jobs:
         artifactPath: '/opt/opencue/cuegui-$(setBuildId.buildId)-all.tar.gz'
 
   - template: ci/templates/build_docker.yml
-      parameters:
-        imageName: 'cuesubmit'
-        displayName: 'CueSubmit'
-        artifactPath: '/opt/opencue/cuesubmit-$(setBuildId.buildId)-all.tar.gz'
+    parameters:
+      imageName: 'cuesubmit'
+      displayName: 'CueSubmit'
+      artifactPath: '/opt/opencue/cuesubmit-$(setBuildId.buildId)-all.tar.gz'
 
   - template: ci/templates/build_docker.yml
-      parameters:
-        imageName: 'cueadmin'
-        displayName: 'CueAdmin'
-        artifactPath: '/opt/opencue/cueadmin-$(setBuildId.buildId)-all.tar.gz'
+    parameters:
+      imageName: 'cueadmin'
+      displayName: 'CueAdmin'
+      artifactPath: '/opt/opencue/cueadmin-$(setBuildId.buildId)-all.tar.gz'
 
   - bash: ci/extract_artifacts.sh $(setBuildId.buildId) ./$(ARTIFACT_DIRECTORY)
     name: extractArtifacts

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,9 @@ jobs:
   - bash: |
       build_image_id="opencuebuild/cuebot:$(setBuildId.buildId)"
       branch_image_id="opencuebuild/cuebot:$(Build.SourceBranchName)"
+      echo $branch_image_id
+      echo "FOO"
+      exit 1
       docker pull $branch_image_id || true
       docker build -t $image_id -f cuebot/Dockerfile .
       docker tag $image_id $branch_image_id

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,9 +34,6 @@ jobs:
       branch_name=${SYSTEM_PULLREQUEST_SOURCEBRANCH:-$BUILD_SOURCEBRANCHNAME}
       build_image_id="opencuebuild/cuebot:$(setBuildId.buildId)"
       branch_image_id="opencuebuild/cuebot:${branch_name}"
-      echo $branch_image_id
-      echo "FOO"
-      exit 1
       docker pull $branch_image_id || true
       docker build -t $image_id -f cuebot/Dockerfile .
       docker tag $image_id $branch_image_id

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,9 +34,8 @@ jobs:
       branch_name=${SYSTEM_PULLREQUEST_SOURCEBRANCH:-$BUILD_SOURCEBRANCHNAME}
       build_image_id="opencuebuild/cuebot:$(setBuildId.buildId)"
       branch_image_id="opencuebuild/cuebot:${branch_name}"
-      docker pull centos:7
-      docker pull $branch_image_id && docker tag $branch_image_id $build_image_id || true
-      docker build -t $build_image_id -f cuebot/Dockerfile .
+      docker pull $branch_image_id || true
+      docker build --cache-from $branch_image_id -t $build_image_id -f cuebot/Dockerfile .
       docker tag $build_image_id $branch_image_id
       docker push $build_image_id
       docker push $branch_image_id

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,9 +31,13 @@ jobs:
     displayName: Create Artifact Directory
 
   - bash: |
-      image_id="opencuebuild/cuebot:$(setBuildId.buildId)"
+      build_image_id="opencuebuild/cuebot:$(setBuildId.buildId)"
+      branch_image_id="opencuebuild/cuebot:$(Build.SourceBranchName)"
+      docker pull $branch_image_id || true
       docker build -t $image_id -f cuebot/Dockerfile .
+      docker tag $image_id $branch_image_id
       docker push $image_id
+      docker push $branch_image_id
       container_id=$(docker create ${image_id})
       docker cp $container_id:/opt/opencue/cuebot-$(setBuildId.buildId)-all.jar "$(ARTIFACT_DIRECTORY)/"
       docker rm $container_id

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,13 +20,21 @@ jobs:
     name: setBuildId
     displayName: Generate Build ID
 
+  - task: Docker@2
+    displayName: Log in to Docker Hub
+    inputs:
+      containerRegistry: 'Docker Hub'
+      command: 'login'
+
   - bash: mkdir -p $(ARTIFACT_DIRECTORY)
     name: createArtifactDirectory
     displayName: Create Artifact Directory
 
   - bash: |
-      docker build -t opencue/cuebot:$(setBuildId.buildId) -f cuebot/Dockerfile .
-      container_id=$(docker create opencue/cuebot:$(setBuildId.buildId))
+      image_id="opencuebuild/cuebot:$(setBuildId.buildId)"
+      docker build -t $image_id -f cuebot/Dockerfile .
+      docker push $image_id
+      container_id=$(docker create ${image_id})
       docker cp $container_id:/opt/opencue/cuebot-$(setBuildId.buildId)-all.jar "$(ARTIFACT_DIRECTORY)/"
       docker rm $container_id
     name: cuebot

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,10 +56,10 @@ jobs:
       artifactPath: '/opt/opencue/pyoutline-$(setBuildId.buildId)-all.tar.gz'
 
   - template: ci/templates/build_docker.yml
-      parameters:
-        imageName: 'cuegui'
-        displayName: 'CueGUI'
-        artifactPath: '/opt/opencue/cuegui-$(setBuildId.buildId)-all.tar.gz'
+    parameters:
+      imageName: 'cuegui'
+      displayName: 'CueGUI'
+      artifactPath: '/opt/opencue/cuegui-$(setBuildId.buildId)-all.tar.gz'
 
   - template: ci/templates/build_docker.yml
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ jobs:
   - bash: |
       ci/generate_version_number.sh > VERSION
       echo "##vso[task.setvariable variable=buildId;isOutput=true]$(cat ./VERSION)"
-      echo "Build ID: $(buildId)"
+      echo "Build ID: $BUILDID"
     name: setBuildId
     displayName: Generate Build ID
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,8 +15,9 @@ jobs:
     vmImage: 'ubuntu-16.04'
   steps:
   - bash: |
-      ci/generate_version_number.sh
+      ci/generate_version_number.sh > VERSION
       echo "##vso[task.setvariable variable=buildId;isOutput=true]$(cat ./VERSION)"
+      echo "Build ID: $(buildId)"
     name: setBuildId
     displayName: Generate Build ID
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,6 @@ jobs:
   - bash: |
       ci/generate_version_number.sh > VERSION
       echo "##vso[task.setvariable variable=buildId;isOutput=true]$(cat ./VERSION)"
-      echo "Build ID: $BUILDID"
     name: setBuildId
     displayName: Generate Build ID
 

--- a/ci/extract_artifacts.sh
+++ b/ci/extract_artifacts.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
-if [ "$#" -ne 2 ]; then
+if [[ "$#" -ne 2 ]]; then
   echo "Usage: $0 <BUILD_ID> <ARTIFACT_DIRECTORY>"
   exit 1
 fi
@@ -10,7 +10,7 @@ fi
 build_id=$1
 artifact_directory=$2
 
-if [ -z "${BUILD_SOURCEVERSION}" ]; then
+if [[ -z "${BUILD_SOURCEVERSION}" ]]; then
   echo 'Environment var BUILD_SOURCEVERSION must be set.'
   exit 1
 fi

--- a/ci/extract_schema.sh
+++ b/ci/extract_schema.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
-if [ "$#" -ne 2 ]; then
+if [[ "$#" -ne 2 ]]; then
   echo "Usage: $0 <BUILD_ID> <ARTIFACT_DIRECTORY>"
   exit 1
 fi
@@ -11,27 +11,27 @@ BUILD_ID=$1
 ARTIFACT_DIRECTORY=$2
 
 DB_USER=postgres
-DB_NAME=cuebot_extract_$BUILD_ID
-PG_CONTAINER=postgres-$BUILD_ID
-FLYWAY_CONTAINER=flyway-$BUILD_ID
+DB_NAME=cuebot_extract_${BUILD_ID}
+PG_CONTAINER=postgres-${BUILD_ID}
+FLYWAY_CONTAINER=flyway-${BUILD_ID}
 SCHEMA_DIRECTORY="$(pwd)/cuebot/src/main/resources/conf/ddl/postgres"
 
 # Use migrations to populate a temporary database, then dump the full schema.
 docker pull postgres
 docker pull boxfuse/flyway
-docker run --rm --name $PG_CONTAINER -d postgres
+docker run --rm --name ${PG_CONTAINER} -d postgres
 sleep 10
-PG_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $PG_CONTAINER)
-docker exec -t --user=$DB_USER $PG_CONTAINER createdb $DB_NAME
-docker run -td --rm --name $FLYWAY_CONTAINER --entrypoint bash boxfuse/flyway
+PG_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${PG_CONTAINER})
+docker exec -t --user=${DB_USER} ${PG_CONTAINER} createdb ${DB_NAME}
+docker run -td --rm --name ${FLYWAY_CONTAINER} --entrypoint bash boxfuse/flyway
 docker cp ${SCHEMA_DIRECTORY}/migrations/* ${FLYWAY_CONTAINER}:/flyway/sql/
-docker exec -t $FLYWAY_CONTAINER flyway -url=jdbc:postgresql://$PG_IP/$DB_NAME -user=$DB_USER -n migrate
-docker exec -t --user=$DB_USER $PG_CONTAINER pg_dump --no-privileges --no-owner -s $DB_NAME \
+docker exec -t ${FLYWAY_CONTAINER} flyway -url=jdbc:postgresql://${PG_IP}/${DB_NAME} -user=${DB_USER} -n migrate
+docker exec -t --user=${DB_USER} ${PG_CONTAINER} pg_dump --no-privileges --no-owner -s ${DB_NAME} \
     | tee "${ARTIFACT_DIRECTORY}/schema-${BUILD_ID}.sql"
 
 # The demo data gets its own build artifact too.
 cp "${SCHEMA_DIRECTORY}/demo_data.sql" "${ARTIFACT_DIRECTORY}/demo_data-${BUILD_ID}.sql"
 
-docker kill $FLYWAY_CONTAINER
-docker kill $PG_CONTAINER
+docker kill ${FLYWAY_CONTAINER}
+docker kill ${PG_CONTAINER}
 

--- a/ci/generate_version_number.sh
+++ b/ci/generate_version_number.sh
@@ -10,8 +10,6 @@ version_in="$toplevel_dir/VERSION.in"
 version_major_minor="$(cat "$version_in" | sed 's/[[:space:]]//g')"
 current_branch="$(git branch --remote --verbose --no-abbrev --contains | sed -rne 's/^[^\/]*\/([^\ ]+).*$/\1/p')"
 
-echo ${current_branch} 1>&2
-
 if [[ "$current_branch" = "master" ]]; then
   commit_count=$(git rev-list --count $(git log --follow -1 --pretty=%H "$version_in")..HEAD)
   full_version="${version_major_minor}.${commit_count}"

--- a/ci/generate_version_number.sh
+++ b/ci/generate_version_number.sh
@@ -19,6 +19,4 @@ else
   full_version="${version_major_minor}.$((commit_count_in_master + 1))-${commit_short_hash}"
 fi
 
-echo ${full_version} 1>&2
 echo ${full_version}
-

--- a/ci/generate_version_number.sh
+++ b/ci/generate_version_number.sh
@@ -10,7 +10,7 @@ version_in="$toplevel_dir/VERSION.in"
 version_major_minor="$(cat "$version_in" | sed 's/[[:space:]]//g')"
 current_branch="$(git branch --remote --verbose --no-abbrev --contains | sed -rne 's/^[^\/]*\/([^\ ]+).*$/\1/p')"
 
-echo ${current_branch}
+echo ${current_branch} 1>&2
 
 if [[ "$current_branch" = "master" ]]; then
   commit_count=$(git rev-list --count $(git log --follow -1 --pretty=%H "$version_in")..HEAD)
@@ -21,5 +21,6 @@ else
   full_version="${version_major_minor}.$((commit_count_in_master + 1))-${commit_short_hash}"
 fi
 
+echo ${full_version} 1>&2
 echo ${full_version}
 

--- a/ci/generate_version_number.sh
+++ b/ci/generate_version_number.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -14,11 +14,10 @@ if [ "$current_branch" = "master" ]; then
   commit_count=$(git rev-list --count $(git log --follow -1 --pretty=%H "$version_in")..HEAD)
   full_version="${version_major_minor}.${commit_count}"
 else
+  commit_count_in_master=$(git rev-list --count $(git log --follow -1 --pretty=%H "$version_in")..master)
   commit_short_hash=$(git rev-parse --short HEAD)
-  full_version="${version_major_minor}.0-${commit_short_hash}"
+  full_version="${version_major_minor}.$((commit_count_in_master + 1))-${commit_short_hash}"
 fi
 
-version_out_file="${toplevel_dir}/VERSION"
-
-echo $full_version > "$version_out_file"
+echo ${full_version}
 

--- a/ci/generate_version_number.sh
+++ b/ci/generate_version_number.sh
@@ -10,11 +10,13 @@ version_in="$toplevel_dir/VERSION.in"
 version_major_minor="$(cat "$version_in" | sed 's/[[:space:]]//g')"
 current_branch="$(git branch --remote --verbose --no-abbrev --contains | sed -rne 's/^[^\/]*\/([^\ ]+).*$/\1/p')"
 
-if [ "$current_branch" = "master" ]; then
+echo ${current_branch}
+
+if [[ "$current_branch" = "master" ]]; then
   commit_count=$(git rev-list --count $(git log --follow -1 --pretty=%H "$version_in")..HEAD)
   full_version="${version_major_minor}.${commit_count}"
 else
-  commit_count_in_master=$(git rev-list --count $(git log --follow -1 --pretty=%H "$version_in")..master)
+  commit_count_in_master=$(git rev-list --count $(git log --follow -1 --pretty=%H "$version_in")..origin/master)
   commit_short_hash=$(git rev-parse --short HEAD)
   full_version="${version_major_minor}.$((commit_count_in_master + 1))-${commit_short_hash}"
 fi

--- a/ci/templates/build_docker.yml
+++ b/ci/templates/build_docker.yml
@@ -10,6 +10,16 @@ steps:
 - bash: |
     set -e
 
+    # Docker files are split into two stages -- build, which does build/test/package, and runtime,
+    # which includes only what's needed to run the software. We build both in sequence.
+
+    # We tag images both with build ID -- so each build has a unique Docker image -- as well as
+    # branch -- so that subsequent commits to a working branch / Pull Request will be able to
+    # use the previous commit's images as a cache.
+
+    # This requires a few workarounds due to the lack of long-running Docker caches in transient
+    # CI environments.
+
     branch_name=${SYSTEM_PULLREQUEST_SOURCEBRANCH:-$BUILD_SOURCEBRANCHNAME}
 
     build_image_for_build_id="opencuebuild/${{ parameters.imageName }}-build:$(setBuildId.buildId)"
@@ -18,8 +28,11 @@ steps:
     runtime_image_for_build_id="opencuebuild/${{ parameters.imageName }}:$(setBuildId.buildId)"
     runtime_image_for_branch="opencuebuild/${{ parameters.imageName }}:${branch_name}"
 
+    # Try to pull an image for the branch but don't fail if it doesn't exist.
     docker pull ${build_image_for_branch} || true
 
+    # Build the build-level image. You need to use --cache-from to use the previously-pulled
+    # image as a cache.
     docker build \
       --target build \
       --cache-from ${build_image_for_branch} \
@@ -28,11 +41,17 @@ steps:
       -f ${{ parameters.imageName }}/Dockerfile \
       "."
 
+    # Push both tags of the build-level image.
     docker push ${build_image_for_build_id}
     docker push ${build_image_for_branch}
 
+    # Now do the same for the runtime image.
     docker pull ${runtime_image_for_branch} || true
 
+    # --cache-from overrides the local Docker cache completely -- *only* the images specified
+    # by --cache-from will be used for cache purposes. So we need to specify both the build
+    # image, even though it was built on this machine a few steps earlier, as well as the
+    # branch-level runtime image.
     docker build \
       --cache-from ${build_image_for_build_id} \
       --cache-from ${runtime_image_for_branch} \
@@ -43,7 +62,9 @@ steps:
 
     docker push ${runtime_image_for_build_id}
     docker push ${runtime_image_for_branch}
-    
+
+    # Create a temporary container from the runtime image but don't start it -- it's just
+    # used to extract the packaged component for archiving and later release.
     container_id=$(docker create ${runtime_image_for_build_id})
     docker cp $container_id:${{ parameters.artifactPath }} "$(ARTIFACT_DIRECTORY)/"
     docker rm $container_id

--- a/ci/templates/build_docker.yml
+++ b/ci/templates/build_docker.yml
@@ -12,24 +12,37 @@ steps:
 
     branch_name=${SYSTEM_PULLREQUEST_SOURCEBRANCH:-$BUILD_SOURCEBRANCHNAME}
 
-    image_id="opencuebuild/${{ parameters.imageName }}:$(setBuildId.buildId)"
-    image_id_build="opencuebuild/${{ parameters.imageName }}-build:$(setBuildId.buildId)"
+    build_image_for_build_id="opencuebuild/${{ parameters.imageName }}-build:$(setBuildId.buildId)"
+    build_image_for_branch="opencuebuild/${{ parameters.imageName }}-build:${branch_name}"
 
-    branch_image_id="opencuebuild/${{ parameters.imageName }}:${branch_name}"
-    branch_image_id_build="opencuebuild/${{ parameters.imageName }}-build:${branch_name}"
-    
-    docker pull $branch_image_id || true
-    docker pull $branch_image_id_build || true
+    runtime_image_for_build_id="opencuebuild/${{ parameters.imageName }}:$(setBuildId.buildId)"
+    runtime_image_for_branch="opencuebuild/${{ parameters.imageName }}:${branch_name}"
 
-    docker build --cache-from $branch_image_id_build --target build -t $image_id_build -f ${{ parameters.imageName }}/Dockerfile .
-    docker tag $image_id_build $branch_image_id_build
-    docker push $image_id_build
-    docker push $branch_image_id_build
+    docker pull ${build_image_for_branch} || true
 
-    docker build --cache-from $branch_image_id --cache-from ${image_id_build} -t $image_id -f ${{ parameters.imageName }}/Dockerfile .
-    docker tag $image_id $branch_image_id
-    docker push $image_id
-    docker push $branch_image_id
+    docker build \
+      --target build \
+      --cache-from ${build_image_for_branch} \
+      -t ${build_image_for_build_id} \
+      -t ${build_image_for_branch} \
+      -f ${{ parameters.imageName }}/Dockerfile \
+      "."
+
+    docker push ${build_image_for_build_id}
+    docker push ${build_image_for_branch}
+
+    docker pull ${runtime_image_for_branch} || true
+
+    docker build \
+      --cache-from ${build_image_for_build_id} \
+      --cache-from ${runtime_image_for_branch} \
+      -t ${runtime_image_for_build_id} \
+      -t ${runtime_image_for_branch} \
+      -f ${{ parameters.imageName }}/Dockerfile \
+      "."
+
+    docker push ${runtime_image_for_build_id}
+    docker push ${runtime_image_for_branch}
     
     container_id=$(docker create ${image_id})
     docker cp $container_id:${{ parameters.artifactPath }} "$(ARTIFACT_DIRECTORY)/"

--- a/ci/templates/build_docker.yml
+++ b/ci/templates/build_docker.yml
@@ -1,0 +1,23 @@
+# azure-pipelines template file
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/process/templates?view=azure-devops
+
+parameters:
+  imageName: ''
+  displayName: ''
+  artifactPath: ''
+
+steps:
+- bash: |
+    branch_name=${SYSTEM_PULLREQUEST_SOURCEBRANCH:-$BUILD_SOURCEBRANCHNAME}
+    build_image_id="opencuebuild/${{ parameters.imageName }}:$(setBuildId.buildId)"
+    branch_image_id="opencuebuild/${{ parameters.imageName }}:${branch_name}"
+    docker pull $branch_image_id || true
+    docker build --cache-from $branch_image_id -t $build_image_id -f ${{ parameters.imageName }}/Dockerfile .
+    docker tag $build_image_id $branch_image_id
+    docker push $build_image_id
+    docker push $branch_image_id
+    container_id=$(docker create ${build_image_id})
+    docker cp $container_id:${{ parameters.artifactPath }} "$(ARTIFACT_DIRECTORY)/"
+    docker rm $container_id
+  name: ${{ parameters.imageName }}
+  displayName: Build and Test ${{ parameters.displayName }}

--- a/ci/templates/build_docker.yml
+++ b/ci/templates/build_docker.yml
@@ -18,7 +18,7 @@ steps:
     docker pull $branch_image_id_build || true
 
     docker build --cache-from $branch_image_id_build --target build -t $image_id_build -f ${{ parameters.imageName }}/Dockerfile .
-    docker build --cache-from $branch_image_id -t $image_id -f ${{ parameters.imageName }}/Dockerfile .
+    docker build --cache-from ${branch_image_id},${image_id_build} -t $image_id -f ${{ parameters.imageName }}/Dockerfile .
     
     docker tag $image_id $branch_image_id
     docker push $image_id_build

--- a/ci/templates/build_docker.yml
+++ b/ci/templates/build_docker.yml
@@ -13,9 +13,11 @@ steps:
     # Docker files are split into two stages -- build, which does build/test/package, and runtime,
     # which includes only what's needed to run the software. We build both in sequence.
 
-    # We tag images both with build ID -- so each build has a unique Docker image -- as well as
-    # branch -- so that subsequent commits to a working branch / Pull Request will be able to
-    # use the previous commit's images as a cache.
+    # We tag images both with build ID -- so each build has a unique Docker image -- as well
+    # as branch -- so that subsequent commits to a working branch / Pull Request will be able
+    # to use the previous commit's images as a cache. We also use the "latest" tag, so new
+    # branches will have something to work from, though how much speedup they get in that case
+    # can vary widely.
 
     # This requires a few workarounds due to the lack of long-running Docker caches in transient
     # CI environments.
@@ -24,44 +26,54 @@ steps:
 
     build_image_for_build_id="opencuebuild/${{ parameters.imageName }}-build:$(setBuildId.buildId)"
     build_image_for_branch="opencuebuild/${{ parameters.imageName }}-build:${branch_name}"
+    build_image_latest="opencuebuild/${{ parameters.imageName }}-build:latest"
 
     runtime_image_for_build_id="opencuebuild/${{ parameters.imageName }}:$(setBuildId.buildId)"
     runtime_image_for_branch="opencuebuild/${{ parameters.imageName }}:${branch_name}"
+    runtime_image_latest="opencuebuild/${{ parameters.imageName }}:latest"
 
-    # Try to pull an image for the branch but don't fail if it doesn't exist.
+    # Try to pull branch and latest images but don't fail if they don't exist.
     docker pull ${build_image_for_branch} || true
+    docker pull ${build_image_latest} || true
 
-    # Build the build-level image. You need to use --cache-from to use the previously-pulled
-    # image as a cache.
+    # Build the build image. You need to use --cache-from to use pulled images as cache.
+    # --cache-from is applied in the order given, i.e. branch-level images will take
+    # precedence here over "latest" images.
     docker build \
       --target build \
       --cache-from ${build_image_for_branch} \
+      --cache-from ${build_image_latest} \
       -t ${build_image_for_build_id} \
       -t ${build_image_for_branch} \
+      -t ${build_image_latest} \
       -f ${{ parameters.imageName }}/Dockerfile \
       "."
 
-    # Push both tags of the build-level image.
     docker push ${build_image_for_build_id}
     docker push ${build_image_for_branch}
+    docker push ${build_image_latest}
 
     # Now do the same for the runtime image.
     docker pull ${runtime_image_for_branch} || true
+    docker pull ${runtime_image_latest} || true
 
     # --cache-from overrides the local Docker cache completely -- *only* the images specified
-    # by --cache-from will be used for cache purposes. So we need to specify both the build
-    # image, even though it was built on this machine a few steps earlier, as well as the
-    # branch-level runtime image.
+    # by --cache-from will be used for cache purposes. So in addition to branch and latest
+    # images we also need to specify the build image, despite it being present in the local
+    # machine's Docker cache already.
     docker build \
       --cache-from ${build_image_for_build_id} \
       --cache-from ${runtime_image_for_branch} \
+      --cache-from ${runtime_image_latest} \
       -t ${runtime_image_for_build_id} \
       -t ${runtime_image_for_branch} \
+      -t ${runtime_image_latest} \
       -f ${{ parameters.imageName }}/Dockerfile \
       "."
 
     docker push ${runtime_image_for_build_id}
     docker push ${runtime_image_for_branch}
+    docker push ${runtime_image_latest}
 
     # Create a temporary container from the runtime image but don't start it -- it's just
     # used to extract the packaged component for archiving and later release.

--- a/ci/templates/build_docker.yml
+++ b/ci/templates/build_docker.yml
@@ -12,7 +12,7 @@ steps:
     build_image_id="opencuebuild/${{ parameters.imageName }}:$(setBuildId.buildId)"
     branch_image_id="opencuebuild/${{ parameters.imageName }}:${branch_name}"
     docker pull $branch_image_id || true
-    docker build --cache-from $branch_image_id -t $build_image_id -f ${{ parameters.imageName }}/Dockerfile .
+    docker build --cache-from centos:7 --cache-from $branch_image_id -t $build_image_id -f ${{ parameters.imageName }}/Dockerfile .
     docker tag $build_image_id $branch_image_id
     docker push $build_image_id
     docker push $branch_image_id

--- a/ci/templates/build_docker.yml
+++ b/ci/templates/build_docker.yml
@@ -30,6 +30,6 @@ steps:
     container_id=$(docker create ${image_id})
     docker cp $container_id:${{ parameters.artifactPath }} "$(ARTIFACT_DIRECTORY)/"
     docker rm $container_id
-    echo "dummy change"
+    echo "dummy change 2"
   name: ${{ parameters.imageName }}
   displayName: Build and Test ${{ parameters.displayName }}

--- a/ci/templates/build_docker.yml
+++ b/ci/templates/build_docker.yml
@@ -18,11 +18,12 @@ steps:
     docker pull $branch_image_id_build || true
 
     docker build --cache-from $branch_image_id_build --target build -t $image_id_build -f ${{ parameters.imageName }}/Dockerfile .
-    docker build --cache-from ${branch_image_id},${image_id_build} -t $image_id -f ${{ parameters.imageName }}/Dockerfile .
-    
-    docker tag $image_id $branch_image_id
+    docker tag $image_id_build $branch_image_id_build
     docker push $image_id_build
     docker push $branch_image_id_build
+
+    docker build --cache-from ${branch_image_id},${image_id_build} -t $image_id -f ${{ parameters.imageName }}/Dockerfile .
+    docker tag $image_id $branch_image_id
     docker push $image_id
     docker push $branch_image_id
     

--- a/ci/templates/build_docker.yml
+++ b/ci/templates/build_docker.yml
@@ -11,8 +11,10 @@ steps:
     set -e
 
     branch_name=${SYSTEM_PULLREQUEST_SOURCEBRANCH:-$BUILD_SOURCEBRANCHNAME}
+
     image_id="opencuebuild/${{ parameters.imageName }}:$(setBuildId.buildId)"
     image_id_build="opencuebuild/${{ parameters.imageName }}-build:$(setBuildId.buildId)"
+
     branch_image_id="opencuebuild/${{ parameters.imageName }}:${branch_name}"
     branch_image_id_build="opencuebuild/${{ parameters.imageName }}-build:${branch_name}"
     
@@ -24,7 +26,7 @@ steps:
     docker push $image_id_build
     docker push $branch_image_id_build
 
-    docker build --cache-from ${image_id_build} --cache-from $branch_image_id -t $image_id -f ${{ parameters.imageName }}/Dockerfile .
+    docker build --cache-from $branch_image_id -t $image_id -f ${{ parameters.imageName }}/Dockerfile .
     docker tag $image_id $branch_image_id
     docker push $image_id
     docker push $branch_image_id

--- a/ci/templates/build_docker.yml
+++ b/ci/templates/build_docker.yml
@@ -19,5 +19,6 @@ steps:
     container_id=$(docker create ${build_image_id})
     docker cp $container_id:${{ parameters.artifactPath }} "$(ARTIFACT_DIRECTORY)/"
     docker rm $container_id
+    echo "dummy change"
   name: ${{ parameters.imageName }}
   displayName: Build and Test ${{ parameters.displayName }}

--- a/ci/templates/build_docker.yml
+++ b/ci/templates/build_docker.yml
@@ -26,7 +26,7 @@ steps:
     docker push $image_id_build
     docker push $branch_image_id_build
 
-    docker build --cache-from $branch_image_id -t $image_id -f ${{ parameters.imageName }}/Dockerfile .
+    docker build --cache-from $branch_image_id --cache-from ${image_id_build} -t $image_id -f ${{ parameters.imageName }}/Dockerfile .
     docker tag $image_id $branch_image_id
     docker push $image_id
     docker push $branch_image_id

--- a/ci/templates/build_docker.yml
+++ b/ci/templates/build_docker.yml
@@ -44,7 +44,7 @@ steps:
     docker push ${runtime_image_for_build_id}
     docker push ${runtime_image_for_branch}
     
-    container_id=$(docker create ${image_id})
+    container_id=$(docker create ${runtime_image_for_build_id})
     docker cp $container_id:${{ parameters.artifactPath }} "$(ARTIFACT_DIRECTORY)/"
     docker rm $container_id
 

--- a/ci/templates/build_docker.yml
+++ b/ci/templates/build_docker.yml
@@ -9,14 +9,24 @@ parameters:
 steps:
 - bash: |
     branch_name=${SYSTEM_PULLREQUEST_SOURCEBRANCH:-$BUILD_SOURCEBRANCHNAME}
-    build_image_id="opencuebuild/${{ parameters.imageName }}:$(setBuildId.buildId)"
+    image_id="opencuebuild/${{ parameters.imageName }}:$(setBuildId.buildId)"
+    image_id_build="opencuebuild/${{ parameters.imageName }}-build:$(setBuildId.buildId)"
     branch_image_id="opencuebuild/${{ parameters.imageName }}:${branch_name}"
+    branch_image_id_build="opencuebuild/${{ parameters.imageName }}-build:${branch_name}"
+    
     docker pull $branch_image_id || true
-    docker build --cache-from centos:7 --cache-from $branch_image_id -t $build_image_id -f ${{ parameters.imageName }}/Dockerfile .
-    docker tag $build_image_id $branch_image_id
-    docker push $build_image_id
+    docker pull $branch_image_id_build || true
+
+    docker build --cache-from $branch_image_id_build --target build -t $image_id_build -f ${{ parameters.imageName }}/Dockerfile .
+    docker build --cache-from $branch_image_id -t $image_id -f ${{ parameters.imageName }}/Dockerfile .
+    
+    docker tag $image_id $branch_image_id
+    docker push $image_id_build
+    docker push $branch_image_id_build
+    docker push $image_id
     docker push $branch_image_id
-    container_id=$(docker create ${build_image_id})
+    
+    container_id=$(docker create ${image_id})
     docker cp $container_id:${{ parameters.artifactPath }} "$(ARTIFACT_DIRECTORY)/"
     docker rm $container_id
     echo "dummy change"

--- a/ci/templates/build_docker.yml
+++ b/ci/templates/build_docker.yml
@@ -47,6 +47,5 @@ steps:
     container_id=$(docker create ${runtime_image_for_build_id})
     docker cp $container_id:${{ parameters.artifactPath }} "$(ARTIFACT_DIRECTORY)/"
     docker rm $container_id
-
   name: ${{ parameters.imageName }}
   displayName: Build and Test ${{ parameters.displayName }}

--- a/ci/templates/build_docker.yml
+++ b/ci/templates/build_docker.yml
@@ -9,7 +9,7 @@ parameters:
 steps:
 - bash: |
     set -e
-    
+
     branch_name=${SYSTEM_PULLREQUEST_SOURCEBRANCH:-$BUILD_SOURCEBRANCHNAME}
     image_id="opencuebuild/${{ parameters.imageName }}:$(setBuildId.buildId)"
     image_id_build="opencuebuild/${{ parameters.imageName }}-build:$(setBuildId.buildId)"

--- a/ci/templates/build_docker.yml
+++ b/ci/templates/build_docker.yml
@@ -22,7 +22,7 @@ steps:
     docker push $image_id_build
     docker push $branch_image_id_build
 
-    docker build --cache-from ${image_id_build} -t $image_id -f ${{ parameters.imageName }}/Dockerfile .
+    docker build --cache-from ${image_id_build} --cache-from $branch_image_id -t $image_id -f ${{ parameters.imageName }}/Dockerfile .
     docker tag $image_id $branch_image_id
     docker push $image_id
     docker push $branch_image_id

--- a/ci/templates/build_docker.yml
+++ b/ci/templates/build_docker.yml
@@ -22,7 +22,7 @@ steps:
     docker push $image_id_build
     docker push $branch_image_id_build
 
-    docker build --cache-from ${branch_image_id},${image_id_build} -t $image_id -f ${{ parameters.imageName }}/Dockerfile .
+    docker build --cache-from ${image_id_build} -t $image_id -f ${{ parameters.imageName }}/Dockerfile .
     docker tag $image_id $branch_image_id
     docker push $image_id
     docker push $branch_image_id

--- a/ci/templates/build_docker.yml
+++ b/ci/templates/build_docker.yml
@@ -50,4 +50,3 @@ steps:
 
   name: ${{ parameters.imageName }}
   displayName: Build and Test ${{ parameters.displayName }}
-  dependsOn: createArtifactDirectory

--- a/ci/templates/build_docker.yml
+++ b/ci/templates/build_docker.yml
@@ -8,6 +8,8 @@ parameters:
 
 steps:
 - bash: |
+    set -e
+    
     branch_name=${SYSTEM_PULLREQUEST_SOURCEBRANCH:-$BUILD_SOURCEBRANCHNAME}
     image_id="opencuebuild/${{ parameters.imageName }}:$(setBuildId.buildId)"
     image_id_build="opencuebuild/${{ parameters.imageName }}-build:$(setBuildId.buildId)"
@@ -30,6 +32,6 @@ steps:
     container_id=$(docker create ${image_id})
     docker cp $container_id:${{ parameters.artifactPath }} "$(ARTIFACT_DIRECTORY)/"
     docker rm $container_id
-    echo "dummy change 2"
+
   name: ${{ parameters.imageName }}
   displayName: Build and Test ${{ parameters.displayName }}

--- a/ci/templates/build_docker.yml
+++ b/ci/templates/build_docker.yml
@@ -47,5 +47,7 @@ steps:
     container_id=$(docker create ${runtime_image_for_build_id})
     docker cp $container_id:${{ parameters.artifactPath }} "$(ARTIFACT_DIRECTORY)/"
     docker rm $container_id
+
   name: ${{ parameters.imageName }}
   displayName: Build and Test ${{ parameters.displayName }}
+  dependsOn: createArtifactDirectory

--- a/cueadmin/Dockerfile
+++ b/cueadmin/Dockerfile
@@ -75,5 +75,5 @@ RUN echo "CueAdmin runtime stage"
 
 WORKDIR /opt/opencue
 
-COPY --from=package /src/cueadmin-*-all.tar.gz ./
+COPY --from=build /src/cueadmin-*-all.tar.gz ./
 

--- a/cueadmin/Dockerfile
+++ b/cueadmin/Dockerfile
@@ -1,9 +1,9 @@
-FROM centos:7 as base
-
 # -----------------
 # BUILD
 # -----------------
-FROM base as build
+FROM centos:7 as build
+
+RUN echo "CueAdmin build stage"
 
 WORKDIR /src
 
@@ -25,9 +25,6 @@ RUN pip install -r requirements.txt
 
 RUN pip3.6 install -r requirements.txt
 
-COPY VERSION.in VERSIO[N] ./
-RUN test -e VERSION || echo "$(cat VERSION.in)-custom" | tee VERSION
-
 COPY proto/ ./proto
 COPY pycue/README.md ./pycue/
 COPY pycue/setup.py ./pycue/
@@ -44,33 +41,23 @@ RUN python -m grpc_tools.protoc \
 # <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
 RUN sed -i 's/^\(import.*_pb2\)/from . \1/' pycue/opencue/compiled_proto/*.py
 
+COPY cueadmin/README.md ./cueadmin/
+COPY cueadmin/setup.py ./cueadmin/
+COPY cueadmin/tests/ ./cueadmin/tests
+COPY cueadmin/cueadmin ./cueadmin/cueadmin
+
+COPY VERSION.in VERSIO[N] ./
+RUN test -e VERSION || echo "$(cat VERSION.in)-custom" | tee VERSION
+
 RUN cd pycue && python setup.py install
 
 RUN cd pycue && python3.6 setup.py install
 
-COPY cueadmin/README.md ./cueadmin/
-COPY cueadmin/setup.py ./cueadmin/
-COPY cueadmin/cueadmin ./cueadmin/cueadmin
-
 # TODO(bcipriano) Lint the code here. (Issue #78)
-
-
-# -----------------
-# TEST
-# -----------------
-FROM build as test
-
-COPY cueadmin/tests/ ./cueadmin/tests
 
 RUN cd cueadmin && python setup.py test
 
 RUN cd cueadmin && python3.6 setup.py test
-
-
-# -----------------
-# PACKAGE
-# -----------------
-FROM build as package
 
 RUN cp LICENSE requirements.txt VERSION cueadmin/
 
@@ -82,7 +69,9 @@ RUN versioned_name="cueadmin-$(cat ./VERSION)-all" \
 # -----------------
 # RUN
 # -----------------
-FROM base
+FROM centos:7
+
+RUN echo "CueAdmin runtime stage"
 
 WORKDIR /opt/opencue
 

--- a/cueadmin/Dockerfile
+++ b/cueadmin/Dockerfile
@@ -3,6 +3,7 @@
 # -----------------
 FROM centos:7 as build
 
+# First line after FROM should be unique to avoid --cache-from weirdness.
 RUN echo "CueAdmin build stage"
 
 WORKDIR /src
@@ -71,6 +72,7 @@ RUN versioned_name="cueadmin-$(cat ./VERSION)-all" \
 # -----------------
 FROM centos:7
 
+# First line after FROM should be unique to avoid --cache-from weirdness.
 RUN echo "CueAdmin runtime stage"
 
 WORKDIR /opt/opencue

--- a/cuebot/Dockerfile
+++ b/cuebot/Dockerfile
@@ -1,6 +1,8 @@
-FROM centos:7 as base
+# -----------------
+# BUILD AND TEST
+# -----------------
+FROM centos:7 as build
 
-# Packages needed at both build and runtime.
 RUN yum install -y \
       java-1.8.0-openjdk.x86_64 \
       java-1.8.0-openjdk-devel.x86_64 \
@@ -8,13 +10,13 @@ RUN yum install -y \
       which \
     && yum clean all
 
-
-# -----------------
-# BUILD
-# -----------------
-FROM base as build
-
 WORKDIR /src
+
+ENV CUEBOT_DB_ENGINE=postgres
+
+RUN adduser builduser
+
+RUN mkdir logs
 
 COPY cuebot/build.gradle cuebot/
 COPY cuebot/gradlew cuebot/
@@ -22,56 +24,50 @@ COPY cuebot/gradlew.bat cuebot/
 COPY cuebot/settings.gradle cuebot/
 COPY cuebot/gradle/ cuebot/gradle/
 
+# Give builduser access to the gradle config.
+RUN chmod -R 777 .
+
+# Download dependencies but do not build.
+RUN su -c "cd cuebot && ./gradlew dependencies --stacktrace" builduser
+
 COPY proto/ proto/
 COPY cuebot/src/main/resources/ cuebot/src/main/resources/
+COPY cuebot/src/test/ cuebot/src/test/
 COPY cuebot/src/main/java/ cuebot/src/main/java/
 
-RUN mkdir logs
-
-# Run as builduser in case tests get run later.
+# Give builduser access to the sources. This is done as a separate step to speed
+# up the image build.
 RUN chmod -R 777 .
-RUN adduser builduser
-RUN su -c "cd cuebot && ./gradlew build --stacktrace" builduser
-
-COPY VERSION.in VERSIO[N] ./
-RUN test -e VERSION || echo "$(cat VERSION.in)-custom" | tee VERSION
-
-
-# -----------------
-# TEST
-# -----------------
-FROM build as test
-
-ENV CUEBOT_DB_ENGINE=postgres
-
-COPY cuebot/src/test/ cuebot/src/test/
 
 # Tests must be run as a non-root user as the embedded Postgres server will not
 # work otherwise.
 RUN su -c "cd cuebot && ./gradlew build --stacktrace" builduser
 
-
-# -----------------
-# PACKAGE
-# -----------------
-FROM build as package
-
 RUN su -c "cd cuebot && ./gradlew shadowJar --stacktrace" builduser
 
 RUN mv cuebot/build/libs/cuebot-all.jar cuebot/build/libs/cuebot-$(cat ./VERSION)-all.jar
 
+COPY VERSION.in VERSIO[N] ./
+RUN test -e VERSION || echo "$(cat VERSION.in)-custom" | tee VERSION
 
 # -----------------
 # RUN
 # -----------------
-FROM base
+FROM centos:7
+
+RUN yum install -y \
+      java-1.8.0-openjdk.x86_64 \
+      java-1.8.0-openjdk-devel.x86_64 \
+      libaio \
+      which \
+    && yum clean all
 
 ARG CUEBOT_GRPC_CUE_PORT=8443
 ARG CUEBOT_GRPC_RQD_PORT=8444
 
 WORKDIR /opt/opencue
 
-COPY --from=package /src/cuebot/build/libs/cuebot-*-all.jar ./
+COPY --from=build /src/cuebot/build/libs/cuebot-*-all.jar ./
 
 RUN ln -s $(ls ./cuebot-*-all.jar) ./cuebot-latest.jar
 

--- a/cuebot/Dockerfile
+++ b/cuebot/Dockerfile
@@ -1,9 +1,9 @@
 # -----------------
-# BUILD AND TEST
+# BUILD
 # -----------------
 FROM centos:7 as build
 
-# First line after FROM must be unique to the Docker stage for proper cache selection.
+# First line after FROM should be unique to avoid --cache-from weirdness.
 RUN echo "Cuebot build stage"
 
 RUN yum install -y \
@@ -51,7 +51,7 @@ RUN mv cuebot/build/libs/cuebot-all.jar cuebot/build/libs/cuebot-$(cat ./VERSION
 # -----------------
 FROM centos:7
 
-# First line after FROM must be unique to the Docker stage for proper cache selection.
+# First line after FROM should be unique to avoid --cache-from weirdness.
 RUN echo "Cuebot runtime stage"
 
 RUN yum install -y \

--- a/cuebot/Dockerfile
+++ b/cuebot/Dockerfile
@@ -3,6 +3,7 @@
 # -----------------
 FROM centos:7 as build
 
+# First line after FROM must be unique to the Docker stage for proper cache selection.
 RUN echo "build stage"
 
 RUN yum install -y \
@@ -50,6 +51,7 @@ RUN mv cuebot/build/libs/cuebot-all.jar cuebot/build/libs/cuebot-$(cat ./VERSION
 # -----------------
 FROM centos:7
 
+# First line after FROM must be unique to the Docker stage for proper cache selection.
 RUN echo "runtime stage"
 
 RUN yum install -y \

--- a/cuebot/Dockerfile
+++ b/cuebot/Dockerfile
@@ -4,7 +4,7 @@
 FROM centos:7 as build
 
 # First line after FROM must be unique to the Docker stage for proper cache selection.
-RUN echo "build stage"
+RUN echo "Cuebot build stage"
 
 RUN yum install -y \
       java-1.8.0-openjdk.x86_64 \
@@ -52,7 +52,7 @@ RUN mv cuebot/build/libs/cuebot-all.jar cuebot/build/libs/cuebot-$(cat ./VERSION
 FROM centos:7
 
 # First line after FROM must be unique to the Docker stage for proper cache selection.
-RUN echo "runtime stage"
+RUN echo "Cuebot runtime stage"
 
 RUN yum install -y \
       java-1.8.0-openjdk.x86_64 \

--- a/cuebot/Dockerfile
+++ b/cuebot/Dockerfile
@@ -3,6 +3,8 @@
 # -----------------
 FROM centos:7 as build
 
+RUN echo "build stage"
+
 RUN yum install -y \
       java-1.8.0-openjdk.x86_64 \
       java-1.8.0-openjdk-devel.x86_64 \
@@ -47,6 +49,8 @@ RUN mv cuebot/build/libs/cuebot-all.jar cuebot/build/libs/cuebot-$(cat ./VERSION
 # RUN
 # -----------------
 FROM centos:7
+
+RUN echo "runtime stage"
 
 RUN yum install -y \
       java-1.8.0-openjdk.x86_64 \

--- a/cuebot/Dockerfile
+++ b/cuebot/Dockerfile
@@ -24,19 +24,11 @@ COPY cuebot/gradlew.bat cuebot/
 COPY cuebot/settings.gradle cuebot/
 COPY cuebot/gradle/ cuebot/gradle/
 
-# Give builduser access to the gradle config.
-RUN chmod -R 777 .
-
-# Download dependencies but do not build.
-RUN su -c "cd cuebot && ./gradlew dependencies --stacktrace" builduser
-
 COPY proto/ proto/
 COPY cuebot/src/main/resources/ cuebot/src/main/resources/
 COPY cuebot/src/test/ cuebot/src/test/
 COPY cuebot/src/main/java/ cuebot/src/main/java/
 
-# Give builduser access to the sources. This is done as a separate step to speed
-# up the image build.
 RUN chmod -R 777 .
 
 # Tests must be run as a non-root user as the embedded Postgres server will not
@@ -45,10 +37,11 @@ RUN su -c "cd cuebot && ./gradlew build --stacktrace" builduser
 
 RUN su -c "cd cuebot && ./gradlew shadowJar --stacktrace" builduser
 
-RUN mv cuebot/build/libs/cuebot-all.jar cuebot/build/libs/cuebot-$(cat ./VERSION)-all.jar
-
 COPY VERSION.in VERSIO[N] ./
 RUN test -e VERSION || echo "$(cat VERSION.in)-custom" | tee VERSION
+
+RUN mv cuebot/build/libs/cuebot-all.jar cuebot/build/libs/cuebot-$(cat ./VERSION)-all.jar
+
 
 # -----------------
 # RUN

--- a/cuegui/Dockerfile
+++ b/cuegui/Dockerfile
@@ -1,9 +1,9 @@
-FROM centos:7 as base
-
 # -----------------
 # BUILD
 # -----------------
-FROM base as build
+FROM centos:7 as build
+
+RUN echo "CueGUI build stage"
 
 WORKDIR /src
 
@@ -19,14 +19,11 @@ COPY requirements.txt ./
 
 RUN pip install -r requirements.txt
 
-COPY VERSION.in VERSIO[N] ./
-RUN test -e VERSION || echo "$(cat VERSION.in)-custom" | tee VERSION
-
 COPY proto/ ./proto
 COPY pycue/README.md ./pycue/
 COPY pycue/setup.py ./pycue/
-COPY pycue/opencue ./pycue/opencue
 COPY pycue/FileSequence ./pycue/FileSequence
+COPY pycue/opencue ./pycue/opencue
 
 RUN python -m grpc_tools.protoc \
   -I=./proto \
@@ -38,27 +35,18 @@ RUN python -m grpc_tools.protoc \
 # <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
 RUN sed -i 's/^\(import.*_pb2\)/from . \1/' pycue/opencue/compiled_proto/*.py
 
-RUN cd pycue && python setup.py install
-
 COPY cuegui/README.md ./cuegui/
 COPY cuegui/setup.py ./cuegui/
 COPY cuegui/cuegui ./cuegui/cuegui
 
+COPY VERSION.in VERSIO[N] ./
+RUN test -e VERSION || echo "$(cat VERSION.in)-custom" | tee VERSION
+
+RUN cd pycue && python setup.py install
+
 # TODO(bcipriano) Lint the code here. (Issue #78)
 
-
-# -----------------
-# TEST
-# -----------------
-FROM build as test
-
 # TODO(bcipriano) Run unit tests. (Issue #149)
-
-
-# -----------------
-# PACKAGE
-# -----------------
-FROM build as package
 
 RUN cp LICENSE requirements.txt VERSION cuegui/
 
@@ -70,9 +58,11 @@ RUN versioned_name="cuegui-$(cat ./VERSION)-all" \
 # -----------------
 # RUN
 # -----------------
-FROM base
+FROM centos:7
+
+RUN echo "CueGUI runtime stage"
 
 WORKDIR /opt/opencue
 
-COPY --from=package /src/cuegui-*-all.tar.gz ./
+COPY --from=build /src/cuegui-*-all.tar.gz ./
 

--- a/cuegui/Dockerfile
+++ b/cuegui/Dockerfile
@@ -3,6 +3,7 @@
 # -----------------
 FROM centos:7 as build
 
+# First line after FROM should be unique to avoid --cache-from weirdness.
 RUN echo "CueGUI build stage"
 
 WORKDIR /src
@@ -60,6 +61,7 @@ RUN versioned_name="cuegui-$(cat ./VERSION)-all" \
 # -----------------
 FROM centos:7
 
+# First line after FROM should be unique to avoid --cache-from weirdness.
 RUN echo "CueGUI runtime stage"
 
 WORKDIR /opt/opencue

--- a/cuesubmit/Dockerfile
+++ b/cuesubmit/Dockerfile
@@ -3,6 +3,7 @@
 # -----------------
 FROM centos:7 as build
 
+# First line after FROM should be unique to avoid --cache-from weirdness.
 RUN echo "CueSubmit build stage"
 
 WORKDIR /src
@@ -68,6 +69,7 @@ RUN versioned_name="cuesubmit-$(cat ./VERSION)-all" \
 # -----------------
 FROM centos:7
 
+# First line after FROM should be unique to avoid --cache-from weirdness.
 RUN echo "CueSubmit runtime stage"
 
 WORKDIR /opt/opencue

--- a/cuesubmit/Dockerfile
+++ b/cuesubmit/Dockerfile
@@ -1,9 +1,9 @@
-FROM centos:7 as base
-
 # -----------------
 # BUILD
 # -----------------
-FROM base as build
+FROM centos:7 as build
+
+RUN echo "CueSubmit build stage"
 
 WORKDIR /src
 
@@ -20,9 +20,6 @@ COPY requirements.txt ./
 
 RUN pip install -r requirements.txt
 
-COPY VERSION.in VERSIO[N] ./
-RUN test -e VERSION || echo "$(cat VERSION.in)-custom" | tee VERSION
-
 COPY proto/ ./proto
 COPY pycue/README.md ./pycue/
 COPY pycue/setup.py ./pycue/
@@ -35,8 +32,6 @@ RUN python -m grpc_tools.protoc \
   --grpc_python_out=./pycue/opencue/compiled_proto \
   ./proto/*.proto
 
-RUN cd pycue && python setup.py install
-
 COPY pyoutline/README.md ./pyoutline/
 COPY pyoutline/setup.py ./pyoutline/
 COPY pyoutline/bin ./pyoutline/bin
@@ -44,30 +39,22 @@ COPY pyoutline/etc ./pyoutline/etc
 COPY pyoutline/wrappers ./pyoutline/wrappers
 COPY pyoutline/outline ./pyoutline/outline
 
-RUN cd pyoutline && python setup.py install
-
 COPY cuesubmit/README.md ./cuesubmit/
 COPY cuesubmit/setup.py ./cuesubmit/
+COPY cuesubmit/tests/ ./cuesubmit/tests
 COPY cuesubmit/plugins ./cuesubmit/plugins
 COPY cuesubmit/cuesubmit ./cuesubmit/cuesubmit
 
+COPY VERSION.in VERSIO[N] ./
+RUN test -e VERSION || echo "$(cat VERSION.in)-custom" | tee VERSION
+
+RUN cd pycue && python setup.py install
+
+RUN cd pyoutline && python setup.py install
+
 # TODO(bcipriano) Lint the code here. (Issue #78)
 
-
-# -----------------
-# TEST
-# -----------------
-FROM build as test
-
-COPY cuesubmit/tests/ ./cuesubmit/tests
-
 RUN cd cuesubmit && python setup.py test
-
-
-# -----------------
-# PACKAGE
-# -----------------
-FROM build as package
 
 RUN cp LICENSE requirements.txt VERSION cuesubmit/
 
@@ -79,9 +66,11 @@ RUN versioned_name="cuesubmit-$(cat ./VERSION)-all" \
 # -----------------
 # RUN
 # -----------------
-FROM base
+FROM centos:7
+
+RUN echo "CueSubmit runtime stage"
 
 WORKDIR /opt/opencue
 
-COPY --from=package /src/cuesubmit-*-all.tar.gz ./
+COPY --from=build /src/cuesubmit-*-all.tar.gz ./
 

--- a/pycue/Dockerfile
+++ b/pycue/Dockerfile
@@ -1,8 +1,9 @@
 # -----------------
-# BUILD AND TEST
+# BUILD
 # -----------------
 FROM centos:7 as build
 
+# First line after FROM should be unique to avoid --cache-from weirdness.
 RUN echo "PyCue build stage"
 
 WORKDIR /src
@@ -63,6 +64,7 @@ RUN versioned_name="pycue-$(cat ./VERSION)-all" \
 # -----------------
 FROM centos:7
 
+# First line after FROM should be unique to avoid --cache-from weirdness.
 RUN echo "PyCue runtime stage"
 
 WORKDIR /opt/opencue

--- a/pycue/Dockerfile
+++ b/pycue/Dockerfile
@@ -1,9 +1,9 @@
-FROM centos:7 as base
+# -----------------
+# BUILD AND TEST
+# -----------------
+FROM centos:7 as build
 
-# -----------------
-# BUILD
-# -----------------
-FROM base as build
+RUN echo "PyCue build stage"
 
 WORKDIR /src
 
@@ -25,14 +25,12 @@ RUN pip install -r requirements.txt
 
 RUN pip3.6 install -r requirements.txt
 
-COPY VERSION.in VERSIO[N] ./
-RUN test -e VERSION || echo "$(cat VERSION.in)-custom" | tee VERSION
-
 COPY proto/ ./proto
 COPY pycue/README.md ./pycue/
 COPY pycue/setup.py ./pycue/
-COPY pycue/opencue ./pycue/opencue
 COPY pycue/FileSequence ./pycue/FileSequence
+COPY pycue/tests/ ./pycue/tests
+COPY pycue/opencue ./pycue/opencue
 
 RUN python -m grpc_tools.protoc \
   -I=./proto \
@@ -46,23 +44,12 @@ RUN sed -i 's/^\(import.*_pb2\)/from . \1/' pycue/opencue/compiled_proto/*.py
 
 # TODO(bcipriano) Lint the code here. (Issue #78)
 
-
-# -----------------
-# TEST
-# -----------------
-FROM build as test
-
-COPY pycue/tests/ ./pycue/tests
+COPY VERSION.in VERSIO[N] ./
+RUN test -e VERSION || echo "$(cat VERSION.in)-custom" | tee VERSION
 
 RUN cd pycue && python setup.py test
 
 RUN cd pycue && python3.6 setup.py test
-
-
-# -----------------
-# PACKAGE
-# -----------------
-FROM build as package
 
 RUN cp LICENSE requirements.txt VERSION pycue/
 
@@ -74,9 +61,10 @@ RUN versioned_name="pycue-$(cat ./VERSION)-all" \
 # -----------------
 # RUN
 # -----------------
-FROM base
+FROM centos:7
+
+RUN echo "PyCue runtime stage"
 
 WORKDIR /opt/opencue
 
-COPY --from=package /src/pycue-*-all.tar.gz ./
-
+COPY --from=build /src/pycue-*-all.tar.gz ./

--- a/pyoutline/Dockerfile
+++ b/pyoutline/Dockerfile
@@ -3,6 +3,7 @@
 # -----------------
 FROM centos:7 as build
 
+# First line after FROM should be unique to avoid --cache-from weirdness.
 RUN echo "PyCue build stage"
 
 WORKDIR /src
@@ -74,6 +75,7 @@ RUN versioned_name="pyoutline-$(cat ./VERSION)-all" \
 # -----------------
 FROM centos:7
 
+# First line after FROM should be unique to avoid --cache-from weirdness.
 RUN echo "PyCue runtime stage"
 
 WORKDIR /opt/opencue

--- a/pyoutline/Dockerfile
+++ b/pyoutline/Dockerfile
@@ -1,7 +1,7 @@
 # -----------------
 # BUILD
 # -----------------
-FROM centos:7
+FROM centos:7 as build
 
 RUN echo "PyCue build stage"
 

--- a/pyoutline/Dockerfile
+++ b/pyoutline/Dockerfile
@@ -1,9 +1,9 @@
-FROM centos:7 as base
-
 # -----------------
 # BUILD
 # -----------------
-FROM base as build
+FROM centos:7
+
+RUN echo "PyCue build stage"
 
 WORKDIR /src
 
@@ -25,9 +25,6 @@ RUN pip install -r requirements.txt
 
 RUN pip3.6 install -r requirements.txt
 
-COPY VERSION.in VERSIO[N] ./
-RUN test -e VERSION || echo "$(cat VERSION.in)-custom" | tee VERSION
-
 COPY proto/ ./proto
 COPY pycue/README.md ./pycue/
 COPY pycue/setup.py ./pycue/
@@ -44,36 +41,26 @@ RUN python -m grpc_tools.protoc \
 # <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
 RUN sed -i 's/^\(import.*_pb2\)/from . \1/' pycue/opencue/compiled_proto/*.py
 
-RUN cd pycue && python setup.py install
-
-RUN cd pycue && python3.6 setup.py install
-
 COPY pyoutline/README.md ./pyoutline/
 COPY pyoutline/setup.py ./pyoutline/
 COPY pyoutline/bin ./pyoutline/bin
 COPY pyoutline/etc ./pyoutline/etc
+COPY pyoutline/tests/ ./pyoutline/tests
 COPY pyoutline/wrappers ./pyoutline/wrappers
 COPY pyoutline/outline ./pyoutline/outline
 
+COPY VERSION.in VERSIO[N] ./
+RUN test -e VERSION || echo "$(cat VERSION.in)-custom" | tee VERSION
+
+RUN cd pycue && python setup.py install
+
+RUN cd pycue && python3.6 setup.py install
+
 # TODO(bcipriano) Lint the code here. (Issue #78)
-
-
-# -----------------
-# TEST
-# -----------------
-FROM build as test
-
-COPY pyoutline/tests/ ./pyoutline/tests
 
 RUN cd pyoutline && python setup.py test
 
 RUN cd pyoutline && python3.6 setup.py test
-
-
-# -----------------
-# PACKAGE
-# -----------------
-FROM build as package
 
 RUN cp LICENSE requirements.txt VERSION pyoutline/
 
@@ -85,9 +72,11 @@ RUN versioned_name="pyoutline-$(cat ./VERSION)-all" \
 # -----------------
 # RUN
 # -----------------
-FROM base
+FROM centos:7
+
+RUN echo "PyCue runtime stage"
 
 WORKDIR /opt/opencue
 
-COPY --from=package /src/pyoutline-*-all.tar.gz ./
+COPY --from=build /src/pyoutline-*-all.tar.gz ./
 

--- a/rqd/Dockerfile
+++ b/rqd/Dockerfile
@@ -1,4 +1,7 @@
-FROM centos:7 as base
+# -----------------
+# BUILD AND TEST
+# -----------------
+FROM centos:7 as build
 
 RUN yum -y install \
   epel-release \
@@ -7,12 +10,6 @@ RUN yum -y install \
   time
 
 RUN yum -y install python-pip
-
-
-# -----------------
-# BUILD
-# -----------------
-FROM base as build
 
 WORKDIR /src
 
@@ -24,10 +21,13 @@ RUN pip install -r requirements.txt
 COPY VERSION.in VERSIO[N] ./
 RUN test -e VERSION || echo "$(cat VERSION.in)-custom" | tee VERSION
 
+RUN mkdir dist
+
 COPY proto/ ./proto
 COPY rqd/deploy ./rqd/deploy
 COPY rqd/README.md ./rqd/
 COPY rqd/setup.py ./rqd/
+COPY rqd/tests/ ./rqd/tests
 COPY rqd/rqd/ ./rqd/rqd
 
 RUN python -m grpc_tools.protoc \
@@ -38,23 +38,7 @@ RUN python -m grpc_tools.protoc \
 
 # TODO(bcipriano) Lint the code here. (Issue #78)
 
-
-# -----------------
-# TEST
-# -----------------
-FROM build as test
-
-COPY rqd/tests/ ./rqd/tests
-
 RUN cd rqd && python setup.py test
-
-
-# -----------------
-# PACKAGE
-# -----------------
-FROM build as package
-
-RUN mkdir dist
 
 RUN cp rqd/deploy/install_and_run.sh dist/
 
@@ -65,20 +49,29 @@ RUN versioned_name="rqd-$(cat ./VERSION)-all" \
   && cd dist \
   && tar -cvzf $versioned_name.tar.gz $versioned_name/*
 
+RUN cat VERSION
+
 
 # -----------------
 # RUN
 # -----------------
-FROM base
+FROM centos:7
+
+RUN yum -y install \
+  epel-release \
+  gcc \
+  python-devel \
+  time
+
+RUN yum -y install python-pip
 
 WORKDIR /opt/opencue
 
-COPY --from=package /src/dist/rqd-*-all.tar.gz ./
-COPY --from=package /src/dist/install_and_run.sh ./
+COPY --from=build /src/dist/rqd-*-all.tar.gz ./
+COPY --from=build /src/dist/install_and_run.sh ./
 RUN chmod +x ./install_and_run.sh
 
 # RQD gRPC server
 EXPOSE 8444
 
 ENTRYPOINT ["/opt/opencue/install_and_run.sh"]
-

--- a/rqd/Dockerfile
+++ b/rqd/Dockerfile
@@ -20,9 +20,6 @@ COPY requirements.txt ./
 
 RUN pip install -r requirements.txt
 
-COPY VERSION.in VERSIO[N] ./
-RUN test -e VERSION || echo "$(cat VERSION.in)-custom" | tee VERSION
-
 RUN mkdir dist
 
 COPY proto/ ./proto
@@ -39,6 +36,9 @@ RUN python -m grpc_tools.protoc \
   ./proto/*.proto
 
 # TODO(bcipriano) Lint the code here. (Issue #78)
+
+COPY VERSION.in VERSIO[N] ./
+RUN test -e VERSION || echo "$(cat VERSION.in)-custom" | tee VERSION
 
 RUN cd rqd && python setup.py test
 

--- a/rqd/Dockerfile
+++ b/rqd/Dockerfile
@@ -3,6 +3,8 @@
 # -----------------
 FROM centos:7 as build
 
+RUN echo "RQD build stage"
+
 RUN yum -y install \
   epel-release \
   gcc \
@@ -49,13 +51,13 @@ RUN versioned_name="rqd-$(cat ./VERSION)-all" \
   && cd dist \
   && tar -cvzf $versioned_name.tar.gz $versioned_name/*
 
-RUN cat VERSION
-
 
 # -----------------
 # RUN
 # -----------------
 FROM centos:7
+
+RUN echo "RQD runtime stage"
 
 RUN yum -y install \
   epel-release \

--- a/rqd/Dockerfile
+++ b/rqd/Dockerfile
@@ -1,8 +1,9 @@
 # -----------------
-# BUILD AND TEST
+# BUILD
 # -----------------
 FROM centos:7 as build
 
+# First line after FROM should be unique to avoid --cache-from weirdness.
 RUN echo "RQD build stage"
 
 RUN yum -y install \
@@ -57,6 +58,7 @@ RUN versioned_name="rqd-$(cat ./VERSION)-all" \
 # -----------------
 FROM centos:7
 
+# First line after FROM should be unique to avoid --cache-from weirdness.
 RUN echo "RQD runtime stage"
 
 RUN yum -y install \


### PR DESCRIPTION
A few related changes to speed up our build pipeline runtime.

In my tests these changes bring our baseline build time from 27min -> 14min (better, but more work is needed).

- Use Docker Hub as an external cache.
  - Push images there as they're built.
  - Use a new `opencuebuild` repo to keep these mostly-ephemeral images from polluting the release-quality, published images.
  - Tag the pushed images with branch name and `latest` to enable images to be reused between subsequent builds in the same branch and to some extent between branches.
- Break the Docker image build process out into a separate template YAML file to reduce repetition.
- Reformat `Dockerfile`s
  - Ditch most of the stages, they're not used anymore.
  - We still need two stages -- one for build and one for runtime -- because build artifacts should not pollute the runtime container.
  - Reorder some of the lines to improve layer reuse between builds.