### PR TITLE
Fixing cuewho file dir path and subprocess call

### DIFF
--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -195,7 +195,7 @@ def getCuewho(show):
     @return: The username who is cuewho for the show
     @rtype:  string"""
     try:
-        file = open("cuewho.who" % show, "r")
+        file = open("/shots/%s/home/cue/cuewho.who" % show, "r")
         return file.read()
     except Exception as e:
         logger.warning("Failed to update cuewho: %s\n%s" % (show, e))
@@ -214,7 +214,7 @@ def getExtension(username):
     try:
         # TODO: Replace this with a direct call to the phone util that the
         # phone widget uses once code is stable
-        results = subprocess.check_output('phone %s' % username)
+        results = subprocess.check_output(['phone', username])
 
         for line in results.splitlines():
             if line.find('Extension') != -1 and len(line.split()) == 2:


### PR DESCRIPTION
**Two changes**

line 198 -- Fixing cuewho file dir path
- It is easier to track where we create the `cuewho.who` file to get the current cuewho username by changing the path from
`cuewho.who` to `/shots/%s/home/cue/cuewho.who`, and also the `%s` converted all arguments during string formatting

line 217 -- Fixing subprocess call
- to execute a command `phone username` in a new subprocess and return the output as the var `results`. Testing on python 2.7, If using without the `[]`, subprocess would raise an exception

