### PR TITLE
Fix static content url in cuebot

### DIFF
--- a/cuebot/src/main/resources/application.properties
+++ b/cuebot/src/main/resources/application.properties
@@ -2,3 +2,4 @@ server.contextPath=/spcue
 server.port=8080
 
 spring.main.allow-bean-definition-overriding=true
+spring.mvc.static-path-pattern=/spcue/**


### PR DESCRIPTION
After updating spring boot, the static content began being served at the root instead of being prefixed with `/spcue/`. The xml schema are hosted with this path, this change fixes the urls to behave as they did before.