### PR TITLE
Use a non-deprecated rounding mode.

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/util/Convert.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/util/Convert.java
@@ -20,6 +20,7 @@
 package com.imageworks.spcue.util;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import java.util.Locale;
 
@@ -29,7 +30,7 @@ import java.util.Locale;
 public final class Convert {
 
     public static final int coresToCoreUnits(float cores) {
-        return new BigDecimal(cores * 100).setScale(2,BigDecimal.ROUND_HALF_UP).intValue();
+        return new BigDecimal(cores * 100).setScale(2, RoundingMode.HALF_UP).intValue();
     }
 
     public static final int coresToCoreUnits(int cores) {


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
#790 

**Summarize your change.**
`BigDecimal` rounding modes have been deprecated and replaced by the `RoundingMode` module. This resolves a `deprecated` warning from the Java compiler.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.
-->
