### PR TITLE
Find and get methods should raise EntityNotFoundException in pycue

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageAllocation.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageAllocation.java
@@ -3,7 +3,9 @@ package com.imageworks.spcue.servant;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import org.springframework.dao.EmptyResultDataAccessException;
 
 import com.imageworks.spcue.AllocationEntity;
 import com.imageworks.spcue.HostEntity;
@@ -90,20 +92,34 @@ public class ManageAllocation extends AllocationInterfaceGrpc.AllocationInterfac
     @Override
     public void find(
             AllocFindRequest request, StreamObserver<AllocFindResponse> responseObserver) {
-        responseObserver.onNext(
-                AllocFindResponse.newBuilder()
-                        .setAllocation(whiteboard.findAllocation(request.getName()))
-                        .build());
-        responseObserver.onCompleted();
+        try {
+            responseObserver.onNext(
+                    AllocFindResponse.newBuilder()
+                            .setAllocation(whiteboard.findAllocation(request.getName()))
+                            .build());
+            responseObserver.onCompleted();
+        } catch (EmptyResultDataAccessException e) {
+            responseObserver.onError(Status.NOT_FOUND
+                    .withDescription(e.getMessage())
+                    .withCause(e)
+                    .asRuntimeException());
+        }
     }
 
     @Override
     public void get(AllocGetRequest request, StreamObserver<AllocGetResponse> responseObserver) {
-        responseObserver.onNext(
-                AllocGetResponse.newBuilder()
-                    .setAllocation(whiteboard.findAllocation(request.getId()))
-                    .build());
-        responseObserver.onCompleted();
+        try {
+            responseObserver.onNext(
+                    AllocGetResponse.newBuilder()
+                        .setAllocation(whiteboard.findAllocation(request.getId()))
+                        .build());
+            responseObserver.onCompleted();
+        } catch (EmptyResultDataAccessException e) {
+            responseObserver.onError(Status.NOT_FOUND
+                    .withDescription(e.getMessage())
+                    .withCause(e)
+                    .asRuntimeException());
+        }
     }
 
     @Override

--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageDepend.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageDepend.java
@@ -19,8 +19,10 @@
 
 package com.imageworks.spcue.servant;
 
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import org.apache.log4j.Logger;
+import org.springframework.dao.EmptyResultDataAccessException;
 
 import com.imageworks.spcue.LightweightDependency;
 import com.imageworks.spcue.dispatcher.DispatchQueue;
@@ -44,10 +46,17 @@ public class ManageDepend extends DependInterfaceGrpc.DependInterfaceImplBase {
 
     @Override
     public void getDepend(DependGetDependRequest request, StreamObserver<DependGetDependResponse> responseObserver) {
-        responseObserver.onNext(DependGetDependResponse.newBuilder()
-                .setDepend(whiteboard.getDepend(request.getId()))
-                .build());
-        responseObserver.onCompleted();
+        try {
+            responseObserver.onNext(DependGetDependResponse.newBuilder()
+                    .setDepend(whiteboard.getDepend(request.getId()))
+                    .build());
+            responseObserver.onCompleted();
+        } catch (EmptyResultDataAccessException e) {
+            responseObserver.onError(Status.NOT_FOUND
+                    .withDescription(e.getMessage())
+                    .withCause(e)
+                    .asRuntimeException());
+        }
     }
 
     public void satisfy(DependSatisfyRequest request, StreamObserver<DependSatisfyResponse> responseObserver) {

--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageFacility.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageFacility.java
@@ -1,6 +1,8 @@
 package com.imageworks.spcue.servant;
 
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import org.springframework.dao.EmptyResultDataAccessException;
 
 import com.imageworks.spcue.grpc.facility.FacilityCreateRequest;
 import com.imageworks.spcue.grpc.facility.FacilityCreateResponse;
@@ -34,11 +36,18 @@ public class ManageFacility extends FacilityInterfaceGrpc.FacilityInterfaceImplB
 
     @Override
     public void get(FacilityGetRequest request, StreamObserver<FacilityGetResponse> responseObserver) {
-        FacilityGetResponse response = FacilityGetResponse.newBuilder()
-                .setFacility(whiteboard.getFacility(request.getName()))
-                .build();
-        responseObserver.onNext(response);
-        responseObserver.onCompleted();
+        try {
+            FacilityGetResponse response = FacilityGetResponse.newBuilder()
+                    .setFacility(whiteboard.getFacility(request.getName()))
+                    .build();
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (EmptyResultDataAccessException e) {
+            responseObserver.onError(Status.NOT_FOUND
+                    .withDescription(e.getMessage())
+                    .withCause(e)
+                    .asRuntimeException());
+        }
     }
 
     @Override

--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageFilter.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageFilter.java
@@ -21,7 +21,9 @@ package com.imageworks.spcue.servant;
 
 import java.util.List;
 
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import org.springframework.dao.EmptyResultDataAccessException;
 
 import com.imageworks.spcue.ActionEntity;
 import com.imageworks.spcue.FilterEntity;
@@ -81,10 +83,17 @@ public class ManageFilter extends FilterInterfaceGrpc.FilterInterfaceImplBase {
 
     @Override
     public void findFilter(FilterFindFilterRequest request, StreamObserver<FilterFindFilterResponse> responseObserver) {
-        responseObserver.onNext(FilterFindFilterResponse.newBuilder()
-                .setFilter(whiteboard.findFilter(request.getShow(), request.getName()))
-                .build());
-        responseObserver.onCompleted();
+        try {
+            responseObserver.onNext(FilterFindFilterResponse.newBuilder()
+                    .setFilter(whiteboard.findFilter(request.getShow(), request.getName()))
+                    .build());
+            responseObserver.onCompleted();
+        } catch (EmptyResultDataAccessException e) {
+            responseObserver.onError(Status.NOT_FOUND
+                    .withDescription(e.getMessage())
+                    .withCause(e)
+                    .asRuntimeException());
+        }
     }
 
     @Override

--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageFrame.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageFrame.java
@@ -21,6 +21,7 @@ package com.imageworks.spcue.servant;
 
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import org.springframework.dao.EmptyResultDataAccessException;
 
 import com.imageworks.spcue.FrameEntity;
 import com.imageworks.spcue.LocalHostAssignment;
@@ -91,18 +92,32 @@ public class ManageFrame extends FrameInterfaceGrpc.FrameInterfaceImplBase {
 
     @Override
     public void findFrame(FrameFindFrameRequest request, StreamObserver<FrameFindFrameResponse> responseObserver) {
-        responseObserver.onNext(FrameFindFrameResponse.newBuilder()
-                .setFrame(whiteboard.findFrame(request.getJob(), request.getLayer(), request.getFrame()))
-                .build());
-        responseObserver.onCompleted();
+        try {
+            responseObserver.onNext(FrameFindFrameResponse.newBuilder()
+                    .setFrame(whiteboard.findFrame(request.getJob(), request.getLayer(), request.getFrame()))
+                    .build());
+            responseObserver.onCompleted();
+        } catch (EmptyResultDataAccessException e) {
+            responseObserver.onError(Status.NOT_FOUND
+                    .withDescription(e.getMessage())
+                    .withCause(e)
+                    .asRuntimeException());
+        }
     }
 
     @Override
     public void getFrame(FrameGetFrameRequest request, StreamObserver<FrameGetFrameResponse> responseObserver) {
-        responseObserver.onNext(FrameGetFrameResponse.newBuilder()
-                .setFrame(whiteboard.getFrame(request.getId()))
-                .build());
-        responseObserver.onCompleted();
+        try {
+            responseObserver.onNext(FrameGetFrameResponse.newBuilder()
+                    .setFrame(whiteboard.getFrame(request.getId()))
+                    .build());
+            responseObserver.onCompleted();
+        } catch (EmptyResultDataAccessException e) {
+            responseObserver.onError(Status.NOT_FOUND
+                    .withDescription(e.getMessage())
+                    .withCause(e)
+                    .asRuntimeException());
+        }
     }
 
     @Override

--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageGroup.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageGroup.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import org.springframework.dao.EmptyResultDataAccessException;
 
 import com.imageworks.spcue.GroupDetail;
 import com.imageworks.spcue.GroupInterface;
@@ -84,18 +85,32 @@ public class ManageGroup extends GroupInterfaceGrpc.GroupInterfaceImplBase {
 
     @Override
     public void getGroup(GroupGetGroupRequest request, StreamObserver<GroupGetGroupResponse> responseObserver) {
-        responseObserver.onNext(GroupGetGroupResponse.newBuilder()
-                .setGroup(whiteboard.getGroup(request.getId()))
-                .build());
-        responseObserver.onCompleted();
+        try {
+            responseObserver.onNext(GroupGetGroupResponse.newBuilder()
+                    .setGroup(whiteboard.getGroup(request.getId()))
+                    .build());
+            responseObserver.onCompleted();
+        } catch (EmptyResultDataAccessException e) {
+            responseObserver.onError(Status.NOT_FOUND
+                    .withDescription(e.getMessage())
+                    .withCause(e)
+                    .asRuntimeException());
+        }
     }
 
     @Override
     public void findGroup(GroupFindGroupRequest request, StreamObserver<GroupFindGroupResponse> responseObserver) {
-        responseObserver.onNext(GroupFindGroupResponse.newBuilder()
-                .setGroup(whiteboard.findGroup(request.getShow(), request.getName()))
-                .build());
-        responseObserver.onCompleted();
+        try {
+            responseObserver.onNext(GroupFindGroupResponse.newBuilder()
+                    .setGroup(whiteboard.findGroup(request.getShow(), request.getName()))
+                    .build());
+            responseObserver.onCompleted();
+        } catch (EmptyResultDataAccessException e) {
+            responseObserver.onError(Status.NOT_FOUND
+                    .withDescription(e.getMessage())
+                    .withCause(e)
+                    .asRuntimeException());
+        }
     }
 
     @Override

--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageHost.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageHost.java
@@ -22,7 +22,9 @@ package com.imageworks.spcue.servant;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import org.springframework.dao.EmptyResultDataAccessException;
 
 import com.imageworks.spcue.CommentDetail;
 import com.imageworks.spcue.HostInterface;
@@ -120,19 +122,33 @@ public class ManageHost extends HostInterfaceGrpc.HostInterfaceImplBase {
     @Override
     public void findHost(HostFindHostRequest request,
                                   StreamObserver<HostFindHostResponse> responseObserver) {
-        responseObserver.onNext(HostFindHostResponse.newBuilder()
-                .setHost(whiteboard.findHost(request.getName()))
-                .build());
-        responseObserver.onCompleted();
+        try {
+            responseObserver.onNext(HostFindHostResponse.newBuilder()
+                    .setHost(whiteboard.findHost(request.getName()))
+                    .build());
+            responseObserver.onCompleted();
+        } catch (EmptyResultDataAccessException e) {
+            responseObserver.onError(Status.NOT_FOUND
+                    .withDescription(e.getMessage())
+                    .withCause(e)
+                    .asRuntimeException());
+        }
     }
 
     @Override
     public void getHost(HostGetHostRequest request,
                          StreamObserver<HostGetHostResponse> responseObserver) {
-        responseObserver.onNext(HostGetHostResponse.newBuilder()
-                .setHost(whiteboard.findHost(request.getId()))
-                .build());
-        responseObserver.onCompleted();
+        try {
+            responseObserver.onNext(HostGetHostResponse.newBuilder()
+                    .setHost(whiteboard.findHost(request.getId()))
+                    .build());
+            responseObserver.onCompleted();
+        } catch (EmptyResultDataAccessException e) {
+            responseObserver.onError(Status.NOT_FOUND
+                    .withDescription(e.getMessage())
+                    .withCause(e)
+                    .asRuntimeException());
+        }
     }
 
     @Override

--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageJob.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageJob.java
@@ -184,10 +184,17 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
 
     @Override
     public void getJob(JobGetJobRequest request, StreamObserver<JobGetJobResponse> responseObserver) {
-        responseObserver.onNext(JobGetJobResponse.newBuilder()
-                .setJob(whiteboard.getJob(request.getId()))
-                .build());
-        responseObserver.onCompleted();
+        try {
+            responseObserver.onNext(JobGetJobResponse.newBuilder()
+                    .setJob(whiteboard.getJob(request.getId()))
+                    .build());
+            responseObserver.onCompleted();
+        } catch (EmptyResultDataAccessException e) {
+            responseObserver.onError(Status.NOT_FOUND
+                    .withDescription(e.getMessage())
+                    .withCause(e)
+                    .asRuntimeException());
+        }
     }
 
     @Override

--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageLayer.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageLayer.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import com.google.protobuf.Descriptors;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import org.springframework.dao.EmptyResultDataAccessException;
 
 import com.imageworks.spcue.LayerDetail;
 import com.imageworks.spcue.LocalHostAssignment;
@@ -122,18 +123,32 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
 
     @Override
     public void findLayer(LayerFindLayerRequest request, StreamObserver<LayerFindLayerResponse> responseObserver) {
-        responseObserver.onNext(LayerFindLayerResponse.newBuilder()
-                .setLayer(whiteboard.findLayer(request.getJob(), request.getLayer()))
-                .build());
-        responseObserver.onCompleted();
+        try {
+            responseObserver.onNext(LayerFindLayerResponse.newBuilder()
+                    .setLayer(whiteboard.findLayer(request.getJob(), request.getLayer()))
+                    .build());
+            responseObserver.onCompleted();
+        } catch (EmptyResultDataAccessException e) {
+            responseObserver.onError(Status.NOT_FOUND
+                    .withDescription(e.getMessage())
+                    .withCause(e)
+                    .asRuntimeException());
+        }
     }
 
     @Override
     public void getLayer(LayerGetLayerRequest request, StreamObserver<LayerGetLayerResponse> responseObserver) {
-        responseObserver.onNext(LayerGetLayerResponse.newBuilder()
-                .setLayer(whiteboard.getLayer(request.getId()))
-                .build());
-        responseObserver.onCompleted();
+        try {
+            responseObserver.onNext(LayerGetLayerResponse.newBuilder()
+                    .setLayer(whiteboard.getLayer(request.getId()))
+                    .build());
+            responseObserver.onCompleted();
+        } catch (EmptyResultDataAccessException e) {
+            responseObserver.onError(Status.NOT_FOUND
+                    .withDescription(e.getMessage())
+                    .withCause(e)
+                    .asRuntimeException());
+        }
     }
 
     @Override

--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageOwner.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageOwner.java
@@ -19,7 +19,9 @@
 
 package com.imageworks.spcue.servant;
 
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import org.springframework.dao.EmptyResultDataAccessException;
 
 import com.imageworks.spcue.OwnerEntity;
 import com.imageworks.spcue.grpc.host.OwnerDeleteRequest;
@@ -49,10 +51,17 @@ public class ManageOwner extends OwnerInterfaceGrpc.OwnerInterfaceImplBase {
 
     @Override
     public void getOwner(OwnerGetOwnerRequest request, StreamObserver<OwnerGetOwnerResponse> responseObserver) {
-        responseObserver.onNext(OwnerGetOwnerResponse.newBuilder()
-                .setOwner(whiteboard.getOwner(request.getName()))
-                .build());
-        responseObserver.onCompleted();
+        try {
+            responseObserver.onNext(OwnerGetOwnerResponse.newBuilder()
+                    .setOwner(whiteboard.getOwner(request.getName()))
+                    .build());
+            responseObserver.onCompleted();
+        } catch (EmptyResultDataAccessException e) {
+            responseObserver.onError(Status.NOT_FOUND
+                    .withDescription(e.getMessage())
+                    .withCause(e)
+                    .asRuntimeException());
+        }
     }
 
     @Override

--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageShow.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageShow.java
@@ -20,6 +20,7 @@ package com.imageworks.spcue.servant;
 import com.google.common.collect.Sets;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import org.springframework.dao.EmptyResultDataAccessException;
 
 import com.imageworks.spcue.AllocationEntity;
 import com.imageworks.spcue.FilterEntity;
@@ -133,10 +134,17 @@ public class ManageShow extends ShowInterfaceGrpc.ShowInterfaceImplBase {
 
     @Override
     public void findShow(ShowFindShowRequest request, StreamObserver<ShowFindShowResponse> responseObserver) {
-        responseObserver.onNext(ShowFindShowResponse.newBuilder()
-                .setShow(whiteboard.findShow(request.getName()))
-                .build());
-        responseObserver.onCompleted();
+        try {
+            responseObserver.onNext(ShowFindShowResponse.newBuilder()
+                    .setShow(whiteboard.findShow(request.getName()))
+                    .build());
+            responseObserver.onCompleted();
+        } catch (EmptyResultDataAccessException e) {
+            responseObserver.onError(Status.NOT_FOUND
+                    .withDescription(e.getMessage())
+                    .withCause(e)
+                    .asRuntimeException());
+        }
     }
 
     @Override

--- a/pycue/tests/util_test.py
+++ b/pycue/tests/util_test.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from builtins import range
+import grpc
 import mock
 import unittest
 
@@ -27,8 +28,51 @@ from opencue.compiled_proto import job_pb2
 from opencue.wrappers.job import Job
 
 
+@opencue.util.grpcExceptionParser
+def testRaise(exc):
+    raise exc
+
+
 class ProxyTests(unittest.TestCase):
     """proxy converts different types of entities to usable Ice proxies"""
+
+    
+
+    def testNotFoundExceptionParser(self):
+        response = grpc.RpcError()
+        response.code = lambda: grpc.StatusCode.NOT_FOUND
+        response.details = lambda: "testing not found"
+        self.assertRaises(opencue.exception.EntityNotFoundException,
+                          lambda: testRaise(response))
+
+    def testExistsExceptionParser(self):
+        response = grpc.RpcError()
+        response.code = lambda: grpc.StatusCode.ALREADY_EXISTS
+        response.details = lambda: "already exists"
+        self.assertRaises(opencue.exception.EntityAlreadyExistsException,
+                          lambda: testRaise(response))
+
+    def testDeadlineExceptionParser(self):
+        response = grpc.RpcError()
+        response.code = lambda: grpc.StatusCode.DEADLINE_EXCEEDED
+        response.details = lambda: "deadline exceeded"
+        self.assertRaises(opencue.exception.DeadlineExceededException,
+                          lambda: testRaise(response))
+
+    def testInternalExceptionParser(self):
+        response = grpc.RpcError()
+        response.code = lambda: grpc.StatusCode.INTERNAL
+        response.details = lambda: "Internal Error"
+        self.assertRaises(opencue.exception.CueInternalErrorException,
+                          lambda: testRaise(response))
+
+    def testUnknownExceptionParser(self):
+        response = grpc.RpcError()
+        response.code = lambda: "unknown"
+        response.details = lambda: "unknown"
+        self.assertRaises(opencue.exception.CueException,
+                          lambda: testRaise(response))
+    
 
     @mock.patch('opencue.cuebot.Cuebot.getStub')
     def testProxyUniqueId(self, getStubMock):

--- a/pycue/tests/util_test.py
+++ b/pycue/tests/util_test.py
@@ -70,7 +70,6 @@ class ProxyTests(unittest.TestCase):
         response.details = lambda: "unknown"
         self.assertRaises(opencue.exception.CueException,
                           lambda: testRaise(response))
-    
 
     @mock.patch('opencue.cuebot.Cuebot.getStub')
     def testProxyUniqueId(self, getStubMock):

--- a/pycue/tests/util_test.py
+++ b/pycue/tests/util_test.py
@@ -36,8 +36,6 @@ def testRaise(exc):
 class ProxyTests(unittest.TestCase):
     """proxy converts different types of entities to usable Ice proxies"""
 
-    
-
     def testNotFoundExceptionParser(self):
         response = grpc.RpcError()
         response.code = lambda: grpc.StatusCode.NOT_FOUND


### PR DESCRIPTION
Issue #401 
The existing code does not follow any standards when returning error codes from `find` and `get` calls. As a standard these should raise an `EntityNotFoundException` in pycue not a `CueInternalErrorException`.

I've decided to open this PR without tests of the cuebot servants as this should be addressed in #396 and is going to take a bit more wiring up. I have added tests for the pycue exception parser.
