### PR TITLE
RQD lock and unlock behavior

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
@@ -399,7 +399,7 @@ public class HostReportHandler {
                 host.lockState = LockState.OPEN;
                 hostManager.setHostLock(host, LockState.OPEN, new Source("cores"));
             }
-        } else if (coreInfo.getLockedCores() == coreInfo.getTotalCores()) {
+        } else if (coreInfo.getLockedCores() >= coreInfo.getTotalCores()) {
             host.lockState = LockState.LOCKED;
             hostManager.setHostLock(host, LockState.LOCKED, new Source("cores"));
         }

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
@@ -394,16 +394,14 @@ public class HostReportHandler {
      * @param renderHost RenderHost
      */
     private void changeLockState(DispatchHost host, CoreDetail coreInfo) {
-        if (host.lockState != LockState.LOCKED) {
-            if (coreInfo.getLockedCores() == coreInfo.getTotalCores()) {
-                host.lockState = LockState.LOCKED;
-                hostManager.setHostLock(host, LockState.LOCKED, new Source("cores"));
-            }
-        } else if (host.lockState != LockState.OPEN) {
+        if (host.lockState == LockState.LOCKED) {
             if (coreInfo.getLockedCores() < coreInfo.getTotalCores()) {
                 host.lockState = LockState.OPEN;
                 hostManager.setHostLock(host, LockState.OPEN, new Source("cores"));
             }
+        } else if (coreInfo.getLockedCores() == coreInfo.getTotalCores()) {
+            host.lockState = LockState.LOCKED;
+            hostManager.setHostLock(host, LockState.LOCKED, new Source("cores"));
         }
     }
 

--- a/cuebot/src/main/java/com/imageworks/spcue/rqd/RqdClient.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/rqd/RqdClient.java
@@ -19,6 +19,7 @@ package com.imageworks.spcue.rqd;
 
 import com.imageworks.spcue.HostInterface;
 import com.imageworks.spcue.VirtualProc;
+import com.imageworks.spcue.grpc.host.LockState;
 import com.imageworks.spcue.grpc.report.RunningFrameInfo;
 import com.imageworks.spcue.grpc.rqd.RunFrame;
 
@@ -38,6 +39,28 @@ public interface RqdClient {
      * @return
      */
     RunningFrameInfo getFrameStatus(VirtualProc proc);
+
+    /**
+     * Sets the host lock to the provided state.
+     *
+     * @param host
+     * @param lock
+     */
+    public void setHostLock(HostInterface host, LockState lock);
+
+    /**
+     * Locks the host.
+     *
+     * @param host
+     */
+    public void lockHost(HostInterface host);
+
+    /**
+     * Unlocks the host.
+     *
+     * @param host
+     */
+    public void unlockHost(HostInterface host);
 
     /**
      * Reboots the host now.

--- a/cuebot/src/main/java/com/imageworks/spcue/rqd/RqdClientGrpc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/rqd/RqdClientGrpc.java
@@ -118,10 +118,6 @@ public final class RqdClientGrpc implements RqdClient {
     public void lockHost(HostInterface host) {
         RqdStaticLockAllRequest request = RqdStaticLockAllRequest.newBuilder().build();
 
-        if (testMode) {
-            return;
-        }
-
         try {
             getStub(host.getName()).lockAll(request);
         } catch (StatusRuntimeException | ExecutionException e) {
@@ -132,10 +128,6 @@ public final class RqdClientGrpc implements RqdClient {
     public void unlockHost(HostInterface host) {
         RqdStaticUnlockAllRequest request = RqdStaticUnlockAllRequest.newBuilder().build();
 
-        if (testMode) {
-            return;
-        }
-
         try {
             getStub(host.getName()).unlockAll(request);
         } catch (StatusRuntimeException | ExecutionException e) {
@@ -145,10 +137,6 @@ public final class RqdClientGrpc implements RqdClient {
 
     public void rebootNow(HostInterface host) {
         RqdStaticRebootNowRequest request = RqdStaticRebootNowRequest.newBuilder().build();
-
-        if (testMode) {
-            return;
-        }
 
         try {
             getStub(host.getName()).rebootNow(request);

--- a/cuebot/src/main/java/com/imageworks/spcue/rqd/RqdClientGrpc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/rqd/RqdClientGrpc.java
@@ -32,11 +32,14 @@ import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
 import com.imageworks.spcue.HostInterface;
 import com.imageworks.spcue.VirtualProc;
+import com.imageworks.spcue.grpc.host.LockState;
 import com.imageworks.spcue.grpc.report.RunningFrameInfo;
 import com.imageworks.spcue.grpc.rqd.RqdInterfaceGrpc;
 import com.imageworks.spcue.grpc.rqd.RqdStaticGetRunFrameRequest;
 import com.imageworks.spcue.grpc.rqd.RqdStaticGetRunFrameResponse;
 import com.imageworks.spcue.grpc.rqd.RqdStaticKillRunningFrameRequest;
+import com.imageworks.spcue.grpc.rqd.RqdStaticLockAllRequest;
+import com.imageworks.spcue.grpc.rqd.RqdStaticUnlockAllRequest;
 import com.imageworks.spcue.grpc.rqd.RqdStaticLaunchFrameRequest;
 import com.imageworks.spcue.grpc.rqd.RqdStaticRebootIdleRequest;
 import com.imageworks.spcue.grpc.rqd.RqdStaticRebootNowRequest;
@@ -98,6 +101,46 @@ public final class RqdClientGrpc implements RqdClient {
         }
         ManagedChannel channel = channelCache.get(host);
         return RunningFrameGrpc.newBlockingStub(channel);
+    }
+
+    public void setHostLock(HostInterface host, LockState lock) {
+        if (lock == LockState.OPEN) {
+            logger.debug("Unlocking RQD host");
+            unlockHost(host);
+        } else if (lock == LockState.LOCKED) {
+            logger.debug("Locking RQD host");
+            lockHost(host);
+        } else {
+            logger.debug("Unkown LockState passed to setHostLock.");
+        }
+    }
+
+    public void lockHost(HostInterface host) {
+        RqdStaticLockAllRequest request = RqdStaticLockAllRequest.newBuilder().build();
+
+        if (testMode) {
+            return;
+        }
+
+        try {
+            getStub(host.getName()).lockAll(request);
+        } catch (StatusRuntimeException | ExecutionException e) {
+            throw new RqdClientException("failed to lock host: " + host.getName(), e);
+        }
+    }
+
+    public void unlockHost(HostInterface host) {
+        RqdStaticUnlockAllRequest request = RqdStaticUnlockAllRequest.newBuilder().build();
+
+        if (testMode) {
+            return;
+        }
+
+        try {
+            getStub(host.getName()).unlockAll(request);
+        } catch (StatusRuntimeException | ExecutionException e) {
+            throw new RqdClientException("failed to unlock host: " + host.getName(), e);
+        }
     }
 
     public void rebootNow(HostInterface host) {

--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageHost.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageHost.java
@@ -154,7 +154,7 @@ public class ManageHost extends HostInterfaceGrpc.HostInterfaceImplBase {
     @Override
     public void lock(HostLockRequest request, StreamObserver<HostLockResponse> responseObserver) {
         HostInterface host = getHostInterface(request.getHost());
-        hostManager.setHostLock(host, LockState.LOCKED, new Source(request.toString()));
+        hostManager.setHostLock(host, LockState.LOCKED, new Source("HostApi"));
         responseObserver.onNext(HostLockResponse.newBuilder().build());
         responseObserver.onCompleted();
     }
@@ -162,7 +162,7 @@ public class ManageHost extends HostInterfaceGrpc.HostInterfaceImplBase {
     @Override
     public void unlock(HostUnlockRequest request, StreamObserver<HostUnlockResponse> responseObserver) {
         HostInterface host = getHostInterface(request.getHost());
-        hostManager.setHostLock(host, LockState.OPEN, new Source(request.toString()));
+        hostManager.setHostLock(host, LockState.OPEN, new Source("HostApi"));
         responseObserver.onNext(HostUnlockResponse.newBuilder().build());
         responseObserver.onCompleted();
     }

--- a/cuebot/src/main/java/com/imageworks/spcue/service/HostManagerService.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/service/HostManagerService.java
@@ -71,6 +71,7 @@ public class HostManagerService implements HostManager {
     @Override
     public void setHostLock(HostInterface host, LockState lock, Source source) {
         hostDao.updateHostLock(host, lock, source);
+        rqdClient.setHostLock(host, lock);
     }
 
     @Override

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HostReportHandlerTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HostReportHandlerTests.java
@@ -1,0 +1,125 @@
+
+/*
+ * Copyright (c) 2018 Sony Pictures Imageworks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dispatcher;
+
+import javax.annotation.Resource;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.DispatchHost;
+import com.imageworks.spcue.dispatcher.Dispatcher;
+import com.imageworks.spcue.dispatcher.HostReportHandler;
+import com.imageworks.spcue.grpc.host.HardwareState;
+import com.imageworks.spcue.grpc.host.LockState;
+import com.imageworks.spcue.grpc.report.CoreDetail;
+import com.imageworks.spcue.grpc.report.HostReport;
+import com.imageworks.spcue.grpc.report.RenderHost;
+import com.imageworks.spcue.service.AdminManager;
+import com.imageworks.spcue.service.HostManager;
+import com.imageworks.spcue.test.TransactionalTest;
+import com.imageworks.spcue.util.CueUtil;
+
+import static org.junit.Assert.assertEquals;
+
+@ContextConfiguration
+public class HostReportHandlerTests extends TransactionalTest {
+
+    @Resource
+    AdminManager adminManager;
+
+    @Resource
+    HostManager hostManager;
+
+    @Resource
+    HostReportHandler hostReportHandler;
+
+    @Resource
+    Dispatcher dispatcher;
+
+    private static final String HOSTNAME = "beta";
+
+    @Before
+    public void setTestMode() {
+        dispatcher.setTestMode(true);
+    }
+
+    @Before
+    public void createHost() {
+        hostManager.createHost(getRenderHost(),
+                adminManager.findAllocationDetail("spi","general"));
+    }
+
+    public static CoreDetail getCoreDetail(int total, int idle, int booked, int locked) {
+        return CoreDetail.newBuilder()
+                .setTotalCores(total)
+                .setIdleCores(idle)
+                .setBookedCores(booked)
+                .setLockedCores(locked)
+                .build();
+    }
+
+    public DispatchHost getHost() {
+        return hostManager.findDispatchHost(HOSTNAME);
+    }
+
+    public RenderHost getRenderHost() {
+        return RenderHost.newBuilder()
+                .setName(HOSTNAME)
+                .setBootTime(1192369572)
+                .setFreeMcp(76020)
+                .setFreeMem(53500)
+                .setFreeSwap(20760)
+                .setLoad(0)
+                .setTotalMcp(195430)
+                .setTotalMem(8173264)
+                .setTotalSwap(20960)
+                .setNimbyEnabled(false)
+                .setNumProcs(2)
+                .setCoresPerProc(100)
+                .addTags("test")
+                .setState(HardwareState.UP)
+                .setFacility("spi")
+                .putAttributes("SP_OS", "Linux")
+                .putAttributes("freeGpu", String.format("%d", CueUtil.MB512))
+                .putAttributes("totalGpu", String.format("%d", CueUtil.MB512))
+                .build();
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testHandleHostReport() {
+        boolean isBoot = false;
+        CoreDetail cores = getCoreDetail(200, 200, 0, 0);
+        HostReport report = HostReport.newBuilder()
+                .setHost(getRenderHost())
+                .setCoreInfo(cores)
+                .build();
+
+        hostReportHandler.handleHostReport(report, isBoot);
+        DispatchHost host = getHost();
+        assertEquals(host.lockState, LockState.OPEN);
+    }
+}
+

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HostReportHandlerTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HostReportHandlerTests.java
@@ -70,7 +70,7 @@ public class HostReportHandlerTests extends TransactionalTest {
                 adminManager.findAllocationDetail("spi","general"));
     }
 
-    public static CoreDetail getCoreDetail(int total, int idle, int booked, int locked) {
+    private static CoreDetail getCoreDetail(int total, int idle, int booked, int locked) {
         return CoreDetail.newBuilder()
                 .setTotalCores(total)
                 .setIdleCores(idle)
@@ -79,11 +79,11 @@ public class HostReportHandlerTests extends TransactionalTest {
                 .build();
     }
 
-    public DispatchHost getHost() {
+    private DispatchHost getHost() {
         return hostManager.findDispatchHost(HOSTNAME);
     }
 
-    public RenderHost getRenderHost() {
+    private static RenderHost getRenderHost() {
         return RenderHost.newBuilder()
                 .setName(HOSTNAME)
                 .setBootTime(1192369572)

--- a/cuegui/cuegui/HostMonitorTree.py
+++ b/cuegui/cuegui/HostMonitorTree.py
@@ -46,6 +46,22 @@ logger = cuegui.Logger.getLogger(__file__)
 
 COMMENT_COLUMN = 1
 
+HOST_STATE_MAP = {
+  0: 'Open',
+  1: 'Locked',
+  2: 'Nimby Locked'
+}
+
+HOST_HARDWARE_MAP = {
+  0: 'Up',
+  1: 'Down'
+}
+
+HOST_THREADMODE_MAP = {
+  0: 'All',
+  1: 'Auto'
+}
+
 
 class HostMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
     def __init__(self, parent):
@@ -120,11 +136,11 @@ class HostMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                            "in every 60 seconds so a number larger than this\n"
                            "indicates a problem")
         self.addColumn("Hardware", 70, id=15,
-                       data=lambda host: str(host.data.state),
+                       data=lambda host: HOST_HARDWARE_MAP[host.data.state],
                        tip="The state of the hardware as Up or Down.\n\n"
                            "On a frame it is the amount of memory used.")
         self.addColumn("Locked", 90, id=16,
-                       data=lambda host: str(host.data.lock_state),
+                       data=lambda host: HOST_STATE_MAP[host.data.lock_state],
                        tip="A host can be:\n"
                            "Locked \t\t It was manually locked to prevent booking\n"
                            "Open \t\t It is available to be booked if resources are idle\n"
@@ -132,7 +148,7 @@ class HostMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                            "\t\t someone actively using it or not enough \n"
                            "\t\t resources are available on a desktop.")
         self.addColumn("ThreadMode", 80, id=17,
-                       data=lambda host: str(host.data.thread_mode),
+                       data=lambda host: HOST_THREADMODE_MAP[host.data.thread_mode],
                        tip="A frame that runs on this host will:\n"
                            "All:  Use all cores.\n"
                            "Auto: Use the number of cores as decided by the cuebot.\n")

--- a/cuegui/cuegui/HostMonitorTree.py
+++ b/cuegui/cuegui/HostMonitorTree.py
@@ -41,26 +41,14 @@ import cuegui.MenuActions
 import cuegui.Style
 import cuegui.Utils
 
+from opencue.compiled_proto.host_pb2 import HardwareState
+from opencue.compiled_proto.host_pb2 import LockState
+from opencue.compiled_proto.host_pb2 import ThreadMode
+
 
 logger = cuegui.Logger.getLogger(__file__)
 
 COMMENT_COLUMN = 1
-
-HOST_STATE_MAP = {
-  0: 'Open',
-  1: 'Locked',
-  2: 'Nimby Locked'
-}
-
-HOST_HARDWARE_MAP = {
-  0: 'Up',
-  1: 'Down'
-}
-
-HOST_THREADMODE_MAP = {
-  0: 'All',
-  1: 'Auto'
-}
 
 
 class HostMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
@@ -136,11 +124,11 @@ class HostMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                            "in every 60 seconds so a number larger than this\n"
                            "indicates a problem")
         self.addColumn("Hardware", 70, id=15,
-                       data=lambda host: HOST_HARDWARE_MAP[host.data.state],
+                       data=lambda host: HardwareState.Name(host.data.state),
                        tip="The state of the hardware as Up or Down.\n\n"
                            "On a frame it is the amount of memory used.")
         self.addColumn("Locked", 90, id=16,
-                       data=lambda host: HOST_STATE_MAP[host.data.lock_state],
+                       data=lambda host: LockState.Name(host.data.lock_state),
                        tip="A host can be:\n"
                            "Locked \t\t It was manually locked to prevent booking\n"
                            "Open \t\t It is available to be booked if resources are idle\n"
@@ -148,7 +136,7 @@ class HostMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                            "\t\t someone actively using it or not enough \n"
                            "\t\t resources are available on a desktop.")
         self.addColumn("ThreadMode", 80, id=17,
-                       data=lambda host: HOST_THREADMODE_MAP[host.data.thread_mode],
+                       data=lambda host: ThreadMode.Name(host.data.thread_mode),
                        tip="A frame that runs on this host will:\n"
                            "All:  Use all cores.\n"
                            "Auto: Use the number of cores as decided by the cuebot.\n")

--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -261,12 +261,16 @@ def shellOut(cmd):
     os.system("%s &" % cmd)
 
 
-def checkShellOut(cmdList):
+def checkShellOut(cmdList, lockGui=False):
     """Run the provided command and check it's results.
     Display an error message if the command failed
     @type: list<string>
     @param: The command to run as a space separated list.
+    @type: bool
+    @param: True will lock the gui while the cmd is executed, otherwise it is run in the background.
     """
+    if not lockGui:
+        cmdList.append('&')
     try:
         subprocess.check_call(cmdList)
     except subprocess.CalledProcessError as e:

--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -817,6 +817,9 @@ class RqCore(object):
             log.info("frameId {} is not running on this machine".format(frameId))
             return None
 
+    def getCoreInfo(self):
+        return self.cores
+
     def reportStatus(self, current=None):
         """Replies with hostReport"""
         return self.machine.getHostReport()
@@ -881,7 +884,7 @@ class RqCore(object):
             return
         if not self.nimby.active and platform.system() == "Linux":
             try:
-                self.nimby.start()
+                self.nimby.run()
                 log.info("Nimby has been activated")
             except:
                 self.nimby.locked = False

--- a/rqd/rqd/rqmachine.py
+++ b/rqd/rqd/rqmachine.py
@@ -601,6 +601,8 @@ class Machine:
             except KeyError:
                 pass
 
+        self.__hostReport.core_info.CopyFrom(self.__rqCore.getCoreInfo())
+
         return self.__hostReport
 
     def getBootReport(self):


### PR DESCRIPTION
Fixes #431 

(Un)Locking cores in cuegui was not working because it was never calling out to the rqd instance to lock the cores. (Un)Locking cores via `cuerqd.py` did not work reliably because rqd never updated the lock state in the cuebot database.

This PR addresses these problems by making sure the locks are checked in the host report and that api calls to lock a host also communicate that lock to the rqd instance.