### PR TITLE
Wire up Python component test coverage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ venv/
 /build/
 /VERSION
 .scannerwork/
+*.egg-info/
+.coverage
+coverage.xml
+htmlcov/

--- a/ci/python_coverage_report.sh
+++ b/ci/python_coverage_report.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+pip install --user -r requirements.txt
+pip install --user coverage
+
+# pip --user installs scripts such as `coverage` into an alternate location.
+export PATH=~/.local/bin:$PATH
+
+# Protos need to have their Python code generated in order for tests to pass.
+python -m grpc_tools.protoc -I=proto/ --python_out=pycue/opencue/compiled_proto --grpc_python_out=pycue/opencue/compiled_proto proto/*.proto
+python -m grpc_tools.protoc -I=proto/ --python_out=rqd/rqd/compiled_proto --grpc_python_out=rqd/rqd/compiled_proto proto/*.proto
+
+# Run coverage for each component individually, but append it all into the same report.
+coverage run --source=pycue/opencue/,pycue/FileSequence/ --omit=pycue/opencue/compiled_proto/* pycue/setup.py test
+PYTHONPATH=pycue coverage run -a --source=pyoutline/outline/ pyoutline/setup.py test
+PYTHONPATH=pycue coverage run -a --source=cueadmin/cueadmin/ cueadmin/setup.py test
+PYTHONPATH=pycue coverage run -a --source=cuegui/cuegui/ cuegui/setup.py test
+PYTHONPATH=pycue:pyoutline coverage run -a --source=cuesubmit/cuesubmit/ cuesubmit/setup.py test
+coverage run -a --source=rqd/rqd/ --omit=rqd/rqd/compiled_proto/* rqd/setup.py test
+
+# SonarCloud needs the report in XML.
+coverage xml

--- a/pycue/tests/__init__.py
+++ b/pycue/tests/__init__.py
@@ -11,5 +11,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-import util_test

--- a/pycue/tests/__init__.py
+++ b/pycue/tests/__init__.py
@@ -11,3 +11,5 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+
+import util_test

--- a/rqd/rqd/__init__.py
+++ b/rqd/rqd/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright (c) 2018 Sony Pictures Imageworks Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/rqd/rqd/compiled_proto/__init__.py
+++ b/rqd/rqd/compiled_proto/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright (c) 2018 Sony Pictures Imageworks Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/rqd/setup.py
+++ b/rqd/setup.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 import os
+from setuptools import find_packages
 from setuptools import setup
 
 rqd_dir = os.path.abspath(os.path.dirname(__file__))
@@ -43,7 +44,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
     ],
-    packages=['rqd', 'rqd.compiled_proto'],
+    packages=find_packages(),
     entry_points={
         'console_scripts': [
             'rqd=rqd.__main__:main'

--- a/sonar-cloud-pipeline.yml
+++ b/sonar-cloud-pipeline.yml
@@ -19,6 +19,7 @@ jobs:
       wget -q https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_VERSION}-linux.zip
       unzip -q sonar-scanner-cli-${SONAR_VERSION}-linux.zip
 
+      pip install virtualenv
       virtualenv venv
       source venv/bin/activate
       pip install -r requirements.txt

--- a/sonar-cloud-pipeline.yml
+++ b/sonar-cloud-pipeline.yml
@@ -9,6 +9,7 @@ jobs:
   displayName: Analyze with SonarCloud
   pool:
     vmImage: 'ubuntu-16.04'
+  container: aswf/ci-base:2019.0
   steps:
   - bash: |
       set -e
@@ -17,6 +18,14 @@ jobs:
 
       wget -q https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_VERSION}-linux.zip
       unzip -q sonar-scanner-cli-${SONAR_VERSION}-linux.zip
+
+      virtualenv venv
+      source venv/bin/activate
+      pip install -r requirements.txt
+
+      coverage run --source=pycue/opencue/,pycue/FileSequence/ --omit=pycue/opencue/compiled_proto/* pycue/setup.py test
+      PYTHONPATH=pycue coverage run -a --source=pyoutline/outline/ pyoutline/setup.py test
+      coverage xml
 
       # sonar-scanner by default reads most of its configuration from sonar-project.properties
       sonar-scanner-${SONAR_VERSION}-linux/bin/sonar-scanner -Dsonar.login=$(SONAR_TOKEN)

--- a/sonar-cloud-pipeline.yml
+++ b/sonar-cloud-pipeline.yml
@@ -20,7 +20,7 @@ jobs:
       unzip -q sonar-scanner-cli-${SONAR_VERSION}-linux.zip
 
       pip install --user virtualenv
-      virtualenv venv
+      ~/.local/bin/virtualenv venv
       source venv/bin/activate
       pip install --user -r requirements.txt
 

--- a/sonar-cloud-pipeline.yml
+++ b/sonar-cloud-pipeline.yml
@@ -11,6 +11,9 @@ jobs:
     vmImage: 'ubuntu-16.04'
   container: aswf/ci-base:2019.0
   steps:
+  - bash: ci/python_coverage_report.sh
+    name: coverageReport
+    displayName: Generate Test Coverage Report
   - bash: |
       set -e
 
@@ -19,26 +22,10 @@ jobs:
       wget -q https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_VERSION}-linux.zip
       unzip -q sonar-scanner-cli-${SONAR_VERSION}-linux.zip
 
-      pip install --user -r requirements.txt
-      pip install --user coverage
-      # pip --user installs scripts such as `coverage` into an alternate location.
-      export PATH=~/.local/bin:$PATH
-
-      python -m grpc_tools.protoc -I=proto/ --python_out=pycue/opencue/compiled_proto --grpc_python_out=pycue/opencue/compiled_proto proto/*.proto
-      python -m grpc_tools.protoc -I=proto/ --python_out=rqd/rqd/compiled_proto --grpc_python_out=rqd/rqd/compiled_proto proto/*.proto
-
-      coverage run --source=pycue/opencue/,pycue/FileSequence/ --omit=pycue/opencue/compiled_proto/* pycue/setup.py test
-      PYTHONPATH=pycue coverage run -a --source=pyoutline/outline/ pyoutline/setup.py test
-      PYTHONPATH=pycue coverage run -a --source=cueadmin/cueadmin/ cueadmin/setup.py test
-      PYTHONPATH=pycue coverage run -a --source=cuegui/cuegui/ cuegui/setup.py test
-      PYTHONPATH=pycue:pyoutline coverage run -a --source=cuesubmit/cuesubmit/ cuesubmit/setup.py test
-      coverage run -a --source=rqd/rqd/ --omit=rqd/rqd/compiled_proto/* rqd/setup.py test
-      coverage xml
-
       # sonar-scanner by default reads most of its configuration from sonar-project.properties
       sonar-scanner-${SONAR_VERSION}-linux/bin/sonar-scanner -Dsonar.login=$(SONAR_TOKEN)
     name: analyzePython
-    displayName: Analyze Python Components
+    displayName: Analyze and Send to SonarCloud
 
 - job: analyzeCuebot
   displayName: Analyze Cuebot
@@ -46,5 +33,5 @@ jobs:
     vmImage: 'ubuntu-16.04'
   steps:
   - bash: cd cuebot && ./gradlew jacocoTestReport sonarqube -Dsonar.login=$(SONAR_TOKEN)
-    name: analyzeCuebot
-    displayName: Analyze Cuebot
+    name: analyze
+    displayName: Analyze and Send to SonarCloud

--- a/sonar-cloud-pipeline.yml
+++ b/sonar-cloud-pipeline.yml
@@ -28,6 +28,10 @@ jobs:
 
       coverage run --source=pycue/opencue/,pycue/FileSequence/ --omit=pycue/opencue/compiled_proto/* pycue/setup.py test
       PYTHONPATH=pycue coverage run -a --source=pyoutline/outline/ pyoutline/setup.py test
+      PYTHONPATH=pycue coverage run -a --source=cueadmin/cueadmin/ cueadmin/setup.py test
+      PYTHONPATH=pycue coverage run -a --source=cuegui/cuegui/ cuegui/setup.py test
+      PYTHONPATH=pycue:pyoutline coverage run -a --source=cuesubmit/cuesubmit/ cuesubmit/setup.py test
+      coverage run -a --source=rqd/rqd/ rqd/setup.py test
       coverage xml
 
       # sonar-scanner by default reads most of its configuration from sonar-project.properties
@@ -35,7 +39,6 @@ jobs:
     name: analyzePython
     displayName: Analyze Python Components
 
-<<<<<<< HEAD
 - job: analyzeCuebot
   displayName: Analyze Cuebot
   pool:

--- a/sonar-cloud-pipeline.yml
+++ b/sonar-cloud-pipeline.yml
@@ -9,7 +9,7 @@ jobs:
   displayName: Analyze with SonarCloud
   pool:
     vmImage: 'ubuntu-16.04'
-  container: aswf/ci-base:2019.0
+  container: aswftesting/ci-base:2019.0
   steps:
   - bash: |
       set -e

--- a/sonar-cloud-pipeline.yml
+++ b/sonar-cloud-pipeline.yml
@@ -21,7 +21,9 @@ jobs:
 
       pip install --user -r requirements.txt
       pip install --user coverage
-      
+
+      python -m grpc_tools.protoc -I=proto/ --python_out=pycue/opencue/compiled_proto --grpc_python_out=pycue/opencue/compiled_proto proto/*.proto
+
       coverage run --source=pycue/opencue/,pycue/FileSequence/ --omit=pycue/opencue/compiled_proto/* pycue/setup.py test
       PYTHONPATH=pycue coverage run -a --source=pyoutline/outline/ pyoutline/setup.py test
       coverage xml

--- a/sonar-cloud-pipeline.yml
+++ b/sonar-cloud-pipeline.yml
@@ -19,10 +19,10 @@ jobs:
       wget -q https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_VERSION}-linux.zip
       unzip -q sonar-scanner-cli-${SONAR_VERSION}-linux.zip
 
-      pip install virtualenv
+      pip install --user virtualenv
       virtualenv venv
       source venv/bin/activate
-      pip install -r requirements.txt
+      pip install --user -r requirements.txt
 
       coverage run --source=pycue/opencue/,pycue/FileSequence/ --omit=pycue/opencue/compiled_proto/* pycue/setup.py test
       PYTHONPATH=pycue coverage run -a --source=pyoutline/outline/ pyoutline/setup.py test

--- a/sonar-cloud-pipeline.yml
+++ b/sonar-cloud-pipeline.yml
@@ -25,6 +25,7 @@ jobs:
       export PATH=~/.local/bin:$PATH
 
       python -m grpc_tools.protoc -I=proto/ --python_out=pycue/opencue/compiled_proto --grpc_python_out=pycue/opencue/compiled_proto proto/*.proto
+      python -m grpc_tools.protoc -I=proto/ --python_out=rqd/rqd/compiled_proto --grpc_python_out=rqd/rqd/compiled_proto proto/*.proto
 
       coverage run --source=pycue/opencue/,pycue/FileSequence/ --omit=pycue/opencue/compiled_proto/* pycue/setup.py test
       PYTHONPATH=pycue coverage run -a --source=pyoutline/outline/ pyoutline/setup.py test

--- a/sonar-cloud-pipeline.yml
+++ b/sonar-cloud-pipeline.yml
@@ -19,15 +19,9 @@ jobs:
       wget -q https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_VERSION}-linux.zip
       unzip -q sonar-scanner-cli-${SONAR_VERSION}-linux.zip
 
-      # Container user isn't allowed to install packages at system-level, so we use --user and
-      # the custom path to the virtualenv script.
-      pip install --user virtualenv
-      ~/.local/bin/virtualenv venv
-      source venv/bin/activate
-      # Don't need --user here as we're now in the virtual environment.
-      pip install -r requirements.txt
-
-      pip install coverage
+      pip install --user -r requirements.txt
+      pip install --user coverage
+      
       coverage run --source=pycue/opencue/,pycue/FileSequence/ --omit=pycue/opencue/compiled_proto/* pycue/setup.py test
       PYTHONPATH=pycue coverage run -a --source=pyoutline/outline/ pyoutline/setup.py test
       coverage xml

--- a/sonar-cloud-pipeline.yml
+++ b/sonar-cloud-pipeline.yml
@@ -21,6 +21,8 @@ jobs:
 
       pip install --user -r requirements.txt
       pip install --user coverage
+      # pip --user installs scripts such as `coverage` into an alternate location.
+      export PATH=~/.local/bin:$PATH
 
       python -m grpc_tools.protoc -I=proto/ --python_out=pycue/opencue/compiled_proto --grpc_python_out=pycue/opencue/compiled_proto proto/*.proto
 

--- a/sonar-cloud-pipeline.yml
+++ b/sonar-cloud-pipeline.yml
@@ -5,11 +5,11 @@ trigger: none
 pr: none
 
 jobs:
-- job: analyze
-  displayName: Analyze with SonarCloud
+- job: analyzePython
+  displayName: Analyze Python Components
   pool:
     vmImage: 'ubuntu-16.04'
-  container: aswftesting/ci-base:2019.0
+  container: aswf/ci-base:2019.0
   steps:
   - bash: |
       set -e
@@ -35,8 +35,11 @@ jobs:
     name: analyzePython
     displayName: Analyze Python Components
 
+- job: analyzeCuebot
+  displayName: Analyze Cuebot
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
   - bash: cd cuebot && ./gradlew sonarqube -Dsonar.login=$(SONAR_TOKEN)
     name: analyzeCuebot
     displayName: Analyze Cuebot
-
-

--- a/sonar-cloud-pipeline.yml
+++ b/sonar-cloud-pipeline.yml
@@ -32,7 +32,7 @@ jobs:
       PYTHONPATH=pycue coverage run -a --source=cueadmin/cueadmin/ cueadmin/setup.py test
       PYTHONPATH=pycue coverage run -a --source=cuegui/cuegui/ cuegui/setup.py test
       PYTHONPATH=pycue:pyoutline coverage run -a --source=cuesubmit/cuesubmit/ cuesubmit/setup.py test
-      coverage run -a --source=rqd/rqd/ rqd/setup.py test
+      coverage run -a --source=rqd/rqd/ --omit=rqd/rqd/compiled_proto/* rqd/setup.py test
       coverage xml
 
       # sonar-scanner by default reads most of its configuration from sonar-project.properties

--- a/sonar-cloud-pipeline.yml
+++ b/sonar-cloud-pipeline.yml
@@ -27,6 +27,7 @@ jobs:
       # Don't need --user here as we're now in the virtual environment.
       pip install -r requirements.txt
 
+      pip install coverage
       coverage run --source=pycue/opencue/,pycue/FileSequence/ --omit=pycue/opencue/compiled_proto/* pycue/setup.py test
       PYTHONPATH=pycue coverage run -a --source=pyoutline/outline/ pyoutline/setup.py test
       coverage xml

--- a/sonar-cloud-pipeline.yml
+++ b/sonar-cloud-pipeline.yml
@@ -19,10 +19,13 @@ jobs:
       wget -q https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_VERSION}-linux.zip
       unzip -q sonar-scanner-cli-${SONAR_VERSION}-linux.zip
 
+      # Container user isn't allowed to install packages at system-level, so we use --user and
+      # the custom path to the virtualenv script.
       pip install --user virtualenv
       ~/.local/bin/virtualenv venv
       source venv/bin/activate
-      pip install --user -r requirements.txt
+      # Don't need --user here as we're now in the virtual environment.
+      pip install -r requirements.txt
 
       coverage run --source=pycue/opencue/,pycue/FileSequence/ --omit=pycue/opencue/compiled_proto/* pycue/setup.py test
       PYTHONPATH=pycue coverage run -a --source=pyoutline/outline/ pyoutline/setup.py test

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,3 +4,4 @@ sonar.projectKey=bcipriano_OpenCue
 sonar.projectName=OpenCue Python Components
 sonar.sources=cueadmin/cueadmin,cuegui/cuegui,cuesubmit/cuesubmit,pycue/opencue,\
   pycue/FileSequence,pyoutline/outline,rqd/rqd
+sonar.python.coverage.reportPaths=./coverage.xml


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
#396 

**Summarize your change.**
Update pipeline to run all Python tests, collect coverage into a single report, and send the report to SonarCloud.

I've also split the Cuebot and Python coverage tasks into separate pipeline jobs, because I wanted to use the ASWF VFX reference platform image for the python environment but it turns out that image is not quite JDK-friendly yet.