### PR TITLE
Fix bug with host search where search text would be ignored.

### DIFF
--- a/cuegui/cuegui/HostMonitor.py
+++ b/cuegui/cuegui/HostMonitor.py
@@ -105,12 +105,13 @@ class HostMonitor(QtWidgets.QWidget):
 
     def __filterByHostNameHandle(self):
         regex = str(self.__filterByHostName.text()).split()
-        if regex and regex != self.__filterByHostNameLastInput:
-            self.__filterByHostNameLastInput = regex
+        if regex:
             self.hostMonitorTree.hostSearch.options['regex'] = regex
         else:
             self.hostMonitorTree.hostSearch.options['regex'] = []
-        self.hostMonitorTree.updateRequest()
+        if regex != self.__filterByHostNameLastInput:
+            self.__filterByHostNameLastInput = regex
+            self.hostMonitorTree.updateRequest()
 
     def __filterByHostNameClear(self):
         self.__filterByHostNameLastInput = ""


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
#694 

**Summarize your change.**
I think the `if` in this handler is a bit off. From my reading, it's trying to accomplish two things:
1. If the regex is blank, set a special "blank" value into the search object -- in this case an empty array.
2. If the search term has changed, refresh the widget so the host filtering can occur.

But there are two problems with the way it's currently written:
1. If the search term has not changed, a blank value will be stored in search object, regardless of the contents of the search box. This causes #694. 
2. The widget is outside the `if/else` block, so it's always refreshed, even if the search term hasn't changed, so (2) above is not accomplished.

The reason this doesn't crop up more often is because it's kind of difficult to trigger this handler without also changing the contents of the search box. (Hence the alt+tab in the reproduction steps in the issue.)

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.
-->
