### PR TITLE
Wire up Cuebot test coverage.

### DIFF
--- a/cuebot/build.gradle
+++ b/cuebot/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'java'
 apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'com.google.protobuf'
 apply plugin: 'org.sonarqube'
+apply plugin: 'jacoco'
 
 sourceCompatibility = 1.8
 
@@ -20,7 +21,7 @@ buildscript {
     dependencies {
         classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.3'
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.3'
-        classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.7.1"
+        classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.7.1'
     }
 }
 
@@ -105,12 +106,34 @@ shadowJar {
     mergeServiceFiles('META-INF/spring.*')
 }
 
+jacoco {
+    toolVersion = "0.8.4"
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        html.enabled true
+    }
+
+    afterEvaluate {
+        classDirectories = files(classDirectories.files.collect {
+            fileTree(dir: it,
+                     exclude: ['com/imageworks/spcue/grpc/**',
+                               'com/imageworks/spcue/dao/oracle/**',
+                               'com/imageworks/spcue/dao/criteria/oracle/**',])
+        })
+    }
+}
+
 sonarqube {
     properties {
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.organization", "bcipriano"
         property "sonar.projectKey", "bcipriano_OpenCue_Cuebot"
         property "sonar.projectName", "OpenCue Cuebot"
+        property "sonar.coverage.exclusions", "src/main/java/com/imageworks/spcue/dao/oracle/**," +
+                                              "src/main/java/com/imageworks/spcue/dao/criteria/oracle/**"
         // NOTE: sonar.login must be provided manually, like:
         //   ./gradlew sonarqube -Dsonar.login=<login key>
     }

--- a/cuebot/build.gradle
+++ b/cuebot/build.gradle
@@ -112,16 +112,24 @@ jacoco {
 
 jacocoTestReport {
     reports {
+        // XML is used by SonarCloud. HTML is generated if you want to generate a human-readable
+        // report locally. Reports are placed in build/reports/jacoco/.
         xml.enabled true
         html.enabled true
     }
 
+    // Exclude files from test coverage.
     afterEvaluate {
         classDirectories = files(classDirectories.files.collect {
             fileTree(dir: it,
-                     exclude: ['com/imageworks/spcue/grpc/**',
-                               'com/imageworks/spcue/dao/oracle/**',
-                               'com/imageworks/spcue/dao/criteria/oracle/**',])
+                     exclude: [
+                        // Exclude proto files' generated Java code.
+                        'com/imageworks/spcue/grpc/**',
+                        // Exclude Oracle classes; our standard test environment isn't currently
+                        // able to run Oracle unit tests, so coverage of those files will always
+                        // read as 0% even though tests do exist.
+                        'com/imageworks/spcue/dao/oracle/**',
+                        'com/imageworks/spcue/dao/criteria/oracle/**',])
         })
     }
 }
@@ -132,6 +140,9 @@ sonarqube {
         property "sonar.organization", "bcipriano"
         property "sonar.projectKey", "bcipriano_OpenCue_Cuebot"
         property "sonar.projectName", "OpenCue Cuebot"
+        // SonarCloud will pick up the JaCoCo report automatically, but has its own options
+        // for excluding files. We don't need to exclude generated code here as it isn't
+        // checked into the repository, so SonarCloud doesn't even know it exists.
         property "sonar.coverage.exclusions", "src/main/java/com/imageworks/spcue/dao/oracle/**," +
                                               "src/main/java/com/imageworks/spcue/dao/criteria/oracle/**"
         // NOTE: sonar.login must be provided manually, like:

--- a/sonar-cloud-pipeline.yml
+++ b/sonar-cloud-pipeline.yml
@@ -23,7 +23,7 @@ jobs:
     name: analyzePython
     displayName: Analyze Python Components
 
-  - bash: cd cuebot && ./gradlew sonarqube -Dsonar.login=$(SONAR_TOKEN)
+  - bash: cd cuebot && ./gradlew jacocoTestReport sonarqube -Dsonar.login=$(SONAR_TOKEN)
     name: analyzeCuebot
     displayName: Analyze Cuebot
 


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
#396 

**Summarize your change.**
Add JaCoCo into our Gradle config for generation of test coverage reports. SonarCloud picks these reports up automatically as long as they exist; run the `jacocoTestReport` task as part of the SonarCloud pipeline.