### PR TITLE
Make Cuegui logview work on Windows by default

### DIFF
--- a/cuegui/cuegui/Constants.py
+++ b/cuegui/cuegui/Constants.py
@@ -23,6 +23,7 @@ from __future__ import division
 from __future__ import absolute_import
 
 import os
+import platform
 
 from PySide2 import QtCore
 from PySide2 import QtGui
@@ -68,7 +69,10 @@ URL_USERGUIDE = "https://www.opencue.io/docs/"
 URL_SUGGESTION = "https://github.com/AcademySoftwareFoundation/OpenCue/issues/new?labels=enhancement&template=enhancement.md"
 URL_BUG = "https://github.com/AcademySoftwareFoundation/OpenCue/issues/new?labels=bug&template=bug_report.md"
 
-DEFAULT_EDITOR = "gview -R -m -M -U %s/gvimrc +" % DEFAULT_INI_PATH
+if platform.system() == "Windows":
+    DEFAULT_EDITOR = "notepad"
+else:
+    DEFAULT_EDITOR = "gview -R -m -M -U %s/gvimrc +" % DEFAULT_INI_PATH
 
 EMPTY_INDEX = QtCore.QModelIndex()
 

--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -26,6 +26,7 @@ from builtins import str
 from builtins import map
 import getpass
 import os
+import platform
 import re
 import subprocess
 import sys
@@ -269,7 +270,7 @@ def checkShellOut(cmdList, lockGui=False):
     @type: bool
     @param: True will lock the gui while the cmd is executed, otherwise it is run in the background.
     """
-    if not lockGui:
+    if not lockGui and platform.system() != "Windows":
         cmdList.append('&')
     try:
         subprocess.check_call(cmdList)


### PR DESCRIPTION
Fixes an outstanding issue in #61.

Default the Cuegui logview editor to Notepad on Windows.