### PR TITLE
Publish the VERSION file as a build artifact.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,6 +85,10 @@ jobs:
     artifact: License
     displayName: Publish LICENSE
 
+  - publish: $(ARTIFACT_DIRECTORY)/VERSION
+    artifact: Version
+    displayName: Publish VERSION
+
   - publish: $(ARTIFACT_DIRECTORY)/build_metadata.json
     artifact: Build Metadata
     displayName: Publish Build Metadata

--- a/ci/extract_artifacts.sh
+++ b/ci/extract_artifacts.sh
@@ -15,8 +15,8 @@ if [[ -z "${BUILD_SOURCEVERSION}" ]]; then
   exit 1
 fi
 
-mkdir -p "$artifact_directory"
+mkdir -p "${artifact_directory}"
 
-cp LICENSE VERSION "$artifact_directory"
+cp LICENSE VERSION "${artifact_directory}/"
 
 echo "{\"git_commit\": \"${BUILD_SOURCEVERSION}\"}" | tee "${artifact_directory}/build_metadata.json"

--- a/ci/extract_artifacts.sh
+++ b/ci/extract_artifacts.sh
@@ -17,6 +17,6 @@ fi
 
 mkdir -p "$artifact_directory"
 
-cp LICENSE "$artifact_directory"
+cp LICENSE VERSION "$artifact_directory"
 
 echo "{\"git_commit\": \"${BUILD_SOURCEVERSION}\"}" | tee "${artifact_directory}/build_metadata.json"


### PR DESCRIPTION
This will make it easier to fetch a build's full version number downstream.