### PR TITLE
Add some debugging info to generate_version_number.sh.

### DIFF
--- a/.github/workflows/packaging-pipeline.yml
+++ b/.github/workflows/packaging-pipeline.yml
@@ -17,7 +17,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set build ID
         run: |
+          set -e
           ci/generate_version_number.sh > VERSION
+          echo "Build ID: $(cat ./VERSION)"
           echo "::set-env name=BUILD_ID::$(cat ./VERSION)"
       - uses: docker/build-push-action@v1
         name: Build Docker image

--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -10,7 +10,7 @@ jobs:
   print_version_number:
     name: Print Version Number
     runs-on: ubuntu-latest
-    container: aswf/ci-opencue:2019
+    #container: aswf/ci-opencue:2019
     steps:
       - uses: actions/checkout@v2
       - name: Run script

--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -10,7 +10,7 @@ jobs:
   print_version_number:
     name: Print Version Number
     runs-on: ubuntu-latest
-    #container: aswf/ci-opencue:2019
+    container: aswf/ci-opencue:2019
     steps:
       - uses: actions/checkout@v2
       - name: Run script

--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -13,7 +13,7 @@ jobs:
     container: aswf/ci-opencue:2019
     steps:
       - name: Upgrade Git
-        run: yum -y install https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.7-1.x86_64.rpm && yum install git
+        run: yum -y install https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.7-1.x86_64.rpm && yum -y install git
       - uses: actions/checkout@v2
       - name: Run script
         run: ci/generate_version_number.sh

--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -7,17 +7,6 @@ on:
     branches: [ master ]
 
 jobs:
-  print_version_number:
-    name: Print Version Number
-    runs-on: ubuntu-latest
-    container: aswf/ci-opencue:2019
-    steps:
-      - name: Upgrade Git
-        run: yum -y install https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.7-1.x86_64.rpm && yum -y install git
-      - uses: actions/checkout@v2
-      - name: Run script
-        run: ci/generate_version_number.sh
-
   test_python_2019:
     name: Run Python Unit Tests (CY2019)
     runs-on: ubuntu-latest

--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -7,6 +7,14 @@ on:
     branches: [ master ]
 
 jobs:
+  print_version_number:
+    name: Print Version Number
+    runs-on: ubuntu-latest
+    container: aswf/ci-opencue:2019
+    steps:
+      - name: Run script
+        run: ci/generate_version_number.sh
+
   test_python_2019:
     name: Run Python Unit Tests (CY2019)
     runs-on: ubuntu-latest

--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     container: aswf/ci-opencue:2019
     steps:
+      - uses: actions/checkout@v2
       - name: Run script
         run: ci/generate_version_number.sh
 

--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     container: aswf/ci-opencue:2019
     steps:
+      - name: Upgrade Git
+        run: yum -y install https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.7-1.x86_64.rpm && yum install git
       - uses: actions/checkout@v2
       - name: Run script
         run: ci/generate_version_number.sh

--- a/ci/generate_version_number.sh
+++ b/ci/generate_version_number.sh
@@ -49,7 +49,7 @@ version_major_minor="$(cat "$version_in" | sed 's/[[:space:]]//g')"
 
 current_branch="$(git branch --show-current)"
 >&2 echo "Current branch: ${current_branch}"
-if [[ ! -z "${current_branch}" ]]; then
+if [[ -z "${current_branch}" ]]; then
   >&2 echo "Falling back"
   current_branch="$(git branch --remote --verbose --no-abbrev --contains | ${sed_cmd} -rne 's/^[^\/]*\/([^\ ]+).*$/\1/p')"
 fi

--- a/ci/generate_version_number.sh
+++ b/ci/generate_version_number.sh
@@ -42,6 +42,8 @@ else
   sed_cmd="sed"
 fi
 
+echo $(git status)
+
 version_major_minor="$(cat "$version_in" | sed 's/[[:space:]]//g')"
 >&2 echo "Base version number: ${version_major_minor}"
 current_branch="$(git branch --show-current)"

--- a/ci/generate_version_number.sh
+++ b/ci/generate_version_number.sh
@@ -41,7 +41,8 @@ else
 fi
 
 version_major_minor="$(cat "$version_in" | sed 's/[[:space:]]//g')"
-current_branch="$(git branch --remote --verbose --no-abbrev --contains | ${sed_cmd} -rne 's/^[^\/]*\/([^\ ]+).*$/\1/p')"
+current_branch="$(git branch --show-current)"
+>&2 echo "Current branch: ${current_branch}"
 
 git fetch origin
 

--- a/ci/generate_version_number.sh
+++ b/ci/generate_version_number.sh
@@ -48,7 +48,9 @@ version_major_minor="$(cat "$version_in" | sed 's/[[:space:]]//g')"
 >&2 echo "Base version number: ${version_major_minor}"
 
 current_branch="$(git branch --show-current)"
+>&2 echo "Current branch: ${current_branch}"
 if [[ ! -z "${current_branch}" ]]; then
+  >&2 echo "Falling back"
   current_branch="$(git branch --remote --verbose --no-abbrev --contains | ${sed_cmd} -rne 's/^[^\/]*\/([^\ ]+).*$/\1/p')"
 fi
 >&2 echo "Current branch: ${current_branch}"

--- a/ci/generate_version_number.sh
+++ b/ci/generate_version_number.sh
@@ -42,14 +42,15 @@ else
   sed_cmd="sed"
 fi
 
-echo $(git status)
-
-echo $(git branch --remote --verbose --no-abbrev --contains | ${sed_cmd} -rne 's/^[^\/]*\/([^\ ]+).*$/\1/p')
-
+>&2 echo $(git status)
 
 version_major_minor="$(cat "$version_in" | sed 's/[[:space:]]//g')"
 >&2 echo "Base version number: ${version_major_minor}"
+
 current_branch="$(git branch --show-current)"
+if [[ ! -z "${current_branch}" ]]; then
+  current_branch="$(git branch --remote --verbose --no-abbrev --contains | ${sed_cmd} -rne 's/^[^\/]*\/([^\ ]+).*$/\1/p')"
+fi
 >&2 echo "Current branch: ${current_branch}"
 
 git fetch origin

--- a/ci/generate_version_number.sh
+++ b/ci/generate_version_number.sh
@@ -29,6 +29,8 @@
 
 set -e
 
+>&2 echo "Starting"
+
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 toplevel_dir="$(dirname "$script_dir")"
 
@@ -41,6 +43,7 @@ else
 fi
 
 version_major_minor="$(cat "$version_in" | sed 's/[[:space:]]//g')"
+>&2 echo "Base version number: ${version_major_minor}"
 current_branch="$(git branch --show-current)"
 >&2 echo "Current branch: ${current_branch}"
 

--- a/ci/generate_version_number.sh
+++ b/ci/generate_version_number.sh
@@ -29,8 +29,6 @@
 
 set -e
 
->&2 echo "Starting"
-
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 toplevel_dir="$(dirname "$script_dir")"
 
@@ -41,8 +39,6 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
 else
   sed_cmd="sed"
 fi
-
->&2 echo $(git status)
 
 version_major_minor="$(cat "$version_in" | sed 's/[[:space:]]//g')"
 >&2 echo "Base version number: ${version_major_minor}"
@@ -59,6 +55,7 @@ git fetch origin
 
 if [[ "$current_branch" = "master" ]]; then
   commit_count=$(git rev-list --count $(git log --follow -1 --pretty=%H "$version_in")..HEAD)
+  >&2 echo "Commit count since last release: ${commit_count}"
   full_version="${version_major_minor}.${commit_count}"
 else
   commit_count_in_master=$(git rev-list --count $(git log --follow -1 --pretty=%H "$version_in")..origin/master)

--- a/ci/generate_version_number.sh
+++ b/ci/generate_version_number.sh
@@ -44,6 +44,9 @@ fi
 
 echo $(git status)
 
+echo $(git branch --remote --verbose --no-abbrev --contains | ${sed_cmd} -rne 's/^[^\/]*\/([^\ ]+).*$/\1/p')
+
+
 version_major_minor="$(cat "$version_in" | sed 's/[[:space:]]//g')"
 >&2 echo "Base version number: ${version_major_minor}"
 current_branch="$(git branch --show-current)"


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
https://github.com/AcademySoftwareFoundation/OpenCue/issues/715

**Summarize your change.**
The version number isn't being generated correctly when Github Actions runs against the master branch, and I need some additional debugging info to figure out why.

This also fixes an issue I had on my local workstation where an incorrect version number would be generated when the current branch was `master`. Using `git branch --show-current` fixes this, but that method isn't available when using Github Actions on a PR branch, so we need to use the current method as a fallback still.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.
-->
