### PR TITLE
Update the FrameSearch page option

### DIFF
--- a/cuegui/cuegui/FrameMonitor.py
+++ b/cuegui/cuegui/FrameMonitor.py
@@ -244,7 +244,6 @@ class FrameMonitor(QtWidgets.QWidget):
                        frameSearch
         @type offset: int'''
         self.page += offset
-        self.frameMonitorTree.frameSearch.page = self.page
         self.frameMonitorTree.frameSearch.options['page'] = self.page
         self.frameMonitorTree.updateRequest()
         self._updatePageButtonState()

--- a/cuegui/cuegui/FrameMonitor.py
+++ b/cuegui/cuegui/FrameMonitor.py
@@ -245,6 +245,7 @@ class FrameMonitor(QtWidgets.QWidget):
         @type offset: int'''
         self.page += offset
         self.frameMonitorTree.frameSearch.page = self.page
+        self.frameMonitorTree.frameSearch.options['page'] = self.page
         self.frameMonitorTree.updateRequest()
         self._updatePageButtonState()
 


### PR DESCRIPTION
Solves this issue: Jobs with a large number of frames are grouped into pages 
of 1000 for easier viewing. However, the next page button doesn't update the frames even when clicking refresh.