### PR TITLE
Fixing blank submission dropdown for LineEdit in CueSubmit

### DIFF
--- a/cuesubmit/cuesubmit/ui/Style.py
+++ b/cuesubmit/cuesubmit/ui/Style.py
@@ -124,6 +124,10 @@ QTextEdit {
 }
 """
 
+POPUP_LIST_VIEW = """
+    background-color: rgb(70, 80, 90);
+"""
+
 INVALID_TEXT = """
 QLabel {
     color: rgb(220, 20, 20);

--- a/cuesubmit/cuesubmit/ui/Widgets.py
+++ b/cuesubmit/cuesubmit/ui/Widgets.py
@@ -116,6 +116,7 @@ class CueLineEdit(QtWidgets.QLineEdit):
         self.completer.setCaseSensitivity(QtCore.Qt.CaseInsensitive)
         self.completerModel.setStringList(self.completerStrings)
         self.completer.setModel(self.completerModel)
+        self.completer.popup().setStyleSheet(Style.POPUP_LIST_VIEW)
         self.setCompleter(self.completer)
 
     def keyPressEvent(self, event):


### PR DESCRIPTION
Associated Issue: #275 

Change summary: 
QCompleter on the LineEdit for CueSubmit widgets was rendering white text over a white background and hence seemed like blank suggestions.
Added a background specifically for the popup listview in the style.py and used it to set the style of the completer pop up list view. 

Why this change? 
This maintains the look of the widget and helps solve the blank suggestion bug 
