### PR TITLE
Use ci-opencue Docker image for SonarCloud pipeline.

### DIFF
--- a/ci/python_coverage_report.sh
+++ b/ci/python_coverage_report.sh
@@ -16,7 +16,7 @@ python -m grpc_tools.protoc -I=proto/ --python_out=rqd/rqd/compiled_proto --grpc
 coverage run --source=pycue/opencue/,pycue/FileSequence/ --omit=pycue/opencue/compiled_proto/* pycue/setup.py test
 PYTHONPATH=pycue coverage run -a --source=pyoutline/outline/ pyoutline/setup.py test
 PYTHONPATH=pycue coverage run -a --source=cueadmin/cueadmin/ cueadmin/setup.py test
-ci/run-with-xvfb.sh "PYTHONPATH=pycue coverage run -a --source=cuegui/cuegui/ cuegui/setup.py test"
+PYTHONPATH=pycue xvfb-run coverage run -a --source=cuegui/cuegui/ cuegui/setup.py test
 PYTHONPATH=pycue:pyoutline coverage run -a --source=cuesubmit/cuesubmit/ cuesubmit/setup.py test
 coverage run -a --source=rqd/rqd/ --omit=rqd/rqd/compiled_proto/* rqd/setup.py test
 

--- a/ci/python_coverage_report.sh
+++ b/ci/python_coverage_report.sh
@@ -16,7 +16,7 @@ python -m grpc_tools.protoc -I=proto/ --python_out=rqd/rqd/compiled_proto --grpc
 coverage run --source=pycue/opencue/,pycue/FileSequence/ --omit=pycue/opencue/compiled_proto/* pycue/setup.py test
 PYTHONPATH=pycue coverage run -a --source=pyoutline/outline/ pyoutline/setup.py test
 PYTHONPATH=pycue coverage run -a --source=cueadmin/cueadmin/ cueadmin/setup.py test
-PYTHONPATH=pycue coverage run -a --source=cuegui/cuegui/ cuegui/setup.py test
+ci/run-with-xvfb.sh "PYTHONPATH=pycue coverage run -a --source=cuegui/cuegui/ cuegui/setup.py test"
 PYTHONPATH=pycue:pyoutline coverage run -a --source=cuesubmit/cuesubmit/ cuesubmit/setup.py test
 coverage run -a --source=rqd/rqd/ --omit=rqd/rqd/compiled_proto/* rqd/setup.py test
 

--- a/ci/python_coverage_report.sh
+++ b/ci/python_coverage_report.sh
@@ -3,10 +3,6 @@
 set -e
 
 pip install --user -r requirements.txt
-pip install --user coverage
-
-# pip --user installs scripts such as `coverage` into an alternate location.
-export PATH=~/.local/bin:$PATH
 
 # Protos need to have their Python code generated in order for tests to pass.
 python -m grpc_tools.protoc -I=proto/ --python_out=pycue/opencue/compiled_proto --grpc_python_out=pycue/opencue/compiled_proto proto/*.proto

--- a/ci/run-with-xvfb.sh
+++ b/ci/run-with-xvfb.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-Xvfb :1 -screen 0 1024x768x16 & bash -c "export DISPLAY=:1.0; $@"
-

--- a/ci/run-with-xvfb.sh
+++ b/ci/run-with-xvfb.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+Xvfb :1 -screen 0 1024x768x16 &> /tmp/xvfb.log & bash -c "export DISPLAY=:1.0; $@"
+

--- a/ci/run-with-xvfb.sh
+++ b/ci/run-with-xvfb.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-Xvfb :1 -screen 0 1024x768x16 &> /tmp/xvfb.log & bash -c "export DISPLAY=:1.0; $@"
+Xvfb :1 -screen 0 1024x768x16 & bash -c "export DISPLAY=:1.0; $@"
 

--- a/cuegui/Dockerfile
+++ b/cuegui/Dockerfile
@@ -57,7 +57,7 @@ RUN cd pycue && python setup.py install
 
 # TODO(bcipriano) Lint the code here. (Issue #78)
 
-RUN ./run-with-xvfb.sh "cd cuegui && python setup.py test"
+RUN Xvfb :1 -screen 0 1024x768x16 &> /tmp/xvfb.log & cd cuegui && DISPLAY=:1.0 python setup.py test
 
 RUN cp LICENSE requirements.txt VERSION cuegui/
 

--- a/cuegui/Dockerfile
+++ b/cuegui/Dockerfile
@@ -44,6 +44,7 @@ RUN python -m grpc_tools.protoc \
 # <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
 RUN sed -i 's/^\(import.*_pb2\)/from . \1/' pycue/opencue/compiled_proto/*.py
 
+COPY ci/run-with-xvfb.sh ./
 COPY cuegui/README.md ./cuegui/
 COPY cuegui/setup.py ./cuegui/
 COPY cuegui/tests ./cuegui/tests
@@ -56,7 +57,7 @@ RUN cd pycue && python setup.py install
 
 # TODO(bcipriano) Lint the code here. (Issue #78)
 
-RUN Xvfb :1 -screen 0 1024x768x16 &> /tmp/xvfb.log & cd cuegui && DISPLAY=:1.0 python setup.py test
+RUN ./run-with-xvfb.sh "cd cuegui && python setup.py test"
 
 RUN cp LICENSE requirements.txt VERSION cuegui/
 

--- a/cuegui/Dockerfile
+++ b/cuegui/Dockerfile
@@ -57,7 +57,7 @@ RUN cd pycue && python setup.py install
 
 # TODO(bcipriano) Lint the code here. (Issue #78)
 
-RUN Xvfb :1 -screen 0 1024x768x16 &> /tmp/xvfb.log & cd cuegui && DISPLAY=:1.0 python setup.py test
+RUN cd cuegui && xvfb-run python setup.py test
 
 RUN cp LICENSE requirements.txt VERSION cuegui/
 

--- a/cuegui/Dockerfile
+++ b/cuegui/Dockerfile
@@ -17,6 +17,7 @@ RUN yum -y install \
   libXrender \
   mesa-libGL \
   python-devel \
+  which \
   Xvfb
 
 RUN yum -y install python-pip
@@ -44,7 +45,6 @@ RUN python -m grpc_tools.protoc \
 # <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
 RUN sed -i 's/^\(import.*_pb2\)/from . \1/' pycue/opencue/compiled_proto/*.py
 
-COPY ci/run-with-xvfb.sh ./
 COPY cuegui/README.md ./cuegui/
 COPY cuegui/setup.py ./cuegui/
 COPY cuegui/tests ./cuegui/tests

--- a/sonar-cloud-pipeline.yml
+++ b/sonar-cloud-pipeline.yml
@@ -31,6 +31,7 @@ jobs:
   displayName: Analyze Cuebot
   pool:
     vmImage: 'ubuntu-16.04'
+  container: opencuebuild/ci-opencue:latest
   steps:
   - bash: cd cuebot && ./gradlew jacocoTestReport sonarqube -Dsonar.login=$(SONAR_TOKEN)
     name: analyze

--- a/sonar-cloud-pipeline.yml
+++ b/sonar-cloud-pipeline.yml
@@ -9,7 +9,7 @@ jobs:
   displayName: Analyze Python Components
   pool:
     vmImage: 'ubuntu-16.04'
-  container: opencuebuild/ci-opencue:2019
+  container: aswf/ci-opencue:2019.0
   steps:
   - bash: ci/python_coverage_report.sh
     name: coverageReport
@@ -31,7 +31,7 @@ jobs:
   displayName: Analyze Cuebot
   pool:
     vmImage: 'ubuntu-16.04'
-  container: opencuebuild/ci-opencue:2019
+  container: aswf/ci-opencue:2019.0
   steps:
   - bash: cd cuebot && ./gradlew jacocoTestReport sonarqube -Dsonar.login=$(SONAR_TOKEN)
     name: analyze

--- a/sonar-cloud-pipeline.yml
+++ b/sonar-cloud-pipeline.yml
@@ -9,7 +9,7 @@ jobs:
   displayName: Analyze Python Components
   pool:
     vmImage: 'ubuntu-16.04'
-  container: aswf/ci-base:2019.0
+  container: opencuebuild/ci-opencue:latest
   steps:
   - bash: ci/python_coverage_report.sh
     name: coverageReport

--- a/sonar-cloud-pipeline.yml
+++ b/sonar-cloud-pipeline.yml
@@ -9,7 +9,7 @@ jobs:
   displayName: Analyze Python Components
   pool:
     vmImage: 'ubuntu-16.04'
-  container: opencuebuild/ci-opencue:latest
+  container: opencuebuild/ci-opencue:2019
   steps:
   - bash: ci/python_coverage_report.sh
     name: coverageReport
@@ -31,7 +31,7 @@ jobs:
   displayName: Analyze Cuebot
   pool:
     vmImage: 'ubuntu-16.04'
-  container: opencuebuild/ci-opencue:latest
+  container: opencuebuild/ci-opencue:2019
   steps:
   - bash: cd cuebot && ./gradlew jacocoTestReport sonarqube -Dsonar.login=$(SONAR_TOKEN)
     name: analyze


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Fixes #442 

**Summarize your change.**
https://github.com/AcademySoftwareFoundation/aswf-docker/pull/15 creates the first version of our `ci-opencue` Docker image; start to use it with our SonarCloud pipeline.

I also remove a few things from the pipeline + associated scripts that aren't needed anymore as those pieces are installed directly in the CI image now.