### PR TITLE
refactor: Remove simplejson dependency

### DIFF
--- a/cuesubmit/setup.py
+++ b/cuesubmit/setup.py
@@ -60,6 +60,5 @@ setup(
         'grpcio-tools',
         'PySide2',
         'PyYAML',
-        'simplejson'
     ]
 )

--- a/pyoutline/outline/loader.py
+++ b/pyoutline/outline/loader.py
@@ -25,7 +25,7 @@ from builtins import str
 from builtins import object
 import os
 import logging
-import simplejson
+import json
 import time
 import uuid
 import yaml
@@ -93,12 +93,12 @@ def load_outline(path):
 
     return ol
 
-def load_json(json):
+def load_json(json_str):
     """
     Parse a json repesentation of an outline file.
 
-    :type  json: str
-    :param json: A json string.
+    :type  json_str: str
+    :param json_str: A json string.
 
     :rtype: L{Outline}
     :return: The resulting outline object.
@@ -117,7 +117,7 @@ def load_json(json):
         del result["name"]
         return result
 
-    data = simplejson.loads(json)
+    data = json.loads(json_str)
     ol = Outline(current=True)
 
     if "name" in data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,4 @@ pexpect==4.6.0
 psutil==5.6.6
 pyfakefs==3.6
 PyYAML==5.1
-simplejson==3.16.0
 six==1.11.0


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Fixes #789

**Summarize your change.**

Remove `simplejson` as a dependency and rely on the standard `json` library shipped with python. One less dependency to worry about.
