### PR TITLE
Add badges showing officially supported VFX Reference Platform and Python versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![OpenCue](/images/opencue_logo_with_text.png)
 
+[![Supported VFX Platform Versions](https://img.shields.io/badge/vfx%20platform-2019--2020-lightgrey.svg)](http://www.vfxplatform.com/)
+![Supported Python Versions](https://img.shields.io/badge/python-2.7%2C%203.6%2C%203.7-blue.svg)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2837/badge)](https://bestpractices.coreinfrastructure.org/projects/2837)
 
 - [Introduction](#Introduction)


### PR DESCRIPTION
[OpenTimelineIO](https://github.com/PixarAnimationStudios/OpenTimelineIO#opentimelineio) has these neat badges, adding them for OpenCue as well.