### PR TITLE
Add install_requires packages for CueGUI

### DIFF
--- a/cuegui/setup.py
+++ b/cuegui/setup.py
@@ -58,11 +58,11 @@ setup(
     },
     test_suite='tests',
     install_requires=[
-        'PySide2',
-        'PyYAML',
         'grpcio',
         'grpcio-tools',
         'pexpect',
+        'PySide2',
+        'PyYAML',
     ]
 )
 

--- a/cuegui/setup.py
+++ b/cuegui/setup.py
@@ -57,5 +57,12 @@ setup(
         ]
     },
     test_suite='tests',
+    install_requires=[
+        'PySide2',
+        'PyYAML',
+        'grpcio',
+        'grpcio-tools',
+        'pexpect',
+    ]
 )
 


### PR DESCRIPTION
This allows (for example) PyCharm to correctly configure the project when opening the directory directly, rather than installing everything in the repo-wide `requirements.txt`.

