### PR TITLE
Add separate pipelines for tests and packaging.

### DIFF
--- a/ci/packaging-pipeline.yml
+++ b/ci/packaging-pipeline.yml
@@ -1,0 +1,131 @@
+# OpenCue Packaging Pipeline
+
+# Packages code from a commit into distributable artifacts i.e. Docker images, tarballs, etc.
+
+variables:
+  ARTIFACT_DIRECTORY: ./build
+
+# Trigger the pipeline on every commit to master. Don't run it for PRs.
+trigger:
+- master
+pr: none
+
+jobs:
+- job: build
+  displayName: Build
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+  - bash: |
+      set -e
+      ci/generate_version_number.sh > VERSION
+      echo "##vso[task.setvariable variable=buildId;isOutput=true]$(cat ./VERSION)"
+    name: setBuildId
+    displayName: Generate Build ID
+
+  - task: Docker@2
+    inputs:
+      containerRegistry: 'Docker Hub (build)'
+      command: 'login'
+
+  - bash: mkdir -p $(ARTIFACT_DIRECTORY)
+    name: createArtifactDirectory
+    displayName: Create Artifact Directory
+
+  - template: ci/templates/build_docker.yml
+    parameters:
+      imageName: 'cuebot'
+      displayName: 'Cuebot'
+      artifactPath: '/opt/opencue/cuebot-$(setBuildId.buildId)-all.jar'
+
+  - template: ci/templates/build_docker.yml
+    parameters:
+      imageName: 'rqd'
+      displayName: 'RQD'
+      artifactPath: '/opt/opencue/rqd-$(setBuildId.buildId)-all.tar.gz'
+
+  - template: ci/templates/build_docker.yml
+    parameters:
+      imageName: 'pycue'
+      displayName: 'PyCue'
+      artifactPath: '/opt/opencue/pycue-$(setBuildId.buildId)-all.tar.gz'
+
+  - template: ci/templates/build_docker.yml
+    parameters:
+      imageName: 'pyoutline'
+      displayName: 'PyOutline'
+      artifactPath: '/opt/opencue/pyoutline-$(setBuildId.buildId)-all.tar.gz'
+
+  - template: ci/templates/build_docker.yml
+    parameters:
+      imageName: 'cuegui'
+      displayName: 'CueGUI'
+      artifactPath: '/opt/opencue/cuegui-$(setBuildId.buildId)-all.tar.gz'
+
+  - template: ci/templates/build_docker.yml
+    parameters:
+      imageName: 'cuesubmit'
+      displayName: 'CueSubmit'
+      artifactPath: '/opt/opencue/cuesubmit-$(setBuildId.buildId)-all.tar.gz'
+
+  - template: ci/templates/build_docker.yml
+    parameters:
+      imageName: 'cueadmin'
+      displayName: 'CueAdmin'
+      artifactPath: '/opt/opencue/cueadmin-$(setBuildId.buildId)-all.tar.gz'
+
+  - bash: ci/extract_artifacts.sh $(setBuildId.buildId) ./$(ARTIFACT_DIRECTORY)
+    name: extractArtifacts
+    displayName: Extract Build Artifacts
+
+  - bash: ci/extract_schema.sh $(setBuildId.buildId) ./$(ARTIFACT_DIRECTORY)
+    name: extractSchema
+    displayName: Extract Database Schema
+
+  - publish: $(ARTIFACT_DIRECTORY)/LICENSE
+    artifact: License
+    displayName: Publish LICENSE
+
+  - publish: $(ARTIFACT_DIRECTORY)/VERSION
+    artifact: Version
+    displayName: Publish VERSION
+
+  - publish: $(ARTIFACT_DIRECTORY)/build_metadata.json
+    artifact: Build Metadata
+    displayName: Publish Build Metadata
+
+  - publish: $(ARTIFACT_DIRECTORY)/cuebot-$(setBuildId.buildId)-all.jar
+    artifact: Cuebot JAR
+    displayName: Publish Cuebot JAR
+
+  - publish: $(ARTIFACT_DIRECTORY)/rqd-$(setBuildId.buildId)-all.tar.gz
+    artifact: RQD Tarball
+    displayName: Publish RQD Tarball
+
+  - publish: $(ARTIFACT_DIRECTORY)/pycue-$(setBuildId.buildId)-all.tar.gz
+    artifact: PyCue Tarball
+    displayName: Publish PyCue Tarball
+
+  - publish: $(ARTIFACT_DIRECTORY)/pyoutline-$(setBuildId.buildId)-all.tar.gz
+    artifact: PyOutline Tarball
+    displayName: Publish PyOutline Tarball
+
+  - publish: $(ARTIFACT_DIRECTORY)/cuegui-$(setBuildId.buildId)-all.tar.gz
+    artifact: CueGUI Tarball
+    displayName: Publish CueGUI Tarball
+
+  - publish: $(ARTIFACT_DIRECTORY)/cuesubmit-$(setBuildId.buildId)-all.tar.gz
+    artifact: CueSubmit Tarball
+    displayName: Publish CueSubmit Tarball
+
+  - publish: $(ARTIFACT_DIRECTORY)/cueadmin-$(setBuildId.buildId)-all.tar.gz
+    artifact: CueAdmin Tarball
+    displayName: Publish CueAdmin Tarball
+
+  - publish: $(ARTIFACT_DIRECTORY)/schema-$(setBuildId.buildId).sql
+    artifact: Database Schema
+    displayName: Publish Database Schema
+
+  - publish: $(ARTIFACT_DIRECTORY)/demo_data-$(setBuildId.buildId).sql
+    artifact: Demo SQL Data
+    displayName: Publish Demo SQL Data

--- a/ci/packaging-pipeline.yml
+++ b/ci/packaging-pipeline.yml
@@ -1,11 +1,12 @@
-# OpenCue Packaging Pipeline
+# OpenCue packaging pipeline
 
 # Packages code from a commit into distributable artifacts i.e. Docker images, tarballs, etc.
 
 variables:
   ARTIFACT_DIRECTORY: $(Build.ArtifactStagingDirectory)
 
-# Trigger the pipeline on every commit to master. Don't run it for PRs.
+# Only run this pipeline after new commits are merged into master. Don't run for
+# PRs, which is the default behavior.
 trigger:
 - master
 pr: none

--- a/ci/packaging-pipeline.yml
+++ b/ci/packaging-pipeline.yml
@@ -3,7 +3,7 @@
 # Packages code from a commit into distributable artifacts i.e. Docker images, tarballs, etc.
 
 variables:
-  ARTIFACT_DIRECTORY: ./build
+  ARTIFACT_DIRECTORY: $(Build.ArtifactStagingDirectory)
 
 # Trigger the pipeline on every commit to master. Don't run it for PRs.
 trigger:
@@ -28,57 +28,53 @@ jobs:
       containerRegistry: 'Docker Hub (build)'
       command: 'login'
 
-  - bash: mkdir -p $(ARTIFACT_DIRECTORY)
-    name: createArtifactDirectory
-    displayName: Create Artifact Directory
-
-  - template: ci/templates/build_docker.yml
+  - template: templates/build_docker.yml
     parameters:
       imageName: 'cuebot'
       displayName: 'Cuebot'
       artifactPath: '/opt/opencue/cuebot-$(setBuildId.buildId)-all.jar'
 
-  - template: ci/templates/build_docker.yml
+  - template: templates/build_docker.yml
     parameters:
       imageName: 'rqd'
       displayName: 'RQD'
       artifactPath: '/opt/opencue/rqd-$(setBuildId.buildId)-all.tar.gz'
 
-  - template: ci/templates/build_docker.yml
+  - template: templates/build_docker.yml
     parameters:
       imageName: 'pycue'
       displayName: 'PyCue'
       artifactPath: '/opt/opencue/pycue-$(setBuildId.buildId)-all.tar.gz'
 
-  - template: ci/templates/build_docker.yml
+  - template: templates/build_docker.yml
     parameters:
       imageName: 'pyoutline'
       displayName: 'PyOutline'
       artifactPath: '/opt/opencue/pyoutline-$(setBuildId.buildId)-all.tar.gz'
 
-  - template: ci/templates/build_docker.yml
+  - template: templates/build_docker.yml
     parameters:
       imageName: 'cuegui'
       displayName: 'CueGUI'
       artifactPath: '/opt/opencue/cuegui-$(setBuildId.buildId)-all.tar.gz'
 
-  - template: ci/templates/build_docker.yml
+  - template: templates/build_docker.yml
     parameters:
       imageName: 'cuesubmit'
       displayName: 'CueSubmit'
       artifactPath: '/opt/opencue/cuesubmit-$(setBuildId.buildId)-all.tar.gz'
 
-  - template: ci/templates/build_docker.yml
+  - template: templates/build_docker.yml
     parameters:
       imageName: 'cueadmin'
       displayName: 'CueAdmin'
       artifactPath: '/opt/opencue/cueadmin-$(setBuildId.buildId)-all.tar.gz'
 
-  - bash: ci/extract_artifacts.sh $(setBuildId.buildId) ./$(ARTIFACT_DIRECTORY)
+  - bash: ci/extract_artifacts.sh $(setBuildId.buildId) $(ARTIFACT_DIRECTORY)
     name: extractArtifacts
     displayName: Extract Build Artifacts
 
-  - bash: ci/extract_schema.sh $(setBuildId.buildId) ./$(ARTIFACT_DIRECTORY)
+  - bash: ci/extract_schema.sh $(setBuildId.buildId) $(ARTIFACT_DIRECTORY)
     name: extractSchema
     displayName: Extract Database Schema
 

--- a/ci/run_python_tests.sh
+++ b/ci/run_python_tests.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+pip install --user -r requirements.txt
+
+# Protos need to have their Python code generated in order for tests to pass.
+python -m grpc_tools.protoc -I=proto/ --python_out=pycue/opencue/compiled_proto --grpc_python_out=pycue/opencue/compiled_proto proto/*.proto
+python -m grpc_tools.protoc -I=proto/ --python_out=rqd/rqd/compiled_proto --grpc_python_out=rqd/rqd/compiled_proto proto/*.proto
+
+python pycue/setup.py test
+PYTHONPATH=pycue python pyoutline/setup.py test
+PYTHONPATH=pycue python cueadmin/setup.py test
+PYTHONPATH=pycue xvfb-run python cuegui/setup.py test
+PYTHONPATH=pycue:pyoutline python cuesubmit/setup.py test
+python rqd/setup.py test

--- a/ci/testing-pipeline.yml
+++ b/ci/testing-pipeline.yml
@@ -1,0 +1,29 @@
+# OpenCue testing pipeline
+
+# Runs tests for all components.
+
+# Trigger the pipeline on every commit to master. Pull Requests to any branch will trigger
+# the pipeline as well, by default.
+trigger:
+- master
+
+jobs:
+- job: testPython
+  displayName: Test Python Components
+  pool:
+    vmImage: 'ubuntu-16.04'
+  container: aswf/ci-opencue:2019.0
+  steps:
+  - bash: ci/run_python_tests.sh
+    name: runTests
+    displayName: Run Python Tests
+
+- job: testCuebot
+  displayName: Test Cuebot
+  pool:
+    vmImage: 'ubuntu-16.04'
+  container: aswf/ci-opencue:2019.0
+  steps:
+  - bash: cd cuebot && ./gradlew build --stacktrace
+    name: test
+    displayName: Build and Test Cuebot


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
#487 

**Summarize your change.**
- The testing pipeline is based on the SonarCloud pipeline, which uses the ci-opencue docker image instead of building all Docker images separately. This will become the main pipeline run for all PR commits.
- The packaging pipeline is based on the existing test pipeline, which builds all Docker images and other artifacts. It contains almost no changes, except it will only run on commits that are merged into master.

Once these are in place and confirmed working, I'll send a followup PR to remove the old pipeline and will remove it from Azure as well.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.
-->
