### PR TITLE
View and Edit Subscriptions in full cores.

### DIFF
--- a/cuegui/cuegui/MenuActions.py
+++ b/cuegui/cuegui/MenuActions.py
@@ -1154,7 +1154,7 @@ class SubscriptionActions(AbstractActions):
                 for sub in subs:
                     self.cuebotCall(sub.setSize,
                                     "Set Size on Subscription %s Failed" % sub.data.name,
-                                    int(value))
+                                    int(value*100.0))
                 self._update()
 
     editBurst_info = ["Edit Subscription Burst...", None, "configure"]
@@ -1174,7 +1174,7 @@ class SubscriptionActions(AbstractActions):
                 for sub in subs:
                     self.cuebotCall(sub.setBurst,
                                     "Set Burst on Subscription %s Failed" % sub.data.name,
-                                    int(value))
+                                    int(value*100.0))
                 self._update()
 
     delete_info = ["Delete Subscription", None, "configure"]

--- a/cuegui/cuegui/MenuActions.py
+++ b/cuegui/cuegui/MenuActions.py
@@ -1138,7 +1138,7 @@ class SubscriptionActions(AbstractActions):
                    "contact the resource department."
             minSize = 0
             decimalPlaces = 0
-            (value, choice) = QtWidgets.QInputDialog.getDouble(self._caller, title, body, current,
+            (value, choice) = QtWidgets.QInputDialog.getDouble(self._caller, title, body, current/100.0,
                                                                minSize, cuegui.Constants.QT_MAX_INT,
                                                                decimalPlaces)
             if choice:
@@ -1167,7 +1167,7 @@ class SubscriptionActions(AbstractActions):
                    "subscription should be allowed to reach:"
             minSize = 0
             decimalPlaces = 0
-            (value, choice) = QtWidgets.QInputDialog.getDouble(self._caller, title, body, current,
+            (value, choice) = QtWidgets.QInputDialog.getDouble(self._caller, title, body, current/100.0,
                                                                minSize, cuegui.Constants.QT_MAX_INT,
                                                                decimalPlaces)
             if choice:

--- a/cuegui/cuegui/SubscriptionsWidget.py
+++ b/cuegui/cuegui/SubscriptionsWidget.py
@@ -155,14 +155,14 @@ class SubscriptionsTreeWidget(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                        sort=lambda sub: (sub.data.size and
                                          sub.data.reserved_cores / sub.data.size or 0))
         self.addColumn("Size", 70, id=3,
-                       data=lambda sub: sub.data.size,
-                       sort=lambda sub: sub.data.size)
+                       data=lambda sub: (sub.data.size/100.0),
+                       sort=lambda sub: (sub.data.size/100.0))
         self.addColumn("Burst", 70, id=4,
-                       data=lambda sub: sub.data.burst,
-                       sort=lambda sub: sub.data.burst)
+                       data=lambda sub: (sub.data.burst/100.0),
+                       sort=lambda sub: (sub.data.burst/100.0))
         self.addColumn("Used", 70, id=5,
-                       data=lambda sub: ("%.2f" % sub.data.reserved_cores),
-                       sort=lambda sub: sub.data.reserved_cores)
+                       data=lambda sub: ("%.2f" % (sub.data.reserved_cores/100.0)),
+                       sort=lambda sub: (sub.data.reserved_cores/100.0))
 
         cuegui.AbstractTreeWidget.AbstractTreeWidget.__init__(self, parent)
 

--- a/cuegui/tests/MenuActions_tests.py
+++ b/cuegui/tests/MenuActions_tests.py
@@ -1107,7 +1107,7 @@ class SubscriptionActionsTests(unittest.TestCase):
 
         self.subscription_actions.editSize(rpcObjects=[sub])
 
-        sub.setSize.assert_called_with(newSize)
+        sub.setSize.assert_called_with(newSize*100.0)
 
     @mock.patch('PySide2.QtWidgets.QInputDialog.getDouble')
     def test_editBurst(self, getDoubleMock):
@@ -1119,7 +1119,7 @@ class SubscriptionActionsTests(unittest.TestCase):
 
         self.subscription_actions.editBurst(rpcObjects=[sub])
 
-        sub.setBurst.assert_called_with(newSize)
+        sub.setBurst.assert_called_with(newSize*100.0)
 
     @mock.patch('cuegui.Utils.questionBoxYesNo', new=mock.Mock(return_value=True))
     def test_delete(self):


### PR DESCRIPTION
Fixes #639 

Changed the subscriptions display so as to display straight cores instead of cores*100.