### PR TITLE
Add method addRenderPartition to api wrappers

### DIFF
--- a/pycue/opencue/wrappers/frame.py
+++ b/pycue/opencue/wrappers/frame.py
@@ -22,6 +22,7 @@ Module: frame.py - opencue Library implementation of a frame
 
 import enum
 import time
+import os
 
 from opencue import Cuebot
 from opencue.compiled_proto import job_pb2
@@ -71,6 +72,28 @@ class Frame(object):
         """Retry frame"""
         if self.data.state != job_pb2.FrameState.Value('WAITING'):
             self.stub.Retry(job_pb2.FrameRetryRequest(frame=self.data), timeout=Cuebot.Timeout)
+
+    def addRenderPartition(self, hostname, threads, max_cores, num_mem, max_gpu):
+        """Add a render partition to the frame.
+        @type  hostname: str
+        @param hostname: hostname of the partition
+        @type  threads: int
+        @param threads: number of threads of the partition
+        @type  max_cores: int
+        @param max_cores: max cores enabled for the partition
+        @type  num_mem: int
+        @param num_mem: amount of memory reserved for the partition
+        @type  max_gpu: int
+        @param max_gpu: max gpu cores enabled for the partition
+        """
+        response = self.stub.AddRenderPartition(
+            job_pb2.FrameAddRenderPartitionRequest(frame=self.data,
+                                                   host=hostname,
+                                                   threads=threads,
+                                                   max_cores=max_cores,
+                                                   max_memory=num_mem,
+                                                   max_gpu=max_gpu,
+                                                   username=os.getenv("USER", "unknown")))
 
     def getWhatDependsOnThis(self):
         """Returns a list of dependencies that depend directly on this frame.

--- a/pycue/opencue/wrappers/job.py
+++ b/pycue/opencue/wrappers/job.py
@@ -206,6 +206,28 @@ class Job(object):
         self.stub.SetAutoEat(job_pb2.JobSetAutoEatRequest(job=self.data, value=value),
                              timeout=Cuebot.Timeout)
 
+    def addRenderPartition(self, hostname, threads, max_cores, num_mem, max_gpu):
+        """Add a render partition to the job.
+        @type  hostname: str
+        @param hostname: hostname of the partition
+        @type  threads: int
+        @param threads: number of threads of the partition
+        @type  max_cores: int
+        @param max_cores: max cores enabled for the partition
+        @type  num_mem: int
+        @param num_mem: amount of memory reserved for the partition
+        @type  max_gpu: int
+        @param max_gpu: max gpu cores enabled for the partition
+        """
+        self.stub.AddRenderPartition(
+            job_pb2.JobAddRenderPartRequest(job=self.data,
+                                            host=hostname,
+                                            threads=threads,
+                                            max_cores=max_cores,
+                                            max_memory=num_mem,
+                                            max_gpu=max_gpu,
+                                            username=os.getenv("USER", "unknown")))
+
     def getWhatDependsOnThis(self):
         """Returns a list of dependencies that depend directly on this job.
 

--- a/pycue/opencue/wrappers/layer.py
+++ b/pycue/opencue/wrappers/layer.py
@@ -20,6 +20,7 @@ implementation of a layer in opencue
 """
 
 import enum
+import os
 
 from opencue.compiled_proto import job_pb2
 from opencue.cuebot import Cuebot
@@ -160,6 +161,28 @@ class Layer(object):
         return self.stub.SetThreadable(job_pb2.LayerSetThreadableRequest(
             layer=self.data, threadable=threadable),
             timeout=Cuebot.Timeout)
+
+    def addRenderPartition(self, hostname, threads, max_cores, num_mem, max_gpu):
+        """Add a render partition to the layer.
+        @type  hostname: str
+        @param hostname: hostname of the partition
+        @type  threads: int
+        @param threads: number of threads of the partition
+        @type  max_cores: int
+        @param max_cores: max cores enabled for the partition
+        @type  num_mem: int
+        @param num_mem: amount of memory reserved for the partition
+        @type  max_gpu: int
+        @param max_gpu: max gpu cores enabled for the partition
+        """
+        self.stub.AddRenderPartition(
+            job_pb2.LayerAddRenderPartitionRequest(layer=self.data,
+                                                   host=hostname,
+                                                   threads=threads,
+                                                   max_cores=max_cores,
+                                                   max_memory=num_mem,
+                                                   max_gpu=max_gpu,
+                                                   username=os.getenv("USER", "unknown")))
 
     def getWhatDependsOnThis(self):
         """Gets a list of dependencies that depend directly on this layer.


### PR DESCRIPTION
The new method only exposes an existing feature from job_pb2 to api users in the job, frame and
layer wrappers.