### PR TITLE
Change argument type on SqlUtil.buildBindVariableArray.

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dao/oracle/GroupDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/oracle/GroupDaoJdbc.java
@@ -325,7 +325,7 @@ public class GroupDaoJdbc extends JdbcDaoSupport implements GroupDao {
     public List<GroupInterface> getGroups(List<String> idl) {
         return getJdbcTemplate().query(
                 "SELECT pk_show, pk_folder, str_name FROM folder WHERE  " +
-                SqlUtil.buildBindVariableArray("pk_folder", idl),
+                SqlUtil.buildBindVariableArray("pk_folder", idl.size()),
                 GROUP_MAPPER, idl.toArray());
     }
 

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/GroupDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/GroupDaoJdbc.java
@@ -325,7 +325,7 @@ public class GroupDaoJdbc extends JdbcDaoSupport implements GroupDao {
     public List<GroupInterface> getGroups(List<String> idl) {
         return getJdbcTemplate().query(
                 "SELECT pk_show, pk_folder, str_name FROM folder WHERE  " +
-                SqlUtil.buildBindVariableArray("pk_folder", idl),
+                SqlUtil.buildBindVariableArray("pk_folder", idl.size()),
                 GROUP_MAPPER, idl.toArray());
     }
 

--- a/cuebot/src/main/java/com/imageworks/spcue/util/SqlUtil.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/util/SqlUtil.java
@@ -21,16 +21,15 @@ package com.imageworks.spcue.util;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Collection;
 import java.util.UUID;
 
 public class SqlUtil {
 
-    public static String buildBindVariableArray(String col, Collection c) {
+    public static String buildBindVariableArray(String col, Integer numValues) {
         StringBuilder sb = new StringBuilder(1024);
         sb.append(col);
         sb.append(" IN (");
-        for (int i = 0; i < c.size(); i++) {
+        for (int i = 0; i < numValues; i++) {
             sb.append("?,");
         }
         sb.delete(sb.length() - 1, sb.length());

--- a/cuebot/src/test/java/com/imageworks/spcue/test/util/SqlUtilTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/util/SqlUtilTests.java
@@ -1,0 +1,18 @@
+package com.imageworks.spcue.test.util;
+
+import org.junit.Test;
+
+import static com.imageworks.spcue.util.SqlUtil.buildBindVariableArray;
+import static org.junit.Assert.assertEquals;
+
+public class SqlUtilTests {
+
+    @Test
+    public void testBuildBindVariableArray() {
+        String colName = "arbitrary-column-name";
+
+        String queryString = buildBindVariableArray(colName, 6);
+
+        assertEquals(colName + " IN (?,?,?,?,?,?)", queryString);
+    }
+}


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
#790 

**Summarize your change.**
This was throwing a `rawtypes` warning about the use of `Collection` without a type. On further inspection, passing the full list isn't necessary here, as we only need to know the number of values. I've updated the argument type, fixed places in the code where this method is called, and added a unit test for this method.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.
-->
