### PR TITLE
Fix error dialog on submission failure.

### DIFF
--- a/cuesubmit/cuesubmit/ui/Submit.py
+++ b/cuesubmit/cuesubmit/ui/Submit.py
@@ -463,7 +463,7 @@ class CueSubmitWidget(QtWidgets.QWidget):
         try:
             jobs = Submission.submitJob(jobData)
         except opencue.exception.CueException as e:
-            message = "Failed to submit job!\n" + e.message
+            message = "Failed to submit job!\n" + str(e)
             Widgets.CueMessageBox(message, title="Failed Job Submission", parent=self).show()
             raise e
 


### PR DESCRIPTION
The `message` field isn't defined, at least for the failure I was getting. `str()` should be safer.
