### PR TITLE
Increase max environment variable name length

### DIFF
--- a/cuebot/src/main/resources/conf/ddl/postgres/migrations/V5__Increase_environment_variable_length.sql
+++ b/cuebot/src/main/resources/conf/ddl/postgres/migrations/V5__Increase_environment_variable_length.sql
@@ -1,0 +1,4 @@
+-- Increase the length of environment variable names:
+
+ALTER TABLE "job_env" ALTER COLUMN "str_key" TYPE VARCHAR(2048);
+ALTER TABLE "layer_env" ALTER COLUMN "str_key" TYPE VARCHAR(2048);


### PR DESCRIPTION
Fixes #553 

Increase maximum env var name length to match maximum env var value length (2048).