### PR TITLE
Fix spelling of getRecentPgoutRate method call #433

### DIFF
--- a/rqd/rqd/rqmachine.py
+++ b/rqd/rqd/rqmachine.py
@@ -340,7 +340,7 @@ class Machine:
     def __getSwapout(self):
         if platform.system() == "Linux":
             try:
-                return str(int(self.__vmstat.get_recent_pgout_rate()))
+                return str(int(self.__vmstat.getRecentPgoutRate()))
             except:
                 return str(0)
         return str(0)


### PR DESCRIPTION
Per https://github.com/AcademySoftwareFoundation/OpenCue/issues/433