### PR TITLE
Enable -Werror for main and test code.

### DIFF
--- a/cuebot/build.gradle
+++ b/cuebot/build.gradle
@@ -67,6 +67,14 @@ dependencies {
     testCompile group: 'org.flywaydb', name: 'flyway-core', version: '5.2.0'
 }
 
+compileJava {
+    options.compilerArgs << "-Xlint:all" << "-Werror"
+}
+
+compileTestJava {
+    options.compilerArgs << "-Xlint:all" << "-Werror"
+}
+
 protobuf {
     protoc {
         // The protoc compiler


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Fixes #790 

**Summarize your change.**
Now that we've resolved any existing warnings, we can turn this option on. Any lint issues or other warnings will cause the build to fail.

This option is required by the CII badge process.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.
-->
