### PR TITLE
Attempt to fix xvfb-run flake.

### DIFF
--- a/ci/python_coverage_report.sh
+++ b/ci/python_coverage_report.sh
@@ -12,7 +12,7 @@ python -m grpc_tools.protoc -I=proto/ --python_out=rqd/rqd/compiled_proto --grpc
 coverage run --source=pycue/opencue/,pycue/FileSequence/ --omit=pycue/opencue/compiled_proto/* pycue/setup.py test
 PYTHONPATH=pycue coverage run -a --source=pyoutline/outline/ pyoutline/setup.py test
 PYTHONPATH=pycue coverage run -a --source=cueadmin/cueadmin/ cueadmin/setup.py test
-PYTHONPATH=pycue xvfb-run coverage run -a --source=cuegui/cuegui/ cuegui/setup.py test
+PYTHONPATH=pycue xvfb-run -d coverage run -a --source=cuegui/cuegui/ cuegui/setup.py test
 PYTHONPATH=pycue:pyoutline coverage run -a --source=cuesubmit/cuesubmit/ cuesubmit/setup.py test
 coverage run -a --source=rqd/rqd/ --omit=rqd/rqd/compiled_proto/* rqd/setup.py test
 

--- a/ci/run_python_tests.sh
+++ b/ci/run_python_tests.sh
@@ -11,6 +11,6 @@ python -m grpc_tools.protoc -I=proto/ --python_out=rqd/rqd/compiled_proto --grpc
 python pycue/setup.py test
 PYTHONPATH=pycue python pyoutline/setup.py test
 PYTHONPATH=pycue python cueadmin/setup.py test
-PYTHONPATH=pycue xvfb-run python cuegui/setup.py test
+PYTHONPATH=pycue xvfb-run -d python cuegui/setup.py test
 PYTHONPATH=pycue:pyoutline python cuesubmit/setup.py test
 python rqd/setup.py test

--- a/cuegui/Dockerfile
+++ b/cuegui/Dockerfile
@@ -65,9 +65,9 @@ RUN cd pycue && python3.6 setup.py install
 
 # TODO(bcipriano) Lint the code here. (Issue #78)
 
-RUN cd cuegui && xvfb-run python setup.py test
+RUN cd cuegui && xvfb-run -d python setup.py test
 
-RUN cd cuegui && xvfb-run python3.6 setup.py test
+RUN cd cuegui && xvfb-run -d python3.6 setup.py test
 
 RUN cp LICENSE requirements.txt VERSION cuegui/
 


### PR DESCRIPTION
We're getting sporadic test flakes from `xvfb-run`:

```
test_getCores (tests.FrameMonitorTree_tests.FrameMonitorTreeTests) ... qt.qpa.screen: QXcbConnection: Could not connect to display :99
Could not connect to any X display.
```

This PR adds the `-d` switch to all uses of `xvfb-run`.

```
-d        --auto-display            use the X server to find a display number
                                    automatically
```

So far in tests on Azure this has resolved the problem, but it's hard to know for sure.