### PR TITLE
Cuebot: dockerfile update to set permissions for VERSION file (#751)

### DIFF
--- a/cuebot/Dockerfile
+++ b/cuebot/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /home/gradle/cuebot
 
 RUN gradle build --stacktrace
 
-COPY VERSION.in VERSIO[N] ./
+COPY --chown=gradle:gradle VERSION.in VERSIO[N] ./
 RUN test -e VERSION || echo "$(cat VERSION.in)-custom" | tee VERSION
 RUN mv ./build/libs/cuebot.jar ./build/libs/cuebot-$(cat ./VERSION)-all.jar
 


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Fixes #751 

**Summarize your change.**
Updating dockerfile for cuebot build to include permissions for VERSION. Fixes issue where build fails on certain systems due to access/permissions issues. 

