### PR TITLE
Remove redundant casts.

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/DispatchHost.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/DispatchHost.java
@@ -104,8 +104,8 @@ public class DispatchHost extends Entity
             idleCoresOrig = idleCores;
             idleGpuOrig = idleGpu;
 
-            idleMemory = (long) idleMemory - Math.min(CueUtil.GB4, idleMemory);
-            idleCores = (int) idleCores - Math.min(100, idleCores);
+            idleMemory = idleMemory - Math.min(CueUtil.GB4, idleMemory);
+            idleCores = idleCores - Math.min(100, idleCores);
             idleGpu = 0;
         }
     }

--- a/cuebot/src/main/java/com/imageworks/spcue/LayerStats.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/LayerStats.java
@@ -155,17 +155,17 @@ public class LayerStats {
 
         if (hightestAverageSec < 60) {
             graphUnits = "Seconds";
-            scale = (int) ((hightestAverageSec / 2 + 1) * 2);
+            scale = ((hightestAverageSec / 2 + 1) * 2);
             conversionUnits = 1f;
         }
         else if (hightestAverageSec < 3600) {
             graphUnits = "Minutes";
-            scale = (int) ((hightestAverageSec / 60) + 1);
+            scale = ((hightestAverageSec / 60) + 1);
             conversionUnits = 60f;
         }
         else {
             graphUnits = "Hours";
-            scale = (int) ((hightestAverageSec / 3600)  + 1);
+            scale = ((hightestAverageSec / 3600)  + 1);
             conversionUnits = 3600f;
         }
     }

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchQueue.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchQueue.java
@@ -76,11 +76,11 @@ public class DispatchQueue {
     }
 
     public long getTotalDispatched() {
-        return (long) tasksRun.get();
+        return tasksRun.get();
     }
 
     public long getTotalRejected() {
-        return (long) tasksRejected.get();
+        return tasksRejected.get();
     }
 
     public TaskExecutor getDispatchPool() {

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
@@ -455,7 +455,7 @@ public class HostReportHandler {
                     p.memoryReserved = f.getRss();
                     logger.info("frame " + f.getFrameName() + " on job " + f.getJobName()
                             + " increased its reserved memory to " +
-                            CueUtil.KbToMb((long)f.getRss()));
+                            CueUtil.KbToMb(f.getRss()));
                 }
 
             } catch (ResourceReservationFailureException e) {

--- a/cuebot/src/main/java/com/imageworks/spcue/util/Convert.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/util/Convert.java
@@ -39,7 +39,7 @@ public final class Convert {
 
     public static final int coresToWholeCoreUnits(float cores) {
         if (cores == -1) { return -1;}
-        return (int)((float)((cores * 100.0f) + 0.5f) / 100) * 100;
+        return (int)(((cores * 100.0f) + 0.5f) / 100) * 100;
     }
 
     public static final float coreUnitsToCores(int coreUnits) {

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/CoreUnitDispatcherGpuJobTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/CoreUnitDispatcherGpuJobTests.java
@@ -151,8 +151,8 @@ public class CoreUnitDispatcherGpuJobTests extends TransactionalTest {
         DispatchHost host = getHost();
         JobDetail job = getJob();
 
-        host.idleMemory = (long) host.idleMemory - Math.min(CueUtil.GB4, host.idleMemory);
-        host.idleCores = (int) host.idleCores - Math.min(100, host.idleCores);
+        host.idleMemory = host.idleMemory - Math.min(CueUtil.GB4, host.idleMemory);
+        host.idleCores = host.idleCores - Math.min(100, host.idleCores);
         host.idleGpu = 0;
         List<VirtualProc> procs =  dispatcher.dispatchHost(host, job);
         assertEquals(0, procs.size());

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/CoreUnitDispatcherGpuTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/CoreUnitDispatcherGpuTests.java
@@ -151,8 +151,8 @@ public class CoreUnitDispatcherGpuTests extends TransactionalTest {
         DispatchHost host = getHost();
         JobDetail job = getJob();
 
-        host.idleMemory = (long) host.idleMemory - Math.min(CueUtil.GB4, host.idleMemory);
-        host.idleCores = (int) host.idleCores - Math.min(100, host.idleCores);
+        host.idleMemory = host.idleMemory - Math.min(CueUtil.GB4, host.idleMemory);
+        host.idleCores = host.idleCores - Math.min(100, host.idleCores);
         host.idleGpu = 0;
         List<VirtualProc> procs =  dispatcher.dispatchHost(host, job);
         assertEquals(1, procs.size());


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
#790 

**Summarize your change.**
These casts are redundant, and removing them resolves `cast` lint warnings.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.
-->
