### PR TITLE
Protect job updates to avoid accessing closed views

### DIFF
--- a/cuegui/cuegui/CueJobMonitorTree.py
+++ b/cuegui/cuegui/CueJobMonitorTree.py
@@ -428,10 +428,13 @@ class CueJobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
 
             for jobId in group.data.jobs:
                 job = opencue.api.getJob(jobId)
-                if job.id() in self._items:
-                    self._items[job.id()].update(job, groupItem)
-                else:
-                    self._items[job.id()] = JobWidgetItem(job, groupItem)
+                try:
+                    if job.id() in self._items:
+                        self._items[job.id()].update(job, groupItem)
+                    else:
+                        self._items[job.id()] = JobWidgetItem(job, groupItem)
+                except RuntimeError:
+                    logger.warning("Failed to create tree item. RootView might be closed", exc_info=True)
 
     def mouseDoubleClickEvent(self,event):
         objects = self.selectedObjects()


### PR DESCRIPTION
Closing a tab that has jobs on a treeView causes the updated function to
access a non-existing object