### PR TITLE
Remove arnold specific override

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/VirtualProc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/VirtualProc.java
@@ -127,18 +127,11 @@ public class VirtualProc extends FrameEntity implements ProcInterface {
                 proc.coresReserved = wholeCores * 100;
             } else {
                 if (frame.threadable) {
-                    // The following condition checks to see if the service being invoked is arnold. If it is, take up all the remaining
-                    // cores.
-                    if ("arnold".equals(frame.services)) {
+                    if (host.idleMemory - frame.minMemory
+                            <= Dispatcher.MEM_STRANDED_THRESHHOLD) {
                         proc.coresReserved = wholeCores * 100;
                     } else {
-                        if (host.idleMemory - frame.minMemory
-                                <= Dispatcher.MEM_STRANDED_THRESHHOLD) {
-                            proc.coresReserved = wholeCores * 100;
-                        }
-                        else {
-                            proc.coresReserved = getCoreSpan(host, frame.minMemory);
-                        }
+                        proc.coresReserved = getCoreSpan(host, frame.minMemory);
                     }
 
                     if (host.threadMode == ThreadMode.VARIABLE_VALUE

--- a/cuebot/src/test/java/com/imageworks/spcue/test/util/CoreSaturationTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/util/CoreSaturationTests.java
@@ -40,23 +40,6 @@ public class CoreSaturationTests extends TestCase {
 
     public void testCoreAndMemorySaturation1() {
         host.memory = CueUtil.GB32;
-        host.idleMemory = CueUtil.GB16;
-        host.cores = 800;
-        host.idleCores = 700;
-
-        DispatchFrame frame = new DispatchFrame();
-        frame.services = "arnold";
-        frame.minCores = 100;
-        frame.minMemory = CueUtil.GB;
-        frame.threadable = true;
-
-        VirtualProc proc = VirtualProc.build(host, frame);
-        assertEquals(700, proc.coresReserved);
-        assertEquals(CueUtil.GB, proc.memoryReserved);
-    }
-
-    public void testCoreAndMemorySaturation2() {
-        host.memory = CueUtil.GB32;
         host.idleMemory = CueUtil.GB8;
         host.cores = 800;
         host.idleCores = 700;


### PR DESCRIPTION
When the Arnold service is found on a frame it uses all available cores
on the host.

Removing this in favour of default min/max core behaviour.

Closes #549