### PR TITLE
Ignore all venv directories.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.idea/
 *.pyc
 .DS_Store
-venv/
+venv*/
 /build/
 /VERSION
 .scannerwork/


### PR DESCRIPTION
We already ignore `venv/`, the conventional name for a virtual environment. But I tend to have multiple virtual environments going at once -- Python 2/3, one for testing a new release, and so on -- all named with a `venv` prefix.

Not sure if others are working this way or not but this change will help keep my Git status clean.