### PR TITLE
fix: Layer dependency creation API typos

### DIFF
--- a/pycue/opencue/wrappers/layer.py
+++ b/pycue/opencue/wrappers/layer.py
@@ -176,7 +176,7 @@ class Layer(object):
         @param job: the job you want this job to depend on
         @rtype:  opencue.wrappers.depend.Depend
         @return: the new dependency"""
-        response = self.stub.CreateDependOnJob(
+        response = self.stub.CreateDependencyOnJob(
             job_pb2.LayerCreateDependOnJobRequest(layer=self.data, job=job.data),
             timeout=Cuebot.Timeout)
         return opencue.wrappers.depend.Depend(response.depend)
@@ -187,7 +187,7 @@ class Layer(object):
         @param layer: the layer you want this layer to depend on
         @rtype:  opencue.wrappers.depend.Depend
         @return: the new dependency"""
-        response = self.stub.CreateDependOnLayer(
+        response = self.stub.CreateDependencyOnLayer(
             job_pb2.LayerCreateDependOnLayerRequest(layer=self.data, depend_on_layer=layer.data),
             timeout=Cuebot.Timeout)
         return opencue.wrappers.depend.Depend(response.depend)
@@ -198,7 +198,7 @@ class Layer(object):
         @param frame: the frame you want this layer to depend on
         @rtype:  opencue.wrappers.depend.Depend
         @return: the new dependency"""
-        response = self.stub.CreateDependOnFrame(
+        response = self.stub.CreateDependencyOnFrame(
             job_pb2.LayerCreateDependOnFrameRequest(layer=self.data, frame=frame.data),
             timeout=Cuebot.Timeout)
         return opencue.wrappers.depend.Depend(response.depend)

--- a/pycue/tests/wrappers/layer_test.py
+++ b/pycue/tests/wrappers/layer_test.py
@@ -276,7 +276,7 @@ class LayerTests(unittest.TestCase):
         dependId = 'dddd-ddd-dddd'
         jobId = 'jjjj-jjj-jjjj'
         stubMock = mock.Mock()
-        stubMock.CreateDependOnJob.return_value = job_pb2.LayerCreateDependOnJobResponse(
+        stubMock.CreateDependencyOnJob.return_value = job_pb2.LayerCreateDependOnJobResponse(
             depend=depend_pb2.Depend(id=dependId))
         getStubMock.return_value = stubMock
 
@@ -286,7 +286,7 @@ class LayerTests(unittest.TestCase):
             job_pb2.Job(id=jobId))
         depend = layer.createDependencyOnJob(job)
 
-        stubMock.CreateDependOnJob.assert_called_with(
+        stubMock.CreateDependencyOnJob.assert_called_with(
             job_pb2.LayerCreateDependOnJobRequest(layer=layer.data, job=job.data),
             timeout=mock.ANY)
         self.assertEqual(depend.id(), dependId)
@@ -295,7 +295,7 @@ class LayerTests(unittest.TestCase):
         dependId = 'dddd-ddd-dddd'
         layerId = 'llll-lll-llll'
         stubMock = mock.Mock()
-        stubMock.CreateDependOnLayer.return_value = job_pb2.LayerCreateDependOnLayerResponse(
+        stubMock.CreateDependencyOnLayer.return_value = job_pb2.LayerCreateDependOnLayerResponse(
             depend=depend_pb2.Depend(id=dependId))
         getStubMock.return_value = stubMock
 
@@ -305,7 +305,7 @@ class LayerTests(unittest.TestCase):
             job_pb2.Layer(id=layerId))
         depend = layer.createDependencyOnLayer(dependLayer)
 
-        stubMock.CreateDependOnLayer.assert_called_with(
+        stubMock.CreateDependencyOnLayer.assert_called_with(
             job_pb2.LayerCreateDependOnLayerRequest(layer=layer.data,
                                                     depend_on_layer=dependLayer.data),
             timeout=mock.ANY)
@@ -315,7 +315,7 @@ class LayerTests(unittest.TestCase):
         dependId = 'dddd-ddd-dddd'
         frameId = 'ffff-fff-ffff'
         stubMock = mock.Mock()
-        stubMock.CreateDependOnFrame.return_value = job_pb2.LayerCreateDependOnFrameResponse(
+        stubMock.CreateDependencyOnFrame.return_value = job_pb2.LayerCreateDependOnFrameResponse(
             depend=depend_pb2.Depend(id=dependId))
         getStubMock.return_value = stubMock
 
@@ -325,7 +325,7 @@ class LayerTests(unittest.TestCase):
             job_pb2.Frame(id=frameId))
         depend = layer.createDependencyOnFrame(frame)
 
-        stubMock.CreateDependOnFrame.assert_called_with(
+        stubMock.CreateDependencyOnFrame.assert_called_with(
             job_pb2.LayerCreateDependOnFrameRequest(layer=layer.data, frame=frame.data),
             timeout=mock.ANY)
         self.assertEqual(depend.id(), dependId)


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**

Fixes #497


**Summarize your change.**

Fix typos in `opencue.wrappers.layer.Layer` that prevent creating Layer dependencies through API.   

