### PR TITLE
Add a connection exception and retries to the pycue grpc decorator

### DIFF
--- a/pycue/opencue/cuebot.py
+++ b/pycue/opencue/cuebot.py
@@ -54,6 +54,7 @@ from opencue.compiled_proto import subscription_pb2
 from opencue.compiled_proto import subscription_pb2_grpc
 from opencue.compiled_proto import task_pb2
 from opencue.compiled_proto import task_pb2_grpc
+from opencue.exception import ConnectionException
 from opencue.exception import CueException
 
 
@@ -179,8 +180,8 @@ class Cuebot(object):
                 continue
             atexit.register(Cuebot.closeChannel)
             return None
-        raise CueException('No grpc connection could be established. ' +
-                           'Please check configured cuebot hosts.')
+        raise ConnectionException('No grpc connection could be established. ' +
+                                  'Please check configured cuebot hosts.')
 
     @staticmethod
     def closeChannel():

--- a/pycue/opencue/default.yaml
+++ b/pycue/opencue/default.yaml
@@ -9,6 +9,7 @@ cuebot.protocol: tcp
 cuebot.grpc_port: 8443
 cuebot.timeout: 10000
 cuebot.max_message_bytes: 104857600
+cuebot.exception_retries: 3
 
 cuebot.facility_default: cloud
 cuebot.facility:

--- a/pycue/opencue/exception.py
+++ b/pycue/opencue/exception.py
@@ -66,6 +66,8 @@ class ConnectionException(CueException):
 
 
 def getRetryCount():
+    """Return the configured number of retries a cuebot call can make.
+    If not specified in the config, all retryable calls will be called once and retried 3 times."""
     return opencue.cuebot.Cuebot.getConfig().get('cuebot.exception_retries', 3)
 
 

--- a/pycue/opencue/exception.py
+++ b/pycue/opencue/exception.py
@@ -29,6 +29,9 @@ import opencue
 
 class CueException(Exception):
     """A Base class for all client side cue exceptions"""
+    failMsg = 'Caught an unknown server exception. Please check the server logs. {details}'
+    retryMsg = 'Caught an unknown server exception, checking again...'
+    retryable = False
     retryBackoff = 0.5  # seconds
 
 
@@ -36,28 +39,24 @@ class DeadlineExceededException(CueException):
     """Raised when the deadline for response has been exceeded."""
     failMsg = 'Request deadline exceeded. {details}'
     retryMsg = 'Request deadline exceeded, checking again...'
-    retryable = False
 
 
 class EntityAlreadyExistsException(CueException):
     """Raised when the entity was not created because it already exists on the server"""
     failMsg = 'Object already exists. {details}'
     retryMsg = 'Object already exists, checking again...'
-    retryable = False
 
 
 class EntityNotFoundException(CueException):
     """Raised when the entity was not found on the server."""
     failMsg = 'Object does not exist. {details}'
     retryMsg = 'Object does not exist, checking again...'
-    retryable = False
 
 
 class CueInternalErrorException(CueException):
     """Raised when the server encountered a catchable error"""
     failMsg = 'Server caught an internal exception. {details}'
     retryMsg = 'Server caught an internal exception, checking again...'
-    retryable = False
 
 class ConnectionException(CueException):
     """Raised when unable to connect to grpc server."""

--- a/pycue/opencue/util.py
+++ b/pycue/opencue/util.py
@@ -30,6 +30,7 @@ import grpc
 import logging
 import os
 import six
+import time
 
 import opencue
 
@@ -40,27 +41,27 @@ def grpcExceptionParser(grpcFunc):
     """Decorator to wrap functions making GRPC calls.
     Attempts to throw the appropriate exception based on grpc status code."""
     def _decorator(*args, **kwargs):
-        try:
-            return grpcFunc(*args, **kwargs)
-        except grpc.RpcError as exc:
-            code = exc.code()
-            details = exc.details() or "No details found. Check server logs."
-            if code == grpc.StatusCode.NOT_FOUND:
-                future.utils.raise_with_traceback(opencue.exception.EntityNotFoundException(
-                    "Object does not exist. {}".format(details)))
-            elif code == grpc.StatusCode.ALREADY_EXISTS:
-                future.utils.raise_with_traceback(opencue.exception.EntityAlreadyExistsException(
-                    "Object already exists. {}".format(details)))
-            elif code == grpc.StatusCode.DEADLINE_EXCEEDED:
-                future.utils.raise_with_traceback(opencue.exception.DeadlineExceededException(
-                    "Request deadline exceeded. {}".format(details)))
-            elif code == grpc.StatusCode.INTERNAL:
-                future.utils.raise_with_traceback(opencue.exception.CueInternalErrorException(
-                    "Server caught an internal exception. {}".format(details)))
-            else:
-                future.utils.raise_with_traceback(opencue.exception.CueException(
-                    "Encountered a server error. {code} : {details}".format(
-                        code=code, details=details)))
+        triesRemaining = opencue.exception.getRetryCount()
+        while triesRemaining > 0:
+            triesRemaining -= 1
+            try:
+                return grpcFunc(*args, **kwargs)
+            except grpc.RpcError as exc:
+                code = exc.code()
+                details = exc.details() or "No details found. Check server logs."
+                exception = opencue.exception.EXCEPTION_MAP.get(code)
+                if exception:
+                    if exception.retryable and triesRemaining >= 1:
+                        logger.warning(exception.retryMsg)
+                        time.sleep(exception.retryBackoff)
+                    else:
+                        future.utils.raise_with_traceback(
+                            exception(exception.failMsg.format(details=details)))
+                else:
+                    future.utils.raise_with_traceback(opencue.exception.CueException(
+                        "Encountered a server error. {code} : {details}".format(
+                            code=code, details=details)))
+
     return functools.wraps(grpcFunc)(_decorator)
 
 

--- a/pycue/opencue/util.py
+++ b/pycue/opencue/util.py
@@ -41,7 +41,7 @@ def grpcExceptionParser(grpcFunc):
     """Decorator to wrap functions making GRPC calls.
     Attempts to throw the appropriate exception based on grpc status code."""
     def _decorator(*args, **kwargs):
-        triesRemaining = opencue.exception.getRetryCount()
+        triesRemaining = opencue.exception.getRetryCount() + 1
         while triesRemaining > 0:
             triesRemaining -= 1
             try:

--- a/pycue/tests/util_test.py
+++ b/pycue/tests/util_test.py
@@ -64,6 +64,13 @@ class ProxyTests(unittest.TestCase):
         self.assertRaises(opencue.exception.CueInternalErrorException,
                           lambda: testRaise(response))
 
+    def testConnectionExceptionParser(self):
+        response = grpc.RpcError()
+        response.code = lambda: grpc.StatusCode.UNAVAILABLE
+        response.details = lambda: "Connection Error"
+        self.assertRaises(opencue.exception.ConnectionException,
+                          lambda: testRaise(response))
+
     def testUnknownExceptionParser(self):
         response = grpc.RpcError()
         response.code = lambda: "unknown"

--- a/pycue/tests/util_test.py
+++ b/pycue/tests/util_test.py
@@ -22,6 +22,7 @@ from builtins import range
 import grpc
 import mock
 import unittest
+import uuid
 
 import opencue
 from opencue.compiled_proto import job_pb2
@@ -30,6 +31,7 @@ from opencue.wrappers.job import Job
 
 @opencue.util.grpcExceptionParser
 def testRaise(exc):
+    uuid.uuid4()
     raise exc
 
 
@@ -64,12 +66,25 @@ class ProxyTests(unittest.TestCase):
         self.assertRaises(opencue.exception.CueInternalErrorException,
                           lambda: testRaise(response))
 
-    def testConnectionExceptionParser(self):
-        response = grpc.RpcError()
-        response.code = lambda: grpc.StatusCode.UNAVAILABLE
-        response.details = lambda: "Connection Error"
-        self.assertRaises(opencue.exception.ConnectionException,
-                          lambda: testRaise(response))
+    @mock.patch('uuid.uuid4')
+    def testConnectionExceptionParser(self, mockUuid):
+        with mock.patch('opencue.exception.getRetryCount', return_value=3):
+            response = grpc.RpcError()
+            response.code = lambda: grpc.StatusCode.UNAVAILABLE
+            response.details = lambda: "Connection Error"
+            self.assertRaises(opencue.exception.ConnectionException,
+                              lambda: testRaise(response))
+        self.assertEqual(mockUuid.call_count, 4)
+
+    @mock.patch('uuid.uuid4')
+    def testConnectionExceptionZeroRetries(self, mockUuid):
+        with mock.patch('opencue.exception.getRetryCount', return_value=0):
+            response = grpc.RpcError()
+            response.code = lambda: grpc.StatusCode.UNAVAILABLE
+            response.details = lambda: "Connection Error"
+            self.assertRaises(opencue.exception.ConnectionException,
+                              lambda: testRaise(response))
+        self.assertEqual(mockUuid.call_count, 1)
 
     def testUnknownExceptionParser(self):
         response = grpc.RpcError()


### PR DESCRIPTION
Fixes #534 

Adds a new `ConnectionException` type and allows for retryable exceptions. `ConnectionException` errors will retry 3 times with a 0.5 second backoff by default.