### PR TITLE
Add tests for FrameMonitorTree.

### DIFF
--- a/cuegui/Dockerfile
+++ b/cuegui/Dockerfile
@@ -10,11 +10,18 @@ WORKDIR /src
 
 RUN yum -y install \
   epel-release \
+  fontconfig \
+  freetype \
   gcc \
+  libXi \
+  libXrender \
   mesa-libGL \
-  python-devel
+  python-devel \
+  Xvfb
 
 RUN yum -y install python-pip
+
+RUN dbus-uuidgen > /etc/machine-id
 
 COPY LICENSE ./
 COPY requirements.txt ./
@@ -49,7 +56,7 @@ RUN cd pycue && python setup.py install
 
 # TODO(bcipriano) Lint the code here. (Issue #78)
 
-RUN cd cuegui && python setup.py test
+RUN Xvfb :1 -screen 0 1024x768x16 &> /tmp/xvfb.log & cd cuegui && DISPLAY=:1.0 python setup.py test
 
 RUN cp LICENSE requirements.txt VERSION cuegui/
 

--- a/cuegui/tests/FrameMonitorTree_tests.py
+++ b/cuegui/tests/FrameMonitorTree_tests.py
@@ -21,6 +21,7 @@ import PySide2.QtGui
 import PySide2.QtTest
 import PySide2.QtWidgets
 
+import cuegui.Constants
 import cuegui.FrameMonitor
 import cuegui.FrameMonitorTree
 import cuegui.Main
@@ -50,10 +51,6 @@ class FrameMonitorTreeTests(unittest.TestCase):
         self.frameMonitorTree = cuegui.FrameMonitorTree.FrameMonitorTree(self.parentWidget)
         self.job = opencue.wrappers.job.Job(opencue.compiled_proto.job_pb2.Job(id='foo'))
         self.frameMonitorTree.setJob(self.job)
-
-    def tearDown(self):
-        #del self.app
-        pass
 
     @mock.patch.object(opencue.wrappers.job.Job, 'getFrames', autospec=True)
     def test_tickInitialLoad(self, getFramesMock):
@@ -127,17 +124,87 @@ class FrameMonitorTreeTests(unittest.TestCase):
         self.assertEqual(125.82723, self.frameMonitorTree.getCores(frame))
         self.assertEqual('125.83', self.frameMonitorTree.getCores(frame, format=True))
 
-    @mock.patch.object(opencue.wrappers.job.Job, 'getFrames', autospec=True)
-    def test_rightClickItem(self, getFramesMock):
-        frames = [
-            opencue.wrappers.frame.Frame(
-                opencue.compiled_proto.job_pb2.Frame(name='frame1')),
-            opencue.wrappers.frame.Frame(
-                opencue.compiled_proto.job_pb2.Frame(name='frame2'))]
-        getFramesMock.return_value = frames
-        self.frameMonitorTree.tick()
+    @mock.patch.object(cuegui.FrameMonitorTree.FrameContextMenu, 'exec_')
+    def test_rightClickItem(self, execMock):
+        mouse_position = PySide2.QtCore.QPoint()
 
-        PySide2.QtTest.QTest.mouseClick(self.frameMonitorTree, PySide2.QtCore.Qt.RightButton)
+        self.frameMonitorTree.contextMenuEvent(
+            PySide2.QtGui.QContextMenuEvent(
+                PySide2.QtGui.QContextMenuEvent.Reason.Mouse, mouse_position, mouse_position))
+
+        execMock.assert_called_with(mouse_position)
+
+
+class FrameWidgetItemTests(unittest.TestCase):
+
+    @mock.patch('opencue.cuebot.Cuebot.getStub', new=mock.Mock())
+    def setUp(self):
+        self.host_name = 'arbitrary-hostname'
+        self.dispatch_order = 285
+        self.state = opencue.compiled_proto.job_pb2.RUNNING
+
+        self.frame = opencue.wrappers.frame.Frame(
+            opencue.compiled_proto.job_pb2.Frame(
+                name='frame1',
+                last_resource='{}/foo'.format(self.host_name),
+                dispatch_order=self.dispatch_order,
+                state=self.state,
+                checkpoint_state=opencue.compiled_proto.job_pb2.ENABLED))
+
+        # The widget needs a var, otherwise it gets garbage-collected before tests can run.
+        parentWidget = PySide2.QtWidgets.QWidget()
+
+        self.frameWidgetItem = cuegui.FrameMonitorTree.FrameWidgetItem(
+            self.frame,
+            cuegui.FrameMonitorTree.FrameMonitorTree(parentWidget),
+            opencue.wrappers.job.Job(opencue.compiled_proto.job_pb2.Job(id='unused-job-id')))
+
+    def test_data(self):
+        cuegui.FrameMonitorTree.LOCALRESOURCE = '{}/'.format(self.host_name)
+        dispatch_order_col = 0
+
+        self.assertEqual(
+            self.dispatch_order,
+            self.frameWidgetItem.data(dispatch_order_col, PySide2.QtCore.Qt.DisplayRole))
+
+        self.assertEqual(
+            cuegui.Style.ColorTheme.COLOR_JOB_FOREGROUND,
+            self.frameWidgetItem.data(dispatch_order_col, PySide2.QtCore.Qt.ForegroundRole))
+
+        self.assertEqual(
+            cuegui.FrameMonitorTree.QCOLOR_BLACK,
+            self.frameWidgetItem.data(
+                cuegui.FrameMonitorTree.STATUS_COLUMN, PySide2.QtCore.Qt.ForegroundRole))
+
+        self.assertEqual(
+            cuegui.FrameMonitorTree.QCOLOR_GREEN,
+            self.frameWidgetItem.data(
+                cuegui.FrameMonitorTree.PROC_COLUMN, PySide2.QtCore.Qt.ForegroundRole))
+
+        self.assertEqual(
+            cuegui.Constants.RGB_FRAME_STATE[self.state],
+            self.frameWidgetItem.data(
+                cuegui.FrameMonitorTree.STATUS_COLUMN, PySide2.QtCore.Qt.BackgroundRole))
+
+        self.assertEqual(
+            PySide2.QtGui.QIcon,
+            self.frameWidgetItem.data(
+                cuegui.FrameMonitorTree.CHECKPOINT_COLUMN,
+                PySide2.QtCore.Qt.DecorationRole).__class__)
+
+        self.assertEqual(
+            PySide2.QtCore.Qt.AlignCenter,
+            self.frameWidgetItem.data(
+                cuegui.FrameMonitorTree.STATUS_COLUMN, PySide2.QtCore.Qt.TextAlignmentRole))
+
+        self.assertEqual(
+            PySide2.QtCore.Qt.AlignRight,
+            self.frameWidgetItem.data(
+                cuegui.FrameMonitorTree.PROC_COLUMN, PySide2.QtCore.Qt.TextAlignmentRole))
+
+        self.assertEqual(
+            cuegui.Constants.TYPE_FRAME,
+            self.frameWidgetItem.data(dispatch_order_col, PySide2.QtCore.Qt.UserRole))
 
 
 if __name__ == '__main__':

--- a/cuegui/tests/FrameMonitorTree_tests.py
+++ b/cuegui/tests/FrameMonitorTree_tests.py
@@ -1,0 +1,144 @@
+#  Copyright (c) 2018 Sony Pictures Imageworks Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import mock
+import unittest
+
+import PySide2.QtCore
+import PySide2.QtGui
+import PySide2.QtTest
+import PySide2.QtWidgets
+
+import cuegui.FrameMonitor
+import cuegui.FrameMonitorTree
+import cuegui.Main
+import cuegui.plugins.MonitorJobDetailsPlugin
+import cuegui.Style
+import opencue.compiled_proto.job_pb2
+import opencue.wrappers.frame
+import opencue.wrappers.job
+
+
+_instance = None
+
+
+@mock.patch('opencue.cuebot.Cuebot.getStub', new=mock.Mock())
+class FrameMonitorTreeTests(unittest.TestCase):
+
+    @mock.patch('opencue.cuebot.Cuebot.getStub', new=mock.Mock())
+    def setUp(self):
+        global _instance
+        if _instance is None:
+            _instance = cuegui.Main.CueGuiApplication()
+        self.app = _instance
+
+        PySide2.QtGui.qApp.settings = PySide2.QtCore.QSettings()
+        cuegui.Style.init()
+        self.parentWidget = PySide2.QtWidgets.QWidget()
+        self.frameMonitorTree = cuegui.FrameMonitorTree.FrameMonitorTree(self.parentWidget)
+        self.job = opencue.wrappers.job.Job(opencue.compiled_proto.job_pb2.Job(id='foo'))
+        self.frameMonitorTree.setJob(self.job)
+
+    def tearDown(self):
+        #del self.app
+        pass
+
+    @mock.patch.object(opencue.wrappers.job.Job, 'getFrames', autospec=True)
+    def test_tickInitialLoad(self, getFramesMock):
+        frames = [
+            opencue.wrappers.frame.Frame(
+                opencue.compiled_proto.job_pb2.Frame(name='frame1')),
+            opencue.wrappers.frame.Frame(
+                opencue.compiled_proto.job_pb2.Frame(name='frame2'))]
+        getFramesMock.return_value = frames
+
+        self.frameMonitorTree.tick()
+
+        getFramesMock.assert_called_with(self.job)
+
+    @mock.patch.object(opencue.wrappers.job.Job, 'getUpdatedFrames')
+    @mock.patch.object(opencue.wrappers.job.Job, 'getFrames')
+    def test_tickNoUpdate(self, getFramesMock, getUpdatedFramesMock):
+        getFramesMock.return_value = []
+        # Initial load.
+        self.frameMonitorTree.tick()
+        getFramesMock.reset_mock()
+        getUpdatedFramesMock.reset_mock()
+
+        self.frameMonitorTree.tick()
+
+        getFramesMock.assert_not_called()
+        getUpdatedFramesMock.assert_not_called()
+
+    @mock.patch.object(opencue.wrappers.job.Job, 'getUpdatedFrames', autospec=True)
+    @mock.patch.object(opencue.wrappers.job.Job, 'getFrames')
+    def test_tickUpdateChanged(self, getFramesMock, getUpdatedFramesMock):
+        getFramesMock.return_value = []
+        getUpdatedResponse = opencue.compiled_proto.job_pb2.JobGetUpdatedFramesResponse(
+            state=opencue.compiled_proto.job_pb2.RUNNING,
+            server_time=1000,
+            updated_frames=opencue.compiled_proto.job_pb2.UpdatedFrameSeq(
+                updated_frames=[opencue.compiled_proto.job_pb2.UpdatedFrame(id='foo')]))
+        getUpdatedFramesMock.return_value = getUpdatedResponse
+        # Initial load.
+        self.frameMonitorTree.tick()
+        getFramesMock.reset_mock()
+
+        self.frameMonitorTree.updateChangedRequest()
+        self.frameMonitorTree.tick()
+
+        getFramesMock.assert_not_called()
+        getUpdatedFramesMock.assert_called_with(self.job, mock.ANY)
+
+    @mock.patch.object(opencue.wrappers.job.Job, 'getUpdatedFrames')
+    @mock.patch.object(opencue.wrappers.job.Job, 'getFrames', autospec=True)
+    def test_tickFullUpdate(self, getFramesMock, getUpdatedFramesMock):
+        getFramesMock.return_value = []
+        getUpdatedResponse = opencue.compiled_proto.job_pb2.JobGetUpdatedFramesResponse(
+            state=opencue.compiled_proto.job_pb2.RUNNING,
+            server_time=1000,
+            updated_frames=opencue.compiled_proto.job_pb2.UpdatedFrameSeq(
+                updated_frames=[opencue.compiled_proto.job_pb2.UpdatedFrame(id='foo')]))
+        getUpdatedFramesMock.return_value = getUpdatedResponse
+        # Initial load.
+        self.frameMonitorTree.tick()
+
+        self.frameMonitorTree.updateRequest()
+        self.frameMonitorTree.tick()
+
+        getFramesMock.assert_called_with(self.job)
+        getUpdatedFramesMock.assert_not_called()
+
+    def test_getCores(self):
+        frame = opencue.wrappers.frame.Frame(opencue.compiled_proto.job_pb2.Frame(last_resource='foo/125.82723'))
+
+        self.assertEqual(125.82723, self.frameMonitorTree.getCores(frame))
+        self.assertEqual('125.83', self.frameMonitorTree.getCores(frame, format=True))
+
+    @mock.patch.object(opencue.wrappers.job.Job, 'getFrames', autospec=True)
+    def test_rightClickItem(self, getFramesMock):
+        frames = [
+            opencue.wrappers.frame.Frame(
+                opencue.compiled_proto.job_pb2.Frame(name='frame1')),
+            opencue.wrappers.frame.Frame(
+                opencue.compiled_proto.job_pb2.Frame(name='frame2'))]
+        getFramesMock.return_value = frames
+        self.frameMonitorTree.tick()
+
+        PySide2.QtTest.QTest.mouseClick(self.frameMonitorTree, PySide2.QtCore.Qt.RightButton)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
#396 

**Summarize your change.**
Tests for FrameMonitorTree and the related FrameWidgetItem classes.

This necessitated splitting the context menu out into a new class that subclasses `QMenu`. This allows us to properly mock our own class, in order to avoid triggering GUI code.