### PR TITLE
Introduce OVERRIDE_HOSTNAME to override hostname

### DIFF
--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -113,6 +113,7 @@ OVERRIDE_IS_DESKTOP = None # Force rqd to run in 'desktop' mode
 OVERRIDE_PROCS = None # number of physical cpus. ex: None or 2
 OVERRIDE_MEMORY = None # in Kb
 OVERRIDE_NIMBY = None # True to turn on, False to turn off
+OVERRIDE_HOSTNAME = None # Force to use this hostname
 ALLOW_GPU = False
 ALLOW_PLAYBLAST = False
 LOAD_MODIFIER = 0 # amount to add/subtract from load
@@ -174,6 +175,8 @@ try:
             CUEBOT_HOSTNAME = config.get(__section, "OVERRIDE_CUEBOT")
         if config.has_option(__section, "OVERRIDE_NIMBY"):
             OVERRIDE_NIMBY = config.getboolean(__section, "OVERRIDE_NIMBY")
+        if config.has_option(__section, "OVERRIDE_HOSTNAME"):
+            OVERRIDE_HOSTNAME = config.get(__section, "OVERRIDE_HOSTNAME")
         if config.has_option(__section, "GPU"):
             ALLOW_GPU = config.getboolean(__section, "GPU")
         if config.has_option(__section, "PLAYBLAST"):

--- a/rqd/rqd/rqutil.py
+++ b/rqd/rqd/rqutil.py
@@ -147,7 +147,9 @@ def getHostIp():
 def getHostname():
     """Returns the machine's fully qualified domain name"""
     try:
-        if rqd.rqconstants.RQD_USE_IP_AS_HOSTNAME:
+        if rqd.rqconstants.OVERRIDE_HOSTNAME:
+            return rqd.rqconstants.OVERRIDE_HOSTNAME
+        elif rqd.rqconstants.RQD_USE_IP_AS_HOSTNAME:
             return getHostIp()
         else:
             return socket.gethostbyaddr(socket.gethostname())[0].split('.')[0]


### PR DESCRIPTION
This PR allows RQD to use specific IPv4/v6 address or hostname by overriding it via configuration. This helps these use cases.
- The RQD machine has multiple network interfaces.
- The RQD container has a dedicated IPv6 address.
- The RQD machine has static IPv6 address aside from a dynamic IPv6 address.

The behavior won't change without `OVERRIDE_HOSTNAME` settings.

#845 is required to use IPv6 address.