### PR TITLE
Run testing pipeline against CY 2020.

### DIFF
--- a/ci/run_python_tests.sh
+++ b/ci/run_python_tests.sh
@@ -10,7 +10,7 @@ python -m grpc_tools.protoc -I=proto/ --python_out=rqd/rqd/compiled_proto --grpc
 
 # Fix imports to work in both Python 2 and 3. See
 # <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
-sed -i 's/^\(import.*_pb2\)/from . \1/' pycue/opencue/compiled_proto/*.py
+sed -i 's/^\(import.*_pb2\)/from . \1/' pycue/opencue/compiled_proto/*.py rqd/rqd/compiled_proto/*.py
 
 python pycue/setup.py test
 PYTHONPATH=pycue python pyoutline/setup.py test

--- a/ci/run_python_tests.sh
+++ b/ci/run_python_tests.sh
@@ -8,6 +8,10 @@ pip install --user -r requirements.txt -r requirements_gui.txt
 python -m grpc_tools.protoc -I=proto/ --python_out=pycue/opencue/compiled_proto --grpc_python_out=pycue/opencue/compiled_proto proto/*.proto
 python -m grpc_tools.protoc -I=proto/ --python_out=rqd/rqd/compiled_proto --grpc_python_out=rqd/rqd/compiled_proto proto/*.proto
 
+# Fix imports to work in both Python 2 and 3. See
+# <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
+sed -i 's/^\(import.*_pb2\)/from . \1/' pycue/opencue/compiled_proto/*.py
+
 python pycue/setup.py test
 PYTHONPATH=pycue python pyoutline/setup.py test
 PYTHONPATH=pycue python cueadmin/setup.py test

--- a/ci/testing-pipeline.yml
+++ b/ci/testing-pipeline.yml
@@ -8,8 +8,8 @@ trigger:
 - master
 
 jobs:
-- job: testPython
-  displayName: Test Python Components
+- job: testPython2019
+  displayName: Test Python Components (CY 2019)
   pool:
     vmImage: 'ubuntu-16.04'
   container: aswf/ci-opencue:2019.0
@@ -18,11 +18,31 @@ jobs:
     name: runTests
     displayName: Run Python Tests
 
-- job: testCuebot
-  displayName: Test Cuebot
+- job: testPython2020
+  displayName: Test Python Components (CY 2020)
+  pool:
+    vmImage: 'ubuntu-16.04'
+  container: aswf/ci-opencue:2020.0
+  steps:
+  - bash: ci/run_python_tests.sh
+    name: runTests
+    displayName: Run Python Tests
+
+- job: testCuebot2019
+  displayName: Test Cuebot (CY 2019)
   pool:
     vmImage: 'ubuntu-16.04'
   container: aswf/ci-opencue:2019.0
+  steps:
+  - bash: cd cuebot && ./gradlew build --stacktrace
+    name: test
+    displayName: Build and Test Cuebot
+
+- job: testCuebot2020
+  displayName: Test Cuebot (CY 2020)
+  pool:
+    vmImage: 'ubuntu-16.04'
+  container: aswf/ci-opencue:2020.0
   steps:
   - bash: cd cuebot && ./gradlew build --stacktrace
     name: test

--- a/ci/testing-pipeline.yml
+++ b/ci/testing-pipeline.yml
@@ -22,7 +22,7 @@ jobs:
   displayName: Test Python Components (CY 2020)
   pool:
     vmImage: 'ubuntu-16.04'
-  container: aswf/ci-opencue:2020.0
+  container: aswftesting/ci-opencue:2020.0
   steps:
   - bash: ci/run_python_tests.sh
     name: runTests
@@ -42,7 +42,7 @@ jobs:
   displayName: Test Cuebot (CY 2020)
   pool:
     vmImage: 'ubuntu-16.04'
-  container: aswf/ci-opencue:2020.0
+  container: aswftesting/ci-opencue:2020.0
   steps:
   - bash: cd cuebot && ./gradlew build --stacktrace
     name: test

--- a/ci/testing-pipeline.yml
+++ b/ci/testing-pipeline.yml
@@ -22,7 +22,7 @@ jobs:
   displayName: Test Python Components (CY 2020)
   pool:
     vmImage: 'ubuntu-16.04'
-  container: aswftesting/ci-opencue:2020.0
+  container: aswftesting/ci-opencue:2020
   steps:
   - bash: ci/run_python_tests.sh
     name: runTests
@@ -42,7 +42,7 @@ jobs:
   displayName: Test Cuebot (CY 2020)
   pool:
     vmImage: 'ubuntu-16.04'
-  container: aswftesting/ci-opencue:2020.0
+  container: aswftesting/ci-opencue:2020
   steps:
   - bash: cd cuebot && ./gradlew build --stacktrace
     name: test


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Fixes #557 

**Summarize your change.**
VFX Reference Platform CY2020 uses Python 3 as its default interpreter, so this in effect runs all tests in a Python 3 environment.

Keeping CY2019 as we want to keep testing against Python 2 for the foreseeable future.

Cuebot tests included as well just to test compatibility.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.
-->
