### PR TITLE
Switch to use new Github environment file.

### DIFF
--- a/.github/workflows/packaging-pipeline.yml
+++ b/.github/workflows/packaging-pipeline.yml
@@ -3,7 +3,7 @@ name: OpenCue Packaging Pipeline
 # Trigger this pipeline on new commits to master.
 on:
   push:
-    branches: [ master ]
+    branches: [ master fix-set-env ]
 
 jobs:
   build_components:
@@ -63,7 +63,10 @@ jobs:
           set -e
           ci/generate_version_number.sh > VERSION
           echo "Build ID: $(cat ./VERSION)"
-          echo "::set-env name=BUILD_ID::$(cat ./VERSION)"
+          echo "BUILD_ID=$(cat ./VERSION)" >> ${GITHUB_ENV}
+
+      - name: Debug build ID
+        run: echo ${BUILD_ID}
 
       - name: Build Docker image
         uses: docker/build-push-action@v1
@@ -121,7 +124,10 @@ jobs:
           set -e
           ci/generate_version_number.sh > VERSION
           echo "Build ID: $(cat ./VERSION)"
-          echo "::set-env name=BUILD_ID::$(cat ./VERSION)"
+          echo "BUILD_ID=$(cat ./VERSION)" >> ${GITHUB_ENV}
+
+      - name: Debug build ID
+        run: echo ${BUILD_ID}
 
       - name: Extract database schema
         run: |

--- a/.github/workflows/packaging-pipeline.yml
+++ b/.github/workflows/packaging-pipeline.yml
@@ -3,8 +3,6 @@ name: OpenCue Packaging Pipeline
 # Trigger this pipeline on new commits to master.
 on:
   push:
-    branches: [ master fix-set-env ]
-  pull_request:
     branches: [ master ]
 
 jobs:
@@ -65,11 +63,7 @@ jobs:
           set -e
           ci/generate_version_number.sh > VERSION
           echo "Build ID: $(cat ./VERSION)"
-          echo "foo"
           echo "BUILD_ID=$(cat ./VERSION)" >> ${GITHUB_ENV}
-
-      - name: Debug build ID
-        run: echo ${BUILD_ID}
 
       - name: Build Docker image
         uses: docker/build-push-action@v1
@@ -128,9 +122,6 @@ jobs:
           ci/generate_version_number.sh > VERSION
           echo "Build ID: $(cat ./VERSION)"
           echo "BUILD_ID=$(cat ./VERSION)" >> ${GITHUB_ENV}
-
-      - name: Debug build ID
-        run: echo ${BUILD_ID}
 
       - name: Extract database schema
         run: |

--- a/.github/workflows/packaging-pipeline.yml
+++ b/.github/workflows/packaging-pipeline.yml
@@ -63,6 +63,7 @@ jobs:
           set -e
           ci/generate_version_number.sh > VERSION
           echo "Build ID: $(cat ./VERSION)"
+          echo "foo"
           echo "BUILD_ID=$(cat ./VERSION)" >> ${GITHUB_ENV}
 
       - name: Debug build ID

--- a/.github/workflows/packaging-pipeline.yml
+++ b/.github/workflows/packaging-pipeline.yml
@@ -4,6 +4,8 @@ name: OpenCue Packaging Pipeline
 on:
   push:
     branches: [ master fix-set-env ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build_components:

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -21,10 +21,10 @@ jobs:
           set -e
           ci/generate_version_number.sh > VERSION
           echo "Build ID: $(cat ./VERSION)"
-          echo "::set-env name=BUILD_ID::$(cat ./VERSION)"
+          echo "BUILD_ID=$(cat ./VERSION)" >> ${GITHUB_ENV}
 
       - name: Get current tag name
-        run: echo ::set-env name=TAG_NAME::${GITHUB_REF/refs\/tags\//}
+        run: echo "TAG_NAME=${GITHUB_REF/refs\/tags\//}" >> ${GITHUB_ENV}
 
       - name: Verify tag name and version match
         run: |
@@ -54,7 +54,7 @@ jobs:
           set -e
           ci/generate_version_number.sh > VERSION
           echo "Build ID: $(cat ./VERSION)"
-          echo "::set-env name=BUILD_ID::$(cat ./VERSION)"
+          echo "BUILD_ID=$(cat ./VERSION)" >> ${GITHUB_ENV}
 
       - name: Pull Docker image from staging
         run: |
@@ -94,7 +94,7 @@ jobs:
           set -e
           ci/generate_version_number.sh > VERSION
           echo "Build ID: $(cat ./VERSION)"
-          echo "::set-env name=BUILD_ID::$(cat ./VERSION)"
+          echo "BUILD_ID=$(cat ./VERSION)" >> ${GITHUB_ENV}
 
       - name: Fetch artifacts
         id: fetch_artifacts


### PR DESCRIPTION
The `set-env` command has been deprecated due to a [security issue](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/). The new preferred method is to use the [Github environment file](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files).