### PR TITLE
Add more unit tests for the MenuActions module.

### DIFF
--- a/cuegui/cuegui/MenuActions.py
+++ b/cuegui/cuegui/MenuActions.py
@@ -1143,7 +1143,9 @@ class SubscriptionActions(AbstractActions):
                                                                decimalPlaces)
             if choice:
                 msg = QtWidgets.QMessageBox()
-                msg.setText("You are about to modify a number that can effect a shows billing. Are you in PSR-Resources?")
+                msg.setText(
+                    "You are about to modify a number that can affect a show's billing. Are you "
+                    "sure you want to do this?")
                 msg.setStandardButtons(QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No)
                 msg.setDefaultButton(QtWidgets.QMessageBox.No)
                 if msg.exec_() == QtWidgets.QMessageBox.No:

--- a/cuegui/cuegui/MenuActions.py
+++ b/cuegui/cuegui/MenuActions.py
@@ -1516,7 +1516,7 @@ class MatcherActions(AbstractActions):
         if matchers:
             if cuegui.Utils.questionBoxYesNo(self._caller, "Confirm",
                                              "Delete selected matchers?",
-                                             [matcher.data.name for matcher in matchers]):
+                                             [matcher.name() for matcher in matchers]):
                 for matcher in matchers:
                     matcher.delete()
                 self._update()
@@ -1544,7 +1544,7 @@ class ActionActions(AbstractActions):
         if actions:
             if cuegui.Utils.questionBoxYesNo(self._caller, "Confirm",
                                              "Delete selected actions?",
-                                             [action.data.name for action in actions]):
+                                             [action.name() for action in actions]):
                 for action in actions:
                     action.delete()
                 self._update()

--- a/cuegui/tests/MenuActions_tests.py
+++ b/cuegui/tests/MenuActions_tests.py
@@ -60,6 +60,9 @@ class JobActionsTests(unittest.TestCase):
         self.widgetMock = mock.Mock()
         self.job_actions = cuegui.MenuActions.JobActions(self.widgetMock, mock.Mock(), None, None)
 
+    def test_jobs(self):
+        print(cuegui.MenuActions.MenuActions(self.widgetMock, None, None, None).jobs())
+
     def test_unmonitor(self):
         self.job_actions.unmonitor()
 
@@ -1596,6 +1599,110 @@ class LimitActionsTests(unittest.TestCase):
         self.limit_actions.rename(rpcObjects=[limit])
 
         limit.rename.assert_called_with(newName)
+
+
+@mock.patch('opencue.cuebot.Cuebot.getStub', new=mock.Mock())
+class MenuActionsTests(unittest.TestCase):
+    def setUp(self):
+        self.widgetMock = mock.Mock()
+        self.args = [self.widgetMock, lambda: None, lambda: None, lambda: None]
+        self.menuActions = cuegui.MenuActions.MenuActions(*self.args)
+
+    @mock.patch('cuegui.MenuActions.JobActions')
+    def test_jobs(self, jobActionsMock):
+        self.menuActions.jobs()
+
+        jobActionsMock.assert_called_with(*self.args)
+
+    @mock.patch('cuegui.MenuActions.LayerActions')
+    def test_layers(self, layerActionsMock):
+        self.menuActions.layers()
+
+        layerActionsMock.assert_called_with(*self.args)
+
+    @mock.patch('cuegui.MenuActions.FrameActions')
+    def test_frames(self, frameActionsMock):
+        self.menuActions.frames()
+
+        frameActionsMock.assert_called_with(*self.args)
+
+    @mock.patch('cuegui.MenuActions.ShowActions')
+    def test_shows(self, showActionsMock):
+        self.menuActions.shows()
+
+        showActionsMock.assert_called_with(*self.args)
+
+    @mock.patch('cuegui.MenuActions.RootGroupActions')
+    def test_rootgroups(self, rootGroupActionsMock):
+        self.menuActions.rootgroups()
+
+        rootGroupActionsMock.assert_called_with(*self.args)
+
+    @mock.patch('cuegui.MenuActions.GroupActions')
+    def test_groups(self, groupActionsMock):
+        self.menuActions.groups()
+
+        groupActionsMock.assert_called_with(*self.args)
+
+    @mock.patch('cuegui.MenuActions.SubscriptionActions')
+    def test_subscriptions(self, subscriptionActionsMock):
+        self.menuActions.subscriptions()
+
+        subscriptionActionsMock.assert_called_with(*self.args)
+
+    @mock.patch('cuegui.MenuActions.AllocationActions')
+    def test_allocations(self, allocationActionsMock):
+        self.menuActions.allocations()
+
+        allocationActionsMock.assert_called_with(*self.args)
+
+    @mock.patch('cuegui.MenuActions.HostActions')
+    def test_hosts(self, hostActionsMock):
+        self.menuActions.hosts()
+
+        hostActionsMock.assert_called_with(*self.args)
+
+    @mock.patch('cuegui.MenuActions.ProcActions')
+    def test_procs(self, procActionsMock):
+        self.menuActions.procs()
+
+        procActionsMock.assert_called_with(*self.args)
+
+    @mock.patch('cuegui.MenuActions.DependenciesActions')
+    def test_dependencies(self, dependenciesActionsMock):
+        self.menuActions.dependencies()
+
+        dependenciesActionsMock.assert_called_with(*self.args)
+
+    @mock.patch('cuegui.MenuActions.FilterActions')
+    def test_filters(self, filterActionsMock):
+        self.menuActions.filters()
+
+        filterActionsMock.assert_called_with(*self.args)
+
+    @mock.patch('cuegui.MenuActions.MatcherActions')
+    def test_matchers(self, matcherActionsMock):
+        self.menuActions.matchers()
+
+        matcherActionsMock.assert_called_with(*self.args)
+
+    @mock.patch('cuegui.MenuActions.ActionActions')
+    def test_actions(self, actionActionsMock):
+        self.menuActions.actions()
+
+        actionActionsMock.assert_called_with(*self.args)
+
+    @mock.patch('cuegui.MenuActions.TaskActions')
+    def test_tasks(self, taskActionsMock):
+        self.menuActions.tasks()
+
+        taskActionsMock.assert_called_with(*self.args)
+
+    @mock.patch('cuegui.MenuActions.LimitActions')
+    def test_limits(self, limitActionsMock):
+        self.menuActions.limits()
+
+        limitActionsMock.assert_called_with(*self.args)
 
 
 if __name__ == '__main__':

--- a/cuegui/tests/MenuActions_tests.py
+++ b/cuegui/tests/MenuActions_tests.py
@@ -30,11 +30,13 @@ import cuegui.Main
 import cuegui.MenuActions
 import opencue.compiled_proto.depend_pb2
 import opencue.compiled_proto.facility_pb2
+import opencue.compiled_proto.filter_pb2
 import opencue.compiled_proto.host_pb2
 import opencue.compiled_proto.job_pb2
 import opencue.compiled_proto.subscription_pb2
 import opencue.wrappers.allocation
 import opencue.wrappers.depend
+import opencue.wrappers.filter
 import opencue.wrappers.frame
 import opencue.wrappers.group
 import opencue.wrappers.host
@@ -1379,6 +1381,127 @@ class DependenciesActionsTests(unittest.TestCase):
 
         dep.unsatisfy.assert_called()
 
+
+@mock.patch('opencue.cuebot.Cuebot.getStub', new=mock.Mock())
+class FilterActionsTests(unittest.TestCase):
+
+    @mock.patch('opencue.cuebot.Cuebot.getStub', new=mock.Mock())
+    def setUp(self):
+        self.widgetMock = mock.Mock()
+        self.filter_actions = cuegui.MenuActions.FilterActions(
+            self.widgetMock, mock.Mock(), None, None)
+
+    @mock.patch('PySide2.QtWidgets.QInputDialog.getText')
+    def test_rename(self, getTextMock):
+        filter = opencue.wrappers.filter.Filter(opencue.compiled_proto.filter_pb2.Filter())
+        filter.setName = mock.MagicMock()
+        newName = 'newFilterName'
+        getTextMock.return_value = (newName, True)
+
+        self.filter_actions.rename(rpcObjects=[filter])
+
+        filter.setName.assert_called_with(newName)
+
+    @mock.patch('cuegui.Utils.questionBoxYesNo', new=mock.Mock(return_value=True))
+    def test_delete(self):
+        filter = opencue.wrappers.filter.Filter(opencue.compiled_proto.filter_pb2.Filter())
+        filter.delete = mock.MagicMock()
+
+        self.filter_actions.delete(rpcObjects=[filter])
+
+        filter.delete.assert_called()
+
+    def test_raiseOrder(self):
+        filter = opencue.wrappers.filter.Filter(opencue.compiled_proto.filter_pb2.Filter())
+        filter.raiseOrder = mock.MagicMock()
+
+        self.filter_actions.raiseOrder(rpcObjects=[filter])
+
+        filter.raiseOrder.assert_called()
+
+    def test_lowerOrder(self):
+        filter = opencue.wrappers.filter.Filter(opencue.compiled_proto.filter_pb2.Filter())
+        filter.lowerOrder = mock.MagicMock()
+
+        self.filter_actions.lowerOrder(rpcObjects=[filter])
+
+        filter.lowerOrder.assert_called()
+
+    def test_orderFirst(self):
+        filter = opencue.wrappers.filter.Filter(opencue.compiled_proto.filter_pb2.Filter())
+        filter.orderFirst = mock.MagicMock()
+
+        self.filter_actions.orderFirst(rpcObjects=[filter])
+
+        filter.orderFirst.assert_called()
+
+    def test_orderLast(self):
+        filter = opencue.wrappers.filter.Filter(opencue.compiled_proto.filter_pb2.Filter())
+        filter.orderLast = mock.MagicMock()
+
+        self.filter_actions.orderLast(rpcObjects=[filter])
+
+        filter.orderLast.assert_called()
+
+    @mock.patch('PySide2.QtWidgets.QInputDialog.getInt')
+    def test_setOrder(self, getTextMock):
+        filter = opencue.wrappers.filter.Filter(opencue.compiled_proto.filter_pb2.Filter())
+        filter.setOrder = mock.MagicMock()
+        newOrder = 47
+        getTextMock.return_value = (newOrder, True)
+
+        self.filter_actions.setOrder(rpcObjects=[filter])
+
+        filter.setOrder.assert_called_with(newOrder)
+
+
+@mock.patch('opencue.cuebot.Cuebot.getStub', new=mock.Mock())
+class MatcherActionsTests(unittest.TestCase):
+
+    @mock.patch('opencue.cuebot.Cuebot.getStub', new=mock.Mock())
+    def setUp(self):
+        self.widgetMock = mock.Mock()
+        self.matcher_actions = cuegui.MenuActions.MatcherActions(
+            self.widgetMock, mock.Mock(), None, None)
+
+    @mock.patch('cuegui.Utils.questionBoxYesNo', new=mock.Mock(return_value=True))
+    def test_delete(self):
+        matcher = opencue.wrappers.filter.Matcher(opencue.compiled_proto.filter_pb2.Matcher())
+        matcher.delete = mock.MagicMock()
+
+        self.matcher_actions.delete(rpcObjects=[matcher])
+
+        matcher.delete.assert_called()
+
+    @mock.patch('PySide2.QtWidgets.QInputDialog.getText')
+    def test_setValue(self, getTextMock):
+        matcher = opencue.wrappers.filter.Matcher(opencue.compiled_proto.filter_pb2.Matcher())
+        matcher.setValue = mock.MagicMock()
+        newValue = 'newMatcherValue'
+        getTextMock.return_value = (newValue, True)
+
+        self.matcher_actions.setValue(rpcObjects=[matcher])
+
+        matcher.setValue.assert_called_with(newValue)
+
+
+@mock.patch('opencue.cuebot.Cuebot.getStub', new=mock.Mock())
+class ActionActionsTests(unittest.TestCase):
+
+    @mock.patch('opencue.cuebot.Cuebot.getStub', new=mock.Mock())
+    def setUp(self):
+        self.widgetMock = mock.Mock()
+        self.action_actions = cuegui.MenuActions.ActionActions(
+            self.widgetMock, mock.Mock(), None, None)
+
+    @mock.patch('cuegui.Utils.questionBoxYesNo', new=mock.Mock(return_value=True))
+    def test_delete(self):
+        action = opencue.wrappers.filter.Action(opencue.compiled_proto.filter_pb2.Action())
+        action.delete = mock.MagicMock()
+
+        self.action_actions.delete(rpcObjects=[action])
+
+        action.delete.assert_called()
 
 if __name__ == '__main__':
     unittest.main()

--- a/cuegui/tests/MenuActions_tests.py
+++ b/cuegui/tests/MenuActions_tests.py
@@ -33,6 +33,7 @@ import opencue.compiled_proto.facility_pb2
 import opencue.compiled_proto.filter_pb2
 import opencue.compiled_proto.host_pb2
 import opencue.compiled_proto.job_pb2
+import opencue.compiled_proto.limit_pb2
 import opencue.compiled_proto.subscription_pb2
 import opencue.compiled_proto.task_pb2
 import opencue.wrappers.allocation
@@ -43,6 +44,7 @@ import opencue.wrappers.group
 import opencue.wrappers.host
 import opencue.wrappers.job
 import opencue.wrappers.layer
+import opencue.wrappers.limit
 import opencue.wrappers.proc
 import opencue.wrappers.show
 import opencue.wrappers.subscription
@@ -1542,6 +1544,58 @@ class TaskActionsTests(unittest.TestCase):
         self.task_actions.delete(rpcObjects=[task])
 
         task.delete.assert_called()
+
+
+@mock.patch('opencue.cuebot.Cuebot.getStub', new=mock.Mock())
+class LimitActionsTests(unittest.TestCase):
+
+    @mock.patch('opencue.cuebot.Cuebot.getStub', new=mock.Mock())
+    def setUp(self):
+        self.widgetMock = mock.Mock()
+        self.limit_actions = cuegui.MenuActions.LimitActions(
+            self.widgetMock, mock.Mock(), None, None)
+
+    @mock.patch('opencue.api.createLimit')
+    @mock.patch('PySide2.QtWidgets.QInputDialog.getText')
+    def test_create(self, getTextMock, createLimitMock):
+        limitName = 'newLimitName'
+        getTextMock.return_value = ('%s \t ' % limitName, True)
+
+        self.limit_actions.create()
+
+        createLimitMock.assert_called_with(limitName, 0)
+
+    @mock.patch('cuegui.Utils.questionBoxYesNo', new=mock.Mock(return_value=True))
+    def test_delete(self):
+        limit = opencue.wrappers.limit.Limit(opencue.compiled_proto.limit_pb2.Limit())
+        limit.delete = mock.MagicMock()
+
+        self.limit_actions.delete(rpcObjects=[limit])
+
+        limit.delete.assert_called()
+
+    @mock.patch('PySide2.QtWidgets.QInputDialog.getDouble')
+    def test_editMaxValue(self, getDoubleMock):
+        limit = opencue.wrappers.limit.Limit(opencue.compiled_proto.limit_pb2.Limit(max_value=920))
+        limit.setMaxValue = mock.MagicMock()
+
+        newMaxValue = 527
+        getDoubleMock.return_value = (newMaxValue, True)
+
+        self.limit_actions.editMaxValue(rpcObjects=[limit])
+
+        limit.setMaxValue.assert_called_with(newMaxValue)
+
+    @mock.patch('PySide2.QtWidgets.QInputDialog.getText')
+    def test_rename(self, getTextMock):
+        limit = opencue.wrappers.limit.Limit(opencue.compiled_proto.limit_pb2.Limit())
+        limit.rename = mock.MagicMock()
+        newName = 'newLimitName'
+        getTextMock.return_value = (newName, True)
+
+        self.limit_actions.rename(rpcObjects=[limit])
+
+        limit.rename.assert_called_with(newName)
 
 
 if __name__ == '__main__':

--- a/cuegui/tests/MenuActions_tests.py
+++ b/cuegui/tests/MenuActions_tests.py
@@ -1354,6 +1354,31 @@ class ProcActionsTests(unittest.TestCase):
         proc.unbook.assert_called_with(True)
 
 
+@mock.patch('opencue.cuebot.Cuebot.getStub', new=mock.Mock())
+class DependenciesActionsTests(unittest.TestCase):
+
+    @mock.patch('opencue.cuebot.Cuebot.getStub', new=mock.Mock())
+    def setUp(self):
+        self.widgetMock = mock.Mock()
+        self.dep_actions = cuegui.MenuActions.DependenciesActions(
+            self.widgetMock, mock.Mock(), None, None)
+
+    def test_satisfy(self):
+        dep = opencue.wrappers.depend.Depend(opencue.compiled_proto.depend_pb2.Depend())
+        dep.satisfy = mock.MagicMock()
+
+        self.dep_actions.satisfy(rpcObjects=[dep])
+
+        dep.satisfy.assert_called()
+
+    def test_unsatisfy(self):
+        dep = opencue.wrappers.depend.Depend(opencue.compiled_proto.depend_pb2.Depend())
+        dep.unsatisfy = mock.MagicMock()
+
+        self.dep_actions.unsatisfy(rpcObjects=[dep])
+
+        dep.unsatisfy.assert_called()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/cuegui/tests/MenuActions_tests.py
+++ b/cuegui/tests/MenuActions_tests.py
@@ -40,6 +40,7 @@ import opencue.wrappers.group
 import opencue.wrappers.host
 import opencue.wrappers.job
 import opencue.wrappers.layer
+import opencue.wrappers.proc
 import opencue.wrappers.show
 import opencue.wrappers.subscription
 
@@ -1069,12 +1070,11 @@ class GroupActionsTests(unittest.TestCase):
     @mock.patch('cuegui.Utils.questionBoxYesNo', new=mock.Mock(return_value=True))
     def test_deleteGroup(self):
         group = opencue.wrappers.group.Group(group=opencue.compiled_proto.job_pb2.Group())
-        deleteMock = mock.MagicMock()
-        group.delete = deleteMock
+        group.delete = mock.MagicMock()
 
         self.group_actions.deleteGroup(rpcObjects=[opencue.wrappers.layer.Layer(), group])
 
-        deleteMock.assert_called()
+        group.delete.assert_called()
 
 
 @mock.patch('opencue.cuebot.Cuebot.getStub', new=mock.Mock())
@@ -1091,39 +1091,36 @@ class SubscriptionActionsTests(unittest.TestCase):
     def test_editSize(self, getDoubleMock, qMessageBoxMock):
         sub = opencue.wrappers.subscription.Subscription(
             opencue.compiled_proto.subscription_pb2.Subscription(size=382))
-        setSizeMock = mock.MagicMock()
-        sub.setSize = setSizeMock
+        sub.setSize = mock.MagicMock()
         newSize = 8479
         getDoubleMock.return_value = (newSize, True)
         qMessageBoxMock.return_value.exec_.return_value = PySide2.QtWidgets.QMessageBox.Yes
 
         self.subscription_actions.editSize(rpcObjects=[sub])
 
-        setSizeMock.assert_called_with(newSize)
+        sub.setSize.assert_called_with(newSize)
 
     @mock.patch('PySide2.QtWidgets.QInputDialog.getDouble')
     def test_editBurst(self, getDoubleMock):
         sub = opencue.wrappers.subscription.Subscription(
             opencue.compiled_proto.subscription_pb2.Subscription(burst=922))
-        setBurstMock = mock.MagicMock()
-        sub.setBurst = setBurstMock
+        sub.setBurst = mock.MagicMock()
         newSize = 1078
         getDoubleMock.return_value = (newSize, True)
 
         self.subscription_actions.editBurst(rpcObjects=[sub])
 
-        setBurstMock.assert_called_with(newSize)
+        sub.setBurst.assert_called_with(newSize)
 
     @mock.patch('cuegui.Utils.questionBoxYesNo', new=mock.Mock(return_value=True))
     def test_delete(self):
         sub = opencue.wrappers.subscription.Subscription(
             opencue.compiled_proto.subscription_pb2.Subscription(name='arbitrary-name'))
-        deleteMock = mock.MagicMock()
-        sub.delete = deleteMock
+        sub.delete = mock.MagicMock()
 
         self.subscription_actions.delete(rpcObjects=[sub])
 
-        deleteMock.assert_called()
+        sub.delete.assert_called()
 
 
 class AllocationActionsTests(unittest.TestCase):
@@ -1177,22 +1174,20 @@ class HostActionsTests(unittest.TestCase):
     def test_lock(self):
         host = opencue.wrappers.host.Host(
             opencue.compiled_proto.host_pb2.Host(id='arbitrary-id'))
-        lockMock = mock.MagicMock()
-        host.lock = lockMock
+        host.lock = mock.MagicMock()
 
         self.host_actions.lock(rpcObjects=[opencue.wrappers.layer.Layer, host])
 
-        lockMock.assert_called()
+        host.lock.assert_called()
 
     def test_unlock(self):
         host = opencue.wrappers.host.Host(
             opencue.compiled_proto.host_pb2.Host(id='arbitrary-id'))
-        unlockMock = mock.MagicMock()
-        host.unlock = unlockMock
+        host.unlock = mock.MagicMock()
 
         self.host_actions.unlock(rpcObjects=[opencue.wrappers.layer.Layer, host])
 
-        unlockMock.assert_called()
+        host.unlock.assert_called()
 
     @mock.patch('cuegui.Utils.questionBoxYesNo', new=mock.Mock(return_value=True))
     def test_delete(self):
@@ -1201,25 +1196,23 @@ class HostActionsTests(unittest.TestCase):
         rp1 = mock.MagicMock()
         rp2 = mock.MagicMock()
         host.getRenderPartitions = lambda: [rp1, rp2]
-        deleteMock = mock.MagicMock()
-        host.delete = deleteMock
+        host.delete = mock.MagicMock()
 
         self.host_actions.delete(rpcObjects=[opencue.wrappers.layer.Layer, host])
 
         rp1.delete.assert_called()
         rp2.delete.assert_called()
-        deleteMock.assert_called()
+        host.delete.assert_called()
 
     @mock.patch('cuegui.Utils.questionBoxYesNo', new=mock.Mock(return_value=True))
     def test_rebootWhenIdle(self):
         host = opencue.wrappers.host.Host(
             opencue.compiled_proto.host_pb2.Host(id='arbitrary-id'))
-        rebootWhenIdleMock = mock.MagicMock()
-        host.rebootWhenIdle = rebootWhenIdleMock
+        host.rebootWhenIdle = mock.MagicMock()
 
         self.host_actions.rebootWhenIdle(rpcObjects=[opencue.wrappers.layer.Layer, host])
 
-        rebootWhenIdleMock.assert_called()
+        host.rebootWhenIdle.assert_called()
 
     @mock.patch('PySide2.QtWidgets.QInputDialog.getText')
     def test_addTags(self, getTextMock):
@@ -1227,12 +1220,11 @@ class HostActionsTests(unittest.TestCase):
             opencue.compiled_proto.host_pb2.Host(id='arbitrary-id'))
         tagsText = 'firstTag anotherTag,oneMoreTag'
         getTextMock.return_value = (tagsText, True)
-        addTagsMock = mock.MagicMock()
-        host.addTags = addTagsMock
+        host.addTags = mock.MagicMock()
 
         self.host_actions.addTags(rpcObjects=[opencue.wrappers.layer.Layer, host])
 
-        addTagsMock.assert_called_with(['firstTag', 'anotherTag', 'oneMoreTag'])
+        host.addTags.assert_called_with(['firstTag', 'anotherTag', 'oneMoreTag'])
 
     @mock.patch('PySide2.QtWidgets.QInputDialog.getText')
     def test_removeTags(self, getTextMock):
@@ -1240,12 +1232,11 @@ class HostActionsTests(unittest.TestCase):
             opencue.compiled_proto.host_pb2.Host(
                 id='arbitrary-id', tags=['firstTag', 'anotherTag', 'oneMoreTag', 'tagToKeep']))
         getTextMock.return_value = ('firstTag anotherTag,oneMoreTag', True)
-        removeTagsMock = mock.MagicMock()
-        host.removeTags = removeTagsMock
+        host.removeTags = mock.MagicMock()
 
         self.host_actions.removeTags(rpcObjects=[opencue.wrappers.layer.Layer, host])
 
-        removeTagsMock.assert_called_with(['firstTag', 'anotherTag', 'oneMoreTag'])
+        host.removeTags.assert_called_with(['firstTag', 'anotherTag', 'oneMoreTag'])
 
     @mock.patch('PySide2.QtWidgets.QInputDialog.getText')
     @mock.patch('PySide2.QtWidgets.QInputDialog.getItem')
@@ -1256,12 +1247,11 @@ class HostActionsTests(unittest.TestCase):
         newTagName = 'newTagName'
         getItemMock.return_value = (oldTagName, True)
         getTextMock.return_value = (newTagName, True)
-        renameTagMock = mock.MagicMock()
-        host.renameTag = renameTagMock
+        host.renameTag = mock.MagicMock()
 
         self.host_actions.renameTag(rpcObjects=[opencue.wrappers.layer.Layer, host])
 
-        renameTagMock.assert_called_with(oldTagName, newTagName)
+        host.renameTag.assert_called_with(oldTagName, newTagName)
 
     @mock.patch('PySide2.QtWidgets.QInputDialog.getItem')
     @mock.patch('opencue.api.getAllocations')
@@ -1276,48 +1266,93 @@ class HostActionsTests(unittest.TestCase):
         ]
         getAllocationsMock.return_value = allocs
         getItemMock.return_value = ('alloc2', True)
-        setAllocationMock = mock.MagicMock()
-        host.setAllocation = setAllocationMock
+        host.setAllocation = mock.MagicMock()
 
         self.host_actions.changeAllocation(rpcObjects=[opencue.wrappers.layer.Layer, host])
 
-        setAllocationMock.assert_called_with(allocs[1])
+        host.setAllocation.assert_called_with(allocs[1])
 
     def test_setRepair(self):
         activeHost = opencue.wrappers.host.Host(
             opencue.compiled_proto.host_pb2.Host(
                 id='active-host', state=opencue.api.host_pb2.UP))
-        activeHostSetHardwareStateMock = mock.MagicMock()
-        activeHost.setHardwareState = activeHostSetHardwareStateMock
+        activeHost.setHardwareState = mock.MagicMock()
         repairingHost = opencue.wrappers.host.Host(
             opencue.compiled_proto.host_pb2.Host(
                 id='repairing-host', state=opencue.api.host_pb2.REPAIR))
-        repairingHostSetHardwareStateMock = mock.MagicMock()
-        repairingHost.setHardwareState = repairingHostSetHardwareStateMock
+        repairingHost.setHardwareState = mock.MagicMock()
 
         self.host_actions.setRepair(
             rpcObjects=[opencue.wrappers.layer.Layer, activeHost, repairingHost])
 
-        activeHostSetHardwareStateMock.assert_called_with(opencue.api.host_pb2.REPAIR)
-        repairingHostSetHardwareStateMock.assert_not_called()
+        activeHost.setHardwareState.assert_called_with(opencue.api.host_pb2.REPAIR)
+        repairingHost.setHardwareState.assert_not_called()
 
     def test_clearRepair(self):
         activeHost = opencue.wrappers.host.Host(
             opencue.compiled_proto.host_pb2.Host(
                 id='active-host', state=opencue.api.host_pb2.UP))
-        activeHostSetHardwareStateMock = mock.MagicMock()
-        activeHost.setHardwareState = activeHostSetHardwareStateMock
+        activeHost.setHardwareState = mock.MagicMock()
         repairingHost = opencue.wrappers.host.Host(
             opencue.compiled_proto.host_pb2.Host(
                 id='repairing-host', state=opencue.api.host_pb2.REPAIR))
-        repairingHostSetHardwareStateMock = mock.MagicMock()
-        repairingHost.setHardwareState = repairingHostSetHardwareStateMock
+        repairingHost.setHardwareState = mock.MagicMock()
 
         self.host_actions.clearRepair(
             rpcObjects=[opencue.wrappers.layer.Layer, activeHost, repairingHost])
 
-        repairingHostSetHardwareStateMock.assert_called_with(opencue.api.host_pb2.DOWN)
-        activeHostSetHardwareStateMock.assert_not_called()
+        repairingHost.setHardwareState.assert_called_with(opencue.api.host_pb2.DOWN)
+        activeHost.setHardwareState.assert_not_called()
+
+
+@mock.patch('opencue.cuebot.Cuebot.getStub', new=mock.Mock())
+class ProcActionsTests(unittest.TestCase):
+
+    @mock.patch('opencue.cuebot.Cuebot.getStub', new=mock.Mock())
+    def setUp(self):
+        self.widgetMock = mock.Mock()
+        self.proc_actions = cuegui.MenuActions.ProcActions(
+            self.widgetMock, mock.Mock(), None, None)
+
+    @mock.patch('PySide2.QtGui.qApp')
+    @mock.patch('opencue.api.findJob')
+    def test_view(self, findJobMock, qAppMock):
+        jobName = 'arbitraryJobName'
+        job = opencue.wrappers.job.Job(opencue.compiled_proto.job_pb2.Job(name=jobName))
+        proc = opencue.wrappers.proc.Proc(opencue.compiled_proto.host_pb2.Proc(job_name=jobName))
+        findJobMock.return_value = job
+
+        self.proc_actions.view(rpcObjects=[opencue.wrappers.layer.Layer, proc])
+
+        qAppMock.view_object.emit.assert_called_once_with(job)
+
+    @mock.patch('cuegui.Utils.questionBoxYesNo', new=mock.Mock(return_value=True))
+    def test_kill(self):
+        proc = opencue.wrappers.proc.Proc(opencue.compiled_proto.host_pb2.Proc())
+        proc.kill = mock.MagicMock()
+
+        self.proc_actions.kill(rpcObjects=[opencue.wrappers.layer.Layer, proc])
+
+        proc.kill.assert_called()
+
+    @mock.patch('cuegui.Utils.questionBoxYesNo', new=mock.Mock(return_value=True))
+    def test_unbook(self):
+        proc = opencue.wrappers.proc.Proc(opencue.compiled_proto.host_pb2.Proc())
+        proc.unbook = mock.MagicMock()
+
+        self.proc_actions.unbook(rpcObjects=[opencue.wrappers.layer.Layer, proc])
+
+        proc.unbook.assert_called_with(False)
+
+    @mock.patch('cuegui.Utils.questionBoxYesNo', new=mock.Mock(return_value=True))
+    def test_unbookKill(self):
+        proc = opencue.wrappers.proc.Proc(opencue.compiled_proto.host_pb2.Proc())
+        proc.unbook = mock.MagicMock()
+
+        self.proc_actions.unbookKill(rpcObjects=[opencue.wrappers.layer.Layer, proc])
+
+        proc.unbook.assert_called_with(True)
+
 
 
 if __name__ == '__main__':

--- a/cuegui/tests/MenuActions_tests.py
+++ b/cuegui/tests/MenuActions_tests.py
@@ -34,6 +34,7 @@ import opencue.compiled_proto.filter_pb2
 import opencue.compiled_proto.host_pb2
 import opencue.compiled_proto.job_pb2
 import opencue.compiled_proto.subscription_pb2
+import opencue.compiled_proto.task_pb2
 import opencue.wrappers.allocation
 import opencue.wrappers.depend
 import opencue.wrappers.filter
@@ -45,6 +46,7 @@ import opencue.wrappers.layer
 import opencue.wrappers.proc
 import opencue.wrappers.show
 import opencue.wrappers.subscription
+import opencue.wrappers.task
 
 
 _GB_TO_KB = 1024 * 1024
@@ -1502,6 +1504,45 @@ class ActionActionsTests(unittest.TestCase):
         self.action_actions.delete(rpcObjects=[action])
 
         action.delete.assert_called()
+
+
+@mock.patch('opencue.cuebot.Cuebot.getStub', new=mock.Mock())
+class TaskActionsTests(unittest.TestCase):
+
+    @mock.patch('opencue.cuebot.Cuebot.getStub', new=mock.Mock())
+    def setUp(self):
+        self.widgetMock = mock.Mock()
+        self.task_actions = cuegui.MenuActions.TaskActions(
+            self.widgetMock, mock.Mock(), None, None)
+
+    @mock.patch('PySide2.QtWidgets.QInputDialog.getDouble')
+    def test_setMinCores(self, getDoubleMock):
+        task = opencue.wrappers.task.Task(opencue.compiled_proto.task_pb2.Task(min_cores=10))
+        task.setMinCores = mock.MagicMock()
+        newCoreCount = 28
+        getDoubleMock.return_value = (newCoreCount, True)
+
+        self.task_actions.setMinCores(rpcObjects=[task])
+
+        task.setMinCores.assert_called_with(newCoreCount)
+
+    def test_clearAdjustment(self):
+        task = opencue.wrappers.task.Task(opencue.compiled_proto.task_pb2.Task())
+        task.clearAdjustment = mock.MagicMock()
+
+        self.task_actions.clearAdjustment(rpcObjects=[task])
+
+        task.clearAdjustment.assert_called()
+
+    @mock.patch('cuegui.Utils.questionBoxYesNo', new=mock.Mock(return_value=True))
+    def test_delete(self):
+        task = opencue.wrappers.task.Task(opencue.compiled_proto.task_pb2.Task())
+        task.delete = mock.MagicMock()
+
+        self.task_actions.delete(rpcObjects=[task])
+
+        task.delete.assert_called()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
#396 

**Summarize your change.**
A lot of new code in `MenuAction_tests.py` but it's all very boring. The menu actions are all basically just pass-through code between the UI elements and the wrapper classes so the tests are very simple.

- File coverage 66% -> 94%
- CueGUI overall coverage 27% -> 31%

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.
-->
