### PR TITLE
Stop and delete timer objects when attempting to close the a window

### DIFF
--- a/cuegui/cuegui/AbstractTreeWidget.py
+++ b/cuegui/cuegui/AbstractTreeWidget.py
@@ -106,6 +106,17 @@ class AbstractTreeWidget(QtWidgets.QTreeWidget):
         self.updateRequest()
         self.setUpdateInterval(10)
 
+    def closeEvent(self, event):
+        if hasattr(self, '_timer'):
+            self._timer.stop()
+            del self._timer
+
+        if hasattr(self, '__ticksTimer'):
+            self.__ticksTimer.stop()
+            del self.__ticksTimer
+
+        event.accept()
+
     def startColumnsForType(self, itemType):
         """Start column definitions for the given item type. The first call to
         this defines the primary column type used to populate the column headers.


### PR DESCRIPTION
Fixes #595 

Use the close event on abstract widgets to stop and delete the timer attached to widgets to prevent error messages, crashes and hangs.
