### PR TITLE
Stop qtimer wrong thread segfault (#473)

### DIFF
--- a/cuegui/cuegui/GarbageCollector.py
+++ b/cuegui/cuegui/GarbageCollector.py
@@ -1,0 +1,31 @@
+from PySide2 import QtCore
+import gc
+
+class GarbageCollector(QtCore.QObject):
+
+    '''
+    Disable automatic garbage collection and instead collect manually
+    every INTERVAL milliseconds.
+
+    This is done to ensure that garbage collection only happens in the GUI
+    thread, as otherwise Qt can crash.
+    '''
+
+    INTERVAL = 5000
+
+    def __init__(self, parent, debug=False):
+        QtCore.QObject.__init__(self, parent)
+        self.debug = debug
+
+        self.timer = QtCore.QTimer(self)
+        self.timer.timeout.connect(self.check)
+
+        self.threshold = gc.get_threshold()
+        gc.disable()
+        self.timer.start(self.INTERVAL)
+
+    def check(self):
+        gc.collect()
+        if self.debug:
+            for obj in gc.garbage:
+                print (obj, repr(obj), type(obj))

--- a/cuegui/cuegui/Main.py
+++ b/cuegui/cuegui/Main.py
@@ -35,6 +35,7 @@ import cuegui.SplashWindow
 import cuegui.Style
 import cuegui.ThreadPool
 import cuegui.Utils
+import cuegui.GarbageCollector
 
 
 logger = cuegui.Logger.getLogger(__file__)
@@ -121,6 +122,7 @@ def startup(app_name, app_version, argv):
     # End splash screen
     splash.hide()
 
+    gc = cuegui.GarbageCollector.GarbageCollector(parent=app, debug=False)
     app.aboutToQuit.connect(closingTime)
     app.exec_()
 

--- a/cuegui/cuegui/Main.py
+++ b/cuegui/cuegui/Main.py
@@ -121,7 +121,9 @@ def startup(app_name, app_version, argv):
 
     # End splash screen
     splash.hide()
-
+    
+    # TODO(#609) Refactor the CueGUI classes to make this garbage collector
+    #   replacement unnecessary.
     gc = cuegui.GarbageCollector.GarbageCollector(parent=app, debug=False)
     app.aboutToQuit.connect(closingTime)
     app.exec_()


### PR DESCRIPTION


**Link the Issue(s) this Pull Request is related to.**

Fixes #473

**Summarize your change.**

- Handle garbage collection in the main GUI thread to prevent qtimer stopped in wrong thread which results in segfault.  
- Have tried actions which typically caused crashes and has since been stable.

This work is based on this [thread](https://www.riverbankcomputing.com/pipermail/pyqt/2011-August/030378.html) which might explain why the intermittent crashes were happening.  
Essentially, there are likely cyclic references to various tree widgets, as a result Python's Garbage Collector is clearing them, but Python's GC isn't necessarily running in the correct thread hence `“QObject::killTimer: Timers cannot be stopped from another thread`

This is quite a significant change, to alter the standard python behaviour, so not sure if it's desirable...
A nicer solution might be a combination of https://github.com/AcademySoftwareFoundation/OpenCue/pull/596 and trying to prevent cyclic references if possible.