### PR TITLE
Updaing Socket code to support Windows.

### DIFF
--- a/rqd/rqd/rqutil.py
+++ b/rqd/rqd/rqutil.py
@@ -26,6 +26,7 @@ from __future__ import division
 from builtins import str
 from builtins import object
 import functools
+import logging as log
 import os
 import platform
 import random
@@ -150,7 +151,8 @@ def getHostname():
             return getHostIp()
         else:
             return socket.gethostbyaddr(socket.gethostname())[0].split('.')[0]
-    except socket.herror:
+    except (socket.herror, socket.gaierror):
+        log.warning("Failed to resolve hostname to IP, falling back to local hostname")
         return socket.gethostname()
 
 

--- a/rqd/rqd/rqutil.py
+++ b/rqd/rqd/rqutil.py
@@ -145,13 +145,12 @@ def getHostIp():
 
 def getHostname():
     """Returns the machine's fully qualified domain name"""
-    if platform.system() in ("Linux", "Windows"):
+    try:
         if rqd.rqconstants.RQD_USE_IP_AS_HOSTNAME:
             return getHostIp()
         else:
-            # This may not work in windows/mac, need to test
             return socket.gethostbyaddr(socket.gethostname())[0].split('.')[0]
-    else:
+    except socket.herror:
         return socket.gethostname()
 
 

--- a/rqd/rqd/rqutil.py
+++ b/rqd/rqd/rqutil.py
@@ -145,7 +145,7 @@ def getHostIp():
 
 def getHostname():
     """Returns the machine's fully qualified domain name"""
-    if platform.system() == "Linux":
+    if platform.system() in ("Linux", "Windows"):
         if rqd.rqconstants.RQD_USE_IP_AS_HOSTNAME:
             return getHostIp()
         else:


### PR DESCRIPTION
rqutil.py -- Lines 148 through 153 work on Linux and Windows, however fails on mac. 
Since we can grab IP on Windows & Linux easily we should use that when RQD_USE_IP_AS_HOSTNAME = TRUE

**Link the Issue(s) this Pull Request is related to.**
https://github.com/AcademySoftwareFoundation/OpenCue/issues/738