### PR TITLE
Make pycuerun Python 3 compatible.

### DIFF
--- a/pyoutline/bin/pycuerun
+++ b/pyoutline/bin/pycuerun
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 """PyCuerun is for lanching outline scripts to the cue."""
+from __future__ import print_function
 
 
 import logging
@@ -76,7 +77,7 @@ class PyCuerun(AbstractCuerun):
                 frame, layer = options.execute.split("-", 1)
                 try:
                     cuerun.execute_frame(args[0], layer, frame)
-                except ShellCommandFailureException, e:
+                except ShellCommandFailureException as e:
                     sys.stderr.write("%s" % e)
                     sys.exit(e.exit_status)
 
@@ -88,7 +89,7 @@ class PyCuerun(AbstractCuerun):
                 #
                 if len(args) < 1:
                     parser.print_help()
-                    print "\nYou must provide an outline script to execute."
+                    print("\nYou must provide an outline script to execute.")
                     sys.exit(1)
                 outline = load_outline(args[0])
                 if len(args) == 2:
@@ -107,13 +108,13 @@ class PyCuerun(AbstractCuerun):
 
                 jobs = self.launch_outline(outline, user=options.user)
                 if not jobs:
-                    print "No jobs were submitted, check the outline file."
+                    print("No jobs were submitted, check the outline file.")
                 else:
-                    print "Submitted the following jobs..."
+                    print("Submitted the following jobs...")
                     for job in jobs:
-                        print "    {}".format(job.data.name)
+                        print("    {}".format(job.data.name))
 
-        except Exception, e:
+        except Exception as e:
             sys.stderr.write("cuerun failure, %s" % e)
             traceback.print_exc(file=sys.stderr)
             sys.exit(1)
@@ -123,11 +124,11 @@ def inspect_script(outline):
     """
     Dump some information on the given outline script.
     """
-    print "%s" % outline.get_full_name()
+    print("%s" % outline.get_full_name())
     for layer in outline.get_layers():
-        print " + %s" % layer.get_name()
+        print(" + %s" % layer.get_name())
         for key, val in layer.get_args().iteritems():
-            print "   - %s = %s" % (key, val)
+            print("   - %s = %s" % (key, val))
 
 
 if __name__ == '__main__':

--- a/pyoutline/bin/pycuerun
+++ b/pyoutline/bin/pycuerun
@@ -24,7 +24,7 @@ def convert_sys_args_from_olrun():
         '-retry': '-m',
         '-jobid': '-j'
     }
-    for k, v in translation_dict.iteritems():
+    for k, v in translation_dict.items():
         if k in sys.argv:
             logger.warn('olrun params detected, converting {0} to {1}'.format(
                 k, v))
@@ -127,7 +127,7 @@ def inspect_script(outline):
     print("%s" % outline.get_full_name())
     for layer in outline.get_layers():
         print(" + %s" % layer.get_name())
-        for key, val in layer.get_args().iteritems():
+        for key, val in layer.get_args().items():
             print("   - %s = %s" % (key, val))
 
 


### PR DESCRIPTION
Script is in the `bin/` subdir so I missed it when I was migrating `pyoutline` originally.