### PR TITLE
Double clicking layer in cuegui should filter the frames view

### DIFF
--- a/cuegui/cuegui/FrameMonitor.py
+++ b/cuegui/cuegui/FrameMonitor.py
@@ -92,6 +92,9 @@ class FrameMonitor(QtWidgets.QWidget):
     def setColumnVisibility(self, settings):
         self.frameMonitorTree.setColumnVisibility(settings)
 
+    def filterLayersFromDoubleClick(self, layerNames):
+        self._filterLayersHandleByLayer(layerNames)
+
 # ==============================================================================
 # Frame range bar to filter by frame range
 # ==============================================================================

--- a/cuegui/cuegui/plugins/MonitorJobDetailsPlugin.py
+++ b/cuegui/cuegui/plugins/MonitorJobDetailsPlugin.py
@@ -62,8 +62,7 @@ class MonitorLayerFramesDockWidget(cuegui.AbstractDockWidget.AbstractDockWidget)
         QtGui.qApp.view_object.connect(self.__setJob)
         QtGui.qApp.unmonitor.connect(self.__unmonitor)
         QtGui.qApp.facility_changed.connect(self.__setJob)
-        self.__monitorLayers.handle_filter_layers_byLayer.connect(
-            self.__monitorFrames.handle_filter_layers_byLayer.emit)
+        self.__monitorLayers.handle_filter_layers_byLayer.connect(self.handleLayerFilter)
         self.__splitter.splitterMoved.connect(self.__splitterMoved)
 
 
@@ -82,6 +81,9 @@ class MonitorLayerFramesDockWidget(cuegui.AbstractDockWidget.AbstractDockWidget)
                                      ("layerColumnWidths",
                                       self.__monitorLayers.getColumnWidths,
                                       self.__monitorLayers.setColumnWidths)])
+
+    def handleLayerFilter(self, names):
+        self.__monitorFrames.filterLayersFromDoubleClick(names)
 
     def __splitterMoved(self, pos, index):
         self.__monitorLayers.disableUpdate = not bool(pos)

--- a/cuesubmit/cuesubmit/ui/Submit.py
+++ b/cuesubmit/cuesubmit/ui/Submit.py
@@ -268,8 +268,8 @@ class CueSubmitWidget(QtWidgets.QWidget):
             chunk=self.chunkInput.text(),
             cores=self.coresInput.text(),
             env=None,
-            services=[i.strip() for i in self.servicesSelector.text().split(',')],
-            limits=[i.strip() for i in self.limitsSelector.text().split(',')],
+            services=self.servicesSelector.getChecked(),
+            limits=self.limitsSelector.getChecked(),
             dependType=self.dependSelector.text(),
             dependsOn=None
         )


### PR DESCRIPTION
Fixes #474 

Directly hook up double click in layers view to frames filter call.
Also cleans up cuesubmit, to make sure the default "empty" values for services and limits are not sent on job submission