### PR TITLE
Raise exception when search args are not passed the correct type

### DIFF
--- a/cuegui/cuegui/MenuActions.py
+++ b/cuegui/cuegui/MenuActions.py
@@ -323,7 +323,7 @@ class JobActions(AbstractActions):
                                              "Eat all DEAD frames in selected jobs?",
                                              [job.data.name for job in jobs]):
                 for job in jobs:
-                    job.eatFrames(state=opencue.compiled_proto.job_pb2.DEAD)
+                    job.eatFrames(state=[opencue.compiled_proto.job_pb2.DEAD])
                 self._update()
 
     autoEatOn_info = ["Enable auto eating", None, "eat"]
@@ -332,7 +332,7 @@ class JobActions(AbstractActions):
         if jobs:
             for job in jobs:
                 job.setAutoEat(True)
-                job.eatFrames(state=opencue.compiled_proto.job_pb2.DEAD)
+                job.eatFrames(state=[opencue.compiled_proto.job_pb2.DEAD])
             self._update()
 
     autoEatOff_info = ["Disable auto eating", None, "eat"]
@@ -349,7 +349,7 @@ class JobActions(AbstractActions):
         if jobs:
             if cuegui.Utils.questionBoxYesNo(self._caller, "Confirm",
                                              "Retry all DEAD frames in selected jobs?",
-                                            [job.data.name for job in jobs]):
+                                             [job.data.name for job in jobs]):
                 for job in jobs:
                     job.retryFrames(
                         state=[opencue.compiled_proto.job_pb2.DEAD])

--- a/cuegui/tests/MenuActions_tests.py
+++ b/cuegui/tests/MenuActions_tests.py
@@ -233,7 +233,7 @@ class JobActionsTests(unittest.TestCase):
 
         self.job_actions.eatDead(rpcObjects=[job])
 
-        job.eatFrames.assert_called_with(state=opencue.compiled_proto.job_pb2.DEAD)
+        job.eatFrames.assert_called_with(state=[opencue.compiled_proto.job_pb2.DEAD])
 
     @mock.patch('cuegui.Utils.questionBoxYesNo', return_value=False)
     def test_eatDeadCanceled(self, yesNoMock):
@@ -252,7 +252,7 @@ class JobActionsTests(unittest.TestCase):
         self.job_actions.autoEatOn(rpcObjects=[job])
 
         job.setAutoEat.assert_called_with(True)
-        job.eatFrames.assert_called_with(state=opencue.compiled_proto.job_pb2.DEAD)
+        job.eatFrames.assert_called_with(state=[opencue.compiled_proto.job_pb2.DEAD])
 
     def test_autoEatOff(self):
         job = opencue.wrappers.job.Job(opencue.compiled_proto.job_pb2.Job(name='job-name'))

--- a/pycue/opencue/api.py
+++ b/pycue/opencue/api.py
@@ -281,13 +281,13 @@ def getJobs(**options):
     getJobs(show=["pipe"]) would return only pipe jobs.
 
     Possible args:
-        - job: job names
-        - match:  job name substring match
-        - regex: a job name search by regular expression
-        - id: a job search by unique id
-        - show: show names
-        - shot: shot names
-        - user: user names
+        - job: job names - list
+        - match:  job name substring match - str
+        - regex: a job name search by regular expression - str
+        - id: a job search by unique id - str
+        - show: show names - list
+        - shot: shot names - list
+        - user: user names - list
 
     @rtype:  List<Job>
     @return: a list of jobs
@@ -464,11 +464,11 @@ def getHosts(**options):
     getHosts(match=["vrack"]) would return all vrack procs.
 
     Possible args:
-       - host: host names
-       - match: host name substring match
-       - regex: a host name search by regular expression
-       - id: a search by unique id
-       - alloc: search by allocation.
+       - host: host names - list
+       - match: host name substring match - str
+       - regex: a host name search by regular expression - str
+       - id: a search by unique id - str
+       - alloc: search by allocation. - list
 
     @rtype:  List<Host>
     @return: a list of hosts
@@ -629,16 +629,16 @@ def getProcs(**options):
     getProcs(show=["pipe"]) would return procs running pipe jobs.
 
     Possible args:
-       - host: host names
-       - jobs: job names
-       - layer: layer names
-       - show: show names
-       - alloc: allocation names
-       - memory: used memory in gigabytes
+       - host: host names - list
+       - jobs: job names - list
+       - layer: layer names - list
+       - show: show names - list
+       - alloc: allocation names - list
+       - memory: used memory in gigabytes - str
          - "gt5" is greater than 5 gigs
          - "lt5" is less than 5 gigs
          - "5-10" is range of 5 to 10 gigs
-       - duration: run time in hours
+       - duration: run time in hours - str
          - "gt5" is greater than 5 hours
          - "lt5" is less than 5 hours
          - "5-10" is range of 5 to 10 hours

--- a/pycue/opencue/search.py
+++ b/pycue/opencue/search.py
@@ -263,34 +263,57 @@ def _createCriterion(search, searchType, convert=None):
     raise ValueError("Unable to parse this format: %s" % search)
 
 
+def _raiseIfNotType(searchOption, value, expectedType):
+    if not isinstance(value, list):
+        raise TypeError("Failed to set search option: '{}'. Expects type '{}', but got {}.".format(
+            searchOption, expectedType, type(value)))
+
+
+def raiseIfNotList(searchOption, value):
+    _raiseIfNotType(searchOption, value, list)
+
+
 def _setOptions(criteria, options):
 
     for k, v in options.items():
         if k == "job" or (k == "name" and isinstance(criteria, job_pb2.JobSearchCriteria)):
+            raiseIfNotList(k, v)
             criteria.jobs.extend(v)
         elif k == "host" or (k == "name" and isinstance(criteria, host_pb2.HostSearchCriteria)):
+            raiseIfNotList(k, v)
             criteria.hosts.extend(v)
         elif k == "frames" or (k == "name" and isinstance(criteria, job_pb2.FrameSearchCriteria)):
+            raiseIfNotList(k, v)
             criteria.frames.extend(v)
         elif k in("match", "substr"):
+            raiseIfNotList(k, v)
             criteria.substr.extend(v)
         elif k == "regex":
+            raiseIfNotList(k, v)
             criteria.regex.extend(v)
         elif k == "id":
+            raiseIfNotList(k, v)
             criteria.ids.extend(v)
         elif k == "show":
+            raiseIfNotList(k, v)
             criteria.shows.extend(v)
         elif k == "shot":
+            raiseIfNotList(k, v)
             criteria.shots.extend(v)
         elif k == "user":
+            raiseIfNotList(k, v)
             criteria.users.extend(v)
         elif k == "state" and isinstance(criteria, job_pb2.FrameSearchCriteria):
+            raiseIfNotList(k, v)
             criteria.states.frame_states.extend(v)
         elif k == "state" and isinstance(criteria, host_pb2.HostSearchCriteria):
+            raiseIfNotList(k, v)
             criteria.states.state.extend(v)
         elif k == "layer":
+            raiseIfNotList(k, v)
             criteria.layers.extend(v)
         elif k == "alloc":
+            raiseIfNotList(k, v)
             criteria.allocs.extend(v)
         elif k in ("range", "frames"):
             if not v:

--- a/pycue/tests/search_test.py
+++ b/pycue/tests/search_test.py
@@ -69,6 +69,18 @@ class JobSearchTests(unittest.TestCase):
             job_pb2.JobGetJobsRequest(r=job_pb2.JobSearchCriteria(shows=['pipe'], substr=['v6'])),
             timeout=mock.ANY)
 
+    def testRaiseIfNotList(self, getStubMock):
+        with self.assertRaises(TypeError):
+            opencue.search.raiseIfNotList('user', 'iamnotalist')
+
+        with self.assertRaises(TypeError):
+            opencue.search.raiseIfNotList('user', 42)
+
+        with self.assertRaises(TypeError):
+            opencue.search.raiseIfNotList('user', set(['iamnotalist']))
+
+        self.assertIsNone(opencue.search.raiseIfNotList('user', ['iamnotalist']))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #485 

Adds type information to docstrings and validates list type to prevent strings from being treated as lists.