### PR TITLE
Fix reparentHosts to correctly construct its gRPC response.

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageAllocation.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageAllocation.java
@@ -178,6 +178,8 @@ public class ManageAllocation extends AllocationInterfaceGrpc.AllocationInterfac
                 .map(HostEntity::new)
                 .collect(Collectors.toList());
         manageQueue.execute(new ManageReparentHosts(allocEntity, hostEntities, hostManager));
+        responseObserver.onNext(AllocReparentHostsResponse.newBuilder().build());
+        responseObserver.onCompleted();
     }
 
     @Override


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Fixes #655 

**Summarize your change.**
Cuebot wasn't constructing the expected response, causing any calling gRPC clients to hang indefinitely waiting for one.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.
-->
