### PR TITLE
Fixes for Layer.getFrames

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageLayer.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageLayer.java
@@ -163,11 +163,7 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     @Override
     public void getFrames(LayerGetFramesRequest request, StreamObserver<LayerGetFramesResponse> responseObserver) {
         updateLayer(request.getLayer());
-        FrameSearchCriteria searchCriteria = request.getS();
-        Descriptors.FieldDescriptor layerDescriptor = searchCriteria.getDescriptorForType().findFieldByName("layer");
-        searchCriteria = searchCriteria.toBuilder()
-                .clearField(layerDescriptor).build();
-        FrameSeq frames = whiteboard.getFrames(frameSearchFactory.create(layer, searchCriteria));
+        FrameSeq frames = whiteboard.getFrames(frameSearchFactory.create(layer, request.getS()));
         responseObserver.onNext(LayerGetFramesResponse.newBuilder()
                 .setFrames(frames)
                 .build());

--- a/proto/job.proto
+++ b/proto/job.proto
@@ -453,6 +453,9 @@ message FrameSearchCriteria {
     int32 page = 8;
     int32 limit = 9;
     int32 change_date = 10;
+    int32 max_results = 11;
+    int32 offset = 12;
+    bool include_finished = 13;
 }
 
 // A sequence of Frames

--- a/pycue/opencue/search.py
+++ b/pycue/opencue/search.py
@@ -309,8 +309,8 @@ def _setOptions(criteria, options):
                 # this can go away
                 criteria.memory_range = v
             else:
-                criteria.memory_range.append(_createCriterion(v, int,
-                                                      lambda mem: (1048576 * mem)))
+                criteria.memory_range.append(
+                    _createCriterion(v, int, lambda mem: (1048576 * mem)))
         elif k == "duration":
             if not v:
                 continue
@@ -319,10 +319,10 @@ def _setOptions(criteria, options):
                 # this can go away
                 criteria.duration_range = v
             else:
-                criteria.duration_range.append(_createCriterion(v, int,
-                                                        lambda duration:(60 * 60 * duration)))
+                criteria.duration_range.append(
+                    _createCriterion(v, int, lambda duration: (60 * 60 * duration)))
         elif k == "limit":
-            criteria.max_results.extend([int(v)])
+            criteria.max_results = int(v)
         elif k == "offset":
             criteria.first_result = int(v)
         elif k == "include_finished":


### PR DESCRIPTION
Fixes #446 

This change fixes 2 problems.
1. The Layer wrapper object now allows a user to specify a `limit` when calling `getFrames` and the `FrameSeachCriteria` values are correctly set.
2. Cuebot no longer performs an unnecessary cleaning of the `FrameSeachCriteria` that was erroring out.