### PR TITLE
feat: Make tree headers movable

### DIFF
--- a/cuegui/cuegui/AbstractTreeWidget.py
+++ b/cuegui/cuegui/AbstractTreeWidget.py
@@ -88,7 +88,7 @@ class AbstractTreeWidget(QtWidgets.QTreeWidget):
         self.setAlternatingRowColors(True)
 
         self.setSortingEnabled(True)
-        self.header().setSectionsMovable(False)
+        self.header().setSectionsMovable(True)
         self.header().setStretchLastSection(True)
         self.sortByColumn(0, QtCore.Qt.AscendingOrder)
 
@@ -528,3 +528,21 @@ class AbstractTreeWidget(QtWidgets.QTreeWidget):
             for col in range(len(settings)):
                 if col <= self.columnCount():
                     self.setColumnHidden(col, settings[col])
+
+################################################################################
+# Allow the user to move columns and remember position
+################################################################################
+
+    def getColumnOrder(self):
+        settings = {}
+        header = self.header()
+        for col in range(header.count()):
+            settings[col] = header.logicalIndex(col)
+        return settings
+
+    def setColumnOrder(self, settings):
+        header = self.header()
+        cols = sorted(settings.keys(), key=lambda x: int(x))
+        for col in cols:
+            old_col = header.visualIndex(settings[col])
+            header.moveSection(int(old_col), int(col))

--- a/cuegui/cuegui/FrameMonitor.py
+++ b/cuegui/cuegui/FrameMonitor.py
@@ -92,6 +92,12 @@ class FrameMonitor(QtWidgets.QWidget):
     def setColumnVisibility(self, settings):
         self.frameMonitorTree.setColumnVisibility(settings)
 
+    def getColumnOrder(self):
+        return self.frameMonitorTree.getColumnOrder()
+
+    def setColumnOrder(self, settings):
+        self.frameMonitorTree.setColumnOrder(settings)
+
     def filterLayersFromDoubleClick(self, layerNames):
         self._filterLayersHandleByLayer(layerNames)
 

--- a/cuegui/cuegui/HostMonitor.py
+++ b/cuegui/cuegui/HostMonitor.py
@@ -77,6 +77,12 @@ class HostMonitor(QtWidgets.QWidget):
     def setColumnVisibility(self, settings):
         self.hostMonitorTree.setColumnVisibility(settings)
 
+    def getColumnOrder(self):
+        return self.hostMonitorTree.getColumnOrder()
+
+    def setColumnOrder(self, settings):
+        self.hostMonitorTree.setColumnOrder(settings)
+
 # ==============================================================================
 # Text box to filter by host name
 # ==============================================================================

--- a/cuegui/cuegui/LimitsWidget.py
+++ b/cuegui/cuegui/LimitsWidget.py
@@ -69,6 +69,12 @@ class LimitsWidget(QtWidgets.QWidget):
   def setColumnVisibility(self, settings):
     self.__monitorLimits.setColumnVisibility(settings)
 
+  def getColumnOrder(self):
+    return self.__monitorLimits.getColumnOrder()
+  
+  def setColumnOrder(self, settings):
+    self.__monitorLimits.setColumnOrder(settings)
+
 
 class LimitsTreeWidget(cuegui.AbstractTreeWidget.AbstractTreeWidget):
   def __init__(self, parent):

--- a/cuegui/cuegui/ProcMonitor.py
+++ b/cuegui/cuegui/ProcMonitor.py
@@ -77,6 +77,12 @@ class ProcMonitor(QtWidgets.QWidget):
     def setColumnVisibility(self, settings):
         self.procMonitorTree.setColumnVisibility(settings)
 
+    def getColumnOrder(self):
+        return self.procMonitorTree.getColumnOrder()
+
+    def setColumnOrder(self, settings):
+        self.procMonitorTree.setColumnOrder(settings)
+
 # ==============================================================================
 # Text box to load procs by hostname
 # ==============================================================================

--- a/cuegui/cuegui/SubscriptionsWidget.py
+++ b/cuegui/cuegui/SubscriptionsWidget.py
@@ -141,6 +141,12 @@ class SubscriptionsWidget(QtWidgets.QWidget):
     def setColumnVisibility(self, settings):
         self.__monitorSubscriptions.setColumnVisibility(settings)
 
+    def getColumnOrder(self):
+        return self.__monitorSubscriptions.getColumnOrder()
+
+    def setColumnOrder(self, settings):
+        self.__monitorSubscriptions.setColumnOrder(settings)
+
 
 class SubscriptionsTreeWidget(cuegui.AbstractTreeWidget.AbstractTreeWidget):
     def __init__(self, parent):

--- a/cuegui/cuegui/plugins/AllocationsPlugin.py
+++ b/cuegui/cuegui/plugins/AllocationsPlugin.py
@@ -50,7 +50,10 @@ class AllocationsDockWidget(cuegui.AbstractDockWidget.AbstractDockWidget):
 
         self.pluginRegisterSettings([("columnVisibility",
                                       self.__monitorAllocations.getColumnVisibility,
-                                      self.__monitorAllocations.setColumnVisibility)])
+                                      self.__monitorAllocations.setColumnVisibility),
+                                      ("columnOrder",
+                                      self.__monitorAllocations.getColumnOrder,
+                                      self.__monitorAllocations.setColumnOrder)])
 
 ################################################################################
 # Allocations

--- a/cuegui/cuegui/plugins/LimitsPlugin.py
+++ b/cuegui/cuegui/plugins/LimitsPlugin.py
@@ -39,4 +39,7 @@ class LimitsDockWidget(cuegui.AbstractDockWidget.AbstractDockWidget):
     
     self.pluginRegisterSettings([("columnVisibility",
                                   self.__limitsWidget.getColumnVisibility,
-                                  self.__limitsWidget.setColumnVisibility)])
+                                  self.__limitsWidget.setColumnVisibility),
+                                  ("columnOrder",
+                                  self.__limitsWidget.getColumnOrder,
+                                  self.__limitsWidget.setColumnOrder)])

--- a/cuegui/cuegui/plugins/MonitorCuePlugin.py
+++ b/cuegui/cuegui/plugins/MonitorCuePlugin.py
@@ -82,7 +82,10 @@ class MonitorCueDockWidget(cuegui.AbstractDockWidget.AbstractDockWidget):
                                        self.__monitorCue.setColumnVisibility),
                                       ("columnWidths",
                                        self.__monitorCue.getColumnWidths,
-                                       self.__monitorCue.setColumnWidths)])
+                                       self.__monitorCue.setColumnWidths),
+                                       ("columnOrder",
+                                       self.__monitorCue.getColumnOrder,
+                                       self.__monitorCue.setColumnOrder)])
 
         self.addShows([os.getenv('SHOW')])
 

--- a/cuegui/cuegui/plugins/MonitorHostsPlugin.py
+++ b/cuegui/cuegui/plugins/MonitorHostsPlugin.py
@@ -54,4 +54,10 @@ class HostMonitorDockWidget(cuegui.AbstractDockWidget.AbstractDockWidget):
                                       self.__monitorHosts.setColumnVisibility),
                                      ("procColumnVisibility",
                                       self.__monitorProcs.getColumnVisibility,
-                                      self.__monitorProcs.setColumnVisibility)])
+                                      self.__monitorProcs.setColumnVisibility),
+                                      ("hostColumnOrder",
+                                      self.__monitorHosts.getColumnOrder,
+                                      self.__monitorHosts.setColumnOrder),
+                                     ("procColumnOrder",
+                                      self.__monitorProcs.getColumnOrder,
+                                      self.__monitorProcs.setColumnOrder)])

--- a/cuegui/cuegui/plugins/MonitorJobDetailsPlugin.py
+++ b/cuegui/cuegui/plugins/MonitorJobDetailsPlugin.py
@@ -80,7 +80,13 @@ class MonitorLayerFramesDockWidget(cuegui.AbstractDockWidget.AbstractDockWidget)
                                       self.__monitorFrames.setColumnWidths),
                                      ("layerColumnWidths",
                                       self.__monitorLayers.getColumnWidths,
-                                      self.__monitorLayers.setColumnWidths)])
+                                      self.__monitorLayers.setColumnWidths),
+                                      ("frameColumnOrder",
+                                      self.__monitorFrames.getColumnOrder,
+                                      self.__monitorFrames.setColumnOrder),
+                                      ("layerColumnOrder",
+                                      self.__monitorLayers.getColumnOrder,
+                                      self.__monitorLayers.setColumnOrder)])
 
     def handleLayerFilter(self, names):
         self.__monitorFrames.filterLayersFromDoubleClick(names)

--- a/cuegui/cuegui/plugins/MonitorJobsPlugin.py
+++ b/cuegui/cuegui/plugins/MonitorJobsPlugin.py
@@ -79,7 +79,10 @@ class MonitorJobsDockWidget(cuegui.AbstractDockWidget.AbstractDockWidget):
                                       self.jobMonitor.setColumnVisibility),
                                      ("columnWidths",
                                       self.jobMonitor.getColumnWidths,
-                                      self.jobMonitor.setColumnWidths)])
+                                      self.jobMonitor.setColumnWidths),
+                                      ("columnOrder",
+                                      self.jobMonitor.getColumnOrder,
+                                      self.jobMonitor.setColumnOrder)])
 
     def addJob(self, object):
         if cuegui.Utils.isProc(object):

--- a/cuegui/cuegui/plugins/ShowsPlugin.py
+++ b/cuegui/cuegui/plugins/ShowsPlugin.py
@@ -39,4 +39,7 @@ class ShowsDockWidget(cuegui.AbstractDockWidget.AbstractDockWidget):
 
         self.pluginRegisterSettings([("columnVisibility",
                                       self.__showsWidget.getColumnVisibility,
-                                      self.__showsWidget.setColumnVisibility)])
+                                      self.__showsWidget.setColumnVisibility),
+                                      ("columnOrder",
+                                      self.__showsWidget.getColumnOrder,
+                                      self.__showsWidget.setColumnOrder)])

--- a/cuegui/cuegui/plugins/SubscriptionsPlugin.py
+++ b/cuegui/cuegui/plugins/SubscriptionsPlugin.py
@@ -53,4 +53,7 @@ class SubscriptionDockWidget(cuegui.AbstractDockWidget.AbstractDockWidget):
                                       self.__subscriptionsWidget.setShow),
                                      ("columnVisibility",
                                       self.__subscriptionsWidget.getColumnVisibility,
-                                      self.__subscriptionsWidget.setColumnVisibility)])
+                                      self.__subscriptionsWidget.setColumnVisibility),
+                                      ("columnOrder",
+                                      self.__subscriptionsWidget.getColumnOrder,
+                                      self.__subscriptionsWidget.setColumnOrder)])


### PR DESCRIPTION
**Summarize your change.**
Make tree headers movable and save header positions in settings to be used on next load.

This allows users to customize their cuegui layout to their taste.

![movable_headers](https://user-images.githubusercontent.com/8471804/97235292-76e59980-17da-11eb-8213-77fdb77d2699.gif)
