### PR TITLE
Maintain Selection after update

### DIFF
--- a/cuegui/cuegui/CueJobMonitorTree.py
+++ b/cuegui/cuegui/CueJobMonitorTree.py
@@ -371,7 +371,7 @@ class CueJobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                 self.redraw()
             else:
                 # (Something removed) or (Something added)
-                selected_ids = [item.rpcObject.id for item in self.selectedItems()]
+                selected_ids = [item.rpcObject.id() for item in self.selectedItems()]
                 collapsed = self.__getCollapsed()
                 scrolled = self.verticalScrollBar().value()
                 self._items = {}


### PR DESCRIPTION
Fixes an issue on CueJobMonitorTree that would cause selections and collapsed trees to be refreshed in the job's update loop.
