### PR TITLE
Windows rqd nimby

### DIFF
--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -81,11 +81,12 @@ ENABLE_PTREE = False
 
 # Nimby behavior:
 CHECK_INTERVAL_LOCKED = 60  # = seconds to wait before checking if the user has become idle
-MINIMUM_IDLE = 900          # seconds of idle time required before nimby unlocks
-MINIMUM_MEM = 524288        # If available memory drops below this amount, lock nimby (need to take into account cache)
+TIME_TO_WAIT_FOR_INTERACTION = 5  # = seconds to wait for an interaction
+MINIMUM_IDLE = 900  # seconds of idle time required before nimby unlocks
+MINIMUM_MEM = 524288  # If available memory drops below this amount, lock nimby (need to take into account cache)
 MINIMUM_SWAP = 1048576
-MAXIMUM_LOAD = 75           # If (machine load * 100 / cores) goes over this amount, don't unlock nimby
-                            # 1.5 would mean a max load of 1.5 per core
+MAXIMUM_LOAD = 75  # If (machine load * 100 / cores) goes over this amount,
+                   # don't unlock nimby 1.5 would mean a max load of 1.5 per core
 
 EXITSTATUS_FOR_FAILED_LAUNCH = 256
 EXITSTATUS_FOR_NIMBY_KILL = 286

--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -113,6 +113,7 @@ OVERRIDE_IS_DESKTOP = None # Force rqd to run in 'desktop' mode
 OVERRIDE_PROCS = None # number of physical cpus. ex: None or 2
 OVERRIDE_MEMORY = None # in Kb
 OVERRIDE_NIMBY = None # True to turn on, False to turn off
+USE_NIMBY_PYNPUT = platform.system() == 'Windows'
 ALLOW_GPU = False
 ALLOW_PLAYBLAST = False
 LOAD_MODIFIER = 0 # amount to add/subtract from load

--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -542,7 +542,7 @@ class RqCore(object):
             booked_cores=0,
         )
 
-        self.nimby = rqd.rqnimby.Nimby(self)
+        self.nimby = rqd.rqnimby.NimbyFactory.getNimby(self)
 
         self.machine = rqd.rqmachine.Machine(self, self.cores)
 

--- a/rqd/rqd/rqnimby.py
+++ b/rqd/rqd/rqnimby.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
 
+from abc import ABCMeta, abstractmethod
 import os
 import select
 import time
@@ -31,12 +32,22 @@ import rqd.rqconstants
 import rqd.rqutil
 
 
+class NimbyFactory(object):
+    @staticmethod
+    def getNimby(rqCore):
+        if rqd.rqconstants.USE_NIMBY_PYNPUT:
+            return NimbyPynput(rqCore)
+        else:
+            return NimbySelect(rqCore)
+
+
 class Nimby(threading.Thread):
     """Nimby == Not In My Back Yard.
        If enabled, nimby will lock and kill all frames running on the host if
        keyboard or mouse activity is detected. If sufficient idle time has
        passed, defined in the Constants class, nimby will then unlock the host
        and make it available for rendering."""
+    __metaclass__ = ABCMeta
 
     def __init__(self, rqCore):
         """Nimby initialization
@@ -45,16 +56,6 @@ class Nimby(threading.Thread):
         threading.Thread.__init__(self)
 
         self.rqCore = rqCore
-        self.use_pynput = rqd.rqconstants.USE_NIMBY_PYNPUT
-
-        if self.use_pynput:
-            import pynput
-            self.mouse_listener = pynput.mouse.Listener(
-                on_move=self.on_interaction,
-                on_click=self.on_interaction,
-                on_scroll=self.on_interaction)
-            self.keyboard_listener = pynput.keyboard.Listener(on_press=self.on_interaction)
-
         self.locked = False
         self.active = False
 
@@ -67,9 +68,6 @@ class Nimby(threading.Thread):
 
         signal.signal(signal.SIGINT, self.signalHandler)
 
-    def on_interaction(self, *args):
-        self.interaction_detected = True
-
     def signalHandler(self, sig, frame):
         """If a signal is detected, call .stop()"""
         self.stop()
@@ -78,7 +76,7 @@ class Nimby(threading.Thread):
         """Activates the nimby lock, calls lockNimby() in rqcore"""
         if self.active and not self.locked:
             self.locked = True
-            log.info("Locked nimby")
+            log.warn("Locked nimby")
             self.rqCore.onNimbyLock()
 
     def unlockNimby(self, asOf=None):
@@ -86,12 +84,113 @@ class Nimby(threading.Thread):
         @param asOf: Time when idle state began, if known."""
         if self.locked:
             self.locked = False
-            log.info("Unlocked nimby")
+            log.warn("Unlocked nimby")
             self.rqCore.onNimbyUnlock(asOf=asOf)
 
-    def _openEvents(self):
+    def run(self):
+        """Starts the Nimby thread"""
+        log.debug("nimby.run()")
+        self.active = True
+        self.startListener()
+        self.unlockedIdle()
+
+    def stop(self):
+        """Stops the Nimby thread"""
+        log.debug("nimby.stop()")
+        if self.thread:
+            self.thread.cancel()
+        self.active = False
+        self.stopListener()
+        self.unlockNimby()
+
+    @abstractmethod
+    def startListener(self):
+        pass
+
+    @abstractmethod
+    def stopListener(self):
+        pass
+
+    @abstractmethod
+    def lockedInUse(self):
+        pass
+
+    @abstractmethod
+    def lockedIdle(self):
+        pass
+
+    @abstractmethod
+    def unlockedIdle(self):
+        pass
+
+
+class NimbySelect(Nimby):
+    def startListener(self):
+        pass
+
+    def stopListener(self):
+        self.closeEvents()
+
+    def lockedInUse(self):
+        self.openEvents()
+        try:
+            self.results = select.select(self.fileObjList, [], [], 5)
+        except:
+            pass
+        if self.active and self.results[0] == []:
+            self.lockedIdle()
+        elif self.active:
+            self.closeEvents()
+            self.thread = threading.Timer(rqd.rqconstants.CHECK_INTERVAL_LOCKED,
+                                          self.lockedInUse)
+            self.thread.start()
+
+    def unlockedIdle(self):
+        """Nimby State: Machine is idle, host is unlocked,
+                        waiting for user activity"""
+        while self.active and \
+                self.results[0] == [] and \
+                self.rqCore.machine.isNimbySafeToRunJobs():
+            try:
+                self.openEvents()
+                self.results = select.select(self.fileObjList, [], [], 5)
+            except:
+                pass
+            if not self.rqCore.machine.isNimbySafeToRunJobs():
+                log.warning("memory threshold has been exceeded, locking nimby")
+                self.active = True
+
+        if self.active:
+            self.closeEvents()
+            self.lockNimby()
+            self.thread = threading.Timer(rqd.rqconstants.CHECK_INTERVAL_LOCKED,
+                                          self.lockedInUse)
+            self.thread.start()
+
+    def lockedIdle(self):
+        """Nimby State: Machine is idle,
+                        waiting for sufficient idle time to unlock"""
+        self.openEvents()
+        waitStartTime = time.time()
+        try:
+            self.results = select.select(self.fileObjList, [], [],
+                                         rqd.rqconstants.MINIMUM_IDLE)
+        except:
+            pass
+        if self.active and self.results[0] == [] and \
+                self.rqCore.machine.isNimbySafeToUnlock():
+            self.closeEvents()
+            self.unlockNimby(asOf=waitStartTime)
+            self.unlockedIdle()
+        elif self.active:
+            self.closeEvents()
+            self.thread = threading.Timer(rqd.rqconstants.CHECK_INTERVAL_LOCKED,
+                                          self.lockedInUse)
+            self.thread.start()
+
+    def openEvents(self):
         """Opens the /dev/input/event* files so nimby can monitor them"""
-        self._closeEvents()
+        self.closeEvents()
 
         rqd.rqutil.permissionsHigh()
         try:
@@ -106,9 +205,9 @@ class Nimby(threading.Thread):
         finally:
             rqd.rqutil.permissionsLow()
 
-    def _closeEvents(self):
+    def closeEvents(self):
         """Closes the /dev/input/event* files"""
-        log.debug("_closeEvents")
+        log.debug("closeEvents")
         if self.fileObjList:
             for fileObj in self.fileObjList:
                 try:
@@ -117,29 +216,30 @@ class Nimby(threading.Thread):
                     pass
             self.fileObjList = []
 
+
+class NimbyPynput(Nimby):
+    def __init__(self, rqCore):
+        Nimby.__init__(self, rqCore)
+
+        import pynput
+        self.mouse_listener = pynput.mouse.Listener(
+            on_move=self.on_interaction,
+            on_click=self.on_interaction,
+            on_scroll=self.on_interaction)
+        self.keyboard_listener = pynput.keyboard.Listener(on_press=self.on_interaction)
+
+    def on_interaction(self, *args):
+        self.interaction_detected = True
+
+    def startListener(self):
+        self.mouse_listener.start()
+        self.keyboard_listener.start()
+
+    def stopListener(self):
+        self.mouse_listener.stop()
+        self.keyboard_listener.stop()
+
     def lockedInUse(self):
-        """Nimby State: Machine is in use, host is locked, waiting for sufficient idle time"""
-        log.debug("lockedInUse")
-        if self.use_pynput:
-            self._lockedInUsePynput()
-        else:
-            self._lockedInUseSelect()
-
-    def _lockedInUseSelect(self):
-        self._openEvents()
-        try:
-            self.results = select.select(self.fileObjList, [], [], 5)
-        except:
-            pass
-        if self.active and self.results[0] == []:
-            self.lockedIdle()
-        elif self.active:
-            self._closeEvents()
-            self.thread = threading.Timer(rqd.rqconstants.CHECK_INTERVAL_LOCKED,
-                                          self.lockedInUse)
-            self.thread.start()
-
-    def _lockedInUsePynput(self):
         self.interaction_detected = False
 
         time.sleep(5)
@@ -151,82 +251,7 @@ class Nimby(threading.Thread):
                                           self.lockedInUse)
             self.thread.start()
 
-    def lockedIdle(self):
-        """Nimby State: Machine is idle, waiting for sufficient idle time to unlock"""
-        log.debug("locked_idle")
-        if self.use_pynput:
-            self._lockedIdlePynput()
-        else:
-            self._lockedIdleSelect()
-
-    def _lockedIdleSelect(self):
-        """Nimby State: Machine is idle,
-                        waiting for sufficient idle time to unlock"""
-        self._openEvents()
-        waitStartTime = time.time()
-        try:
-            self.results = select.select(self.fileObjList, [], [],
-                                         rqd.rqconstants.MINIMUM_IDLE)
-        except:
-            pass
-        if self.active and self.results[0] == [] and \
-           self.rqCore.machine.isNimbySafeToUnlock():
-            self._closeEvents()
-            self.unlockNimby(asOf=waitStartTime)
-            self.unlockedIdle()
-        elif self.active:
-            self._closeEvents()
-            self.thread = threading.Timer(rqd.rqconstants.CHECK_INTERVAL_LOCKED,
-                                          self.lockedInUse)
-            self.thread.start()
-
-    def _lockedIdlePynput(self):
-        waitStartTime = time.time()
-
-        time.sleep(rqd.rqconstants.MINIMUM_IDLE)
-
-        if self.active and self.interaction_detected == False and \
-                self.rqCore.machine.isNimbySafeToUnlock():
-
-            self.unlockNimby(asOf=waitStartTime)
-            self.unlockedIdle()
-        elif self.active:
-
-            self.thread = threading.Timer(rqd.rqconstants.CHECK_INTERVAL_LOCKED,
-                                          self.lockedInUse)
-            self.thread.start()
-
     def unlockedIdle(self):
-        """Nimby State: Machine is idle, host is unlocked, waiting for user activity"""
-        log.debug("unlockedIdle")
-        if self.use_pynput:
-            self._lockedIdlePynput()
-        else:
-            self._unlockedIdleSelect()
-
-    def _unlockedIdleSelect(self):
-        """Nimby State: Machine is idle, host is unlocked,
-                        waiting for user activity"""
-        while self.active and \
-              self.results[0] == [] and \
-              self.rqCore.machine.isNimbySafeToRunJobs():
-            try:
-                self._openEvents()
-                self.results = select.select(self.fileObjList, [], [], 5)
-            except:
-                pass
-            if not self.rqCore.machine.isNimbySafeToRunJobs():
-                log.warning("memory threshold has been exceeded, locking nimby")
-                self.active = True
-
-        if self.active:
-            self._closeEvents()
-            self.lockNimby()
-            self.thread = threading.Timer(rqd.rqconstants.CHECK_INTERVAL_LOCKED,
-                                          self.lockedInUse)
-            self.thread.start()
-
-    def _unlockedIdlePynput(self):
         while self.active and \
                 self.interaction_detected == False and \
                 self.rqCore.machine.isNimbySafeToRunJobs():
@@ -243,24 +268,18 @@ class Nimby(threading.Thread):
                                           self.lockedInUse)
             self.thread.start()
 
-    def run(self):
-        """Starts the Nimby thread"""
-        log.debug("nimby.run()")
-        self.active = True
-        if self.use_pynput:
-            self.mouse_listener.start()
-            self.keyboard_listener.start()
-        self.unlockedIdle()
+    def lockedIdle(self):
+        waitStartTime = time.time()
 
-    def stop(self):
-        """Stops the Nimby thread"""
-        log.debug("nimby.stop()")
-        if self.thread:
-            self.thread.cancel()
-        self.active = False
-        if self.use_pynput:
-            self.mouse_listener.stop()
-            self.keyboard_listener.stop()
-        else:
-            self._closeEvents()
-        self.unlockNimby()
+        time.sleep(rqd.rqconstants.MINIMUM_IDLE)
+
+        if self.active and self.interaction_detected == False and \
+                self.rqCore.machine.isNimbySafeToUnlock():
+
+            self.unlockNimby(asOf=waitStartTime)
+            self.unlockedIdle()
+        elif self.active:
+
+            self.thread = threading.Timer(rqd.rqconstants.CHECK_INTERVAL_LOCKED,
+                                          self.lockedInUse)
+            self.thread.start()

--- a/rqd/tests/rqcore_tests.py
+++ b/rqd/tests/rqcore_tests.py
@@ -38,7 +38,7 @@ import rqd.rqnimby
 
 class RqCoreTests(unittest.TestCase):
 
-    @mock.patch('rqd.rqnimby.Nimby', autospec=True)
+    @mock.patch('rqd.rqnimby.NimbySelect', autospec=True)
     @mock.patch('rqd.rqnetwork.Network', autospec=True)
     @mock.patch('rqd.rqmachine.Machine', autospec=True)
     def setUp(self, machineMock, networkMock, nimbyMock):
@@ -310,7 +310,7 @@ class RqCoreTests(unittest.TestCase):
         frame = rqd.compiled_proto.rqd_pb2.RunFrame(uid=22, num_cores=10)
         frameIgnoreNimby = rqd.compiled_proto.rqd_pb2.RunFrame(
             uid=22, num_cores=10, ignore_nimby=True)
-        self.rqcore.nimby = mock.create_autospec(rqd.rqnimby.Nimby)
+        self.rqcore.nimby = mock.create_autospec(rqd.rqnimby.NimbySelect)
         self.rqcore.nimby.locked = True
 
         with self.assertRaises(rqd.rqexceptions.CoreReservationFailureException):

--- a/rqd/tests/rqmachine_tests.py
+++ b/rqd/tests/rqmachine_tests.py
@@ -171,7 +171,7 @@ class MachineTests(pyfakefs.fake_filesystem_unittest.TestCase):
         self.meminfo = self.fs.create_file('/proc/meminfo', contents=MEMINFO_MODERATE_USAGE)
 
         self.rqCore = mock.MagicMock(spec=rqd.rqcore.RqCore)
-        self.nimby = mock.MagicMock(spec=rqd.rqnimby.Nimby)
+        self.nimby = mock.MagicMock(spec=rqd.rqnimby.NimbySelect)
         self.rqCore.nimby = self.nimby
         self.nimby.active = False
         self.nimby.locked = False

--- a/rqd/tests/rqnimby_tests.py
+++ b/rqd/tests/rqnimby_tests.py
@@ -38,10 +38,10 @@ class RqNimbyTests(pyfakefs.fake_filesystem_unittest.TestCase):
         self.rqMachine = mock.MagicMock(spec=rqd.rqmachine.Machine)
         self.rqCore = mock.MagicMock(spec=rqd.rqcore.RqCore)
         self.rqCore.machine = self.rqMachine
-        self.nimby = rqd.rqnimby.Nimby(self.rqCore)
+        self.nimby = rqd.rqnimby.NimbyFactory.getNimby(self.rqCore)
         self.nimby.daemon = True
 
-    @mock.patch.object(rqd.rqnimby.Nimby, 'unlockedIdle')
+    @mock.patch.object(rqd.rqnimby.NimbySelect, 'unlockedIdle')
     def test_initialState(self, unlockedIdleMock):
         self.nimby.daemon = True
 
@@ -67,7 +67,7 @@ class RqNimbyTests(pyfakefs.fake_filesystem_unittest.TestCase):
         timerMock.return_value.start.assert_called()
 
     @mock.patch('select.select', new=mock.MagicMock(return_value=[[], [], []]))
-    @mock.patch.object(rqd.rqnimby.Nimby, 'unlockedIdle')
+    @mock.patch.object(rqd.rqnimby.NimbySelect, 'unlockedIdle')
     @mock.patch('threading.Timer')
     def test_lockedIdleWhenIdle(self, timerMock, unlockedIdleMock):
         self.nimby.active = True
@@ -93,7 +93,7 @@ class RqNimbyTests(pyfakefs.fake_filesystem_unittest.TestCase):
         timerMock.return_value.start.assert_called()
 
     @mock.patch('select.select', new=mock.MagicMock(return_value=[[], [], []]))
-    @mock.patch.object(rqd.rqnimby.Nimby, 'lockedIdle')
+    @mock.patch.object(rqd.rqnimby.NimbySelect, 'lockedIdle')
     @mock.patch('threading.Timer')
     def test_lockedInUseWhenIdle(self, timerMock, lockedIdleMock):
         self.nimby.active = True


### PR DESCRIPTION
Update Nimby class to work in windows

The previous solution using the _Select_ package was incompatible with Windows but is still the best option for linux. rqnimby was updated to accommodate both version defaulting to _Select_ in Linux and _Pynput_ in windows.