### PR TITLE
Allow setting RQD_CREATE_USER_IF_NOT_EXISTS in rqd.conf

### DIFF
--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -186,6 +186,8 @@ try:
             DEFAULT_FACILITY = config.get(__section, "DEFAULT_FACILITY")
         if config.has_option(__section, "LAUNCH_FRAME_USER_GID"):
             LAUNCH_FRAME_USER_GID = config.getint(__section, "LAUNCH_FRAME_USER_GID")
+        if config.has_option(__section, "RQD_CREATE_USER_IF_NOT_EXISTS"):
+            RQD_CREATE_USER_IF_NOT_EXISTS = config.getboolean(__section, "RQD_CREATE_USER_IF_NOT_EXISTS")
 except Exception as e:
     logging.warning("Failed to read values from config file %s due to %s at %s" % (CONFIG_FILE, e, traceback.extract_tb(sys.exc_info()[2])))
 

--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -244,10 +244,17 @@ class FrameAttendantThread(threading.Thread):
 
         self.__createEnvVariables()
         self.__writeHeader()
-        if rqd.rqconstants.RQD_CREATE_USER_IF_NOT_EXISTS:
-            rqd.rqutil.permissionsHigh()
-            rqd.rqutil.checkAndCreateUser(runFrame.user_name)
-            rqd.rqutil.permissionsLow()
+
+        if not rqd.rqutil.checkUserExists(runFrame.user_name):
+            if rqd.rqconstants.RQD_CREATE_USER_IF_NOT_EXISTS:
+                rqd.rqutil.permissionsHigh()
+                creatingUserMsg = "Creating user %s." % runFrame.user_name
+                print(creatingUserMsg, file=self.rqlog)
+                rqd.rqutil.createUser(runFrame.user_name)
+                rqd.rqutil.permissionsLow()
+            else:
+                noUserErr = "User %s does not exist." % runFrame.user_name
+                print(noUserErr, file=self.rqlog)
 
         tempStatFile = "%srqd-stat-%s-%s" % (self.rqCore.machine.getTempPath(),
                                              frameInfo.frameId,

--- a/rqd/rqd/rqutil.py
+++ b/rqd/rqd/rqutil.py
@@ -123,20 +123,23 @@ def __becomeRoot():
         except Exception:
             pass
 
-
-def checkAndCreateUser(username):
-    """Check to see if the provided user exists, if not attempt to create it."""
+def checkUserExists(username):
+    """Check to see if the provided user exists."""
     # TODO(gregdenton): Add Windows and Mac support here. (Issue #61)
     try:
         pwd.getpwnam(username)
-        return
+        return True
     except KeyError:
-        subprocess.check_call([
-            'useradd',
-            '-p', str(uuid.uuid4()), # generate a random password
-            username
-        ])
+        return False
 
+def createUser(username):
+    """Create user."""
+    # TODO(gregdenton): Add Windows and Mac support here. (Issue #61)
+    subprocess.check_call([
+        'useradd',
+        '-p', str(uuid.uuid4()), # generate a random password
+        username
+    ])
 
 def getHostIp():
     """Returns the machine's local ip address"""

--- a/rqd/tests/rqcore_tests.py
+++ b/rqd/tests/rqcore_tests.py
@@ -541,7 +541,8 @@ class RqCoreTests(unittest.TestCase):
         self.assertEqual(0, self.rqcore.cores.locked_cores)
 
 
-@mock.patch('rqd.rqutil.checkAndCreateUser', new=mock.MagicMock())
+@mock.patch('rqd.rqutil.createUser', new=mock.MagicMock())
+@mock.patch('rqd.rqutil.checkUserExists', new=mock.MagicMock())
 @mock.patch('rqd.rqutil.permissionsHigh', new=mock.MagicMock())
 @mock.patch('rqd.rqutil.permissionsLow', new=mock.MagicMock())
 @mock.patch('subprocess.Popen')


### PR DESCRIPTION
Fixes #693 .

Added an RQD configuration line -- rqd.conf now has the capacity to set RQD_CREATE_USER_IF_NOT_EXISTS = False (it defaults to True to keep backwards compatibilty).
Removed the rqutil.checkAndCreateUser() method and replaced with checkUserExists() and createUser() methods.

Their functionality is inherently identical to the original method, just divided up such that inside rqcore.runLinux() can check if the user exists, then if RQD_CREATE_USER_IF_NOT_EXISTS=True it creates the user, otherwise it doesn't and the impending subprocess call will (correctly) fail as the user won't exist in the passwd database.