### PR TITLE
Fix root group check to handle standard groups.

### DIFF
--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -141,14 +141,14 @@ def isRootGroup(object):
     """Returns true if the object is a root, false if not
     @return: If the object is a root group
     @rtype:  bool"""
-    return object.__class__.__name__ in ["NestedGroup", "Group"] and not object.hasParent()
+    return object.__class__.__name__ in ["NestedGroup", "Group"] and object.isRootGroup()
 
 
 def isGroup(object):
     """Returns true if the object is a group, false if not
     @return: If the object is a group
     @rtype:  bool"""
-    return object.__class__.__name__ in ["NestedGroup", "Group"] and object.hasParent()
+    return object.__class__.__name__ in ["NestedGroup", "Group"] and not object.isRootGroup()
 
 
 def isHost(object):

--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -150,7 +150,7 @@ def isGroup(object):
     @return: If the object is a group
     @rtype:  bool"""
     return (
-        isinstance(object, opencue.wrappers.group.Group) or
+        type(object) == opencue.wrappers.group.Group or
         (isinstance(object, opencue.wrappers.group.NestedGroup) and not object.isRootGroup()))
 
 

--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -40,6 +40,7 @@ import yaml
 from yaml.scanner import ScannerError
 
 import opencue
+import opencue.wrappers.group
 
 import cuegui.ConfirmationDialog
 import cuegui.Constants
@@ -141,14 +142,16 @@ def isRootGroup(object):
     """Returns true if the object is a root, false if not
     @return: If the object is a root group
     @rtype:  bool"""
-    return object.__class__.__name__ in ["NestedGroup", "Group"] and object.isRootGroup()
+    return isinstance(object, opencue.wrappers.group.NestedGroup) and object.isRootGroup()
 
 
 def isGroup(object):
     """Returns true if the object is a group, false if not
     @return: If the object is a group
     @rtype:  bool"""
-    return object.__class__.__name__ in ["NestedGroup", "Group"] and not object.isRootGroup()
+    return (
+        isinstance(object, opencue.wrappers.group.Group) or
+        (isinstance(object, opencue.wrappers.group.NestedGroup) and not object.isRootGroup()))
 
 
 def isHost(object):

--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -142,7 +142,7 @@ def isRootGroup(object):
     """Returns true if the object is a root, false if not
     @return: If the object is a root group
     @rtype:  bool"""
-    return isinstance(object, opencue.wrappers.group.NestedGroup) and object.isRootGroup()
+    return isinstance(object, opencue.wrappers.group.NestedGroup) and not object.hasParent()
 
 
 def isGroup(object):
@@ -151,7 +151,7 @@ def isGroup(object):
     @rtype:  bool"""
     return (
         type(object) == opencue.wrappers.group.Group or
-        (isinstance(object, opencue.wrappers.group.NestedGroup) and not object.isRootGroup()))
+        (isinstance(object, opencue.wrappers.group.NestedGroup) and object.hasParent()))
 
 
 def isHost(object):

--- a/pycue/opencue/wrappers/group.py
+++ b/pycue/opencue/wrappers/group.py
@@ -197,14 +197,6 @@ class Group(object):
         :return: total number of running jobs"""
         return self.data.group_stats.pending_jobs
 
-    def isRootGroup(self):
-        """Whether this Group/NestedGroup is a root group.
-
-        :rtype: bool
-        :return: whether the group is a root group.
-        """
-        return hasattr(self.data, 'parent') and not self.data.HasField('parent')
-
 
 class NestedGroup(Group):
     """This class contains information and actions related to a nested group."""
@@ -240,3 +232,11 @@ class NestedGroup(Group):
             level=self.data.level,
             group_stats=self.data.stats,
         ))
+
+    def isRootGroup(self):
+        """Whether this Group/NestedGroup is a root group.
+
+        :rtype: bool
+        :return: whether the group is a root group.
+        """
+        return hasattr(self.data, 'parent') and not self.data.HasField('parent')

--- a/pycue/opencue/wrappers/group.py
+++ b/pycue/opencue/wrappers/group.py
@@ -233,10 +233,10 @@ class NestedGroup(Group):
             group_stats=self.data.stats,
         ))
 
-    def isRootGroup(self):
-        """Whether this Group/NestedGroup is a root group.
+    def hasParent(self):
+        """Whether this NestedGroup has a parent group.
 
         :rtype: bool
-        :return: whether the group is a root group.
+        :return: whether the group has a parent group.
         """
-        return hasattr(self.data, 'parent') and not self.data.HasField('parent')
+        return self.data.HasField('parent')

--- a/pycue/opencue/wrappers/group.py
+++ b/pycue/opencue/wrappers/group.py
@@ -197,13 +197,13 @@ class Group(object):
         :return: total number of running jobs"""
         return self.data.group_stats.pending_jobs
 
-    def hasParent(self):
-        """Whether this Group/NestedGroup has a parent group.
+    def isRootGroup(self):
+        """Whether this Group/NestedGroup is a root group.
 
         :rtype: bool
-        :return: whether the group has a parent
+        :return: whether the group is a root group.
         """
-        return self.data.HasField('parent')
+        return hasattr(self.data, 'parent') and not self.data.HasField('parent')
 
 
 class NestedGroup(Group):


### PR DESCRIPTION
Didn't catch this during initial testing because unit tests covering this code were added in a separate PR, which I only just merged.

This code was failing for non-`NestedGroup`s because the `parent` field doesn't exist at all for those groups. So, expand the check to cover both types of objects.

`hasParent` is a bit ambiguous because the standard `Group` object does have a `parent_id` field, which I thought was confusing. So I renamed that method as well.

