### PR TITLE
Upgrade setuptools in RQD docker.

### DIFF
--- a/rqd/Dockerfile
+++ b/rqd/Dockerfile
@@ -12,6 +12,9 @@ RUN yum -y install \
   python36-devel \
   python36-pip
 
+RUN pip install --upgrade setuptools
+RUN pip3.6 install --upgrade setuptools
+
 WORKDIR /opt/opencue
 
 COPY LICENSE ./


### PR DESCRIPTION
**Summarize your change.**
Master build is currently broken -- the ancient setuptools that's the default on CentOS 7 doesn't support the `platform_system` notation we recently added to the RQD `Dockerfile`.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.
-->
