### PR TITLE
The call getInteger was renamed to getInt in pyside2

### DIFF
--- a/cuegui/cuegui/FilterDialog.py
+++ b/cuegui/cuegui/FilterDialog.py
@@ -430,7 +430,7 @@ class ActionMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                     value = float(value)
 
                 elif actionType in (opencue.api.filter_pb2.SET_JOB_PRIORITY,):
-                    (value, choice) = QtWidgets.QInputDialog.getInteger(
+                    (value, choice) = QtWidgets.QInputDialog.getInt(
                         self,
                         "Create Action",
                         "What value should this property be set to?",


### PR DESCRIPTION
Fix FilterDialog create action issue

The call getInteger was renamed to 'getInt' in pyside2, this update fixes the call to work with pyside2