### PR TITLE
automatically fix version in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,11 @@
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#
+
+# To set the following values to the latest version and
+# release, run `python3 docs/version_release_fix.py`
+
+
 import os
 import sys
 sys.path.insert(0, os.path.abspath('../pycue'))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,9 +12,6 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
-# To set the following values to the latest version and
-# release, run `python3 docs/version_release_fix.py`
-
 
 import os
 import sys
@@ -27,6 +24,10 @@ sys.path.insert(0, os.path.abspath('../pyoutline'))
 project = u'OpenCue'
 copyright = u'2019, Academy Software Foundation'
 author = u'Academy Software Foundation'
+
+
+# To set the following values to the latest version and
+# release, run `python3 docs/version_release_fix.py`
 
 # The short X.Y version
 version = u'0.3.6'

--- a/docs/version_release_fix.py
+++ b/docs/version_release_fix.py
@@ -1,0 +1,37 @@
+#  Copyright (c) 2018 Sony Pictures Imageworks Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os,re
+from pathlib import Path
+
+conf_py = Path('./conf.py')
+version_in = Path('../VERSION.in')
+
+with open(conf_py, 'r') as f:
+    old_file = f.read()
+
+# Get version and release
+version = open(version_in, 'r').readline().strip()
+release = str(os.popen('git describe --tags').read()).strip()
+
+# Update version
+new_file = re.sub(r"version = u'[0-9.]+'", \
+	f"version = u'{version}'", old_file)
+
+# Update release
+new_file = re.sub(r"release = u'[0-9.]+'", \
+	f"release = u'{release}'", new_file)
+
+with open(conf_py, 'w') as f:
+    f.write(new_file)

--- a/docs/version_release_fix.py
+++ b/docs/version_release_fix.py
@@ -15,28 +15,27 @@
 import re, os
 
 def main():
-	cur_dir = os.path.dirname(__file__)
-	conf_py = os.path.realpath(os.path.join(cur_dir, 'conf.py'))
-	version_file = os.path.realpath(os.path.join(cur_dir, '..', 'VERSION'))
+  cur_dir = os.path.dirname(__file__)
+  conf_py = os.path.realpath(os.path.join(cur_dir, 'conf.py'))
+  version_file = os.path.realpath(os.path.join(cur_dir, '..', 'VERSION'))
 
-	# Get version and release
-	release = open(version_file, 'r').readline().strip().split('-')[0]
-	version = '.'.join(release.split('.')[:2])
+  # Get version and release
+  release = open(version_file, 'r').readline().strip().split('-')[0]
+  version = '.'.join(release.split('.')[:2])
 
-	with open(conf_py, 'r') as f:
-	    old_file = f.read()
+  with open(conf_py, 'r') as f:
+    old_file = f.read()
 
-	# Update version
-	new_file = re.sub(r"version = u'[0-9.]+'", \
-		"version = u'{0}'".format(version), old_file)
+  # Update version
+  new_file = re.sub(r"version = u'[0-9.]+'", \
+    "version = u'{0}'".format(version), old_file)
 
-	# Update release
-	new_file = re.sub(r"release = u'[0-9.]+'", \
-		"release = u'{0}'".format(release), new_file)
+  # Update release
+  new_file = re.sub(r"release = u'[0-9.]+'", \
+    "release = u'{0}'".format(release), new_file)
 
-	with open(conf_py, 'w') as f:
-	    f.write(new_file)
-
+  with open(conf_py, 'w') as f:
+    f.write(new_file)
 
 if __name__ == '__main__':
 	main()

--- a/docs/version_release_fix.py
+++ b/docs/version_release_fix.py
@@ -17,10 +17,10 @@ import re, os
 def main():
 	cur_dir = os.path.dirname(__file__)
 	conf_py = os.path.realpath(os.path.join(cur_dir, 'conf.py'))
-	version = os.path.realpath(os.path.join(cur_dir, '..', 'VERSION'))
+	version_file = os.path.realpath(os.path.join(cur_dir, '..', 'VERSION'))
 
 	# Get version and release
-	release = open(version, 'r').readline().strip().split('-')[0]
+	release = open(version_file, 'r').readline().strip().split('-')[0]
 	version = '.'.join(release.split('.')[:2])
 
 	with open(conf_py, 'r') as f:

--- a/docs/version_release_fix.py
+++ b/docs/version_release_fix.py
@@ -12,18 +12,18 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import os,re
+import re
 from pathlib import Path
 
 conf_py = Path('./conf.py')
-version_in = Path('../VERSION.in')
+version_file = Path('../ci/VERSION')
+
+# Get version and release
+release = open(version_file, 'r').readline().strip().split('-')[0]
+version = '.'.join(release.split('.')[:2])
 
 with open(conf_py, 'r') as f:
     old_file = f.read()
-
-# Get version and release
-version = open(version_in, 'r').readline().strip()
-release = str(os.popen('git describe --tags').read()).strip()
 
 # Update version
 new_file = re.sub(r"version = u'[0-9.]+'", \

--- a/docs/version_release_fix.py
+++ b/docs/version_release_fix.py
@@ -12,26 +12,31 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import re
-from pathlib import Path
+import re, os
 
-conf_py = Path('./conf.py')
-version_file = Path('../ci/VERSION')
+def main():
+	cur_dir = os.path.dirname(__file__)
+	conf_py = os.path.realpath(os.path.join(cur_dir, 'conf.py'))
+	version = os.path.realpath(os.path.join(cur_dir, '..', 'VERSION'))
 
-# Get version and release
-release = open(version_file, 'r').readline().strip().split('-')[0]
-version = '.'.join(release.split('.')[:2])
+	# Get version and release
+	release = open(version, 'r').readline().strip().split('-')[0]
+	version = '.'.join(release.split('.')[:2])
 
-with open(conf_py, 'r') as f:
-    old_file = f.read()
+	with open(conf_py, 'r') as f:
+	    old_file = f.read()
 
-# Update version
-new_file = re.sub(r"version = u'[0-9.]+'", \
-	f"version = u'{version}'", old_file)
+	# Update version
+	new_file = re.sub(r"version = u'[0-9.]+'", \
+		"version = u'{0}'".format(version), old_file)
 
-# Update release
-new_file = re.sub(r"release = u'[0-9.]+'", \
-	f"release = u'{release}'", new_file)
+	# Update release
+	new_file = re.sub(r"release = u'[0-9.]+'", \
+		"release = u'{0}'".format(release), new_file)
 
-with open(conf_py, 'w') as f:
-    f.write(new_file)
+	with open(conf_py, 'w') as f:
+	    f.write(new_file)
+
+
+if __name__ == '__main__':
+	main()


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Fixes #591

**Summarize your change.**
 [docs/conf.py](https://github.com/AcademySoftwareFoundation/OpenCue/blob/master/docs/conf.py) has two variables, `version` and `release` which is as of now, statically typed. This script changes these two with the current `version` and `release`.

It's also helpful to describe **why** you're making this change.
Doing this manually was not a good solution at all. Having it as an automated process will make it more hassle-free.
