### PR TITLE
Handle Windows compatibility issues

### DIFF
--- a/pyoutline/bin/cuerunbase.py
+++ b/pyoutline/bin/cuerunbase.py
@@ -134,7 +134,11 @@ class AbstractCuerun(object):
         self.__evh = event.EventHandler(self)
 
         # Setup a sigbus signal handler.
-        signal.signal(signal.SIGBUS, signal_handler)
+        try:
+            signal.signal(signal.SIGBUS, signal_handler)
+        except ValueError:
+            # Not every system implements SIGBUS.
+            pass
 
     def add_my_options(self):
         """Implemented by subclass."""

--- a/pyoutline/outline/backend/cue.py
+++ b/pyoutline/outline/backend/cue.py
@@ -215,9 +215,7 @@ def _serialize(launcher, use_pycuerun):
     if not launcher.get("nomail"):
         sub_element(root, "email", "%s@%s" % (user,
                                               config.get("outline", "domain")))
-    uid = util.get_uid()
-    if uid is not None:
-        sub_element(root, "uid", str(uid))
+    sub_element(root, "uid", str(util.get_uid()))
 
     j = Et.SubElement(root, "job", {"name": ol.get_name()})
     sub_element(j, "paused", str(launcher.get("pause")))

--- a/pyoutline/outline/util.py
+++ b/pyoutline/outline/util.py
@@ -126,6 +126,6 @@ def get_uid():
     Return the current users id
     """
     if platform.system() == 'Windows':
-        return None
+        return 1
 
     return os.getuid()

--- a/rqd/rqd/__main__.py
+++ b/rqd/rqd/__main__.py
@@ -78,6 +78,8 @@ def setupLogging():
             logfile = logging.handlers.SysLogHandler(address=syslogAddress)
         else:
             logfile = logging.handlers.SysLogHandler()
+    elif platform.system() == 'Windows':
+        logfile = logging.FileHandler(os.path.expandvars('%TEMP%/openrqd.log'))
     else:
         logfile = logging.handlers.SysLogHandler()
     logfile.setLevel(fileLevel)

--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -116,7 +116,7 @@ class FrameAttendantThread(threading.Thread):
                 rqd_tmp_dir = os.path.join(tempfile.gettempdir(), 'rqd')
                 try:
                     os.mkdir(rqd_tmp_dir)
-                except FileExistsError:
+                except OSError:
                     pass  # okay, already exists
 
                 commandFile = os.path.join(


### PR DESCRIPTION
**Summarize your change.**
Handle issues with rqd and pyoutline running on windows environments.

Errors fixed by this PR:
- UnboundLocalError: local variable 'commandFile' referenced before assignment
- AttributeError: 'RunningFrame' object has no attribute 'forkedCommand'
- RuntimeError: Unable to rotate previous log file due to [Error 32]
- com.imageworks.spcue.rqd.RqdClientException: failed to launch frame

Details of the implementation:
- Although Windows lacks an uid, the backend is not prepared to handle jobs without uid. For now we're returning and arbitrary number, which will not impact the job execution down the line.
- SysLogHandler is specific for linux based systems. 
- Windows doesn't implement SIGBUS
- Windows handles file access exceptions under OSError