### PR TITLE
Fix incorrect function calls

### DIFF
--- a/cuegui/cuegui/MenuActions.py
+++ b/cuegui/cuegui/MenuActions.py
@@ -979,8 +979,8 @@ class FrameActions(AbstractActions):
                                                   frames[0].data.layer_name)
                     if layer.data.layer_stats.total_frames == 1:
                         # Single frame selected of single frame layer, mark done and eat it all
-                        layer.eatFrames()
-                        layer.markdoneFrames()
+                        layer.eat()
+                        layer.markdone()
 
                         self._update()
                         return


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**

Closes https://github.com/AcademySoftwareFoundation/OpenCue/issues/509

**Summarize your change.**

When marking a layer with a single frame as done the functions have
likely been renamed.