### PR TITLE
Fix createFrameByFrameDependency grpc method 

### DIFF
--- a/pycue/opencue/wrappers/layer.py
+++ b/pycue/opencue/wrappers/layer.py
@@ -199,7 +199,7 @@ class Layer(object):
         @return: the new dependency"""
         # anyframe is hard coded right now, this option should be moved
         # to LayerOnLayer for better efficiency.
-        response = self.stub.CreateFrameByFrameDepend(
+        response = self.stub.CreateFrameByFrameDependency(
             job_pb2.LayerCreateFrameByFrameDependRequest(
                 layer=self.data, depend_layer=layer.data, any_frame=False),
             timeout=Cuebot.Timeout)

--- a/pycue/tests/wrappers/layer_test.py
+++ b/pycue/tests/wrappers/layer_test.py
@@ -306,7 +306,7 @@ class LayerTests(unittest.TestCase):
         dependId = 'dddd-ddd-dddd'
         layerId = 'llll-lll-llll'
         stubMock = mock.Mock()
-        stubMock.CreateFrameByFrameDepend.return_value = \
+        stubMock.CreateFrameByFrameDependency.return_value = \
             job_pb2.LayerCreateFrameByFrameDependResponse(depend=depend_pb2.Depend(id=dependId))
         getStubMock.return_value = stubMock
 
@@ -316,7 +316,7 @@ class LayerTests(unittest.TestCase):
             job_pb2.Layer(id=layerId))
         depend = layer.createFrameByFrameDependency(dependLayer)
 
-        stubMock.CreateFrameByFrameDepend.assert_called_with(
+        stubMock.CreateFrameByFrameDependency.assert_called_with(
             job_pb2.LayerCreateFrameByFrameDependRequest(layer=layer.data,
                                                          depend_layer=dependLayer.data,
                                                          any_frame=False),


### PR DESCRIPTION
Fixes #453 

`CreateFrameByFrameDepend` should be `CreateFrameByFrameDependency`
See `proto/job.proto` line 271.
