### PR TITLE
Fix the permission check to include GID and UID.

### DIFF
--- a/rqd/rqd/rqutil.py
+++ b/rqd/rqd/rqutil.py
@@ -87,7 +87,7 @@ def permissionsLow():
        RQD_GID and RQD_UID"""
     if platform.system() == 'Windows':
         return
-    if os.getegid() != rqd.rqconstants.RQD_GID or os.getegid() != rqd.rqconstants.RQD_GID:
+    if os.getegid() != rqd.rqconstants.RQD_GID or os.geteuid() != rqd.rqconstants.RQD_UID:
         __becomeRoot()
         os.setegid(rqd.rqconstants.RQD_GID)
         os.seteuid(rqd.rqconstants.RQD_UID)


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
#364 

**Summarize your change.**
It appears the condition to downgrade permissions has a typo and checks GID twice, instead of GID and UID.

The issue includes a query for @jrray - are you able to confirm the history here?
