### PR TITLE
fix filter alignment in monitor host panel

### DIFF
--- a/cuegui/cuegui/HostMonitor.py
+++ b/cuegui/cuegui/HostMonitor.py
@@ -122,6 +122,7 @@ class HostMonitor(QtWidgets.QWidget):
 
         btn = QtWidgets.QPushButton("Filter Allocation")
         btn.setMaximumHeight(FILTER_HEIGHT)
+        btn.setStyleSheet(" width: 12:0px;");
         btn.setFocusPolicy(QtCore.Qt.NoFocus)
         btn.setContentsMargins(0,0,0,0)
         btn.setFlat(True)
@@ -185,6 +186,7 @@ class HostMonitor(QtWidgets.QWidget):
 
         btn = QtWidgets.QPushButton("Filter HardwareState")
         btn.setMaximumHeight(FILTER_HEIGHT)
+        btn.setStyleSheet(" width: 150px;");
         btn.setFocusPolicy(QtCore.Qt.NoFocus)
         btn.setContentsMargins(0, 0, 0, 0)
         btn.setFlat(True)

--- a/cuegui/cuegui/HostMonitor.py
+++ b/cuegui/cuegui/HostMonitor.py
@@ -122,7 +122,6 @@ class HostMonitor(QtWidgets.QWidget):
 
         btn = QtWidgets.QPushButton("Filter Allocation")
         btn.setMaximumHeight(FILTER_HEIGHT)
-        btn.setStyleSheet(" width: 120px;");
         btn.setFocusPolicy(QtCore.Qt.NoFocus)
         btn.setContentsMargins(0,0,0,0)
         btn.setFlat(True)
@@ -186,7 +185,6 @@ class HostMonitor(QtWidgets.QWidget):
 
         btn = QtWidgets.QPushButton("Filter HardwareState")
         btn.setMaximumHeight(FILTER_HEIGHT)
-        btn.setStyleSheet(" width: 150px;");
         btn.setFocusPolicy(QtCore.Qt.NoFocus)
         btn.setContentsMargins(0, 0, 0, 0)
         btn.setFlat(True)

--- a/cuegui/cuegui/HostMonitor.py
+++ b/cuegui/cuegui/HostMonitor.py
@@ -122,7 +122,7 @@ class HostMonitor(QtWidgets.QWidget):
 
         btn = QtWidgets.QPushButton("Filter Allocation")
         btn.setMaximumHeight(FILTER_HEIGHT)
-        btn.setStyleSheet(" width: 12:0px;");
+        btn.setStyleSheet(" width: 120px;");
         btn.setFocusPolicy(QtCore.Qt.NoFocus)
         btn.setContentsMargins(0,0,0,0)
         btn.setFlat(True)

--- a/cuegui/cuegui/config/darkpalette.qss
+++ b/cuegui/cuegui/config/darkpalette.qss
@@ -55,6 +55,11 @@ QPushButton:pressed {
     background-color: rgb(80, 80, 80);
 }
 
+QPushButton::menu-indicator {
+    right: 10px;
+    bottom: 5px;
+}
+
 QSpinBox {
     background-color: rgb(65, 65, 65);
     border: 1px solid rgb(22, 22, 22);

--- a/cuegui/cuegui/config/darkpalette.qss
+++ b/cuegui/cuegui/config/darkpalette.qss
@@ -49,6 +49,7 @@ QPushButton {
     margin-left: 5px;
     min-height: 15px;
     min-width: 5em;
+    padding: 0 15px 0 5px;
 }
 
 QPushButton:pressed {


### PR DESCRIPTION
Fixes #672 by properly aligning the dropdown arrows with the text in Allocation and HardwareState filter in monitor hosts panel in CueGUI.


<img width="1434" alt="Screenshot 2020-03-31 at 2 40 25 AM" src="https://user-images.githubusercontent.com/26320019/77962634-94608c80-72f9-11ea-9fac-afcee216de99.png">
