### PR TITLE
Set reproducible builds for cuebot jar

### DIFF
--- a/cuebot/build.gradle
+++ b/cuebot/build.gradle
@@ -155,3 +155,8 @@ sonarqube {
         //   ./gradlew sonarqube -Dsonar.login=<login key>
     }
 }
+
+tasks.withType(AbstractArchiveTask) {
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+}


### PR DESCRIPTION
This PR is addressing to make the Cuebot build artifact exactly the same, byte for byte, no matter when or where is built by continuous integration. It helps Cuebot binary deployment by detecting only when the build artifact is really updated.
https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives
