### PR TITLE
Disable user switching for macOS.

### DIFF
--- a/rqd/rqd/rqutil.py
+++ b/rqd/rqd/rqutil.py
@@ -86,7 +86,7 @@ def permissionsHigh():
 def permissionsLow():
     """Sets the effective gid/uid to one with less permissions:
        RQD_GID and RQD_UID"""
-    if platform.system() == 'Windows':
+    if platform.system() in ('Windows', 'Darwin'):
         return
     if os.getegid() != rqd.rqconstants.RQD_GID or os.geteuid() != rqd.rqconstants.RQD_UID:
         __becomeRoot()
@@ -99,7 +99,7 @@ def permissionsLow():
 
 def permissionsUser(uid, gid):
     """Sets the effective gid/uid to supplied values"""
-    if platform.system() == 'Windows':
+    if platform.system() in ('Windows', 'Darwin'):
         return
     PERMISSIONS.acquire()
     __becomeRoot()


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Related to #193 

**Summarize your change.**
Skip user switching on macOS as we do for Windows. macOS isn't currently supported, but this change at least allows macOS-based developers to run the program without it crashing outright.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.
-->
