### PR TITLE
Add reset to default layout

### DIFF
--- a/cuegui/cuegui/Main.py
+++ b/cuegui/cuegui/Main.py
@@ -90,12 +90,16 @@ def startup(app_name, app_version, argv):
 
     config_path = "/.%s/config" % app_name.lower()
     settings = QtCore.QSettings(QtCore.QSettings.IniFormat, QtCore.QSettings.UserScope, config_path)
+    local = settings.fileName()
+    # If the user has chose to revert the layout. delete the file and copy the default back.
+    if settings.value('RevertLayout'):
+        os.remove(local)
+
     QtGui.qApp.settings = settings
 
     cuegui.Style.init()
 
-    # If the config file does not exist, copy over the default
-    local = settings.fileName()
+    # If the config file does not exist, copy over the default    
     if not os.path.exists(local):
         default = os.path.join(cuegui.Constants.DEFAULT_INI_PATH, "%s.ini" % app_name.lower())
         logger.warning('Not found: %s\nCopying:   %s' % (local, default))

--- a/cuegui/cuegui/MainWindow.py
+++ b/cuegui/cuegui/MainWindow.py
@@ -240,6 +240,11 @@ class MainWindow(QtWidgets.QMainWindow):
         saveWindowSettings.triggered.connect(self.__saveSettings)
         menu.addAction(saveWindowSettings)
 
+        # Menu Bar: Window -> Revert To Default Window Layout
+        revertWindowSettings = QtWidgets.QAction("Revert To Default Window Layout", self)
+        revertWindowSettings.triggered.connect(self.__revertLayout)
+        menu.addAction(revertWindowSettings)
+
         menu.addSeparator()
 
         # Load list of window titles
@@ -422,3 +427,15 @@ class MainWindow(QtWidgets.QMainWindow):
                                self.size())
         self.settings.setValue("%s/Position" % self.name,
                                self.pos())
+        
+    def __revertLayout(self):
+        """Revert back to default window layout"""
+        result = QtWidgets.QMessageBox.question(
+                    self,
+                    "Restart required ",
+                    "You must restart for this action to take effect, close window?: ",
+                    QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No)
+
+        if result == QtWidgets.QMessageBox.Yes:
+            self.settings.setValue("RevertLayout", True)
+            self.__windowCloseApplication()


### PR DESCRIPTION
Add menu option to reset to default layout option.

Users sometimes remove widgets by accident, this helps to give them a simple way to restore to defaults.

Closes #832
