### PR TITLE
Load job list by default and add setting to control that behavior.

### DIFF
--- a/cuegui/cuegui/JobMonitorTree.py
+++ b/cuegui/cuegui/JobMonitorTree.py
@@ -259,6 +259,15 @@ class JobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         for item in self.findItems("Finished", QtCore.Qt.MatchFixedString, COLUMN_STATE):
             self.removeItem(item)
 
+    def removeAllJobsExcept(self, keepList):
+        """Removes jobs where the name doesn't match the given search string"""
+        keepKeys = [cuegui.Utils.getObjectKey(job) for job in keepList]
+        existingItems = [self.topLevelItem(index) for index in range(self.topLevelItemCount())]
+        for existingItem in existingItems:
+            existingItemKey = cuegui.Utils.getObjectKey(existingItem.rpcObject)
+            if existingItemKey not in keepKeys:
+                self._removeItem(existingItem)
+
     def contextMenuEvent(self, e):
         """Creates a context menu when an item is right clicked.
         @param e: Right click QEvent

--- a/cuegui/cuegui/JobMonitorTree.py
+++ b/cuegui/cuegui/JobMonitorTree.py
@@ -260,10 +260,14 @@ class JobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
             self.removeItem(item)
 
     def removeAllJobsExcept(self, keepList):
-        """Removes jobs where the name doesn't match the given search string"""
-        keepKeys = [cuegui.Utils.getObjectKey(job) for job in keepList]
-        existingItems = [self.topLevelItem(index) for index in range(self.topLevelItemCount())]
-        for existingItem in existingItems:
+        """Removes all jobs except the ones specified.
+
+        :param keepList: List of jobs to keep monitoring.
+        :type  keepList: list of opencue.wrappers.job.Job
+        """
+        keepKeys = set(cuegui.Utils.getObjectKey(job) for job in keepList)
+        for index in range(self.topLevelItemCount()):
+            existingItem = self.topLevelItem(index)
             existingItemKey = cuegui.Utils.getObjectKey(existingItem.rpcObject)
             if existingItemKey not in keepKeys:
                 self._removeItem(existingItem)

--- a/cuegui/cuegui/config/cuecommander.ini
+++ b/cuegui/cuegui/config/cuecommander.ini
@@ -1,4 +1,5 @@
 [General]
+AutoLoadJobs=1
 LastNotice=1550605275
 Version=1.3.0
 


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Fixes #698 

**Summarize your change.**
Beginner OpenCue users have a reasonable expectation that on launching CueGUI they will see a list of jobs currently on the farm. The current behavior doesn't do this, but requires one of the job search options to change before loading jobs. This PR changes the default behavior and causes all jobs to be loaded on startup.

For advanced OpenCue users, this behavior may not be desirable due to having a large number of jobs, so we also add a `cuecommander.ini` setting to allow disabling this behavior.

This PR also fixes a bug where non-matching jobs would not be cleared from the monitored job list, leading to the perceived behavior that the job search was not working.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.
-->
