### PR TITLE
Introduce RQD_REDIRECT_LOG to allow duplicating log to stdout

### DIFF
--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -66,6 +66,7 @@ LAUNCH_FRAME_USER_GID = 20
 RQD_RETRY_STARTUP_CONNECT_DELAY = 30
 RQD_RETRY_CRITICAL_REPORT_DELAY = 30
 RQD_USE_IP_AS_HOSTNAME = True
+RQD_REDIRECT_LOG = True
 RQD_CREATE_USER_IF_NOT_EXISTS = True
 
 KILL_SIGNAL = 9
@@ -182,6 +183,8 @@ try:
             LOAD_MODIFIER = config.getint(__section, "LOAD_MODIFIER")
         if config.has_option(__section, "RQD_USE_IP_AS_HOSTNAME"):
             RQD_USE_IP_AS_HOSTNAME = config.getboolean(__section, "RQD_USE_IP_AS_HOSTNAME")
+        if config.has_option(__section, "RQD_REDIRECT_LOG"):
+            RQD_REDIRECT_LOG = config.getboolean(__section, "RQD_REDIRECT_LOG")
         if config.has_option(__section, "DEFAULT_FACILITY"):
             DEFAULT_FACILITY = config.get(__section, "DEFAULT_FACILITY")
         if config.has_option(__section, "LAUNCH_FRAME_USER_GID"):


### PR DESCRIPTION
RQD machines may already have pretty good stdout handling system.
This PR allows RQD to duplicate logging to both the current log file and stdout simultaneously.

`RQD_REDIRECT_LOG=True` (Default), same behavior as before. logging to the file.
`RQD_REDIRECT_LOG=False`, logging to the file and stdout.