### PR TITLE
Lighten requirements for RQD

### DIFF
--- a/rqd/Dockerfile
+++ b/rqd/Dockerfile
@@ -17,7 +17,7 @@ RUN yum -y install python-pip
 WORKDIR /src
 
 COPY LICENSE ./
-COPY requirements.txt ./
+COPY rqd/requirements.txt ./
 
 RUN pip install -r requirements.txt
 

--- a/rqd/requirements.txt
+++ b/rqd/requirements.txt
@@ -1,0 +1,7 @@
+enum34==1.1.6
+future==0.17.1
+futures==3.2.0;python_version<"3.0"
+grpcio==1.16.0
+grpcio-tools==1.16.0
+psutil==5.4.7
+PyYAML==5.1


### PR DESCRIPTION
**Summarize your change.**

RQD doesn't require PySide2 among other packages.
Remove them from the RQD requirements.txt.