### PR TITLE
Fixing a couple syntax bugs with the oracle queries.

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dao/oracle/FrameDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/oracle/FrameDaoJdbc.java
@@ -172,7 +172,7 @@ public class FrameDaoJdbc extends JdbcDaoSupport  implements FrameDao {
                         "layer_limit " +
                     "LEFT JOIN limit_record ON layer_limit.pk_limit_record = limit_record.pk_limit_record " +
                     "LEFT JOIN layer_stat ON layer_stat.pk_layer = layer_limit.pk_layer " +
-                    "GROUP BY limit_record.pk_limit_record) AS sum_running " +
+                    "GROUP BY limit_record.pk_limit_record) sum_running " +
                 "ON limit_record.pk_limit_record = sum_running.pk_limit_record " +
                 "WHERE " +
                     "sum_running.int_sum_running < limit_record.int_max_value " +

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/oracle/LayerDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/oracle/LayerDaoJdbc.java
@@ -779,7 +779,7 @@ public class LayerDaoJdbc extends JdbcDaoSupport implements LayerDao {
 
     private static final String GET_LIMIT_NAMES =
             "SELECT " +
-                "limit_record.str_name, " +
+                "limit_record.str_name " +
             "FROM " +
                 "layer_limit," +
                 "limit_record " +


### PR DESCRIPTION
There is a syntax error on:
GROUP BY limit_record.pk_limit_record) AS sum_running
It should be:
GROUP BY limit_record.pk_limit_record) sum_running

Also there is a dangling comma on the select statement in the GET_LIMIT_NAMES on LayerDaoJdbc.