### PR TITLE
Upgrade pip in all Docker images.

### DIFF
--- a/cueadmin/Dockerfile
+++ b/cueadmin/Dockerfile
@@ -19,12 +19,17 @@ RUN yum -y install \
   python36-devel \
   python36-pip
 
+RUN python -m pip install --upgrade pip
+RUN python3.6 -m pip install --upgrade pip
+
+RUN python -m pip install --upgrade setuptools
+RUN python3.6 -m pip install --upgrade setuptools
+
 COPY LICENSE ./
 COPY requirements.txt ./
 
-RUN pip install -r requirements.txt
-
-RUN pip3.6 install -r requirements.txt
+RUN python -m pip install -r requirements.txt
+RUN python3.6 -m pip install -r requirements.txt
 
 COPY proto/ ./proto
 COPY pycue/README.md ./pycue/

--- a/cuegui/Dockerfile
+++ b/cuegui/Dockerfile
@@ -26,15 +26,20 @@ RUN yum -y install \
   python36-devel \
   python36-pip
 
+RUN python -m pip install --upgrade pip
+RUN python3.6 -m pip install --upgrade pip
+
+RUN python -m pip install --upgrade setuptools
+RUN python3.6 -m pip install --upgrade setuptools
+
 RUN dbus-uuidgen > /etc/machine-id
 
 COPY LICENSE ./
 COPY requirements.txt ./
 COPY requirements_gui.txt ./
 
-RUN pip install -r requirements.txt -r requirements_gui.txt
-
-RUN pip3.6 install -r requirements.txt -r requirements_gui.txt
+RUN python -m pip install -r requirements.txt -r requirements_gui.txt
+RUN python3.6 -m pip install -r requirements.txt -r requirements_gui.txt
 
 COPY proto/ ./proto
 COPY pycue/README.md ./pycue/

--- a/cuesubmit/Dockerfile
+++ b/cuesubmit/Dockerfile
@@ -20,13 +20,18 @@ RUN yum -y install \
   python36-devel \
   python36-pip
 
+RUN python -m pip install --upgrade pip
+RUN python3.6 -m pip install --upgrade pip
+
+RUN python -m pip install --upgrade setuptools
+RUN python3.6 -m pip install --upgrade setuptools
+
 COPY LICENSE ./
 COPY requirements.txt ./
 COPY requirements_gui.txt ./
 
-RUN pip install -r requirements.txt -r requirements_gui.txt
-
-RUN pip3.6 install -r requirements.txt -r requirements_gui.txt
+RUN python -m pip install -r requirements.txt -r requirements_gui.txt
+RUN python3.6 -m pip install -r requirements.txt -r requirements_gui.txt
 
 COPY proto/ ./proto
 COPY pycue/README.md ./pycue/

--- a/pycue/Dockerfile
+++ b/pycue/Dockerfile
@@ -19,12 +19,17 @@ RUN yum -y install \
   python36-devel \
   python36-pip
 
+RUN python -m pip install --upgrade pip
+RUN python3.6 -m pip install --upgrade pip
+
+RUN python -m pip install --upgrade setuptools
+RUN python3.6 -m pip install --upgrade setuptools
+
 COPY LICENSE ./
 COPY requirements.txt ./
 
-RUN pip install -r requirements.txt
-
-RUN pip3.6 install -r requirements.txt
+RUN python -m pip install -r requirements.txt
+RUN python3.6 -m pip install -r requirements.txt
 
 COPY proto/ ./proto
 COPY pycue/README.md ./pycue/

--- a/pyoutline/Dockerfile
+++ b/pyoutline/Dockerfile
@@ -19,12 +19,17 @@ RUN yum -y install \
   python36-devel \
   python36-pip
 
+RUN python -m pip install --upgrade pip
+RUN python3.6 -m pip install --upgrade pip
+
+RUN python -m pip install --upgrade setuptools
+RUN python3.6 -m pip install --upgrade setuptools
+
 COPY LICENSE ./
 COPY requirements.txt ./
 
-RUN pip install -r requirements.txt
-
-RUN pip3.6 install -r requirements.txt
+RUN python -m pip install -r requirements.txt
+RUN python3.6 -m pip install -r requirements.txt
 
 COPY proto/ ./proto
 COPY pycue/README.md ./pycue/

--- a/rqd/Dockerfile
+++ b/rqd/Dockerfile
@@ -12,16 +12,19 @@ RUN yum -y install \
   python36-devel \
   python36-pip
 
-RUN pip install --upgrade setuptools
-RUN pip3.6 install --upgrade setuptools
+RUN python -m pip install --upgrade pip
+RUN python3.6 -m pip install --upgrade pip
+
+RUN python -m pip install --upgrade setuptools
+RUN python3.6 -m pip install --upgrade setuptools
 
 WORKDIR /opt/opencue
 
 COPY LICENSE ./
 COPY requirements.txt ./
 
-RUN pip install -r requirements.txt
-RUN pip3.6 install -r requirements.txt
+RUN python -m pip install -r requirements.txt
+RUN python3.6 -m pip install -r requirements.txt
 
 COPY proto/ ./proto
 COPY rqd/deploy ./rqd/deploy

--- a/rqd/setup.py
+++ b/rqd/setup.py
@@ -16,11 +16,6 @@ import os
 from setuptools import find_packages
 from setuptools import setup
 
-import setuptools
-print('foo')
-print(setuptools.__file__)
-print(setuptools.__version__)
-
 rqd_dir = os.path.abspath(os.path.dirname(__file__))
 
 version = 'unknown'

--- a/rqd/setup.py
+++ b/rqd/setup.py
@@ -16,6 +16,11 @@ import os
 from setuptools import find_packages
 from setuptools import setup
 
+import setuptools
+print('foo')
+print(setuptools.__file__)
+print(setuptools.__version__)
+
 rqd_dir = os.path.abspath(os.path.dirname(__file__))
 
 version = 'unknown'


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Fixes #745 

**Summarize your change.**
The base CentOS image uses an old version of `pip`, which can cause errors when trying to upgrade `setuptools`. Upgrade pip in all Docker images to fix this.

This exposes an issue with the dual-Python setup we're using. We rely on calling `pip` directly from the shell, which is not a stable symlink. Upgrading pip from either Python 2 or 3 creates a new symlink and it becomes non-obvious which version you're then operating in. To fix this we switch all images to use `python -m pip` instead of `pip`, which always gives us a version-appropriate pip version.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.
-->
