### PR TITLE
Left alignment should not change on selection.

### DIFF
--- a/cuegui/cuegui/ItemDelegate.py
+++ b/cuegui/cuegui/ItemDelegate.py
@@ -125,7 +125,7 @@ class AbstractDelegate(QtWidgets.QItemDelegate):
             # Draw the text
             painter.setPen(QtGui.QColor(index.data(QtCore.Qt.ForegroundRole)))
             painter.drawText(option.rect.adjusted(3, -1, -3, 0),
-                             QtCore.Qt.AlignHCenter | QtCore.Qt.AlignVCenter,
+                             QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter,
                              str(index.data(QtCore.Qt.DisplayRole)))
         finally:
             painter.restore()


### PR DESCRIPTION
Fixes #480 

When selecting an item in CueGui the alignment should stay to the left.