### PR TITLE
Fix regex to allow underscores in job name.

### DIFF
--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -251,7 +251,7 @@ def findJob(job):
         return None
     if isStringId(job):
         return opencue.api.getJob(job)
-    if not re.search("^([a-z0-9]+)\-([a-z0-9\.]+)\-", job, re.IGNORECASE):
+    if not re.search("^([a-z0-9\_]+)\-([a-z0-9\.\_]+)\-", job, re.IGNORECASE):
         return None
     try:
         return opencue.api.findJob(job)

--- a/cuegui/tests/Utils_tests.py
+++ b/cuegui/tests/Utils_tests.py
@@ -1,0 +1,69 @@
+#  Copyright (c) OpenCue Project Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import mock
+import unittest
+
+import opencue.compiled_proto.job_pb2
+import opencue.wrappers.job
+import cuegui.Utils
+
+
+class UtilsTests(unittest.TestCase):
+    def test_shouldReturnJobAsIs(self):
+        originalJob = opencue.wrappers.job.Job()
+
+        returnedJob = cuegui.Utils.findJob(originalJob)
+
+        self.assertEqual(originalJob, returnedJob)
+
+    def test_shouldReturnNoneForString(self):
+        self.assertIsNone(cuegui.Utils.findJob('arbitrary-string'))
+
+    @mock.patch('opencue.api.getJob')
+    def test_shouldSearchForJobById(self, getJobMock):
+        jobId = '666f6f20-6261-7220-6261-740a616e6420'
+
+        cuegui.Utils.findJob(jobId)
+
+        getJobMock.assert_called_with(jobId)
+
+    def test_shouldReturnNoneForInvalidJobName(self):
+        invalidJobId = 'arbitrary$String##With*Disallowed@Characters'
+
+        self.assertIsNone(cuegui.Utils.findJob(invalidJobId))
+
+    @mock.patch('opencue.api.findJob')
+    def test_shouldSearchForJobByName(self, findJobMock):
+        jobId = 'arbitrary-job-id'
+        jobName = 'show_name-and_shot.name-some$other#stuff'
+        expectedJob = opencue.wrappers.job.Job(
+            opencue.compiled_proto.job_pb2.Job(id=jobId, name=jobName))
+        findJobMock.return_value = expectedJob
+
+        returnedJob = cuegui.Utils.findJob(jobName)
+
+        findJobMock.assert_called_with(jobName)
+        self.assertEqual(jobId, returnedJob.id())
+
+    @mock.patch('opencue.api.findJob', new=mock.Mock(side_effect=Exception()))
+    def test_shouldSwallowExceptionAndReturnNone(self):
+        jobName = 'show_name-and_shot.name-some$other#stuff'
+
+        self.assertIsNone(cuegui.Utils.findJob(jobName))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Fixes #522 

**Summarize your change.**
Underscores are allowed in job names, particularly the show and shot name; fix the regex to match.

This change resolves the leftover comments in #523: preserves `.` as an allowed character and adds some tests for `Utils.findJob`.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.
-->
