### PR TITLE
Introduce RQD_BECOME_JOB_USER to allow to not use root privilege

### DIFF
--- a/rqd/rqd/__main__.py
+++ b/rqd/rqd/__main__.py
@@ -101,7 +101,8 @@ def usage():
 def main():
     setupLogging()
 
-    if platform.system() == 'Linux' and os.getuid() != 0:
+    if platform.system() == 'Linux' and os.getuid() != 0 and \
+       rqd.rqconstants.RQD_BECOME_JOB_USER:
         logging.critical("Please run launch as root")
         sys.exit(1)
 

--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -66,6 +66,7 @@ LAUNCH_FRAME_USER_GID = 20
 RQD_RETRY_STARTUP_CONNECT_DELAY = 30
 RQD_RETRY_CRITICAL_REPORT_DELAY = 30
 RQD_USE_IP_AS_HOSTNAME = True
+RQD_BECOME_JOB_USER = True
 RQD_CREATE_USER_IF_NOT_EXISTS = True
 
 KILL_SIGNAL = 9
@@ -182,6 +183,8 @@ try:
             LOAD_MODIFIER = config.getint(__section, "LOAD_MODIFIER")
         if config.has_option(__section, "RQD_USE_IP_AS_HOSTNAME"):
             RQD_USE_IP_AS_HOSTNAME = config.getboolean(__section, "RQD_USE_IP_AS_HOSTNAME")
+        if config.has_option(__section, "RQD_BECOME_JOB_USER"):
+            RQD_BECOME_JOB_USER = config.getboolean(__section, "RQD_BECOME_JOB_USER")
         if config.has_option(__section, "DEFAULT_FACILITY"):
             DEFAULT_FACILITY = config.get(__section, "DEFAULT_FACILITY")
         if config.has_option(__section, "LAUNCH_FRAME_USER_GID"):

--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -263,8 +263,11 @@ class FrameAttendantThread(threading.Thread):
 
         rqd.rqutil.permissionsHigh()
         try:
-            tempCommand += ["/bin/su", runFrame.user_name, rqd.rqconstants.SU_ARGUEMENT,
-                            '"' + self._createCommandFile(runFrame.command) + '"']
+            if rqd.rqconstants.RQD_BECOME_JOB_USER:
+                tempCommand += ["/bin/su", runFrame.user_name, rqd.rqconstants.SU_ARGUEMENT,
+                                '"' + self._createCommandFile(runFrame.command) + '"']
+            else:
+                tempCommand += [self._createCommandFile(runFrame.command)]
 
             # Actual cwd is set by /shots/SHOW/home/perl/etc/qwrap.cuerun
             frameInfo.forkedCommand = subprocess.Popen(tempCommand,

--- a/rqd/rqd/rqutil.py
+++ b/rqd/rqd/rqutil.py
@@ -73,7 +73,7 @@ class Memoize(object):
 
 def permissionsHigh():
     """Sets the effective gid/uid to processes original values (root)"""
-    if platform.system() == "Windows":
+    if platform.system() == "Windows" or not rqd.rqconstants.RQD_BECOME_JOB_USER:
         return
     PERMISSIONS.acquire()
     os.setegid(os.getgid())
@@ -87,7 +87,7 @@ def permissionsHigh():
 def permissionsLow():
     """Sets the effective gid/uid to one with less permissions:
        RQD_GID and RQD_UID"""
-    if platform.system() in ('Windows', 'Darwin'):
+    if platform.system() in ('Windows', 'Darwin') or not rqd.rqconstants.RQD_BECOME_JOB_USER:
         return
     if os.getegid() != rqd.rqconstants.RQD_GID or os.geteuid() != rqd.rqconstants.RQD_UID:
         __becomeRoot()
@@ -100,7 +100,7 @@ def permissionsLow():
 
 def permissionsUser(uid, gid):
     """Sets the effective gid/uid to supplied values"""
-    if platform.system() in ('Windows', 'Darwin'):
+    if platform.system() in ('Windows', 'Darwin') or not rqd.rqconstants.RQD_BECOME_JOB_USER:
         return
     PERMISSIONS.acquire()
     __becomeRoot()
@@ -128,6 +128,8 @@ def __becomeRoot():
 def checkAndCreateUser(username):
     """Check to see if the provided user exists, if not attempt to create it."""
     # TODO(gregdenton): Add Windows and Mac support here. (Issue #61)
+    if not rqd.rqconstants.RQD_BECOME_JOB_USER:
+        return
     try:
         pwd.getpwnam(username)
         return


### PR DESCRIPTION
This PR allows RQD to run without root privilege.

- quoting #804 
    > it needs to run as root. It's not ideal, and something we should address eventually
- With non-NFS use case (like transferring rendered result to distributed storage), RQD process isn't necessary to become the job user. Thus it doesn't need root privilege at all.