### PR TITLE
Unit test scaffolding for CueJobMonitorTree and Redirect.

### DIFF
--- a/cuegui/cuegui/CueJobMonitorTree.py
+++ b/cuegui/cuegui/CueJobMonitorTree.py
@@ -279,7 +279,7 @@ class CueJobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
 
                     self.updateRequest()
 
-    def addShow(self, show, update = True):
+    def addShow(self, show, update=True):
         """Adds a show to the list of monitored shows
         @type  show: Show name
         @param show: string

--- a/cuegui/cuegui/Redirect.py
+++ b/cuegui/cuegui/Redirect.py
@@ -59,7 +59,7 @@ class ShowCombo(QtWidgets.QComboBox):
     def refresh(self):
         self.clear()
         shows = opencue.api.getActiveShows()
-        shows.sort(lambda x,y: cmp(x.data.name, y.data.name))
+        shows.sort(key=lambda x, y: cmp(x.data.name, y.data.name))
 
         for show in shows:
             self.addItem(show.data.name, show)
@@ -92,7 +92,7 @@ class AllocFilter(QtWidgets.QPushButton):
         Refresh the full list of allocations.
         """
         allocs = opencue.api.getAllocations()
-        allocs.sort(lambda x,y: cmp(x.data.name, y.data.name))
+        allocs.sort(key=lambda x, y: cmp(x.data.name, y.data.name))
 
         self.__menu.clear()
         checked = 0
@@ -372,11 +372,11 @@ class RedirectWidget(QtWidgets.QWidget):
     Displays a table of procs that can be selected for redirect.
     """
 
-    HEADERS = ["Name","Cores","Memory","PrcTime", "Group","Service"]
+    HEADERS = ["Name", "Cores", "Memory", "PrcTime", "Group", "Service"]
 
     def __init__(self, parent=None):
         QtWidgets.QWidget.__init__(self, parent)
-        self.__hosts = { }
+        self.__hosts = {}
 
         self.__controls = RedirectControls(self)
 
@@ -398,17 +398,17 @@ class RedirectWidget(QtWidgets.QWidget):
         self.__controls.getClearButton().pressed.connect(self.clearTarget)
 
     def __get_selected_procs_by_alloc(self, selected_items):
-        '''
+        """
         Gathers and returns the selected procs, grouped by allocation their
         allocation names
 
         @param selected_items: The selected rows to analyze
-        @type selected_itmes: list<dict<str:varies>>
+        @type selected_items: list<dict<str:varies>>
 
-        @return: A dictionary with the allocation neames are the keys and the
+        @return: A dictionary with the allocation names are the keys and the
                  selected procs are the values.
         @rtype: dict<str:L{opencue.wrappers.proc.Proc}>
-        '''
+        """
 
         procs_by_alloc = {}
         for item in selected_items:

--- a/cuegui/tests/CueJobMonitorTree_tests.py
+++ b/cuegui/tests/CueJobMonitorTree_tests.py
@@ -1,0 +1,65 @@
+#  Copyright (c) OpenCue Project Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import mock
+import unittest
+
+import PySide2.QtCore
+import PySide2.QtGui
+import PySide2.QtWidgets
+
+import cuegui.CueJobMonitorTree
+import cuegui.plugins.MonitorCuePlugin
+import cuegui.Style
+import opencue.compiled_proto.job_pb2
+import opencue.compiled_proto.show_pb2
+import opencue.wrappers.show
+
+from . import test_utils
+
+
+@mock.patch('opencue.cuebot.Cuebot.getStub', new=mock.Mock())
+class CueJobMonitorTreeTests(unittest.TestCase):
+
+    @mock.patch('opencue.cuebot.Cuebot.getStub')
+    def setUp(self, get_stub_mock):
+        test_utils.createApplication()
+        PySide2.QtGui.qApp.settings = PySide2.QtCore.QSettings()
+        cuegui.Style.init()
+
+        show_name = 'arbitrary-show-name'
+        job_name = 'arbitrary-job-name'
+
+        # Show is specified by name, and show details are fetched using FindShow.
+        get_stub_mock.return_value.FindShow.return_value = \
+            opencue.compiled_proto.show_pb2.ShowFindShowResponse(
+                show=opencue.compiled_proto.show_pb2.Show(name=show_name))
+
+        # The widget loads the show's "whiteboard", a nested data structure containing
+        # all groups and jobs in the show. The top-level item is the show though it
+        # uses the NestedGroup data type.
+        get_stub_mock.return_value.GetJobWhiteboard.return_value = \
+            opencue.compiled_proto.show_pb2.ShowGetJobWhiteboardResponse(
+                whiteboard=opencue.compiled_proto.job_pb2.NestedGroup(
+                    name=show_name,
+                    jobs=[job_name]))
+
+        self.main_window = PySide2.QtWidgets.QMainWindow()
+        self.widget = cuegui.plugins.MonitorCuePlugin.MonitorCueDockWidget(self.main_window)
+        self.cue_job_monitor_tree = cuegui.CueJobMonitorTree.CueJobMonitorTree(self.widget)
+        self.cue_job_monitor_tree.addShow(show_name)
+
+    def test_setup(self):
+        pass

--- a/cuegui/tests/CueJobMonitorTree_tests.py
+++ b/cuegui/tests/CueJobMonitorTree_tests.py
@@ -39,13 +39,13 @@ class CueJobMonitorTreeTests(unittest.TestCase):
         PySide2.QtGui.qApp.settings = PySide2.QtCore.QSettings()
         cuegui.Style.init()
 
-        show_name = 'arbitrary-show-name'
-        job_name = 'arbitrary-job-name'
+        self.show_name = 'arbitrary-show-name'
+        self.jobs = ['arbitrary-job-name']
 
         # Show is specified by name, and show details are fetched using FindShow.
         get_stub_mock.return_value.FindShow.return_value = \
             opencue.compiled_proto.show_pb2.ShowFindShowResponse(
-                show=opencue.compiled_proto.show_pb2.Show(name=show_name))
+                show=opencue.compiled_proto.show_pb2.Show(name=self.show_name))
 
         # The widget loads the show's "whiteboard", a nested data structure containing
         # all groups and jobs in the show. The top-level item is the show though it
@@ -53,13 +53,13 @@ class CueJobMonitorTreeTests(unittest.TestCase):
         get_stub_mock.return_value.GetJobWhiteboard.return_value = \
             opencue.compiled_proto.show_pb2.ShowGetJobWhiteboardResponse(
                 whiteboard=opencue.compiled_proto.job_pb2.NestedGroup(
-                    name=show_name,
-                    jobs=[job_name]))
+                    name=self.show_name,
+                    jobs=self.jobs))
 
         self.main_window = PySide2.QtWidgets.QMainWindow()
         self.widget = cuegui.plugins.MonitorCuePlugin.MonitorCueDockWidget(self.main_window)
         self.cue_job_monitor_tree = cuegui.CueJobMonitorTree.CueJobMonitorTree(self.widget)
-        self.cue_job_monitor_tree.addShow(show_name)
+        self.cue_job_monitor_tree.addShow(self.show_name)
 
     def test_setup(self):
         pass

--- a/cuegui/tests/Redirect_tests.py
+++ b/cuegui/tests/Redirect_tests.py
@@ -1,0 +1,49 @@
+#  Copyright (c) OpenCue Project Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import mock
+import unittest
+
+import PySide2.QtCore
+import PySide2.QtGui
+
+import cuegui.Redirect
+import cuegui.Style
+import opencue.compiled_proto.show_pb2
+import opencue.wrappers.show
+
+from . import test_utils
+
+
+@mock.patch('opencue.cuebot.Cuebot.getStub', new=mock.Mock())
+class RedirectTests(unittest.TestCase):
+
+    @mock.patch('opencue.cuebot.Cuebot.getStub')
+    def setUp(self, getStubMock):
+        test_utils.createApplication()
+        PySide2.QtGui.qApp.settings = PySide2.QtCore.QSettings()
+        cuegui.Style.init()
+
+        getStubMock.return_value.GetActiveShows.return_value = \
+            opencue.compiled_proto.show_pb2.ShowGetActiveShowsResponse(
+                shows=opencue.compiled_proto.show_pb2.ShowSeq(shows=[]))
+        getStubMock.return_value.FindShow.return_value = \
+            opencue.compiled_proto.show_pb2.ShowFindShowResponse(
+                show=opencue.compiled_proto.show_pb2.Show())
+
+        self.redirect = cuegui.Redirect.RedirectWidget()
+
+    def test_setup(self):
+        pass


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
#396 

**Summarize your change.**
No real test logic, but sets up the widgets and some basic data. The aim here is two-fold:
1. Get a cheap boost to our code coverage. Even though we're not validating results this at least ensures the file syntax and basic setup is functional.
2. Make it easier for folks to add tests in the future -- adding one or two tests is easy enough if the basic widget/mock structure is already in place, but starting that from scratch is a high enough barrier to entry to discourage test writing.

This brings CueGUI coverage 33% -> 38%.

I hope to bring this approach to other parts of the codebase in followup PRs.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.
-->
