### PR TITLE
Add CODE_OF_CONDUCT - default version for LF projects

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+The OpenCue project abides by Linux Foundation's code of conduct, which you can read in full at https://lfprojects.org/policies/code-of-conduct.


### PR DESCRIPTION
The TSC can definitely add to this as needed, but wanted to link in what's used by default.
