### PR TITLE
Fix moving hosts between allocs in cueadmin.

### DIFF
--- a/cueadmin/cueadmin/common.py
+++ b/cueadmin/cueadmin/common.py
@@ -719,7 +719,7 @@ def handleArgs(args):
         def moveHosts(hosts_, dst_):
             for host_ in hosts_:
                 logger.debug("moving %s to %s" % (opencue.rep(host_), opencue.rep(dst_)))
-                host_.setAllocation(dst_.data)
+                host_.setAllocation(dst_)
 
         confirm("Move %d hosts to %s" % (len(hosts), args.move),
                 args.force, moveHosts, hosts, opencue.api.findAllocation(args.move))

--- a/cueadmin/tests/common_tests.py
+++ b/cueadmin/tests/common_tests.py
@@ -391,16 +391,17 @@ class HostTests(unittest.TestCase):
     def testMoveHost(self, findAllocMock, getStubMock, hostSearchMock):
         allocName = '%s.%s' % (TEST_FACILITY, TEST_ALLOC)
         args = self.parser.parse_args(['-move', allocName, '-host', TEST_HOST, '-force'])
-        hostMock = mock.Mock()
-        hostSearchMock.byName.return_value = [hostMock]
-        allocMock = mock.Mock()
-        findAllocMock.return_value = allocMock
+        host = opencue.wrappers.host.Host(opencue.compiled_proto.host_pb2.Host())
+        host.setAllocation = mock.Mock()
+        hostSearchMock.byName.return_value = [host]
+        alloc = opencue.wrappers.allocation.Allocation()
+        findAllocMock.return_value = alloc
 
         cueadmin.common.handleArgs(args)
 
         hostSearchMock.byName.assert_called_with([TEST_HOST])
         findAllocMock.assert_called_with(allocName)
-        hostMock.setAllocation.assert_called_with(allocMock.data)
+        host.setAllocation.assert_called_with(alloc)
 
     def testInvalidMoveHost(self, getStubMock, hostSearchMock):
         args = self.parser.parse_args(['-move', TEST_ALLOC, '-force'])


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Fixes #653 

**Summarize your change.**
Pretty straightforward. `setAllocation` wants the wrapper object, not the underlying protobuf data.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.
-->
