### PR TITLE
Finish migrating release pipeline to Github Actions.

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -38,6 +38,9 @@ jobs:
           echo "Build ID: $(cat ./VERSION)"
           echo "::set-env name=BUILD_ID::$(cat ./VERSION)"
 
+      - name: Verify version number
+        run: |
+          set -e
           if [ "$(cat VERSION)" != "${GITHUB_REF}" ]; then
             echo "Version check failed: code version $(cat VERSION) does not match tag name ${GITHUB_REF}"
             exit 1

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -1,14 +1,10 @@
 name: OpenCue Release Pipeline
 
 # Trigger this pipeline when a commit is tagged with a version number, e.g. "v0.4.32".
-#on:
-#  push:
-#    tags:
-#      - 'v*'
-
 on:
   push:
-    branches: [ release-pipeline-s3 ]
+    tags:
+      - 'v*'
 
 jobs:
   preflight:
@@ -66,8 +62,7 @@ jobs:
       - name: Set build ID
         run: |
           set -e
-          #ci/generate_version_number.sh > VERSION
-          echo "0.4.54" > VERSION
+          ci/generate_version_number.sh > VERSION
           echo "Build ID: $(cat ./VERSION)"
           echo "::set-env name=BUILD_ID::$(cat ./VERSION)"
 
@@ -107,8 +102,7 @@ jobs:
       - name: Set build ID
         run: |
           set -e
-          #ci/generate_version_number.sh > VERSION
-          echo "0.4.54" > VERSION
+          ci/generate_version_number.sh > VERSION
           echo "Build ID: $(cat ./VERSION)"
           echo "::set-env name=BUILD_ID::$(cat ./VERSION)"
 

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -86,7 +86,7 @@ jobs:
           draft: true
           prerelease: false
 
-      - name: Upload release asset
+      - name: Upload Cuebot JAR
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -94,4 +94,24 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ${{ github.workspace }}/artifacts/cuebot-${{ env.BUILD_ID }}-all.jar
           asset_name: cuebot-${{ env.BUILD_ID }}-all.jar
+          asset_content_type: application/octet-stream
+
+      - name: Upload Cuebot RPM
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/artifacts/opencue-cuebot-${{ env.BUILD_ID }}-1.noarch.rpm
+          asset_name: opencue-cuebot-${{ env.BUILD_ID }}-1.noarch.rpm
+          asset_content_type: application/octet-stream
+
+      - name: Upload RQD Tar
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/artifacts/rqd-${{ env.BUILD_ID }}-all.tar.gz
+          asset_name: rqd-${{ env.BUILD_ID }}-all.tar.gz
           asset_content_type: application/octet-stream

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/artifacts/"
           aws s3 sync "s3://${S3_BUCKET}/opencue/${BUILD_ID}/" "${GITHUB_WORKSPACE}/artifacts/"
-          echo "::set-output name=filenames::$(ls "${GITHUB_WORKSPACE}/artifacts/")"
+          echo "::set-output name=filenames::$(ls "${GITHUB_WORKSPACE}/artifacts/" | xargs)"
 
       - name: List artifacts
         run: |

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -25,12 +25,12 @@ jobs:
           fetch-depth: 0
 
       - name: Set build ID
-          run: |
-            set -e
-            #ci/generate_version_number.sh > VERSION
-            echo "0.4.54" > VERSION
-            echo "Build ID: $(cat ./VERSION)"
-            echo "::set-env name=BUILD_ID::$(cat ./VERSION)"
+        run: |
+          set -e
+          #ci/generate_version_number.sh > VERSION
+          echo "0.4.54" > VERSION
+          echo "Build ID: $(cat ./VERSION)"
+          echo "::set-env name=BUILD_ID::$(cat ./VERSION)"
 
       - name: Pull Docker image from staging
         run: |

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -11,8 +11,43 @@ on:
     branches: [ release-pipeline-s3 ]
 
 jobs:
-  # TODO(https://github.com/AcademySoftwareFoundation/OpenCue/issues/715) Add another job to
-  #   release the Docker images.
+  upload_docker_images:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        component: [cuebot, rqd, pycue, pyoutline, cuegui, cuesubmit, cueadmin]
+
+    name: Release ${{ matrix.component }} Docker image
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set build ID
+          run: |
+            set -e
+            #ci/generate_version_number.sh > VERSION
+            echo "0.4.54" > VERSION
+            echo "Build ID: $(cat ./VERSION)"
+            echo "::set-env name=BUILD_ID::$(cat ./VERSION)"
+
+      - name: Pull Docker image from staging
+        run: |
+          set -e
+          docker pull opencuebuild/${{ matrix.component }}:${BUILD_ID}
+          docker tag opencuebuild/${{ matrix.component }}:${BUILD_ID} opencue/${{ matrix.component }}:${BUILD_ID}-test
+          docker tag opencuebuild/${{ matrix.component }}:${BUILD_ID} opencue/${{ matrix.component }}:latest-test
+
+      - name: Push Docker image
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+          dockerfile: ${{ matrix.component }}/Dockerfile
+          repository: opencue/${{ matrix.component }}
+          tags: ${{ env.BUILD_ID }}-test, latest-test
+
   create_release:
     name: Create Release
     runs-on: ubuntu-latest
@@ -75,8 +110,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          tag_name: v${{ env.BUILD_ID }}
+          release_name: v${{ env.BUILD_ID }}
           body: |
             To learn how to install and configure OpenCue, see our [Getting Started guide](https://www.opencue.io/docs/getting-started/).
 

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -65,7 +65,8 @@ jobs:
         id: release_notes
         run: |
           last_tagged_version=$(git describe --tags $(git rev-list --tags --max-count=1))
-          commits_since_last_release=$(git log --pretty="* %H %s" ${last_tagged_version}..HEAD) | sed -z s/\\n/\<br\>/g
+          commits_since_last_release=$(git log --pretty="* %H %s" ${last_tagged_version}..HEAD)
+          commits_since_last_release="${commits_since_last_release//$'\n'/'%0A'}"
           echo "::set-output name=commits::${commits_since_last_release}"
 
       - name: Create release

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -86,6 +86,36 @@ jobs:
           draft: true
           prerelease: false
 
+      - name: Upload License
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/artifacts/LICENSE
+          asset_name: LICENSE
+          asset_content_type: application/octet-stream
+
+      - name: Upload Database Schema
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/artifacts/schema-${{ env.BUILD_ID }}.sql
+          asset_name: schema-${{ env.BUILD_ID }}.sql
+          asset_content_type: application/octet-stream
+
+      - name: Upload Demo Data
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/artifacts/demo_data-${{ env.BUILD_ID }}.sql
+          asset_name: demo_data-${{ env.BUILD_ID }}.sql
+          asset_content_type: application/octet-stream
+
       - name: Upload Cuebot JAR
         uses: actions/upload-release-asset@v1
         env:
@@ -114,4 +144,54 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ${{ github.workspace }}/artifacts/rqd-${{ env.BUILD_ID }}-all.tar.gz
           asset_name: rqd-${{ env.BUILD_ID }}-all.tar.gz
+          asset_content_type: application/octet-stream
+
+      - name: Upload CueGUI Tar
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/artifacts/cuegui-${{ env.BUILD_ID }}-all.tar.gz
+          asset_name: cuegui-${{ env.BUILD_ID }}-all.tar.gz
+          asset_content_type: application/octet-stream
+
+      - name: Upload PyCue Tar
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/artifacts/pycue-${{ env.BUILD_ID }}-all.tar.gz
+          asset_name: pycue-${{ env.BUILD_ID }}-all.tar.gz
+          asset_content_type: application/octet-stream
+
+      - name: Upload PyOutline Tar
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/artifacts/pyoutline-${{ env.BUILD_ID }}-all.tar.gz
+          asset_name: pyoutline-${{ env.BUILD_ID }}-all.tar.gz
+          asset_content_type: application/octet-stream
+
+      - name: Upload CueSubmit Tar
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/artifacts/cuesubmit-${{ env.BUILD_ID }}-all.tar.gz
+          asset_name: cuesubmit-${{ env.BUILD_ID }}-all.tar.gz
+          asset_content_type: application/octet-stream
+
+      - name: Upload CueAdmin Tar
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/artifacts/cueadmin-${{ env.BUILD_ID }}-all.tar.gz
+          asset_name: cueadmin-${{ env.BUILD_ID }}-all.tar.gz
           asset_content_type: application/octet-stream

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -38,7 +38,10 @@ jobs:
           echo "Build ID: $(cat ./VERSION)"
           echo "::set-env name=BUILD_ID::$(cat ./VERSION)"
 
-          test "$(cat VERSION)" = "${GITHUB_REF}"
+          if [ "$(cat VERSION)" != "${GITHUB_REF}" ]; then
+            echo "Version check failed: code version $(cat VERSION) does not match tag name ${GITHUB_REF}"
+            exit 1
+          fi
 
       - name: Download artifacts
         env:

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -65,9 +65,8 @@ jobs:
         id: release_notes
         run: |
           last_tagged_version=$(git describe --tags $(git rev-list --tags --max-count=1))
-          commits_since_last_release=$(git log --pretty="* %H %s" ${last_tagged_version}..HEAD)
-          html_commits=echo ${commits_since_last_release} | sed -z s/\\n/\<br\>/g
-          echo "::set-output name=commits::${html_commits}"
+          commits_since_last_release=$(git log --pretty="* %H %s" ${last_tagged_version}..HEAD) | sed -z s/\\n/\<br\>/g
+          echo "::set-output name=commits::${commits_since_last_release}"
 
       - name: Create release
         id: create_release

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -36,10 +36,8 @@ jobs:
         run: |
           set -e
           docker pull opencuebuild/${{ matrix.component }}:${BUILD_ID}
-          docker tag opencuebuild/${{ matrix.component }}:${BUILD_ID} opencue/${{ matrix.component }}:${BUILD_ID}-test
-          docker tag opencuebuild/${{ matrix.component }}:${BUILD_ID} opencue/${{ matrix.component }}:latest-test
 
-      - name: Push Docker image
+      - name: Rebuild and push Docker image
         uses: docker/build-push-action@v1
         with:
           username: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -11,7 +11,41 @@ on:
     branches: [ release-pipeline-s3 ]
 
 jobs:
-  upload_docker_images:
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.S3_REGION }}
+          role-to-assume: ${{ secrets.AWS_S3_ROLE }}
+          role-duration-seconds: 1800
+
+      - name: Set build ID
+        run: |
+          set -e
+          #ci/generate_version_number.sh > VERSION
+          echo "0.4.54" > VERSION
+          echo "Build ID: $(cat ./VERSION)"
+          echo "::set-env name=BUILD_ID::$(cat ./VERSION)"
+
+      - name: Verify version number
+        run: |
+          set -e
+          if [ "$(cat VERSION)" != "${GITHUB_REF}" ]; then
+            echo "Version check failed: code version $(cat VERSION) does not match tag name ${GITHUB_REF}"
+            exit 1
+          fi
+
+  release_docker_images:
+    needs: preflight
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -47,6 +81,7 @@ jobs:
           tags: ${{ env.BUILD_ID }}-test, latest-test
 
   create_release:
+    needs: preflight
     name: Create Release
     runs-on: ubuntu-latest
     steps:
@@ -71,14 +106,6 @@ jobs:
           echo "0.4.54" > VERSION
           echo "Build ID: $(cat ./VERSION)"
           echo "::set-env name=BUILD_ID::$(cat ./VERSION)"
-
-      #- name: Verify version number
-      #  run: |
-      #    set -e
-      #    if [ "$(cat VERSION)" != "${GITHUB_REF}" ]; then
-      #      echo "Version check failed: code version $(cat VERSION) does not match tag name ${GITHUB_REF}"
-      #      exit 1
-      #    fi
 
       - name: Fetch artifacts
         id: fetch_artifacts

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/artifacts/"
           aws s3 sync "s3://${S3_BUCKET}/opencue/${BUILD_ID}/" "${GITHUB_WORKSPACE}/artifacts/"
-          echo ls "${GITHUB_WORKSPACE}/artifacts/"
+          echo $(ls "${GITHUB_WORKSPACE}/artifacts/")
 
       - name: Generate release notes
         id: release_notes

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/artifacts/"
           aws s3 sync "s3://${S3_BUCKET}/opencue/${BUILD_ID}/" "${GITHUB_WORKSPACE}/artifacts/"
-          ls "${GITHUB_WORKSPACE}/artifacts/"
+          echo ls "${GITHUB_WORKSPACE}/artifacts/"
 
       - name: Generate release notes
         id: release_notes
@@ -68,10 +68,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          release_name: ${{ github.ref }}
           body: |
-            To learn how to install and configure OpenCue, see our
-            [Getting Started guide](https://www.opencue.io/docs/getting-started/).
+            To learn how to install and configure OpenCue, see our [Getting Started guide](https://www.opencue.io/docs/getting-started/).
 
             ## Changes:
 

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -16,20 +16,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.S3_REGION }}
-          role-to-assume: ${{ secrets.AWS_S3_ROLE }}
-          role-duration-seconds: 1800
-
       - name: Set build ID
         run: |
           set -e
-          #ci/generate_version_number.sh > VERSION
-          echo "0.4.54" > VERSION
+          ci/generate_version_number.sh > VERSION
           echo "Build ID: $(cat ./VERSION)"
           echo "::set-env name=BUILD_ID::$(cat ./VERSION)"
 

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -34,7 +34,8 @@ jobs:
       - name: Set build ID
         run: |
           set -e
-          ci/generate_version_number.sh > VERSION
+          #ci/generate_version_number.sh > VERSION
+          echo "0.4.54" > VERSION
           echo "Build ID: $(cat ./VERSION)"
           echo "::set-env name=BUILD_ID::$(cat ./VERSION)"
 
@@ -56,7 +57,9 @@ jobs:
           echo "::set-output name=filenames::$(ls "${GITHUB_WORKSPACE}/artifacts/")"
 
       - name: List artifacts
-        run: echo ${{ steps.fetch_artifacts.outputs.filenames }}
+        run: |
+          echo "foo"
+          echo ${{ steps.fetch_artifacts.outputs.filenames }}
 
       - name: Generate release notes
         id: release_notes

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -51,7 +51,8 @@ jobs:
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/artifacts/"
-          aws s3 cp s3://${S3_BUCKET}/opencue/${BUILD_ID}/* "${GITHUB_WORKSPACE}/artifacts/"
+          aws s3 sync "s3://${S3_BUCKET}/opencue/${BUILD_ID}/" "${GITHUB_WORKSPACE}/artifacts/"
+          ls "${GITHUB_WORKSPACE}/artifacts/"
 
       - name: Generate release notes
         id: release_notes

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -58,7 +58,6 @@ jobs:
 
       - name: List artifacts
         run: |
-          echo "foo"
           echo ${{ steps.fetch_artifacts.outputs.filenames }}
 
       - name: Generate release notes
@@ -66,6 +65,7 @@ jobs:
         run: |
           last_tagged_version=$(git describe --tags $(git rev-list --tags --max-count=1))
           commits_since_last_release=$(git log --pretty="* %H %s" ${last_tagged_version}..HEAD)
+          # See https://github.community/t/set-output-truncates-multiline-strings/16852
           commits_since_last_release="${commits_since_last_release//$'\n'/'%0A'}"
           echo "::set-output name=commits::${commits_since_last_release}"
 
@@ -85,3 +85,13 @@ jobs:
             ${{ steps.release_notes.outputs.commits }}
           draft: true
           prerelease: false
+
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${GITHUB_WORKSPACE}/artifacts/cuebot-${BUILD_ID}-all.jar
+          asset_name: cuebot-${BUILD_ID}-all.jar
+          asset_content_type: application/octet-stream

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -1,10 +1,14 @@
 name: OpenCue Release Pipeline
 
 # Trigger this pipeline when a commit is tagged with a version number, e.g. "v0.4.32".
+#on:
+#  push:
+#    tags:
+#      - 'v*'
+
 on:
   push:
-    tags:
-      - 'v*'
+    branches: [ release-pipeline-s3 ]
 
 jobs:
   # TODO(https://github.com/AcademySoftwareFoundation/OpenCue/issues/715) Add another job to
@@ -17,34 +21,39 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Fetch artifacts
-        env:
-          PACKAGING_WORKFLOW_ID: 1539149
-        # Fetching artifacts from another pipeline, or even a different run of the same pipeline,
-        # is currently not well-supported in Github Actions. We must use the Github REST API to
-        # search for the correct workflow by commit SHA, then we can attempt to download the
-        # artifacts from that workflow run.
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.S3_REGION }}
+          role-to-assume: ${{ secrets.AWS_S3_ROLE }}
+          role-duration-seconds: 1800
+
+      - name: Set build ID
         run: |
           set -e
-          echo "SHA: ${{ github.sha }}"
-          run_id=$(curl -s https://api.github.com/repos/${{ github.repository }}/actions/runs \
-            | jq ".workflow_runs[] | select(.head_sha == \"${{ github.sha }}\" and .workflow_id==${PACKAGING_WORKFLOW_ID}).id")
-          echo "Packaging pipeline run ID: ${run_id}"
-          artifact_ids=$(curl -s https://api.github.com/repos/${{ github.repository }}/actions/runs/${run_id}/artifacts \
-            | jq '.artifacts[].id')
-          echo "Artifact IDs: ${artifact_ids}"
-          for artifact_id in ${artifact_ids}; do
-            api_path="repos/${{ github.repository }}/actions/artifacts/${artifact_id}/zip"
-            echo "Fetching artifact ${artifact_id} at https://api.github.com/${api_path}"
-            curl -L -O "https://${{ secrets.GITHUB_TOKEN }}@api.github.com/${api_path}"
-          done
+          ci/generate_version_number.sh > VERSION
+          echo "Build ID: $(cat ./VERSION)"
+          echo "::set-env name=BUILD_ID::$(cat ./VERSION)"
+
+      - name: Download artifacts
+        env:
+          S3_BUCKET: ${{ secrets.S3_BUCKET }}
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/artifacts/
+          aws s3 cp s3://${S3_BUCKET}/opencue/${BUILD_ID}/* "${GITHUB_WORKSPACE}/artifacts/"
+
       - name: Generate release notes
         id: release_notes
         run: |
           last_tagged_version=$(git describe --tags $(git rev-list --tags --max-count=1))
           commits_since_last_release=$(git log --pretty="* %H %s" ${last_tagged_version}..HEAD)
           echo "::set-output name=commits::${commits_since_last_release}"
+
       - name: Create release
+        id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           last_tagged_version=$(git describe --tags $(git rev-list --tags --max-count=1))
           commits_since_last_release=$(git log --pretty="* %H %s" ${last_tagged_version}..HEAD)
-          html_commits=echo $(commits_since_last_release) | sed -z s/\\n/\<br\>/g
+          html_commits=echo ${commits_since_last_release} | sed -z s/\\n/\<br\>/g
           echo "::set-output name=commits::${html_commits}"
 
       - name: Create release

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   preflight:
     runs-on: ubuntu-latest
+    name: Preflight
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -43,7 +44,7 @@ jobs:
         run: |
           set -e
           if [ "v$(cat VERSION)" != "${TAG_NAME}" ]; then
-            echo "Version check failed: code version $(cat VERSION) does not match tag name ${TAG_NAME}"
+            echo "Version check failed: code version v$(cat VERSION) does not match tag name ${TAG_NAME}"
             echo "Original GITHUB_REF: ${GITHUB_REF}"
             exit 1
           fi

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -38,11 +38,13 @@ jobs:
           echo "Build ID: $(cat ./VERSION)"
           echo "::set-env name=BUILD_ID::$(cat ./VERSION)"
 
+          test "$(cat VERSION)" = "${GITHUB_REF}"
+
       - name: Download artifacts
         env:
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
         run: |
-          mkdir -p "${GITHUB_WORKSPACE}/artifacts/
+          mkdir -p "${GITHUB_WORKSPACE}/artifacts/"
           aws s3 cp s3://${S3_BUCKET}/opencue/${BUILD_ID}/* "${GITHUB_WORKSPACE}/artifacts/"
 
       - name: Generate release notes

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -68,7 +68,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASS }}
           dockerfile: ${{ matrix.component }}/Dockerfile
           repository: opencue/${{ matrix.component }}
-          tags: ${{ env.BUILD_ID }}-test, latest-test
+          tags: ${{ env.BUILD_ID }}, latest
 
   create_release:
     needs: preflight

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -36,11 +36,15 @@ jobs:
           echo "Build ID: $(cat ./VERSION)"
           echo "::set-env name=BUILD_ID::$(cat ./VERSION)"
 
-      - name: Verify version number
+      - name: Get current tag name
+        run: echo ::set-env name=TAG_NAME::${GITHUB_REF/refs\/tags\//}
+
+      - name: Verify tag name and version match
         run: |
           set -e
-          if [ "$(cat VERSION)" != "${GITHUB_REF}" ]; then
-            echo "Version check failed: code version $(cat VERSION) does not match tag name ${GITHUB_REF}"
+          if [ "v$(cat VERSION)" != "${TAG_NAME}" ]; then
+            echo "Version check failed: code version $(cat VERSION) does not match tag name ${TAG_NAME}"
+            echo "Original GITHUB_REF: ${GITHUB_REF}"
             exit 1
           fi
 

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -66,7 +66,8 @@ jobs:
         run: |
           last_tagged_version=$(git describe --tags $(git rev-list --tags --max-count=1))
           commits_since_last_release=$(git log --pretty="* %H %s" ${last_tagged_version}..HEAD)
-          echo "::set-output name=commits::${commits_since_last_release}"
+          html_commits=echo $(commits_since_last_release) | sed -z s/\\n/\<br\>/g
+          echo "::set-output name=commits::${html_commits}"
 
       - name: Create release
         id: create_release

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -92,6 +92,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${GITHUB_WORKSPACE}/artifacts/cuebot-${BUILD_ID}-all.jar
-          asset_name: cuebot-${BUILD_ID}-all.jar
+          asset_path: ${{ github.workspace }}/artifacts/cuebot-${{ env.BUILD_ID }}-all.jar
+          asset_name: cuebot-${{ env.BUILD_ID }}-all.jar
           asset_content_type: application/octet-stream

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -46,13 +46,17 @@ jobs:
       #      exit 1
       #    fi
 
-      - name: Download artifacts
+      - name: Fetch artifacts
+        id: fetch_artifacts
         env:
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/artifacts/"
           aws s3 sync "s3://${S3_BUCKET}/opencue/${BUILD_ID}/" "${GITHUB_WORKSPACE}/artifacts/"
-          echo $(ls "${GITHUB_WORKSPACE}/artifacts/")
+          echo "::set-output name=filenames::$(ls "${GITHUB_WORKSPACE}/artifacts/")"
+
+      - name: List artifacts
+        run: echo ${{ steps.fetch_artifacts.outputs.filenames }}
 
       - name: Generate release notes
         id: release_notes

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -38,13 +38,13 @@ jobs:
           echo "Build ID: $(cat ./VERSION)"
           echo "::set-env name=BUILD_ID::$(cat ./VERSION)"
 
-      - name: Verify version number
-        run: |
-          set -e
-          if [ "$(cat VERSION)" != "${GITHUB_REF}" ]; then
-            echo "Version check failed: code version $(cat VERSION) does not match tag name ${GITHUB_REF}"
-            exit 1
-          fi
+      #- name: Verify version number
+      #  run: |
+      #    set -e
+      #    if [ "$(cat VERSION)" != "${GITHUB_REF}" ]; then
+      #      echo "Version check failed: code version $(cat VERSION) does not match tag name ${GITHUB_REF}"
+      #      exit 1
+      #    fi
 
       - name: Download artifacts
         env:


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
#715 

**Summarize your change.**
Adds the job to upload Docker images, switches to pull artifacts from S3 (as added in #753), and amends the Github release to attach those actions.

Having to specify all of the artifacts serially is annoying, but it's the best way I've found so far. We need to have the "create release" and "attach artifacts" steps in the same job so we can access the "create release" step's outputs, and we don't want to create multiple releases, so we can't use a matrix for that job like we do for the Docker image jobs. Hopefully we'll be able to improve on this as Github Actions matures.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.
-->
