### PR TITLE
Use dark stylesheet for Windows too

### DIFF
--- a/cuegui/cuegui/DarkPalette.py
+++ b/cuegui/cuegui/DarkPalette.py
@@ -35,10 +35,10 @@ def init():
     application and configures the palette and style for the Plastique
     color scheme"""
     QtGui.qApp.setPalette(DarkPalette())
-    if platform.system() in ["Darwin", "Linux"]:
+    if platform.system() in ['Darwin', 'Linux']:
         setDarkStyleSheet()
-    elif platform.system() == "Windows":
-        QtGui.qApp.setStyle("Fusion")
+    elif platform.system() == 'Windows':
+        QtGui.qApp.setStyle('Fusion')
     else:
         QtGui.qApp.setStyle(QtWidgets.QStyleFactory.create(cuegui.Constants.COLOR_THEME))
 

--- a/cuegui/cuegui/DarkPalette.py
+++ b/cuegui/cuegui/DarkPalette.py
@@ -37,6 +37,10 @@ def init():
     QtGui.qApp.setPalette(DarkPalette())
     if platform.system() in ['Darwin', 'Linux']:
         setDarkStyleSheet()
+    elif platform.system() == 'Windows':
+        # Use Fusion on Windows (Qt5 default), the other is high contrast and
+        # unreadable.
+        QtGui.qApp.setStyle('Fusion')
     else:
         QtGui.qApp.setStyle(QtWidgets.QStyleFactory.create(cuegui.Constants.COLOR_THEME))
 

--- a/cuegui/cuegui/DarkPalette.py
+++ b/cuegui/cuegui/DarkPalette.py
@@ -35,8 +35,10 @@ def init():
     application and configures the palette and style for the Plastique
     color scheme"""
     QtGui.qApp.setPalette(DarkPalette())
-    if platform.system() in ['Darwin', 'Linux', 'Windows']:
+    if platform.system() in ["Darwin", "Linux"]:
         setDarkStyleSheet()
+    elif platform.system() == "Windows":
+        QtGui.qApp.setStyle("Fusion")
     else:
         QtGui.qApp.setStyle(QtWidgets.QStyleFactory.create(cuegui.Constants.COLOR_THEME))
 

--- a/cuegui/cuegui/DarkPalette.py
+++ b/cuegui/cuegui/DarkPalette.py
@@ -35,12 +35,8 @@ def init():
     application and configures the palette and style for the Plastique
     color scheme"""
     QtGui.qApp.setPalette(DarkPalette())
-    if platform.system() in ['Darwin', 'Linux']:
+    if platform.system() in ['Darwin', 'Linux', 'Windows']:
         setDarkStyleSheet()
-    elif platform.system() == 'Windows':
-        # Use Fusion on Windows (Qt5 default), the other is high contrast and
-        # unreadable.
-        QtGui.qApp.setStyle('Fusion')
     else:
         QtGui.qApp.setStyle(QtWidgets.QStyleFactory.create(cuegui.Constants.COLOR_THEME))
 


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
#61 

**Summarize your change.**
The default theme on Windows is high-contrast and unreadable.  The default Qt5 theme, Fusion, looks much better.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.
-->
![cuegui-default](https://user-images.githubusercontent.com/1001494/70297040-9b422b80-1840-11ea-9cb2-68262187a85f.png)

