### PR TITLE
Protect getRenderPartition call

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageFrame.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageFrame.java
@@ -279,8 +279,7 @@ public class ManageFrame extends FrameInterfaceGrpc.FrameInterfaceImplBase {
                     .setRenderPartition(partition)
                     .build());
             responseObserver.onCompleted();
-        }
-        else {
+        } else {
             responseObserver.onError(Status.INTERNAL
                     .withDescription("Failed to find suitable frames.")
                     .augmentDescription("customException()")

--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageFrame.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageFrame.java
@@ -280,10 +280,12 @@ public class ManageFrame extends FrameInterfaceGrpc.FrameInterfaceImplBase {
                     .build());
             responseObserver.onCompleted();
         }
-        responseObserver.onError(Status.INTERNAL
-                .withDescription("Failed to find suitable frames.")
-                .augmentDescription("customException()")
-                .asRuntimeException());
+        else {
+            responseObserver.onError(Status.INTERNAL
+                    .withDescription("Failed to find suitable frames.")
+                    .augmentDescription("customException()")
+                    .asRuntimeException());
+        }
     }
 
     @Override

--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageJob.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageJob.java
@@ -569,15 +569,23 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
         lha.setType(RenderPartitionType.JOB_PARTITION);
 
         if (localBookingSupport.bookLocal(job, request.getHost(), request.getUsername(), lha)) {
-            RenderPartition renderPart = whiteboard.getRenderPartition(lha);
-            responseObserver.onNext(JobAddRenderPartResponse.newBuilder()
-                    .setRenderPartition(renderPart)
-                    .build());
-            responseObserver.onCompleted();
+            try {
+                RenderPartition renderPart = whiteboard.getRenderPartition(lha);
+                responseObserver.onNext(JobAddRenderPartResponse.newBuilder()
+                        .setRenderPartition(renderPart)
+                        .build());
+                responseObserver.onCompleted();
+            } catch (EmptyResultDataAccessException e) {
+                responseObserver.onError(Status.INTERNAL
+                        .withDescription("Failed to allocate render partition to host.")
+                        .asRuntimeException());
+            }
         }
-        responseObserver.onError(Status.INTERNAL
-                .withDescription("Failed to find suitable frames.")
-                .asRuntimeException());
+        else {
+            responseObserver.onError(Status.INTERNAL
+                    .withDescription("Failed to find suitable frames.")
+                    .asRuntimeException());
+        }
     }
 
     @Override

--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageJob.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageJob.java
@@ -580,8 +580,7 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
                         .withDescription("Failed to allocate render partition to host.")
                         .asRuntimeException());
             }
-        }
-        else {
+        } else {
             responseObserver.onError(Status.INTERNAL
                     .withDescription("Failed to find suitable frames.")
                     .asRuntimeException());


### PR DESCRIPTION
Add a `try catch` block to protect the method from being called with
non-existing frames and fix a logic problem on addRenderPartition that
would always return error.