### PR TITLE
Cleaning up wrapper methods 

### DIFF
--- a/cuegui/cuegui/CreatorDialog.py
+++ b/cuegui/cuegui/CreatorDialog.py
@@ -68,10 +68,8 @@ class SubscriptionCreator(QtWidgets.QWidget):
             show = showMap[str(self.showBox.currentText())]
             alloc = allocMap[str(self.allocBox.currentText())]
 
-            show.createSubscription(alloc.data, float(self.sizeBox.value()),
+            show.createSubscription(alloc, float(self.sizeBox.value()),
                                     float(self.burstBox.value()))
-            # show.proxy.createSubscription(alloc.proxy,
-            #     float(self.sizeBox.value()), float(self.burstBox.value()))
         except Exception as e:
             QtWidgets.QMessageBox.warning(
                 self,

--- a/cuegui/cuegui/CueJobMonitorTree.py
+++ b/cuegui/cuegui/CueJobMonitorTree.py
@@ -277,7 +277,7 @@ class CueJobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                             self._items[proxy].update(self._items[proxy].rpcObject, item)
 
                     if group_ids:
-                        item.rpcObject.reparentGroups(group_ids)
+                        item.rpcObject.reparentGroupIds(group_ids)
                         # If no exception, then move was allowed, so do it locally:
                         for id_ in group_ids:
                             proxy = cuegui.Utils.getObjectKey(opencue.util.proxy(id_, "Group"))

--- a/cuegui/cuegui/Cuedepend.py
+++ b/cuegui/cuegui/Cuedepend.py
@@ -302,8 +302,7 @@ def createFrameOnJobDepend(job, layer, frame, onjob):
     logger.debug("creating foj depend from %s/%s-%04d to %s"
                  % (job, layer, frame, onjob))
     depend_er_frame = opencue.api.findFrame(job, layer, frame)
-    depend_on_job = opencue.api.findJob(onjob)
-    return depend_er_frame.createDependencyOnJob(depend_on_job)
+    return depend_er_frame.createDependencyOnJob(opencue.api.findJob(onjob))
 
 def createFrameOnLayerDepend(job, layer, frame, onjob, onlayer):
     """Creates a frame on layer dependency

--- a/cuegui/cuegui/DependWizard.py
+++ b/cuegui/cuegui/DependWizard.py
@@ -756,8 +756,8 @@ class PageConfirmation(AbstractWizardPage):
     def __createFrameByFrameDepend(self, layer, onLayer):
         """A function callback provided to the ProgressDialog that sets up a
         frame by frame dependency
-        @type  layer: Layer
+        @type  layer: opencue.wrappers.layer.Layer
         @param layer: The layer that contains the frames that will have the dependency
-        @type  onLayer: Layer
+        @type  onLayer: opencue.wrappers.layer.Layer
         @param onLayer: The layer that contains that frames that will be depended on"""
         layer.createFrameByFrameDependency(onLayer)

--- a/cuegui/cuegui/plugins/AllocationsPlugin.py
+++ b/cuegui/cuegui/plugins/AllocationsPlugin.py
@@ -129,7 +129,7 @@ class MonitorAllocations(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                                              "Move the hosts into the allocation: \"%s\"?" %
                                              item.rpcObject.data.name,
                                              hostNames):
-                item.rpcObject.reparentHosts(hostIds)
+                item.rpcObject.reparentHostIds(hostIds)
                 self.updateSoon()
 
 class AllocationWidgetItem(cuegui.AbstractWidgetItem.AbstractWidgetItem):

--- a/pycue/opencue/wrappers/allocation.py
+++ b/pycue/opencue/wrappers/allocation.py
@@ -40,7 +40,7 @@ class Allocation(object):
 
     def getHosts(self):
         """Returns the list of hosts for this allocation.
-        @rtype: list<host>
+        @rtype: list<opencue.wrappers.host.Host>
         @return: list of hosts
         """
         hostSeq = self.stub.GetHosts(facility_pb2.AllocGetHostsRequest(allocation=self.data),
@@ -49,7 +49,7 @@ class Allocation(object):
 
     def getSubscriptions(self):
         """Get the subscriptions of this allocation.
-        @rtype: list<subscription>
+        @rtype: list<opencue.wrappers.subscription.Subscription>
         @return: a list of subscriptions
         """
         subscriptionSeq = self.stub.GetSubscriptions(
@@ -59,15 +59,23 @@ class Allocation(object):
 
     def reparentHosts(self, hosts):
         """Moves the given hosts to the allocation
-        @type  hosts: list<HostInterfacePrx or Host or id or str hostname>
+        @type  hosts: list<opencue.wrappers.host.Host>
         @param hosts: The hosts to move to this allocation
         """
         hostSeq = host_pb2.HostSeq()
-        hostSeq.hosts.extend(hosts)
+        hostSeq.hosts.extend([host.data for host in hosts])
         self.stub.ReparentHosts(
             facility_pb2.AllocReparentHostsRequest(allocation=self.data, hosts=hostSeq),
             timeout=Cuebot.Timeout
         )
+      
+    def reparentHostIds(self, hostIds):
+        """Moves the given hosts to the allocation
+        @type  hostIds: list<str>
+        @param hostIds: The host ids to move to this allocation
+        """
+        hosts = [opencue.wrappers.host.Host(host_pb2.Host(id=hostId)) for hostId in hostIds]
+        self.reparentHosts(hosts)
 
     def setName(self, name):
         """Sets a new name for the allocation.

--- a/pycue/opencue/wrappers/deed.py
+++ b/pycue/opencue/wrappers/deed.py
@@ -38,14 +38,16 @@ class Deed(object):
 
     def getHost(self):
         """Return the host for this deed
-        @rtype:  Host Wrapper
+        @rtype:  opencue.wrappers.host.Host Wrapper
         @return: Host associated with this deed"""
         return opencue.wrappers.host.Host(
             self.stub.GetHost(host_pb2.DeedGetHostRequest(deed=self.data),
                               timeout=Cuebot.Timeout).host)
 
     def getOwner(self):
-        """Returns the owner for these settings."""
+        """Returns the owner for these settings.
+        @rtype: opencue.wrappers.host.Host
+        @return Owner of this deed"""
         return opencue.wrappers.owner.Owner(
             self.stub.GetOwner(host_pb2.DeedGetOwnerRequest(deed=self.data),
                                timeout=Cuebot.Timeout).owner)

--- a/pycue/opencue/wrappers/filter.py
+++ b/pycue/opencue/wrappers/filter.py
@@ -60,9 +60,9 @@ class Filter(object):
 
     def createMatcher(self, subject, matchType, query):
         """Creates a matcher for this filter
-        @type  subject: opencue.MatchSubject.*
+        @type  subject: filter_pb2.MatchSubject.*
         @param subject: The job attribute to match
-        @type  matchType: opencue.MatchType.*
+        @type  matchType: filter_pb2.MatchType.*
         @param matchType: The type of match to perform
         @type  query: string
         @param query: The value to match
@@ -79,7 +79,7 @@ class Filter(object):
 
     def createAction(self, actionType, value):
         """Creates an action for this filter.
-        @type  actionType: opencue.ActionType.*
+        @type  actionType: filter_pb2.ActionType.*
         @param actionType: The action to perform
         @type  value: Group or str, or int or bool
         @param value: Value relevant to the type selected
@@ -153,15 +153,18 @@ class Filter(object):
                             timeout=Cuebot.Timeout)
 
     def runFilterOnGroup(self, group):
+        """Runs the filter on the group provided
+        @type  group: list<opencue.wrapper.group.Group>
+        @param group: The group to run the filter on"""
         self.stub.RunFilterOnGroup(
-            filter_pb2.FilterRunFilterOnGroupRequest(filter=self.data, group=group),
+            filter_pb2.FilterRunFilterOnGroupRequest(filter=self.data, group=group.data),
             timeout=Cuebot.Timeout)
 
     def runFilterOnJobs(self, jobs):
         """Runs the filter on the list of jobs provided
-        @type  jobs: list<JobInterfacePrx or Job or id or str jobname>
-        @param jobs: The jobs to add to this group"""
-        jobSeq = job_pb2.JobSeq(jobs=jobs)
+        @type  jobs: list<opencue.wrapper.job.Job>
+        @param jobs: The jobs to run the filter on"""
+        jobSeq = job_pb2.JobSeq(jobs=[job.data for job in jobs])
         self.stub.RunFilterOnJobs(
             filter_pb2.FilterRunFilterOnJobsRequest(filter=self.data, jobs=jobSeq),
             timeout=Cuebot.Timeout)
@@ -182,7 +185,7 @@ class Filter(object):
 
     def setType(self, filterType):
         """Changes the filter type
-        @type  filterType: FilterType
+        @type  filterType: filter_pb2.FilterType
         @param filterType: The new filter type"""
         self.stub.SetType(filter_pb2.FilterSetTypeRequest(filter=self.data, type=filterType),
                           timeout=Cuebot.Timeout)

--- a/pycue/opencue/wrappers/frame.py
+++ b/pycue/opencue/wrappers/frame.py
@@ -91,34 +91,35 @@ class Frame(object):
 
     def createDependencyOnJob(self, job):
         """Create and return a frame on job dependency
-        @type  job: Job
+        @type  job: opencue.wrappers.job.Job
         @param job: the job you want this frame to depend on
-        @rtype:  Depend
+        @rtype:  opencue.wrappers.depend.Depend
         @return: The new dependency"""
         response = self.stub.CreateDependencyOnJob(
-            job_pb2.FrameCreateDependencyOnJobRequest(frame=self.data, job=job),
+            job_pb2.FrameCreateDependencyOnJobRequest(frame=self.data, job=job.data),
             timeout=Cuebot.Timeout)
         return opencue.wrappers.depend.Depend(response.depend)
 
     def createDependencyOnLayer(self, layer):
         """Create and return a frame on layer dependency
-        @type layer: Layer
+        @type layer: opencue.wrappers.layer.Layer
         @param layer: the layer you want this frame to depend on
-        @rtype:  Depend
+        @rtype:  opencue.wrappers.depend.Depend
         @return: The new dependency"""
         response = self.stub.CreateDependencyOnLayer(
-            job_pb2.FrameCreateDependencyOnLayerRequest(frame=self.data, layer=layer),
+            job_pb2.FrameCreateDependencyOnLayerRequest(frame=self.data, layer=layer.data),
             timeout=Cuebot.Timeout)
         return opencue.wrappers.depend.Depend(response.depend)
 
     def createDependencyOnFrame(self, frame):
         """Create and return a frame on frame dependency
-        @type frame: Frame
+        @type frame: opencue.wrappers.frame.Frame
         @param frame: the frame you want this frame to depend on
-        @rtype:  Depend
+        @rtype:  opencue.wrappers.depend.Depend
         @return: The new dependency"""
         response = self.stub.CreateDependencyOnFrame(
-            job_pb2.FrameCreateDependencyOnFrameRequest(frame=self.data, depend_on_frame=frame),
+            job_pb2.FrameCreateDependencyOnFrameRequest(frame=self.data,
+                                                        depend_on_frame=frame.data),
             timeout=Cuebot.Timeout)
         return opencue.wrappers.depend.Depend(response.depend)
 

--- a/pycue/opencue/wrappers/group.py
+++ b/pycue/opencue/wrappers/group.py
@@ -71,7 +71,7 @@ class Group(object):
 
     def getJobs(self):
         """Returns the jobs in this group
-        @rtype:  list<Job>
+        @rtype:  list<opencue.wrappers.job.Job>
         @return: List of jobs in this group"""
         response = self.stub.GetJobs(job_pb2.GroupGetJobsRequest(group=self.data),
                                      timeout=Cuebot.Timeout)
@@ -79,7 +79,7 @@ class Group(object):
 
     def reparentJobs(self, jobs):
         """Moves the given jobs into this group
-        @type  jobs: list<Job>
+        @type  jobs: list<opencue.wrappers.job.Job>
         @param jobs: The jobs to add to this group"""
         jobsToReparent = []
         for job in jobs:
@@ -92,12 +92,19 @@ class Group(object):
 
     def reparentGroups(self, groups):
         """Moves the given groups into this group
-        @type  groups: list<Group>
+        @type  groups: list<opencue.wrappers.group.Group>
         @param groups: The groups to move into"""
-        groupSeq = job_pb2.GroupSeq(groups=groups)
+        groupSeq = job_pb2.GroupSeq(groups=[group.data for group in groups])
         self.stub.ReparentGroups(
             job_pb2.GroupReparentGroupsRequest(group=self.data, groups=groupSeq),
             timeout=Cuebot.Timeout)
+
+    def reparentGroupIds(self, groupIds):
+        """Moves the given group ids into this group
+        @type  groups: list<str>
+        @param groups: The group ids to move into"""
+        groups = [opencue.wrappers.group.Group(job_pb2.Group(id=groupId)) for groupId in groupIds]
+        self.reparentGroups(groups)
 
     def setDepartment(self, name):
         """Sets the group's department to the specified name.  The department
@@ -113,9 +120,10 @@ class Group(object):
 
     def setGroup(self, parentGroup):
         """Sets this group's parent to parentGroup.
-        @type  parentGroup: Group
+        @type  parentGroup: opencue.wrappers.group.Group
         @param parentGroup: Group to parent under"""
-        self.stub.SetGroup(job_pb2.GroupSetGroupRequest(group=self.data, parent_group=parentGroup),
+        self.stub.SetGroup(job_pb2.GroupSetGroupRequest(group=self.data,
+                                                        parent_group=parentGroup.data),
                            timeout=Cuebot.Timeout)
 
     def id(self):

--- a/pycue/opencue/wrappers/host.py
+++ b/pycue/opencue/wrappers/host.py
@@ -79,7 +79,7 @@ class Host(object):
 
     def getProcs(self):
         """Returns a list of procs under this host.
-        @rtype: list<Proc>
+        @rtype: list<opencue.wrappers.proc.Proc>
         @return: A list of procs under this host
         """
         response = self.stub.GetProcs(host_pb2.HostGetProcsRequest(host=self.data),
@@ -136,7 +136,7 @@ class Host(object):
 
     def setAllocation(self, allocation):
         """Sets the host to the given allocation
-        @type allocation: Allocation
+        @type allocation: opencue.wrappers.allocation.Allocation
         @param allocation: An allocation object
         """
         self.stub.SetAllocation(
@@ -183,7 +183,7 @@ class Host(object):
 
     def setThreadMode(self, mode):
         """Set the thread mode to mode
-        @type mode: ThreadMode
+        @type mode: host_pb2.ThreadMode
         @param mode: ThreadMode to set host to
         """
         self.stub.SetThreadMode(host_pb2.HostSetThreadModeRequest(host=self.data, mode=mode),

--- a/pycue/opencue/wrappers/job.py
+++ b/pycue/opencue/wrappers/job.py
@@ -167,9 +167,9 @@ class Job(object):
         UpdatedFrameSeq updatedFrames =
         @type  lastCheck: int
         @param lastCheck: Epoch when last updated
-        @type  layers: list<Layer>
+        @type  layers: list<job_pb2.Layer>
         @param layers: List of layers to check, empty list checks all
-        @rtype:  UpdatedFrameCheckResult
+        @rtype:  job_pb2.UpdatedFrameCheckResult
         @return: Job state and a list of updatedFrames"""
         if layers is not None:
             layerSeq = job_pb2.LayerSeq()
@@ -190,7 +190,7 @@ class Job(object):
 
     def getWhatDependsOnThis(self):
         """Returns a list of dependencies that depend directly on this job
-        @rtype:  list<Depend>
+        @rtype:  list<opencue.wrappers.depend.Depend>
         @return: List of dependencies that depend directly on this job"""
         response = self.stub.GetWhatDependsOnThis(
             job_pb2.JobGetWhatDependsOnThisRequest(job=self.data),
@@ -200,7 +200,7 @@ class Job(object):
 
     def getWhatThisDependsOn(self):
         """Returns a list of dependencies that this job depends on
-        @rtype:  list<Depend>
+        @rtype:  list<opencue.wrappers.depend.Depend>
         @return: dependencies that this job depends on"""
         response = self.stub.GetWhatThisDependsOn(
             job_pb2.JobGetWhatThisDependsOnRequest(job=self.data),
@@ -210,7 +210,7 @@ class Job(object):
 
     def getDepends(self):
         """Returns a list of all depends this job is involved with
-        @rtype:  list<Depend>
+        @rtype:  list<opencue.wrappers.depend.Depend>
         @return: all depends involved with this job"""
         response = self.stub.GetDepends(
             job_pb2.JobGetDependsRequest(job=self.data),
@@ -220,44 +220,44 @@ class Job(object):
 
     def dropDepends(self, target):
         """Drops the desired dependency target:
-        opencue.DependTarget.AnyTarget
-        opencue.DependTarget.External
-        opencue.DependTarget.Internal
-        @type  target: DependTarget
+        depend_pb2.DependTarget.AnyTarget
+        depend_pb2.DependTarget.External
+        depend_pb2.DependTarget.Internal
+        @type  target: depend_pb2.DependTarget
         @param target: The desired dependency target to drop"""
         return self.stub.DropDepends(job_pb2.JobDropDependsRequest(job=self.data, target=target),
                                      timeout=Cuebot.Timeout)
 
     def createDependencyOnJob(self, job):
         """Create and return a job on job dependency
-        @type  job: Job
+        @type  job: opencue.wrappers.job.Job
         @param job: the job you want this job to depend on
-        @rtype:  Depend
+        @rtype:  opencue.wrappers.depend.Depend
         @return: The new dependency"""
         response = self.stub.CreateDependencyOnJob(
-            job_pb2.JobCreateDependencyOnJobRequest(job=self.data, on_job=job),
+            job_pb2.JobCreateDependencyOnJobRequest(job=self.data, on_job=job.data),
             timeout=Cuebot.Timeout)
         return opencue.wrappers.depend.Depend(response.depend)
 
     def createDependencyOnLayer(self, layer):
         """Create and return a job on layer dependency
-        @type  layer: Layer
+        @type  layer: opencue.wrappers.layer.Layer
         @param layer: the layer you want this job to depend on
-        @rtype:  Depend
+        @rtype:  opencue.wrappers.Depend
         @return: the new dependency"""
         response = self.stub.CreateDependencyOnLayer(
-            job_pb2.JobCreateDependencyOnLayerRequest(job=self.data, layer=layer),
+            job_pb2.JobCreateDependencyOnLayerRequest(job=self.data, layer=layer.data),
             timeout=Cuebot.Timeout)
         return opencue.wrappers.depend.Depend(response.depend)
 
     def createDependencyOnFrame(self, frame):
         """Create and return a job on frame dependency
-        @type  frame: Frame
+        @type  frame: opencue.wrappers.frame.Frame
         @param frame: the frame you want this job to depend on
-        @rtype:  Depend
+        @rtype:  opencue.wrappers.depend.Depend
         @return: the new dependency"""
         response = self.stub.CreateDependencyOnFrame(
-            job_pb2.JobCreateDependencyOnFrameRequest(job=self.data, frame=frame),
+            job_pb2.JobCreateDependencyOnFrameRequest(job=self.data, frame=frame.data),
             timeout=Cuebot.Timeout)
         return opencue.wrappers.depend.Depend(response.depend)
 
@@ -295,9 +295,9 @@ class Job(object):
 
     def setGroup(self, group):
         """Sets the job to a new group
-        @type  group: Group
+        @type  group: opencue.wrappers.group.Group
         @param group: the group you want the job to be in."""
-        self.stub.SetGroup(job_pb2.JobSetGroupRequest(job=self.data, group_id=group.id),
+        self.stub.SetGroup(job_pb2.JobSetGroupRequest(job=self.data, group_id=group.id()),
                            timeout=Cuebot.Timeout)
 
     def reorderFrames(self, range, order):
@@ -667,7 +667,7 @@ class NestedJob(Job):
 
     def getLayers(self):
         """Returns the list of layers
-        @rtype:  list<Layer>
+        @rtype:  list<opencue.wrappers.layer.Layer>
         @return: List of layers"""
         return self.asJob().getLayers()
 
@@ -676,7 +676,7 @@ class NestedJob(Job):
         frames = job.getFrames(show=["edu","beo"],user="jwelborn")
         frames = job.getFrames(show="edu",shot="bs.012")
         Allowed: offset, limit, states+, layers+. frameset, changedate
-        @rtype:  list<Frame>
+        @rtype:  list<opencue.wrappers.frame.Frame>
         @return: List of frames"""
         return self.asJob().getFrames(**options)
 
@@ -706,52 +706,52 @@ class NestedJob(Job):
 
     def getWhatDependsOnThis(self):
         """Returns a list of dependencies that depend directly on this job
-        @rtype:  list<Depend>
+        @rtype:  list<opencue.wrappers.depend.Depend>
         @return: List of dependencies that depend directly on this job"""
         return self.asJob().getWhatDependsOnThis()
 
     def getWhatThisDependsOn(self):
         """Returns a list of dependencies that this job depends on
-        @rtype:  list<Depend>
+        @rtype:  list<opencue.wrappers.depend.Depend>
         @return: dependencies that this job depends on"""
         return self.asJob().getWhatThisDependsOn()
 
     def getDepends(self):
         """Returns a list of all depends this job is involved with
-        @rtype:  list<Depend>
+        @rtype:  list<opencue.wrappers.depend.Depend>
         @return: all depends involved with this job"""
         return self.asJob().getDepends()
 
     def dropDepends(self, target):
         """Drops the desired dependency target:
-        opencue.DependTarget.AnyTarget
-        opencue.DependTarget.External
-        opencue.DependTarget.Internal
-        @type  target: DependTarget
+        depend_pb2.DependTarget.AnyTarget
+        depend_pb2.DependTarget.External
+        depend_pb2.DependTarget.Internal
+        @type  target: depend_pb2.DependTarget
         @param target: The desired dependency target to drop"""
         return self.asJob().dropDepends(target)
 
     def createDependencyOnJob(self, job):
         """Create and return a job on job dependency
-        @type  job: Job
+        @type  job: opencue.wrappers.job.Job
         @param job: the job you want this job to depend on
-        @rtype:  Depend
+        @rtype:  opencue.wrappers.depend.Depend
         @return: The new dependency"""
         return self.asJob().createDependencyOnJOb(job)
 
     def createDependencyOnLayer(self, layer):
         """Create and return a job on layer dependency
-        @type  layer: Layer
+        @type  layer: opencue.wrappers.layer.Layer
         @param layer: the layer you want this job to depend on
-        @rtype:  Depend
+        @rtype:  opencue.wrappers.depend.Depend
         @return: the new dependency"""
         return self.asJob().createDependencyOnLayer(layer)
 
     def createDependencyOnFrame(self, frame):
         """Create and return a job on frame dependency
-        @type  frame: Frame
+        @type  frame: opencue.wrappers.frame.Frame
         @param frame: the frame you want this job to depend on
-        @rtype:  Depend
+        @rtype:  opencue.wrappers.depend.Depend
         @return: the new dependency"""
         return self.asJob().createDependencyOnFrame(frame)
 
@@ -769,7 +769,7 @@ class NestedJob(Job):
 
     def setGroup(self, group):
         """Sets the job to a new group
-        @type  group: Group
+        @type  group: opencue.wrappers.group.Group
         @param group: the group you want the job to be in."""
         self.asJob().setGroup(group)
 

--- a/pycue/opencue/wrappers/layer.py
+++ b/pycue/opencue/wrappers/layer.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 
-
 """
 opencue layer module
 
@@ -49,7 +48,7 @@ class Layer(object):
     def kill(self):
         """Kill entire layer"""
         return self.stub.KillFrames(job_pb2.LayerKillFramesRequest(layer=self.data),
-                              timeout=Cuebot.Timeout)
+                                    timeout=Cuebot.Timeout)
 
     def eat(self):
         """Eat entire layer"""
@@ -77,7 +76,7 @@ class Layer(object):
 
     def getFrames(self, **options):
         """Returns the list of up to 1000 frames from within the layer.
-        @rtype:  list<Frame>
+        @rtype:  list<opencue.wrappers.frame.Frame>
         @return: Sequence of Frame obejcts"""
         criteria = opencue.search.FrameSearch.criteriaFromOptions(**options)
         response = self.stub.GetFrames(job_pb2.LayerGetFramesRequest(layer=self.data, s=criteria),
@@ -141,7 +140,7 @@ class Layer(object):
 
     def getWhatDependsOnThis(self):
         """Gets a list of dependencies that depend directly on this layer
-        @rtype:  list<opencue.depend.Depend>
+        @rtype:  list<opencue.wrappers.depend.Depend>
         @return: List of dependencies that depend directly on this layer"""
         response = self.stub.GetWhatDependsOnThis(
             job_pb2.LayerGetWhatDependsOnThisRequest(layer=self.data),
@@ -151,7 +150,7 @@ class Layer(object):
 
     def getWhatThisDependsOn(self):
         """Get a list of dependencies that this layer depends on
-        @rtype:  list<opencue.depend.Depend>
+        @rtype:  list<opencue.wrappers.depend.Depend>
         @return: List of dependences that this layer depends on"""
         response = self.stub.GetWhatThisDependsOn(
             job_pb2.LayerGetWhatThisDependsOnRequest(layer=self.data),
@@ -161,48 +160,48 @@ class Layer(object):
 
     def createDependencyOnJob(self, job):
         """Create and return a layer on job dependency
-        @type  job: Job
+        @type  job: opencue.wrappers.job.Job
         @param job: the job you want this job to depend on
-        @rtype:  opencue.depend.Depend
+        @rtype:  opencue.wrappers.depend.Depend
         @return: the new dependency"""
         response = self.stub.CreateDependOnJob(
-            job_pb2.LayerCreateDependOnJobRequest(layer=self.data, job=job),
+            job_pb2.LayerCreateDependOnJobRequest(layer=self.data, job=job.data),
             timeout=Cuebot.Timeout)
         return opencue.wrappers.depend.Depend(response.depend)
 
     def createDependencyOnLayer(self, layer):
         """Create and return a layer on layer dependency
-        @type  layer: Layer
+        @type  layer: opencue.wrappers.layer.Layer
         @param layer: the layer you want this layer to depend on
-        @rtype:  opencue.depend.Depend
+        @rtype:  opencue.wrappers.depend.Depend
         @return: the new dependency"""
         response = self.stub.CreateDependOnLayer(
-            job_pb2.LayerCreateDependOnLayerRequest(layer=self.data, depend_on_layer=layer),
+            job_pb2.LayerCreateDependOnLayerRequest(layer=self.data, depend_on_layer=layer.data),
             timeout=Cuebot.Timeout)
         return opencue.wrappers.depend.Depend(response.depend)
 
     def createDependencyOnFrame(self, frame):
         """Create and return a layer on frame dependency
-        @type  frame: Frame
+        @type  frame: opencue.wrappers.frame.Frame
         @param frame: the frame you want this layer to depend on
-        @rtype:  opencue.depend.Depend
+        @rtype:  opencue.wrappers.depend.Depend
         @return: the new dependency"""
         response = self.stub.CreateDependOnFrame(
-            job_pb2.LayerCreateDependOnFrameRequest(layer=self.data, frame=frame),
+            job_pb2.LayerCreateDependOnFrameRequest(layer=self.data, frame=frame.data),
             timeout=Cuebot.Timeout)
         return opencue.wrappers.depend.Depend(response.depend)
 
     def createFrameByFrameDependency(self, layer):
         """Create and return a frame by frame frame dependency
         @param layer: the layer you want this layer to depend on
-        @type  layer: Layer
-        @rtype:  opencue.depend.Depend
+        @type  layer: opencue.wrappers.layer.Layer
+        @rtype:  opencue.wrappers.depend.Depend
         @return: the new dependency"""
         # anyframe is hard coded right now, this option should be moved
         # to LayerOnLayer for better efficiency.
         response = self.stub.CreateFrameByFrameDepend(
             job_pb2.LayerCreateFrameByFrameDependRequest(
-                layer=self.data, depend_layer=layer, any_frame=False),
+                layer=self.data, depend_layer=layer.data, any_frame=False),
             timeout=Cuebot.Timeout)
         return opencue.wrappers.depend.Depend(response.depend)
 
@@ -230,7 +229,7 @@ class Layer(object):
         """Reorders the specified frame range on this layer.
         @type  range: string
         @param range: The frame range to reorder
-        @type  order: opencue.Order
+        @type  order: opencue.wrapper.layer.Layer.Order
         @param order: First, Last or Reverse"""
         self.stub.ReorderFrames(
             job_pb2.LayerReorderFramesRequest(layer=self.data, range=range, order=order),

--- a/pycue/opencue/wrappers/owner.py
+++ b/pycue/opencue/wrappers/owner.py
@@ -38,7 +38,7 @@ class Owner(object):
 
     def getDeeds(self):
         """Return the list of deeds for the owner
-        @rtype:  List<Deed Wrapper>
+        @rtype:  List<opencue.wrappers..deed.Deed Wrapper>
         @return: The list of deeds associated with this owner."""
         response = self.stub.GetDeeds(host_pb2.OwnerGetDeedsRequest(owner=self.data),
                                       timeout=Cuebot.Timeout)
@@ -46,7 +46,7 @@ class Owner(object):
 
     def getHosts(self):
         """Get a list of all hosts this owner is responsible for.
-        @rtype:  List<Host Wrapper>
+        @rtype:  List<opencue.wrappers.host.Host Wrapper>
         @return: List of hosts the owned by this owner."""
         response = self.stub.GetHosts(host_pb2.OwnerGetHostsRequest(owner=self.data),
                                       timeout=Cuebot.Timeout)
@@ -56,7 +56,7 @@ class Owner(object):
         """Return an owner by name.
         @type:   str
         @param:  Name of the owner
-        @rtype:  Owner
+        @rtype:  opencue.wrappers.owner.Owner
         @return: Owner that matches the specified name"""
         return Owner(self.stub.GetOwner(host_pb2.OwnerGetOwnerRequest(name=name),
                                         timeout=Cuebot.Timeout).owner)

--- a/pycue/opencue/wrappers/proc.py
+++ b/pycue/opencue/wrappers/proc.py
@@ -60,7 +60,7 @@ class Proc(object):
 
     def getHost(self):
         """Return the host this proc is allocated from.
-        @rtype:  Host
+        @rtype:  opencue.wrappers.host.Host
         @return: The host this proc is allocated from."""
         response = self.stub.GetHost(host_pb2.ProcGetHostRequest(proc=self.data),
                                      timeout=Cuebot.Timeout)
@@ -68,7 +68,7 @@ class Proc(object):
 
     def getFrame(self):
         """Return the frame this proc is running.
-        @rtype:  Frame
+        @rtype:  opencue.wrappers.frame.Frame
         @return: The fame this proc is running."""
         response = self.stub.GetFrame(host_pb2.ProcGetFrameRequest(proc=self.data),
                                       timeout=Cuebot.Timeout)
@@ -76,7 +76,7 @@ class Proc(object):
 
     def getLayer(self):
         """Return the layer this proc is running.
-        @rtype:  Layer
+        @rtype:  opencue.wrappers.layer.Layer
         @return: The layer this proc is running."""
         response = self.stub.GetLayer(host_pb2.ProcGetLayerRequest(proc=self.data),
                                       timeout=Cuebot.Timeout)
@@ -84,7 +84,7 @@ class Proc(object):
 
     def getJob(self):
         """Return the job this proc is running.
-        @rtype:  Job
+        @rtype:  opencue.wrappers.job.Job
         @return: The job this proc is running."""
         response = self.stub.GetJob(host_pb2.ProcGetJobRequest(proc=self.data),
                                     timeout=Cuebot.Timeout)

--- a/pycue/opencue/wrappers/show.py
+++ b/pycue/opencue/wrappers/show.py
@@ -47,7 +47,7 @@ class Show(object):
 
     def createSubscription(self, allocation, size, burst):
         """Creates a new subscription
-        @type allocation: Allocation
+        @type allocation: opencue.wrappers.allocation.Allocation
         @param allocation: Allocation object
         @type size: float
         @param size: Allocation size
@@ -57,7 +57,7 @@ class Show(object):
         @return: The created subscription object
         """
         response = self.stub.CreateSubscription(show_pb2.ShowCreateSubscriptionRequest(
-            show=self.data, allocation_id=allocation.id, size=size, burst=burst),
+            show=self.data, allocation_id=allocation.id(), size=size, burst=burst),
             timeout=Cuebot.Timeout)
         return opencue.wrappers.subscription.Subscription(response.subscription)
 
@@ -67,7 +67,7 @@ class Show(object):
 
     def getServiceOverrides(self):
         """Returns a list of service overrides on the show.
-        @rtype: list<ServiceOverride>
+        @rtype: list<service_pb2.ServiceOverride>
         @return: a list of service override objects
         """
         serviceOverrideSeq = self.stub.GetServiceOverrides(
@@ -77,7 +77,7 @@ class Show(object):
 
     def getSubscriptions(self):
         """Returns a list of all subscriptions
-        @rtype: list<Subscription>
+        @rtype: list<opencue.wrappers.subscription.Subscription>
         @return: A list of subscription objects
         """
         response = self.stub.GetSubscriptions(show_pb2.ShowGetSubscriptionRequest(
@@ -88,7 +88,7 @@ class Show(object):
 
     def findSubscription(self, name):
         """Returns the matching subscription
-        @rtype: Subscription
+        @rtype: opencue.wrappers.subscription.Subscription
         @return: The matching subscription
         """
         subscriptions = opencue.wrappers.subscription.Subscription()
@@ -96,7 +96,7 @@ class Show(object):
 
     def getFilters(self):
         """Returns the job filters for this show
-        @rtype: list<Filter>
+        @rtype: list<opencue.wrappers.filter.Filter>
         @return: List of Filter wrapper objects for this show.
         """
         response = self.stub.GetFilters(show_pb2.ShowGetFiltersRequest(
@@ -143,7 +143,7 @@ class Show(object):
         """Find the filter by name
         @type: string
         @param: name of filter to find
-        @rtype: Filter
+        @rtype: opencue.wrappers.filter.Filter
         @return: filter wrapper of found filter
         """
         response = self.stub.FindFilter(show_pb2.ShowFindFilterRequest(
@@ -163,7 +163,7 @@ class Show(object):
 
     def getGroups(self):
         """Get the groups for this show
-        @rtype: list<Group>
+        @rtype: list<opencue.wrappers.group.Group>
         @return: list of group wrappers for this show
         """
         response = self.stub.GetGroups(show_pb2.ShowGetGroupsRequest(

--- a/pycue/tests/wrappers/allocation_test.py
+++ b/pycue/tests/wrappers/allocation_test.py
@@ -30,6 +30,7 @@ from opencue.compiled_proto import subscription_pb2
 TEST_ALLOC_NAME = 'test_allocation'
 TEST_ALLOC_TAG = 'test_tag'
 TEST_HOST_NAME = 'test_host'
+TEST_HOST_ID = 'hhh-hhhh-hhh'
 TEST_SUBSCRIPTION_NAME = 'test_subscription'
 
 
@@ -87,9 +88,26 @@ class AllocationTests(unittest.TestCase):
 
         alloc = opencue.wrappers.allocation.Allocation(
             facility_pb2.Allocation(name=TEST_ALLOC_NAME))
-        hosts = [host_pb2.Host(name=TEST_HOST_NAME)]
+        hosts = [opencue.wrappers.host.Host(host_pb2.Host(name=TEST_HOST_NAME))]
         alloc.reparentHosts(hosts)
 
+        stubMock.ReparentHosts.assert_called_with(
+            facility_pb2.AllocReparentHostsRequest(
+                allocation=alloc.data,
+                hosts=host_pb2.HostSeq(hosts=[host.data for host in hosts])),
+            timeout=mock.ANY)
+
+    def testReparentHostIds(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.ReparentHosts.return_value = facility_pb2.AllocReparentHostsResponse()
+        getStubMock.return_value = stubMock
+    
+        alloc = opencue.wrappers.allocation.Allocation(
+            facility_pb2.Allocation(name=TEST_ALLOC_NAME))
+        hostIds = [TEST_HOST_ID]
+        alloc.reparentHostIds(hostIds)
+        hosts = [host_pb2.Host(id=TEST_HOST_ID)]
+    
         stubMock.ReparentHosts.assert_called_with(
             facility_pb2.AllocReparentHostsRequest(
                 allocation=alloc.data, hosts=host_pb2.HostSeq(hosts=hosts)), timeout=mock.ANY)

--- a/pycue/tests/wrappers/filter_test.py
+++ b/pycue/tests/wrappers/filter_test.py
@@ -191,13 +191,14 @@ class FilterTests(unittest.TestCase):
         stubMock.RunFilterOnGroup.return_value = filter_pb2.FilterRunFilterOnGroupResponse()
         getStubMock.return_value = stubMock
 
-        group = job_pb2.Group(name='testGroup')
+        group = opencue.wrappers.group.Group(
+            job_pb2.Group(name='testGroup'))
         filter = opencue.wrappers.filter.Filter(
             filter_pb2.Filter(name=TEST_FILTER_NAME))
         filter.runFilterOnGroup(group)
 
         stubMock.RunFilterOnGroup.assert_called_with(
-            filter_pb2.FilterRunFilterOnGroupRequest(filter=filter.data, group=group),
+            filter_pb2.FilterRunFilterOnGroupRequest(filter=filter.data, group=group.data),
             timeout=mock.ANY)
 
     def testRunFilterOnJobs(self, getStubMock):
@@ -205,8 +206,8 @@ class FilterTests(unittest.TestCase):
         stubMock.RunFilterOnJobs.return_value = filter_pb2.FilterRunFilterOnJobsResponse()
         getStubMock.return_value = stubMock
 
-        jobs = [job_pb2.Job(name='testJob')]
-        jobSeq = job_pb2.JobSeq(jobs=jobs)
+        jobs = [opencue.wrappers.job.Job(job_pb2.Job(name='testJob'))]
+        jobSeq = job_pb2.JobSeq(jobs=[job.data for job in jobs])
         filter = opencue.wrappers.filter.Filter(
             filter_pb2.Filter(name=TEST_FILTER_NAME))
         filter.runFilterOnJobs(jobs)

--- a/pycue/tests/wrappers/frame_test.py
+++ b/pycue/tests/wrappers/frame_test.py
@@ -111,12 +111,13 @@ class FrameTests(unittest.TestCase):
         dependFrameName = 'frameDependTest'
         frame = opencue.wrappers.frame.Frame(
             job_pb2.Frame(name=TEST_FRAME_NAME))
-        dependOnFrame = job_pb2.Frame(name=dependFrameName)
+        dependOnFrame = opencue.wrappers.frame.Frame(
+            job_pb2.Frame(name=dependFrameName))
         depend = frame.createDependencyOnFrame(dependOnFrame)
 
         stubMock.CreateDependencyOnFrame.assert_called_with(
             job_pb2.FrameCreateDependencyOnFrameRequest(frame=frame.data,
-                                                        depend_on_frame=dependOnFrame),
+                                                        depend_on_frame=dependOnFrame.data),
             timeout=mock.ANY)
         self.assertEqual(depend.id(), dependId)
 
@@ -130,11 +131,12 @@ class FrameTests(unittest.TestCase):
         dependJobName = 'jobDependTest'
         frame = opencue.wrappers.frame.Frame(
             job_pb2.Frame(name=TEST_FRAME_NAME, state=job_pb2.RUNNING))
-        dependOnJob = job_pb2.Job(name=dependJobName)
+        dependOnJob = opencue.wrappers.job.Job(
+            job_pb2.Job(name=dependJobName))
         depend = frame.createDependencyOnJob(dependOnJob)
 
         stubMock.CreateDependencyOnJob.assert_called_with(
-            job_pb2.FrameCreateDependencyOnJobRequest(frame=frame.data, job=dependOnJob),
+            job_pb2.FrameCreateDependencyOnJobRequest(frame=frame.data, job=dependOnJob.data),
             timeout=mock.ANY)
         self.assertEqual(depend.id(), dependId)
 
@@ -148,11 +150,12 @@ class FrameTests(unittest.TestCase):
         dependLayerName = 'layerDependTest'
         frame = opencue.wrappers.frame.Frame(
             job_pb2.Frame(name=TEST_FRAME_NAME, state=job_pb2.RUNNING))
-        dependOnLayer = job_pb2.Layer(name=dependLayerName)
+        dependOnLayer = opencue.wrappers.layer.Layer(
+            job_pb2.Layer(name=dependLayerName))
         depend = frame.createDependencyOnLayer(dependOnLayer)
 
         stubMock.CreateDependencyOnLayer.assert_called_with(
-            job_pb2.FrameCreateDependencyOnLayerRequest(frame=frame.data, layer=dependOnLayer),
+            job_pb2.FrameCreateDependencyOnLayerRequest(frame=frame.data, layer=dependOnLayer.data),
             timeout=mock.ANY)
         self.assertEqual(depend.id(), dependId)
 

--- a/pycue/tests/wrappers/group_test.py
+++ b/pycue/tests/wrappers/group_test.py
@@ -201,12 +201,29 @@ class GroupTests(unittest.TestCase):
         stubMock.ReparentGroups.return_value = job_pb2.GroupReparentGroupsResponse()
         getStubMock.return_value = stubMock
 
-        groups = [job_pb2.Group()]
-        groupSeq = job_pb2.GroupSeq(groups=groups)
+        groups = [opencue.wrappers.group.Group(job_pb2.Group())]
+        groupSeq = job_pb2.GroupSeq(groups=[grp.data for grp in groups])
         group = opencue.wrappers.group.Group(
             job_pb2.Group(name=TEST_GROUP_NAME))
         group.reparentGroups(groups)
 
+        stubMock.ReparentGroups.assert_called_with(
+            job_pb2.GroupReparentGroupsRequest(group=group.data, groups=groupSeq),
+            timeout=mock.ANY)
+
+    def testReparentGroupIds(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.ReparentGroups.return_value = job_pb2.GroupReparentGroupsResponse()
+        getStubMock.return_value = stubMock
+    
+        groupId = 'ggg-gggg-ggg'
+        groupIds = [groupId]
+        groups = [opencue.wrappers.group.Group(job_pb2.Group(id='ggg-gggg-ggg'))]
+        groupSeq = job_pb2.GroupSeq(groups=[grp.data for grp in groups])
+        group = opencue.wrappers.group.Group(
+            job_pb2.Group(name=TEST_GROUP_NAME))
+        group.reparentGroupIds(groupIds)
+    
         stubMock.ReparentGroups.assert_called_with(
             job_pb2.GroupReparentGroupsRequest(group=group.data, groups=groupSeq),
             timeout=mock.ANY)
@@ -231,13 +248,13 @@ class GroupTests(unittest.TestCase):
         stubMock.SetGroup.return_value = job_pb2.GroupSetGroupResponse()
         getStubMock.return_value = stubMock
 
-        parentGroup = job_pb2.Group(name='parentGroup')
+        parentGroup = opencue.wrappers.group.Group(job_pb2.Group(name='parentGroup'))
         group = opencue.wrappers.group.Group(
             job_pb2.Group(name=TEST_GROUP_NAME))
         group.setGroup(parentGroup)
 
         stubMock.SetGroup.assert_called_with(
-            job_pb2.GroupSetGroupRequest(group=group.data, parent_group=parentGroup),
+            job_pb2.GroupSetGroupRequest(group=group.data, parent_group=parentGroup.data),
             timeout=mock.ANY)
 
 

--- a/pycue/tests/wrappers/job_test.py
+++ b/pycue/tests/wrappers/job_test.py
@@ -334,13 +334,14 @@ class JobTests(unittest.TestCase):
             depend=depend_pb2.Depend(id=dependId))
         getStubMock.return_value = stubMock
 
-        onJob = job_pb2.Job(name=TEST_JOB_NAME+"Depend")
+        onJob = opencue.wrappers.job.Job(
+            job_pb2.Job(name=TEST_JOB_NAME+"Depend"))
         job = opencue.wrappers.job.Job(
             job_pb2.Job(name=TEST_JOB_NAME))
         depend = job.createDependencyOnJob(onJob)
 
         stubMock.CreateDependencyOnJob.assert_called_with(
-            job_pb2.JobCreateDependencyOnJobRequest(job=job.data, on_job=onJob),
+            job_pb2.JobCreateDependencyOnJobRequest(job=job.data, on_job=onJob.data),
             timeout=mock.ANY)
         self.assertEqual(depend.id(), dependId)
 
@@ -352,13 +353,14 @@ class JobTests(unittest.TestCase):
             depend=depend_pb2.Depend(id=dependId))
         getStubMock.return_value = stubMock
 
-        onLayer = job_pb2.Layer(name=dependLayer)
+        onLayer = opencue.wrappers.layer.Layer(
+            job_pb2.Layer(name=dependLayer))
         job = opencue.wrappers.job.Job(
             job_pb2.Job(name=TEST_JOB_NAME))
         depend = job.createDependencyOnLayer(onLayer)
 
         stubMock.CreateDependencyOnLayer.assert_called_with(
-            job_pb2.JobCreateDependencyOnLayerRequest(job=job.data, layer=onLayer),
+            job_pb2.JobCreateDependencyOnLayerRequest(job=job.data, layer=onLayer.data),
             timeout=mock.ANY)
         self.assertEqual(depend.id(), dependId)
 
@@ -370,13 +372,14 @@ class JobTests(unittest.TestCase):
             depend=depend_pb2.Depend(id=dependId))
         getStubMock.return_value = stubMock
 
-        onFrame = job_pb2.Frame(name=dependFrame)
+        onFrame = opencue.wrappers.frame.Frame(
+            job_pb2.Frame(name=dependFrame))
         job = opencue.wrappers.job.Job(
             job_pb2.Job(name=TEST_JOB_NAME))
         depend = job.createDependencyOnFrame(onFrame)
 
         stubMock.CreateDependencyOnFrame.assert_called_with(
-            job_pb2.JobCreateDependencyOnFrameRequest(job=job.data, frame=onFrame),
+            job_pb2.JobCreateDependencyOnFrameRequest(job=job.data, frame=onFrame.data),
             timeout=mock.ANY)
         self.assertEqual(depend.id(), dependId)
 
@@ -420,7 +423,8 @@ class JobTests(unittest.TestCase):
         getStubMock.return_value = stubMock
 
         groupId = 'ggg-gggg-ggg'
-        group = job_pb2.Group(id=groupId)
+        group = opencue.wrappers.group.Group(
+            job_pb2.Group(id=groupId))
         job = opencue.wrappers.job.Job(
             job_pb2.Job(name=TEST_JOB_NAME))
         job.setGroup(group)

--- a/pycue/tests/wrappers/layer_test.py
+++ b/pycue/tests/wrappers/layer_test.py
@@ -254,11 +254,12 @@ class LayerTests(unittest.TestCase):
 
         layer = opencue.wrappers.layer.Layer(
             job_pb2.Layer(name=TEST_LAYER_NAME))
-        job = job_pb2.Job(id=jobId)
+        job = opencue.wrappers.job.Job(
+            job_pb2.Job(id=jobId))
         depend = layer.createDependencyOnJob(job)
 
         stubMock.CreateDependOnJob.assert_called_with(
-            job_pb2.LayerCreateDependOnJobRequest(layer=layer.data, job=job),
+            job_pb2.LayerCreateDependOnJobRequest(layer=layer.data, job=job.data),
             timeout=mock.ANY)
         self.assertEqual(depend.id(), dependId)
 
@@ -272,11 +273,13 @@ class LayerTests(unittest.TestCase):
 
         layer = opencue.wrappers.layer.Layer(
             job_pb2.Layer(name=TEST_LAYER_NAME))
-        dependLayer = job_pb2.Layer(id=layerId)
+        dependLayer = opencue.wrappers.layer.Layer(
+            job_pb2.Layer(id=layerId))
         depend = layer.createDependencyOnLayer(dependLayer)
 
         stubMock.CreateDependOnLayer.assert_called_with(
-            job_pb2.LayerCreateDependOnLayerRequest(layer=layer.data, depend_on_layer=dependLayer),
+            job_pb2.LayerCreateDependOnLayerRequest(layer=layer.data,
+                                                    depend_on_layer=dependLayer.data),
             timeout=mock.ANY)
         self.assertEqual(depend.id(), dependId)
 
@@ -290,11 +293,12 @@ class LayerTests(unittest.TestCase):
 
         layer = opencue.wrappers.layer.Layer(
             job_pb2.Layer(name=TEST_LAYER_NAME))
-        frame = job_pb2.Frame(id=frameId)
+        frame = opencue.wrappers.frame.Frame(
+            job_pb2.Frame(id=frameId))
         depend = layer.createDependencyOnFrame(frame)
 
         stubMock.CreateDependOnFrame.assert_called_with(
-            job_pb2.LayerCreateDependOnFrameRequest(layer=layer.data, frame=frame),
+            job_pb2.LayerCreateDependOnFrameRequest(layer=layer.data, frame=frame.data),
             timeout=mock.ANY)
         self.assertEqual(depend.id(), dependId)
 
@@ -308,11 +312,13 @@ class LayerTests(unittest.TestCase):
 
         layer = opencue.wrappers.layer.Layer(
             job_pb2.Layer(name=TEST_LAYER_NAME))
-        dependLayer = job_pb2.Layer(id=layerId)
+        dependLayer = opencue.wrappers.layer.Layer(
+            job_pb2.Layer(id=layerId))
         depend = layer.createFrameByFrameDependency(dependLayer)
 
         stubMock.CreateFrameByFrameDepend.assert_called_with(
-            job_pb2.LayerCreateFrameByFrameDependRequest(layer=layer.data, depend_layer=dependLayer,
+            job_pb2.LayerCreateFrameByFrameDependRequest(layer=layer.data,
+                                                         depend_layer=dependLayer.data,
                                                          any_frame=False),
             timeout=mock.ANY)
         self.assertEqual(depend.id(), dependId)

--- a/pycue/tests/wrappers/show_test.py
+++ b/pycue/tests/wrappers/show_test.py
@@ -72,7 +72,8 @@ class ShowTests(unittest.TestCase):
         getStubMock.return_value = stubMock
 
         show = opencue.wrappers.show.Show(show_pb2.Show(name=TEST_SHOW_NAME))
-        allocation = facility_pb2.Allocation(id=TEST_ALLOCATION_ID)
+        allocation = opencue.wrappers.allocation.Allocation(
+            facility_pb2.Allocation(id=TEST_ALLOCATION_ID))
         subscription = show.createSubscription(allocation, TEST_SUBSCRIPTION_SIZE, TEST_SUBSCRIPTION_BURST)
 
         stubMock.CreateSubscription.assert_called_with(


### PR DESCRIPTION
Cleaning up wrapper methods so that no protobuf objects are passed in or returned. Some protobuf enums are still passed around but that is intentional. Also changes update docstrings to further clarify object types.

Fixes #448

