### PR TITLE
fixed sed hack with 2to3 

### DIFF
--- a/ci/build_sphinx_docs.sh
+++ b/ci/build_sphinx_docs.sh
@@ -10,7 +10,7 @@ python -m grpc_tools.protoc -I=proto/ --python_out=pycue/opencue/compiled_proto 
 
 # Fix imports to work in both Python 2 and 3. See
 # <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
-sed -i 's/^\(import.*_pb2\)/from . \1/' pycue/opencue/compiled_proto/*.py
+2to3 -wn -f import pycue/opencue/compiled_proto/*_pb2*.py
 
 # Build the docs and treat warnings as errors
 ~/.local/bin/sphinx-build -W -b html -d docs/_build/doctrees docs docs/_build/html

--- a/ci/run_python_tests.sh
+++ b/ci/run_python_tests.sh
@@ -10,7 +10,8 @@ python -m grpc_tools.protoc -I=proto/ --python_out=rqd/rqd/compiled_proto --grpc
 
 # Fix imports to work in both Python 2 and 3. See
 # <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
-sed -i 's/^\(import.*_pb2\)/from . \1/' pycue/opencue/compiled_proto/*.py rqd/rqd/compiled_proto/*.py
+2to3 -wn -f import pycue/opencue/compiled_proto/*_pb2*.py
+2to3 -wn -f import rqd/rqd/compiled_proto/*_pb2*.py
 
 python pycue/setup.py test
 PYTHONPATH=pycue python pyoutline/setup.py test

--- a/cueadmin/Dockerfile
+++ b/cueadmin/Dockerfile
@@ -40,7 +40,7 @@ RUN python -m grpc_tools.protoc \
 
 # Fix imports to work in both Python 2 and 3. See
 # <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
-RUN sed -i 's/^\(import.*_pb2\)/from . \1/' pycue/opencue/compiled_proto/*.py
+RUN 2to3 -wn -f import pycue/opencue/compiled_proto/*_pb2*.py
 
 COPY cueadmin/README.md ./cueadmin/
 COPY cueadmin/setup.py ./cueadmin/

--- a/cuegui/Dockerfile
+++ b/cuegui/Dockerfile
@@ -50,7 +50,7 @@ RUN python -m grpc_tools.protoc \
 
 # Fix imports to work in both Python 2 and 3. See
 # <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
-RUN sed -i 's/^\(import.*_pb2\)/from . \1/' pycue/opencue/compiled_proto/*.py
+RUN 2to3 -wn -f import pycue/opencue/compiled_proto/*_pb2*.py
 
 COPY cuegui/README.md ./cuegui/
 COPY cuegui/setup.py ./cuegui/

--- a/cuesubmit/Dockerfile
+++ b/cuesubmit/Dockerfile
@@ -42,7 +42,7 @@ RUN python -m grpc_tools.protoc \
 
 # Fix imports to work in both Python 2 and 3. See
 # <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
-RUN sed -i 's/^\(import.*_pb2\)/from . \1/' pycue/opencue/compiled_proto/*.py
+RUN 2to3 -wn -f import pycue/opencue/compiled_proto/*_pb2*.py
 
 COPY pyoutline/README.md ./pyoutline/
 COPY pyoutline/setup.py ./pyoutline/

--- a/pycue/Dockerfile
+++ b/pycue/Dockerfile
@@ -41,7 +41,7 @@ RUN python -m grpc_tools.protoc \
 
 # Fix imports to work in both Python 2 and 3. See
 # <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
-RUN sed -i 's/^\(import.*_pb2\)/from . \1/' pycue/opencue/compiled_proto/*.py
+RUN 2to3 -wn -f import pycue/opencue/compiled_proto/*_pb2*.py
 
 # TODO(bcipriano) Lint the code here. (Issue #78)
 

--- a/pyoutline/Dockerfile
+++ b/pyoutline/Dockerfile
@@ -40,7 +40,7 @@ RUN python -m grpc_tools.protoc \
 
 # Fix imports to work in both Python 2 and 3. See
 # <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
-RUN sed -i 's/^\(import.*_pb2\)/from . \1/' pycue/opencue/compiled_proto/*.py
+RUN 2to3 -wn -f import pycue/opencue/compiled_proto/*_pb2*.py
 
 COPY pyoutline/README.md ./pyoutline/
 COPY pyoutline/setup.py ./pyoutline/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+2to3==1.0
 enum34==1.1.6
 future==0.17.1
 futures==3.2.0;python_version<"3.0"
@@ -11,4 +12,3 @@ pyfakefs==3.6
 PyYAML==5.1
 simplejson==3.16.0
 six==1.11.0
-2to3==1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pyfakefs==3.6
 PyYAML==5.1
 simplejson==3.16.0
 six==1.11.0
+2to3==1.0

--- a/rqd/Dockerfile
+++ b/rqd/Dockerfile
@@ -38,7 +38,7 @@ RUN python3.6 -m grpc_tools.protoc \
 
 # Fix imports to work in both Python 2 and 3. See
 # <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
-RUN sed -i 's/^\(import.*_pb2\)/from . \1/' rqd/rqd/compiled_proto/*.py
+RUN 2to3 -wn -f import rqd/rqd/compiled_proto/*_pb2*.py
 
 # TODO(bcipriano) Lint the code here. (Issue #78)
 


### PR DESCRIPTION
As mentioned in PR #669 
a fresh build that replaces sed hack with 2to3 everywhere, fixes #660

Replaced sed imports with the usage of 2to3 tool everywhere, the changes were mostly in the dockerfiles but there were 1-2 shell scripts too
Added 2to3 in the requrements too