### PR TITLE
Ignore top-level .env file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ venv*/
 .coverage
 coverage.xml
 htmlcov/
+/.env


### PR DESCRIPTION
Following a pattern I've used in other projects, I've dropped my common environment settings into a `.env` file for easier sourcing in a new shell. Ignore this file so it won't get accidentally committed.