### PR TITLE
Merge PR template content into CONTRIBUTING.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,7 @@
 **Link the Issue(s) this Pull Request is related to.**
 One line for each Issue. If merging this Pull Request should auto-close the Issue on that line,
-preface the Issue URL/Number with "Fixes".
-
-Every Pull Request should have at least one Issue linked.
+preface the Issue URL/Number with "Fixes". Every Pull Request should have at least one Issue
+linked.
 
 **Summarize your change.**
 If it's a simple change, a sentence or two is probably sufficient. If it's a complex change,
@@ -10,8 +9,8 @@ adding a list of the three or four main points can be helpful.
 
 It's also helpful to describe **why** you're making this change.
 
-**Checklist**
-You can remove this section before creating your Pull Request.
+<!--
+**PR Checklist**
 
 1. Add a Pull Request title. A descriptive single sentence.
 
@@ -29,7 +28,7 @@ You can remove this section before creating your Pull Request.
    If you feel like your change is ready to be merged or close to that, create a normal Pull
    Request.
 
-   If you feel like your change isn't ready to be merged -- maybe it's just an idea you have -- but
+   If you feel like your change isn't ready to be merged — maybe it's just an idea you have — but
    you want feedback anyway, feel free to create a Draft Pull Request and add any needed reviewers
    (Code Owners will not be automatically added as they are for regular Pull Requests). Draft
 
@@ -43,3 +42,5 @@ You can remove this section before creating your Pull Request.
    After you create your Pull Request, a presubmit check will be run to determine whether you've
    signed the OpenCue CLA. If you haven't, the presubmit check will display instructions for
    how to proceed.
+-->
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,6 @@ adding a list of the three or four main points can be helpful.
 It's also helpful to describe **why** you're making this change.
 
 <!--
-For a step-by-step list to walk you through the pull request process, see our
-[CONTRIBUTING doc](https://github.com/AcademySoftwareFoundation/OpenCue/blob/master/CONTRIBUTING.md#development-and-pull-requests)
+For a step-by-step list to walk you through the pull request process, see
+https://www.opencue.io/contributing/.
 -->
-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,37 +10,7 @@ adding a list of the three or four main points can be helpful.
 It's also helpful to describe **why** you're making this change.
 
 <!--
-**PR Checklist**
-
-1. Add a Pull Request title. A descriptive single sentence.
-
-2. Fill in the Pull Request body as described above.
-
-3. Request any additional reviewers.
-
-   Everyone listed in [CODEOWNERS](https://github.com/AcademySoftwareFoundation/OpenCue/blob/master/CODEOWNERS) will be automatically added to the reviewer list, though
-   you only need one Code Owner approval before the Pull Request can be removed.
-
-   Feel free to add other reviewers if you think their input would be valuable!
-
-4. Choose Draft/Regular mode.
-
-   If you feel like your change is ready to be merged or close to that, create a normal Pull
-   Request.
-
-   If you feel like your change isn't ready to be merged — maybe it's just an idea you have — but
-   you want feedback anyway, feel free to create a Draft Pull Request and add any needed reviewers
-   (Code Owners will not be automatically added as they are for regular Pull Requests). Draft
-
-   You can convert a Draft Pull Request to a regular Pull Request at any point.
-
-   Draft Pull Requests will still have presubmit checks (such as CI tests) run on them, which can
-   be helpful.
-
-5. Sign the CLA.
-
-   After you create your Pull Request, a presubmit check will be run to determine whether you've
-   signed the OpenCue CLA. If you haven't, the presubmit check will display instructions for
-   how to proceed.
+For a step-by-step list to walk you through the pull request process, see our
+[CONTRIBUTING doc](https://github.com/AcademySoftwareFoundation/OpenCue/blob/master/CONTRIBUTING.md#development-and-pull-requests)
 -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,18 +79,18 @@ Having an assigned issue serves a few purposes:
    coordinate with them to find out the current state of their work and if
    you can assist. If you don't get a response, or the issue seems to be stale,
    reach out to a [Code Owner](./CODEOWNERS) to escalate.
-   
+
 -  Provides a centralized place to track related work. There may be related
    discussion, and many issues are complex enough to require more than one
    pull request to be fully resolved. The issue page provides a home for
    all of that material, which is very helpful for future contributors to
-   look back on. 
+   look back on.
 
 -  Helps us populate our release notes. Published
    [OpenCue releases](https://github.com/AcademySoftwareFoundation/OpenCue/releases)
    use Github issue or pull request numbers to identify what has changed in
    each release.
-   
+
 Nearly all pull requests should have an issue associated with them.
 
 ## Development and Pull Requests
@@ -104,44 +104,48 @@ The development cycle for a code change should follow this protocol:
 1. Create a topic branch in your local repository.
 
 2. Make changes, compile, and test thoroughly. Code style should match existing
-style and conventions, and changes should be focused on the topic the pull
-request will be addressing. Make unrelated changes in a separate topic branch
-with a separate pull request.
+   style and conventions, and changes should be focused on the topic the pull
+   request will be addressing. Make unrelated changes in a separate topic branch
+   with a separate pull request.
 
 3. Push commits to your fork.
 
 4. Create a Github pull request from your topic branch. This can be
-a normal pull request or a **draft** pull request:
+   a normal pull request or a **draft** pull request:
 
    -  Normal pull request: Use this if you feel like your change is
    ready to be merged or close to that. Reviews will be automatically
    requested from all of our Code Owners, but feel free to add others
    if you'd like -- we love to get as much feedback as we can!
-   
+
    -  Draft pull request: Use this if you feel like your change isn't
    ready to be merged -- maybe it's just an idea you have -- but
    you want feedback anyway. Reviews will not be automatically
    requested, but feel free to add reviewers anyway and we'll be happy
    to provide feedback -- [CODEOWNERS](./CODEOWNERS) is a good place
    to find a list of potential reviewers.
-   
-   You can convert a Draft pull request to a regular pull request at any point. 
+
+   You can convert a Draft pull request to a regular pull request at any point.
 
 5. All pull requests (including drafts) trigger our CI system, which builds and
-tests your branch. These builds verify that code compiles and all unit tests
-succeed. CI build status is displayed on the GitHub pull request page, and
-changes will only be merged after all builds have succeeded.
+   tests your branch. These builds verify that code compiles and all unit tests
+   succeed. CI build status is displayed on the GitHub pull request page, and
+   changes will only be merged after all builds have succeeded.
 
 6. A status check will also ensure you've signed the requisite
-[Contributor License Agreement](#contributor-license-agreement-cla-and-intellectual-property).
+   [Contributor License Agreement](#contributor-license-agreement-cla-and-intellectual-property).
 
 7. Pull requests will be reviewed by project Committers and Contributors,
-who may discuss, offer constructive feedback, request changes, or approve
-the work.
+   who may discuss, offer constructive feedback, request changes, or approve
+   the work.
+
+   Reviewers will be added to your pull request automatically but feel free to
+   add anyone you'd like! We'll always be happy to receive additional feedback,
+   including from people who aren't normally involved with the project.
 
 8. Upon receiving the required number of Committer approvals (as outlined
-in [Required Approvals](#required-approvals)), any Committer may squash and
-merge changes into the master branch.
+   in [Required Approvals](#required-approvals)), any Committer may squash and
+   merge changes into the master branch.
 
 ## Contributor License Agreement (CLA) and Intellectual Property
 
@@ -149,12 +153,12 @@ To protect the project -- and the contributors! -- we do require a
 Contributor License Agreement (CLA) for anybody submitting changes.
 
 * If you are an individual writing the code on your own time and you're SURE
-you are the sole owner of any intellectual property you contribute, you'll
-want to sign the Individual CLA.
+  you are the sole owner of any intellectual property you contribute, you'll
+  want to sign the Individual CLA.
 
 * If you are writing the code as part of your job, or if there is any
-possibility that your employers might think they own any intellectual
-property you create, then you should use the Corporate CLA.
+  possibility that your employers might think they own any intellectual
+  property you create, then you should use the Corporate CLA.
 
 Our CLAs are based on those used by Apache and many other open source
 projects.
@@ -178,38 +182,38 @@ time the PR has been open to discussion. The following guidelines outline the
 project's established approval rules for merging:
 
 * Core design decisions, large new features, or anything that might be perceived
-as changing the overall direction of the project should be discussed at length
-in the mail list before any PR is submitted, in order to: solicit feedback, try
-to get as much consensus as possible, and alert all the stakeholders to be on
-the lookout for the eventual PR when it appears.
+  as changing the overall direction of the project should be discussed at length
+  in the mail list before any PR is submitted, in order to: solicit feedback, try
+  to get as much consensus as possible, and alert all the stakeholders to be on
+  the lookout for the eventual PR when it appears.
 
 * Small changes (bug fixes, docs, tests, cleanups) can be approved and merged by
-a single Committer.
+  a single Committer.
 
 * Big changes that can alter behavior, add major features, or present a high
-degree of risk should be signed off by TWO Committers, ideally one of whom
-should be the "owner" for that section of the codebase (if a specific owner
-has been designated). If the person submitting the PR is him/herself the "owner"
-of that section of the codebase, then only one additional Committer approval is
-sufficient. But in either case, a 48 hour minimum is helpful to give everybody a
-chance to see it, unless it's a critical emergency fix (which would probably put
-it in the previous "small fix" category, rather than a "big feature").
+  degree of risk should be signed off by TWO Committers, ideally one of whom
+  should be the "owner" for that section of the codebase (if a specific owner
+  has been designated). If the person submitting the PR is him/herself the "owner"
+  of that section of the codebase, then only one additional Committer approval is
+  sufficient. But in either case, a 48 hour minimum is helpful to give everybody a
+  chance to see it, unless it's a critical emergency fix (which would probably put
+  it in the previous "small fix" category, rather than a "big feature").
 
 * Escape valve: big changes can nonetheless be merged by a single Committer if
-the PR has been open for over two weeks without any unaddressed objections from
-other Committers. At some point, we have to assume that the people who know and
-care are monitoring the PRs and that an extended period without objections is
-really assent.
+  the PR has been open for over two weeks without any unaddressed objections from
+  other Committers. At some point, we have to assume that the people who know and
+  care are monitoring the PRs and that an extended period without objections is
+  really assent.
 
 Approval must be from Committers who are not authors of the change. If one or
 more Committers oppose a proposed change, then the change cannot be accepted
 unless:
 
 * Discussions and/or additional changes result in no Committers objecting to the
-change. Previously-objecting Committers do not necessarily have to sign-off on
-the change, but they should not be opposed to it.
+  change. Previously-objecting Committers do not necessarily have to sign-off on
+  the change, but they should not be opposed to it.
 
 * The change is escalated to the TSC and the TSC votes to approve the change.
-This should only happen if disagreements between Committers cannot be resolved
-through discussion.
+  This should only happen if disagreements between Committers cannot be resolved
+  through discussion.
 


### PR DESCRIPTION
Currently the PR template and `CONTRIBUTING` doc duplicate some content. Plus it's annoying to select and delete that PR checklist every time.

Merge the two together and link to `CONTRIBUTING` from the PR template.
