### PR TITLE
Avoid calling time.time() for each row

### DIFF
--- a/cuegui/cuegui/AbstractWidgetItem.py
+++ b/cuegui/cuegui/AbstractWidgetItem.py
@@ -31,6 +31,7 @@ import cuegui.Constants
 import cuegui.Logger
 import cuegui.Style
 
+import opencue
 
 logger = cuegui.Logger.getLogger(__file__)
 
@@ -88,7 +89,8 @@ class AbstractWidgetItem(QtWidgets.QTreeWidgetItem):
         """Custom sorting for columns that have a function defined for sorting"""
         sortLambda = self.column_info[self.treeWidget().sortColumn()][SORT_LAMBDA]
         column = self.treeWidget().sortColumn()
-        if sortLambda:
+
+        if sortLambda and isinstance(other.rpcObject, opencue.wrappers.job.Job):
             try:
                 return sortLambda(self.rpcObject) < sortLambda(other.rpcObject)
             except:

--- a/cuegui/cuegui/CueJobMonitorTree.py
+++ b/cuegui/cuegui/CueJobMonitorTree.py
@@ -62,6 +62,7 @@ class CueJobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
     def __init__(self, parent):
 
         self.__shows = {}
+        self.currtime = time.time()
 
         self.startColumnsForType(cuegui.Constants.TYPE_JOB)
         self.addColumn("Job", 550, id=1,
@@ -115,8 +116,8 @@ class CueJobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                        tip="The maximum number of running cores that the cuebot\n"
                            "will allow.")
         self.addColumn("Age", 50, id=11,
-                       data=lambda job: cuegui.Utils.secondsToHHHMM(time.time() - job.data.start_time),
-                       sort=lambda job: time.time() - job.data.start_time,
+                       data=lambda job: cuegui.Utils.secondsToHHHMM(self.currtime - job.data.start_time),
+                       sort=lambda job: self.currtime - job.data.start_time,
                        tip="The HOURS:MINUTES since the job was launched.")
         self.addColumn("Pri", 30, id=12,
                        data=lambda job: job.data.priority,
@@ -340,6 +341,7 @@ class CueJobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         @rtype:  [list<NestedGroup>, set(str)]
         @return: List that contains updated nested groups and a set of all
         updated item ideas"""
+        self.currtime = time.time()
         try:
             groups = [show.getJobWhiteboard() for show in self.getShows()]
             nestedGroups = []


### PR DESCRIPTION
Calling time.time() for every row was causing segmentation fault erros while trying to sort big TreeWidgets. Also add a protection to avoid calling the lambda sort for NestedGroup types as it's only implemented for Job types

(cherry picked from commit c7057c16d36ca7bb2b1da2fabe1d6a587817251f)
