### PR TITLE
Fetch full Git history in packaging pipeline.

### DIFF
--- a/.github/workflows/packaging-pipeline.yml
+++ b/.github/workflows/packaging-pipeline.yml
@@ -15,6 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          # Fetch all Git history, otherwise the current version number will
+          # not be correctly calculated.
+          fetch-depth: 0
       - name: Set build ID
         run: |
           set -e

--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -13,7 +13,8 @@ jobs:
     #container: aswf/ci-opencue:2019
     steps:
       - uses: actions/checkout@v2
-        fetch-depth: 0
+        with:
+          fetch-depth: 0
       - name: Print Build ID
         run: |
           set -e

--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -13,6 +13,7 @@ jobs:
     #container: aswf/ci-opencue:2019
     steps:
       - uses: actions/checkout@v2
+        fetch-depth: 0
       - name: Print Build ID
         run: |
           set -e

--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -2,27 +2,11 @@ name: OpenCue Testing Pipeline
 
 on:
   push:
-    branches: [ master, fix-version-number ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 
 jobs:
-  test_build_id:
-    name: Test Build ID
-    runs-on: ubuntu-latest
-    #container: aswf/ci-opencue:2019
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          # Fetch all Git history, otherwise the current version number will
-          # not be correctly calculated.
-          fetch-depth: 0
-      - name: Print Build ID
-        run: |
-          set -e
-          ci/generate_version_number.sh > VERSION
-          echo "Build ID: $(cat ./VERSION)"
-
   test_python_2019:
     name: Run Python Unit Tests (CY2019)
     runs-on: ubuntu-latest

--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -2,7 +2,7 @@ name: OpenCue Testing Pipeline
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, fix-version-number ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          # Fetch all Git history, otherwise the current version number will
+          # not be correctly calculated.
           fetch-depth: 0
       - name: Print Build ID
         run: |

--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -7,6 +7,18 @@ on:
     branches: [ master ]
 
 jobs:
+  test_build_id:
+    name: Test Build ID
+    runs-on: ubuntu-latest
+    #container: aswf/ci-opencue:2019
+    steps:
+      - uses: actions/checkout@v2
+      - name: Print Build ID
+        run: |
+          set -e
+          ci/generate_version_number.sh > VERSION
+          echo "Build ID: $(cat ./VERSION)"
+
   test_python_2019:
     name: Run Python Unit Tests (CY2019)
     runs-on: ubuntu-latest

--- a/ci/generate_version_number.sh
+++ b/ci/generate_version_number.sh
@@ -32,7 +32,7 @@ set -e
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 toplevel_dir="$(dirname "$script_dir")"
 
-version_in="$toplevel_dir/VERSION.in"
+version_in="${toplevel_dir}/VERSION.in"
 
 if [[ "$(uname -s)" = "Darwin" ]]; then
   sed_cmd="gsed"
@@ -41,26 +41,18 @@ else
 fi
 
 version_major_minor="$(cat "$version_in" | sed 's/[[:space:]]//g')"
->&2 echo "Base version number: ${version_major_minor}"
 
 current_branch="$(git branch --show-current)"
->&2 echo "Current branch: ${current_branch}"
 if [[ -z "${current_branch}" ]]; then
-  >&2 echo "Falling back"
   current_branch="$(git branch --remote --verbose --no-abbrev --contains | ${sed_cmd} -rne 's/^[^\/]*\/([^\ ]+).*$/\1/p')"
 fi
->&2 echo "Current branch: ${current_branch}"
-
-git fetch origin
 
 if [[ "$current_branch" = "master" ]]; then
-  commit_count=$(git rev-list --count $(git log --follow -1 --pretty=%H "$version_in")..HEAD)
+  commit_count=$(git rev-list --count $(git log --follow -1 --pretty=%H "${version_in}")..HEAD)
   >&2 echo "Commit count since last release: ${commit_count}"
   full_version="${version_major_minor}.${commit_count}"
 else
-  cmd="git log --follow -1 --pretty=%H \"$version_in\""
-  >&2 echo "cmd: $cmd"
-  last_changed_commit=$(git log --follow -1 --pretty=%H "$version_in")
+  last_changed_commit=$(git log --follow -1 --pretty=%H "${version_in}")
   >&2 echo "version file last changed commit: ${last_changed_commit}"
   commit_count_in_master=$(git rev-list --count $(git log --follow -1 --pretty=%H "$version_in")..origin/master)
   >&2 echo "Commit count since last release: ${commit_count_in_master}"

--- a/ci/generate_version_number.sh
+++ b/ci/generate_version_number.sh
@@ -58,6 +58,8 @@ if [[ "$current_branch" = "master" ]]; then
   >&2 echo "Commit count since last release: ${commit_count}"
   full_version="${version_major_minor}.${commit_count}"
 else
+  cmd="git log --follow -1 --pretty=%H \"$version_in\""
+  >&2 echo "cmd: $cmd"
   last_changed_commit=$(git log --follow -1 --pretty=%H "$version_in")
   >&2 echo "version file last changed commit: ${last_changed_commit}"
   commit_count_in_master=$(git rev-list --count $(git log --follow -1 --pretty=%H "$version_in")..origin/master)

--- a/ci/generate_version_number.sh
+++ b/ci/generate_version_number.sh
@@ -58,7 +58,10 @@ if [[ "$current_branch" = "master" ]]; then
   >&2 echo "Commit count since last release: ${commit_count}"
   full_version="${version_major_minor}.${commit_count}"
 else
+  last_changed_commit=$(git log --follow -1 --pretty=%H "$version_in")
+  >&2 echo "version file last changed commit: ${last_changed_commit}"
   commit_count_in_master=$(git rev-list --count $(git log --follow -1 --pretty=%H "$version_in")..origin/master)
+  >&2 echo "Commit count since last release: ${commit_count}"
   commit_short_hash=$(git rev-parse --short HEAD)
   full_version="${version_major_minor}.$((commit_count_in_master + 1))-${commit_short_hash}"
 fi

--- a/ci/generate_version_number.sh
+++ b/ci/generate_version_number.sh
@@ -61,7 +61,7 @@ else
   last_changed_commit=$(git log --follow -1 --pretty=%H "$version_in")
   >&2 echo "version file last changed commit: ${last_changed_commit}"
   commit_count_in_master=$(git rev-list --count $(git log --follow -1 --pretty=%H "$version_in")..origin/master)
-  >&2 echo "Commit count since last release: ${commit_count}"
+  >&2 echo "Commit count since last release: ${commit_count_in_master}"
   commit_short_hash=$(git rev-parse --short HEAD)
   full_version="${version_major_minor}.$((commit_count_in_master + 1))-${commit_short_hash}"
 fi

--- a/ci/testing-pipeline.yml
+++ b/ci/testing-pipeline.yml
@@ -9,6 +9,16 @@ trigger:
 - fix-version-number
 
 jobs:
+- job: testBuildId
+  displayName: Test Build ID
+  pool:
+    vmImage: 'ubuntu-16.04'
+  #container: aswf/ci-opencue:2019.0
+  steps:
+  - bash: ci/generate_version_number.sh
+    name: printBuildId
+    displayName: Print Build ID
+
 - job: testPython2019
   displayName: Test Python Components (CY 2019)
   pool:

--- a/ci/testing-pipeline.yml
+++ b/ci/testing-pipeline.yml
@@ -6,6 +6,7 @@
 # the pipeline as well, by default.
 trigger:
 - master
+- fix-version-number
 
 jobs:
 - job: testPython2019

--- a/ci/testing-pipeline.yml
+++ b/ci/testing-pipeline.yml
@@ -6,19 +6,8 @@
 # the pipeline as well, by default.
 trigger:
 - master
-- fix-version-number
 
 jobs:
-- job: testBuildId
-  displayName: Test Build ID
-  pool:
-    vmImage: 'ubuntu-16.04'
-  #container: aswf/ci-opencue:2019.0
-  steps:
-  - bash: ci/generate_version_number.sh
-    name: printBuildId
-    displayName: Print Build ID
-
 - job: testPython2019
   displayName: Test Python Components (CY 2019)
   pool:


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
#715 

**Summarize your change.**
By default, Github's `checkout` action only fetches the last commit. If you're just working with the code that's fine, but if you're querying Git info within the workflow you end up getting some unexpected results. The most important problem was that version numbers were being generated incorrectly, as the version number is determined based on the full Git history (number of commits in master).

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.
-->
