### PR TITLE
Redirect DTD http request to the resource file

### DIFF
--- a/cuebot/src/main/resources/application.properties
+++ b/cuebot/src/main/resources/application.properties
@@ -1,5 +1,2 @@
-server.contextPath=/spcue
-server.port=8080
-
 spring.main.allow-bean-definition-overriding=true
-spring.mvc.static-path-pattern=/spcue/**
+spring.main.web-application-type=none

--- a/cuebot/src/test/java/com/imageworks/spcue/test/service/JobSpecTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/service/JobSpecTests.java
@@ -1,0 +1,85 @@
+
+/*
+ * Copyright Contributors to the OpenCue Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.imageworks.spcue.test.service;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import javax.annotation.Resource;
+
+import org.junit.Test;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+
+import com.imageworks.spcue.SpecBuilderException;
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.service.JobLauncher;
+import com.imageworks.spcue.service.JobSpec;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+public class JobSpecTests extends AbstractTransactionalJUnit4SpringContextTests {
+
+    @Resource
+    JobLauncher jobLauncher;
+
+    private static String readJobSpec(String name)
+    {
+        String path = "src/test/resources/conf/jobspec/" + name;
+        byte[] encoded = null;
+
+        try {
+            encoded = Files.readAllBytes(Paths.get(path));
+        } catch (IOException e) {
+            fail("readJobSpec should succeed to read jobspec file");
+        }
+
+        return new String(encoded, StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void testParseSuccess() {
+        String xml = readJobSpec("jobspec_1_10.xml");
+        JobSpec spec = jobLauncher.parse(xml);
+        assertEquals(spec.getDoc().getDocType().getPublicID(),
+                "SPI Cue Specification Language");
+        assertEquals(spec.getDoc().getDocType().getSystemID(),
+                "http://localhost:8080/spcue/dtd/cjsl-1.10.dtd");
+        assertEquals(spec.getJobs().size(), 1);
+        assertEquals(spec.getJobs().get(0).detail.name, "testing-default-testuser_test");
+    }
+
+    @Test
+    public void testParseNonExistent() {
+        String xml = readJobSpec("jobspec_nonexistent_dtd.xml");
+        try {
+            jobLauncher.parse(xml);
+            fail("Expected exception");
+        } catch (SpecBuilderException e) {
+            assertEquals(e.getMessage(),
+                    "Failed to parse job spec XML, java.net.MalformedURLException");
+        }
+    }
+}

--- a/cuebot/src/test/resources/conf/jobspec/jobspec_1_10.xml
+++ b/cuebot/src/test/resources/conf/jobspec/jobspec_1_10.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<!--
+   Copyright Contributors to the OpenCue Project
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+
+
+
+<!DOCTYPE spec PUBLIC "SPI Cue Specification Language" "http://localhost:8080/spcue/dtd/cjsl-1.10.dtd">
+<spec>
+    <facility>local</facility>
+    <show>testing</show>
+    <shot>default</shot>
+    <user>testuser</user>
+    <uid>9860</uid>
+
+    <job name="test">
+        <paused>False</paused>
+        <maxretries>2</maxretries>
+        <autoeat>False</autoeat>
+        <env/>
+        <layers>
+            <layer name="test" type="Render">
+                <cmd>echo hello</cmd>
+                <range>1</range>
+                <chunk>1</chunk>
+                <env/>
+                <services>
+                    <service>shell</service>
+                </services>
+            </layer>
+        </layers>
+    </job>
+    <depends/>
+</spec>

--- a/cuebot/src/test/resources/conf/jobspec/jobspec_nonexistent_dtd.xml
+++ b/cuebot/src/test/resources/conf/jobspec/jobspec_nonexistent_dtd.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<!--
+   Copyright Contributors to the OpenCue Project
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+
+
+
+<!DOCTYPE spec PUBLIC "SPI Cue Specification Language" "http://localhost:8080/spcue/dtd/cjsl-nonexistent.dtd">
+<spec>
+    <facility>local</facility>
+    <show>testing</show>
+    <shot>default</shot>
+    <user>testuser</user>
+    <uid>9860</uid>
+
+    <job name="test">
+        <paused>False</paused>
+        <maxretries>2</maxretries>
+        <autoeat>False</autoeat>
+        <env/>
+        <layers>
+            <layer name="test" type="Render">
+                <cmd>echo hello</cmd>
+                <range>1</range>
+                <chunk>1</chunk>
+                <env/>
+                <services>
+                    <service>shell</service>
+                </services>
+            </layer>
+        </layers>
+    </job>
+    <depends/>
+</spec>

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -34,7 +34,6 @@ services:
       - db
     ports:
       - "8443:8443"
-      - "8080:8080"
     depends_on:
       - db
       - flyway


### PR DESCRIPTION
Cuebot requires to bind TCP 8080 port for providing http access to Job XML DTD (`http://localhost:8080/spcue/dtd/cjsl-1.9.dtd`.) But it isn't necessary because the http request can be redirected to Jar resource file via `EntityResolver`. This allows to disable http server.