### PR TITLE
Add a shots volume to the sandbox

### DIFF
--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -55,3 +55,4 @@ services:
       - "8444:8444"
     volumes:
       - /tmp/rqd/logs:/tmp/rqd/logs
+      - /tmp/rqd/shots:/tmp/rqd/shots


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Fixes https://github.com/AcademySoftwareFoundation/OpenCue/issues/532

**Summarize your change.**
Add a volume to the sandbox environment to store input and output files for RQD nodes at /tmp/rqd/shots/

This will help provide more real-world usage examples in the docs and for live demos or screencasts that use rendering software on RQD nodes, such as Blender or ImageMagick

Note: After approval, I'll aim to wait to merge this when I've also updated the quick start to add the mount point for the volume on the sandbox host.