### PR TITLE
Update links in the Cuebot README.

### DIFF
--- a/cuebot/README.md
+++ b/cuebot/README.md
@@ -12,32 +12,14 @@ A typical OpenCue deployment runs a single instance of Cuebot, which is shared b
 ## Deployment Instructions
 
 For instructions on deploying a Cuebot instance see
-[Deploying Cuebot](https://github.com/imageworks/OpenCue/wiki/Deploying-Cuebot) on the Wiki.
+[Deploying Cuebot](https://www.opencue.io/docs/getting-started/deploying-cuebot/) on our website.
 
 ## Development Setup
 
-This section covers setting up a development environment in IntelliJ.
+> NOTE: Only OpenCue developers will need to do this setup. If you just want to use Cuebot, follow
+> [Deployment Instructions](#deployment-instructions).
 
-NOTE: Only OpenCue developers will need to do this setup. If you just want to use Cuebot, follow
-[Deployment Instructions](#deployment-instructions).
+For instructions on setting up a Cuebot development environment, see
+[Getting Started](https://www.opencue.io/contributing/opencue/getting-started/) in the
+Contributing section of our website.
 
-### Import Project
-
-- From the IntelliJ launch screen, choose "Import Project".
-- Browse to the `OpenCue/cuebot` directory. Don't select any files. Click "Open".
-- Choose "Import project from external model" > "gradle". This will initialize the project from
-  what's checked in already.
-- Default Gradle options are typically fine.
-
-### Configure IntelliJ Project
-
-- Import our code style XML. IntelliJ Preferences > Editor > Code Style > Java >
-  Scheme (gear dropdown) > Import Scheme > IntelliJ IDEA code style XML.
-  Select `code_style_ij.xml`.
-- Delegate build commands to Gradle. IntelliJ Preferences > Build, Execution, Deployment >
-  Build Tools > Gradle > Runner. Check "Delegate IDE build/run actions to gradle".
-
-### Build the Project
-
-View > Tool Windows > Gradle. Refresh the Gradle project and run the build task, which will
-run compilation and tests.


### PR DESCRIPTION
Deployment instructions were pointing to the old Wiki link, and development setup info isn't needed here anymore as we have a much more extensive guide in our Contributing section now.