### PR TITLE
Start bash before rqd to prevent zombie processes from being pid 1.

### DIFF
--- a/rqd/Dockerfile
+++ b/rqd/Dockerfile
@@ -78,4 +78,4 @@ RUN chmod +x ./install_and_run.sh
 # RQD gRPC server
 EXPOSE 8444
 
-ENTRYPOINT ["/opt/opencue/install_and_run.sh"]
+ENTRYPOINT ["/bin/bash", "-c", "set -e && /opt/opencue/install_and_run.sh"]


### PR DESCRIPTION
Issue #390 
Start bash before running starting rqd to prevent leaving defunct children processes. See https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/ for a description of the problem. 

This solution causes rqd to forcefully exit, but I don't believe this should be a great concern, since cuebot should handle failing tasks due to lost connectivity.
