### PR TITLE
Add PyCue packages and modules docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,10 +7,9 @@ www.opencue.io, but in the meantime you can build the reference HTML locally.
 This guide is also useful if you want to build the HTML reference during
 development.
 
-Currently, OpenCue supports building HTML reference docs for the `outline`
-package. The `outline` package is the primary package for submitting and
-managing jobs in OpenCue. We'll add support for building additional
-packages soon.
+Currently, OpenCue supports building HTML reference docs for the
+`FileSequence`, `opencue`, and `outline` packages. The `outline` package
+is the primary package for submitting and managing jobs in OpenCue.
 
 ## Before you begin
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,7 +68,7 @@ To build and view the HTML reference docs:
 1.  Change to the `docs` directory:
 
     ```
-    cd ../docs
+    cd docs
     ```
 
 1.  Build the docs:
@@ -81,7 +81,7 @@ To build and view the HTML reference docs:
     browser:
 
     Note: Currently, Sphinx is only configured to generate HTML docs for the
-    `outline` package.
+    `FileSequence`, `opencue`, and `outline` packages.
 
     ```
     <path-to-OpenCue>/OpenCue/docs/_build/html/index.html

--- a/docs/modules/FileSequence.rst
+++ b/docs/modules/FileSequence.rst
@@ -1,0 +1,23 @@
+FileSequence package
+====================
+
+Module contents
+---------------
+
+.. automodule:: FileSequence
+    :members:
+
+Submodules
+----------
+
+FileSequence.FrameRange module
+------------------------------
+
+.. automodule:: FileSequence.FrameRange
+    :members:
+
+FileSequence.FrameSet module
+----------------------------
+
+.. automodule:: FileSequence.FrameSet
+    :members:

--- a/docs/modules/modules.rst
+++ b/docs/modules/modules.rst
@@ -4,4 +4,6 @@ outline
 .. toctree::
    :maxdepth: 4
 
+   FileSequence
+   opencue
    outline

--- a/docs/modules/opencue.compiled_proto.rst
+++ b/docs/modules/opencue.compiled_proto.rst
@@ -1,0 +1,211 @@
+opencue.compiled_proto package
+==============================
+
+Module contents
+---------------
+
+.. automodule:: opencue.compiled_proto
+    :members:
+
+Submodules
+----------
+
+opencue.compiled_proto.comment_pb2_grpc module
+-----------------------------------------------
+
+.. automodule:: opencue.compiled_proto.comment_pb2_grpc
+    :members:
+
+opencue.compiled_proto.comment_pb2 module
+------------------------------------------
+
+.. automodule:: opencue.compiled_proto.comment_pb2
+    :members:
+
+opencue.compiled_proto.criterion_pb2_grpc module
+-------------------------------------------------
+
+.. automodule:: opencue.compiled_proto.criterion_pb2_grpc
+    :members:
+
+opencue.compiled_proto.criterion_pb2 module
+--------------------------------------------
+
+.. automodule:: opencue.compiled_proto.criterion_pb2
+    :members:
+
+opencue.compiled_proto.cue_pb2_grpc module
+-------------------------------------------
+
+.. automodule:: opencue.compiled_proto.cue_pb2_grpc
+    :members:
+
+opencue.compiled_proto.department_pb2_grpc module
+-------------------------------------------------
+
+.. automodule:: opencue.compiled_proto.department_pb2_grpc
+    :members:
+
+opencue.compiled_proto.department_pb2 module
+--------------------------------------------
+
+.. automodule:: opencue.compiled_proto.department_pb2
+    :members:
+
+opencue.compiled_proto.depend_pb2_grpc module
+---------------------------------------------
+
+.. automodule:: opencue.compiled_proto.depend_pb2_grpc
+    :members:
+
+opencue.compiled_proto.depend_pb2 module
+----------------------------------------
+
+.. automodule:: opencue.compiled_proto.depend_pb2
+    :members:
+
+opencue.compiled_proto.facility_pb2_grpc module
+-----------------------------------------------
+
+.. automodule:: opencue.compiled_proto.facility_pb2_grpc
+    :members:
+
+opencue.compiled_proto.facility_pb2 module
+------------------------------------------
+
+.. automodule:: opencue.compiled_proto.facility_pb2
+    :members:
+
+opencue.compiled_proto.filter_pb2_grpc module
+---------------------------------------------
+
+.. automodule:: opencue.compiled_proto.filter_pb2_grpc
+    :members:
+
+opencue.compiled_proto.filter_pb2 module
+----------------------------------------
+
+.. automodule:: opencue.compiled_proto.filter_pb2
+    :members:
+
+opencue.compiled_proto.host_pb2_grpc module
+-------------------------------------------
+
+.. automodule:: opencue.compiled_proto.host_pb2_grpc
+    :members:
+
+
+opencue.compiled_proto.host_pb2 module
+--------------------------------------
+
+.. automodule:: opencue.compiled_proto.host_pb2
+    :members:
+
+opencue.compiled_proto.job_pb2_grpc module
+------------------------------------------
+
+.. automodule:: opencue.compiled_proto.job_pb2_grpc
+    :members:
+
+opencue.compiled_proto.job_pb2 module
+-------------------------------------
+
+.. automodule:: opencue.compiled_proto.job_pb2
+    :members:
+
+opencue.compiled_proto.limit_pb2_grpc module
+--------------------------------------------
+
+.. automodule:: opencue.compiled_proto.limit_pb2_grpc
+    :members:
+
+
+opencue.compiled_proto.limit_pb2 module
+---------------------------------------
+
+.. automodule:: opencue.compiled_proto.limit_pb2
+    :members:
+
+opencue.compiled_proto.renderPartition_pb2_grpc module
+------------------------------------------------------
+
+.. automodule:: opencue.compiled_proto.renderPartition_pb2_grpc
+    :members:
+
+opencue.compiled_proto.renderPartition_pb2 module
+-------------------------------------------------
+
+.. automodule:: opencue.compiled_proto.renderPartition_pb2
+    :members:
+
+opencue.compiled_proto.report_pb2_grpc module
+---------------------------------------------
+
+.. automodule:: opencue.compiled_proto.report_pb2_grpc
+    :members:
+
+opencue.compiled_proto.report_pb2 module
+----------------------------------------
+
+.. automodule:: opencue.compiled_proto.report_pb2
+    :members:
+
+opencue.compiled_proto.rqd_pb2_grpc module
+------------------------------------------
+
+.. automodule:: opencue.compiled_proto.rqd_pb2_grpc
+    :members:
+
+opencue.compiled_proto.rqd_pb2 module
+-------------------------------------
+
+.. automodule:: opencue.compiled_proto.rqd_pb2
+    :members:
+
+opencue.compiled_proto.service_pb2_grpc module
+----------------------------------------------
+
+.. automodule:: opencue.compiled_proto.service_pb2_grpc
+    :members:
+
+opencue.compiled_proto.service_pb2 module
+-----------------------------------------
+
+.. automodule:: opencue.compiled_proto.service_pb2
+    :members:
+
+opencue.compiled_proto.show_pb2_grpc module
+-------------------------------------------
+
+.. automodule:: opencue.compiled_proto.show_pb2_grpc
+    :members:
+
+opencue.compiled_proto.show_pb2 module
+--------------------------------------
+
+.. automodule:: opencue.compiled_proto.show_pb2
+    :members:
+
+opencue.compiled_proto.subscription_pb2_grpc module
+---------------------------------------------------
+
+.. automodule:: opencue.compiled_proto.subscription_pb2_grpc
+    :members:
+
+opencue.compiled_proto.subscription_pb2 module
+----------------------------------------------
+
+.. automodule:: opencue.compiled_proto.subscription_pb2_grpc
+    :members:
+
+opencue.compiled_proto.task_pb2_grpc module
+-------------------------------------------
+
+.. automodule:: opencue.compiled_proto.task_pb2_grpc
+    :members:
+
+opencue.compiled_proto.task_pb2 module
+--------------------------------------
+
+.. automodule:: opencue.compiled_proto.task_pb2_grpc
+    :members:

--- a/docs/modules/opencue.compiled_proto.rst
+++ b/docs/modules/opencue.compiled_proto.rst
@@ -11,13 +11,13 @@ Submodules
 ----------
 
 opencue.compiled_proto.comment_pb2_grpc module
------------------------------------------------
+----------------------------------------------
 
 .. automodule:: opencue.compiled_proto.comment_pb2_grpc
     :members:
 
 opencue.compiled_proto.comment_pb2 module
-------------------------------------------
+-----------------------------------------
 
 .. automodule:: opencue.compiled_proto.comment_pb2
     :members:
@@ -38,6 +38,12 @@ opencue.compiled_proto.cue_pb2_grpc module
 -------------------------------------------
 
 .. automodule:: opencue.compiled_proto.cue_pb2_grpc
+    :members:
+
+opencue.compiled_proto.cue_pb2 module
+-------------------------------------
+
+.. automodule:: opencue.compiled_proto.cue_pb2
     :members:
 
 opencue.compiled_proto.department_pb2_grpc module
@@ -94,7 +100,6 @@ opencue.compiled_proto.host_pb2_grpc module
 .. automodule:: opencue.compiled_proto.host_pb2_grpc
     :members:
 
-
 opencue.compiled_proto.host_pb2 module
 --------------------------------------
 
@@ -118,7 +123,6 @@ opencue.compiled_proto.limit_pb2_grpc module
 
 .. automodule:: opencue.compiled_proto.limit_pb2_grpc
     :members:
-
 
 opencue.compiled_proto.limit_pb2 module
 ---------------------------------------
@@ -195,7 +199,7 @@ opencue.compiled_proto.subscription_pb2_grpc module
 opencue.compiled_proto.subscription_pb2 module
 ----------------------------------------------
 
-.. automodule:: opencue.compiled_proto.subscription_pb2_grpc
+.. automodule:: opencue.compiled_proto.subscription_pb2
     :members:
 
 opencue.compiled_proto.task_pb2_grpc module
@@ -207,5 +211,5 @@ opencue.compiled_proto.task_pb2_grpc module
 opencue.compiled_proto.task_pb2 module
 --------------------------------------
 
-.. automodule:: opencue.compiled_proto.task_pb2_grpc
+.. automodule:: opencue.compiled_proto.task_pb2
     :members:

--- a/docs/modules/opencue.rst
+++ b/docs/modules/opencue.rst
@@ -1,0 +1,55 @@
+opencue package
+===============
+
+Subpackages
+-----------
+
+.. toctree::
+
+    opencue.compiled_proto
+    opencue.wrapper
+
+Module contents
+---------------
+
+.. automodule:: opencue
+    :members:
+
+Submodules
+----------
+
+opencue.api module
+------------------
+
+.. automodule:: opencue.api
+    :members:
+
+opencue.cuebot module
+---------------------
+
+.. automodule:: opencue.cuebot
+    :members:
+
+opencue.exception module
+------------------------
+
+.. automodule:: opencue.exception
+    :members:
+
+opencue.search module
+---------------------
+
+.. automodule:: opencue.search
+    :members:
+
+opencue.util module
+-------------------
+
+.. automodule:: opencue.util
+    :members:
+
+opencue.version module
+----------------------
+
+.. automodule:: opencue.version
+    :members:

--- a/docs/modules/opencue.wrappers.rst
+++ b/docs/modules/opencue.wrappers.rst
@@ -1,0 +1,119 @@
+opencue.wrappers package
+========================
+
+Module contents
+---------------
+
+.. automodule:: opencue.wrappers
+    :members:
+
+Submodules
+----------
+
+opencue.wrappers.allocation module
+----------------------------------
+
+.. automodule:: opencue.wrappers.allocation
+    :members:
+
+opencue.wrappers.comment module
+-------------------------------
+
+.. automodule:: opencue.wrappers.comment
+    :members:
+
+opencue.wrappers.deed module
+----------------------------
+
+.. automodule:: opencue.wrappers.deed
+    :members:
+
+opencue.wrappers.depend module
+------------------------------
+
+.. automodule:: opencue.wrappers.depend
+    :members:
+
+opencue.wrappers.filter module
+------------------------------
+
+.. automodule:: opencue.wrappers.filter
+    :members:
+
+opencue.wrappers.frame module
+-----------------------------
+
+.. automodule:: opencue.wrappers.frame
+    :members:
+
+opencue.wrappers.group module
+-----------------------------
+
+.. automodule:: opencue.wrappers.group
+    :members:
+
+opencue.wrappers.host module
+----------------------------
+
+.. automodule:: opencue.wrappers.host
+    :members:
+
+opencue.wrappers.job module
+---------------------------
+
+.. automodule:: opencue.wrappers.job
+    :members:
+
+opencue.wrappers.layer module
+-----------------------------
+
+.. automodule:: opencue.wrappers.layer
+    :members:
+
+opencue.wrappers.limit module
+-----------------------------
+
+.. automodule:: opencue.wrappers.limit
+    :members:
+
+opencue.wrappers.owner module
+-----------------------------
+
+.. automodule:: opencue.wrappers.owner
+    :members:
+
+opencue.wrappers.proc module
+----------------------------
+
+.. automodule:: opencue.wrappers.proc
+    :members:
+
+opencue.wrappers.service module
+-------------------------------
+
+.. automodule:: opencue.wrappers.service
+    :members:
+
+opencue.wrappers.show module
+----------------------------
+
+.. automodule:: opencue.wrappers.show
+    :members:
+
+opencue.wrappers.subscription module
+------------------------------------
+
+.. automodule:: opencue.wrappers.subscription
+    :members:
+
+opencue.wrappers.task module
+----------------------------
+
+.. automodule:: opencue.wrappers.task
+    :members:
+
+opencue.wrappers.util module
+----------------------------
+
+.. automodule:: opencue.wrappers.util
+    :members:


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
https://github.com/AcademySoftwareFoundation/OpenCue/issues/559

**Summarize your change.**
Updates Sphinx configuration to add support for generating reference docs of `FileSequence` and `opencue` packages. This compliments the existing configuration for the `outline` package.

To review or test the generated output, see the accompanying README.md file, which I've updated in this PR.

The generated docs need a lot of work, but I think that's better addressed in separate PRs as it means updating the Python source code. 

Also, Sphinx produces some warnings (such as `Unexpected indentation.`) that again need to be fixed by updating the Python source code. 