### PR TITLE
Fix burst typecast

### DIFF
--- a/cueadmin/cueadmin/common.py
+++ b/cueadmin/cueadmin/common.py
@@ -204,8 +204,10 @@ def getParser():
     sub.add_argument("-size", action="store", nargs=3, metavar="SHOW ALLOC SIZE",
                      help="Set the guaranteed number of cores.")
     sub.add_argument("-burst", action="store", nargs=3, metavar="SHOW ALLOC BURST",
-                     help="Set the number of burst cores.  Use the percent sign to indicate a "
-                          "percentage of the subscription size instead of a hard size.")
+                     help="Set the number of burst cores for a subscription passing: "
+                          "    show allocation value"
+                          "Use the percent sign in value to indicate a percentage "
+                          "of the subscription size instead of a hard size.")
     #
     # Host
     #

--- a/cueadmin/cueadmin/common.py
+++ b/cueadmin/cueadmin/common.py
@@ -798,7 +798,7 @@ def handleArgs(args):
 
     elif args.size:
         sub_name = "%s.%s" % (args.size[1], args.size[0])
-        opencue.api.findSubscription(sub_name).setSize(float(args.size[2]))
+        opencue.api.findSubscription(sub_name).setSize(int(args.size[2]))
 
     elif args.burst:
         sub_name = "%s.%s" % (args.burst[1], args.burst[0])
@@ -806,7 +806,7 @@ def handleArgs(args):
         burst = args.burst[2]
         if burst.find("%") !=-1:
             burst = int(sub.data.size + (sub.data.size * (int(burst[0:-1]) / 100.0)))
-        sub.setBurst(float(burst))
+        sub.setBurst(burst)
 
 
 def createAllocation(fac, name, tag):

--- a/cueadmin/cueadmin/common.py
+++ b/cueadmin/cueadmin/common.py
@@ -804,9 +804,9 @@ def handleArgs(args):
         sub_name = "%s.%s" % (args.burst[1], args.burst[0])
         sub = opencue.api.findSubscription(sub_name)
         burst = args.burst[2]
-        if burst.find("%") !=-1:
+        if burst.find("%") != -1:
             burst = int(sub.data.size + (sub.data.size * (int(burst[0:-1]) / 100.0)))
-        sub.setBurst(burst)
+        sub.setBurst(long(burst))
 
 
 def createAllocation(fac, name, tag):

--- a/pycue/opencue/wrappers/subscription.py
+++ b/pycue/opencue/wrappers/subscription.py
@@ -44,11 +44,15 @@ class Subscription(object):
         return Subscription(response.subscription)
 
     def setSize(self, size):
+        assert (isinstance(size, int) or
+                isinstance(size, long)), "size is not expected type: int, long"
         self.stub.SetSize(
             subscription_pb2.SubscriptionSetSizeRequest(subscription=self.data, new_size=size),
             timeout=Cuebot.Timeout)
 
     def setBurst(self, burst):
+        assert (isinstance(burst, int) or
+                isinstance(burst, long)), "burst is not expected type: int, long"
         self.stub.SetBurst(
             subscription_pb2.SubscriptionSetBurstRequest(subscription=self.data, burst=burst),
             timeout=Cuebot.Timeout)


### PR DESCRIPTION
Fix typecast error on `-burst` option

When % sign was not being provided on the request the api would pass a string to the server, which expects long. Also updated the option description to better explain its format. 