### PR TITLE
Fix race condition in one of the RqNimby tests.

### DIFF
--- a/rqd/tests/rqnimby_tests.py
+++ b/rqd/tests/rqnimby_tests.py
@@ -42,6 +42,7 @@ class RqNimbyTests(pyfakefs.fake_filesystem_unittest.TestCase):
         self.nimby.daemon = True
 
         self.nimby.start()
+        self.nimby.join()
 
         # Initial state should be "unlocked and idle".
         unlockedIdleMock.assert_called()


### PR DESCRIPTION
If the thread isn't joined, sometimes the mocked method hasn't been called yet.