### PR TITLE
Fix bug with changelog generation in release pipeline.

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -112,8 +112,8 @@ jobs:
       - name: Generate release notes
         id: release_notes
         run: |
-          last_tagged_version=$(git describe --tags $(git rev-list --tags --max-count=1))
-          commits_since_last_release=$(git log --pretty="* %H %s" ${last_tagged_version}..HEAD)
+          last_tagged_version=$(git describe --tags --abbrev=0 $(git rev-list --tags --skip=1 --max-count=1))
+          commits_since_last_release=$(git log --reverse --pretty="* %H %s" ${last_tagged_version}..HEAD)
           # See https://github.community/t/set-output-truncates-multiline-strings/16852
           commits_since_last_release="${commits_since_last_release//$'\n'/'%0A'}"
           echo "::set-output name=commits::${commits_since_last_release}"


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
#715 

**Summarize your change.**
Under the new release process, the "last tag" is actually *the release that's currently running*, causing an empty changelog to be generated. So we need to go back one tag further.

Explanation of flags:
- `--skip=1` lets us skip the current tag, displaying the last tag i.e. the last released version.
- `--abbrev=0` provides the plain tag name. Without it you get the tag name plus some other information e.g. `0.4.14-40-g113a57f`. This extra info breaks the `git log` call later. This only happens on tags before the latest one, which is why we didn't need it before.
- `--reverse` to `git log` just reverses the list. IMO the changelog makes more sense when read from oldest to newest.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.
-->
