### PR TITLE
Blender ignores output path specified by job type

### DIFF
--- a/cuesubmit/cuesubmit/Submission.py
+++ b/cuesubmit/cuesubmit/Submission.py
@@ -55,13 +55,14 @@ def buildBlenderCmd(layerData):
     if not blenderFile:
         raise ValueError('No Blender file provided. Cannot submit job.')
     
-    renderCommand = '{renderCmd} -b -noaudio {blenderFile} -f {frameToken}'.format(
-        renderCmd=Constants.BLENDER_RENDER_CMD, blenderFile=blenderFile,
-        frameToken=Constants.FRAME_TOKEN)
+    renderCommand = '{renderCmd} -b -noaudio {blenderFile}'.format(
+        renderCmd=Constants.BLENDER_RENDER_CMD, blenderFile=blenderFile)
     if outputPath:
         renderCommand += ' -o {}'.format(outputPath)
     if outputFormat:
         renderCommand += ' -F {}'.format(outputFormat)
+    # The render frame must come after the scene and output
+    renderCommand += ' -f {frameToken}'.format(frameToken=Constants.FRAME_TOKEN)
     return renderCommand
 
 


### PR DESCRIPTION
Link the Issue(s) this Pull Request is related to.
Fixes #455

Summarize your change.
The Blender Job Type output path is ignored by Blender because the argument order is not correct. (order matters).

This fix addresses the issue by re-ordering the arguments as per the Blender argument docs and ensures the frame token is after the output path: https://docs.blender.org/manual/en/latest/advanced/command_line/arguments.html