### PR TITLE
Remove unnecessary conversion step when editing subscription size

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageSubscription.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageSubscription.java
@@ -88,8 +88,7 @@ public class ManageSubscription extends SubscriptionInterfaceGrpc.SubscriptionIn
                          StreamObserver<SubscriptionSetBurstResponse> responseObserver) {
         adminManager.setSubscriptionBurst(
                 getSubscriptionDetail(request.getSubscription()),
-                Convert.coresToWholeCoreUnits(request.getBurst())
-        );
+                request.getBurst());
         responseObserver.onNext(SubscriptionSetBurstResponse.newBuilder().build());
         responseObserver.onCompleted();
     }
@@ -99,8 +98,7 @@ public class ManageSubscription extends SubscriptionInterfaceGrpc.SubscriptionIn
                         StreamObserver<SubscriptionSetSizeResponse> responseObserver) {
         adminManager.setSubscriptionSize(
                 getSubscriptionDetail(request.getSubscription()),
-                Convert.coresToWholeCoreUnits(request.getNewSize())
-        );
+                request.getNewSize());
         responseObserver.onNext(SubscriptionSetSizeResponse.newBuilder().build());
         responseObserver.onCompleted();
     }


### PR DESCRIPTION
Fixes #399 

Removes an unnecessary conversion step when editing subscription size and burst size.  This conversion causes the value input into the GUI to not be the value stored which leads to confusion.
