### PR TITLE
Make explicit casts to long.

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dao/oracle/WhiteboardDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/oracle/WhiteboardDaoJdbc.java
@@ -1214,7 +1214,8 @@ public class WhiteboardDaoJdbc extends JdbcDaoSupport implements WhiteboardDao {
                         (int) (rs.getLong("int_clock_time_success") / statsBuilder.getRenderedFrameCount()));
                 statsBuilder.setAvgCoreSec(
                         (int) (statsBuilder.getRenderedCoreSec() / statsBuilder.getRenderedFrameCount()));
-                statsBuilder.setRemainingCoreSec(statsBuilder.getPendingFrames() * statsBuilder.getAvgCoreSec());
+                statsBuilder.setRemainingCoreSec(
+                        (long) statsBuilder.getPendingFrames() * statsBuilder.getAvgCoreSec());
             }
             else {
                 statsBuilder.setAvgFrameSec(0);
@@ -1274,7 +1275,7 @@ public class WhiteboardDaoJdbc extends JdbcDaoSupport implements WhiteboardDao {
                         statsBuilder.setAvgCoreSec(
                             (int) (statsBuilder.getRenderedCoreSec() / statsBuilder.getRenderedFrameCount()));
                         statsBuilder.setRemainingCoreSec(
-                                statsBuilder.getPendingFrames() * statsBuilder.getAvgCoreSec());
+                            (long) statsBuilder.getPendingFrames() * statsBuilder.getAvgCoreSec());
                     }
                     else {
                         statsBuilder.setAvgFrameSec(0);

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/WhiteboardDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/WhiteboardDaoJdbc.java
@@ -1214,7 +1214,8 @@ public class WhiteboardDaoJdbc extends JdbcDaoSupport implements WhiteboardDao {
                     (int) (rs.getLong("int_clock_time_success") / statsBuilder.getRenderedFrameCount()));
             statsBuilder.setAvgCoreSec(
                     (int) (statsBuilder.getRenderedCoreSec() / statsBuilder.getRenderedFrameCount()));
-            statsBuilder.setRemainingCoreSec(statsBuilder.getPendingFrames() * statsBuilder.getAvgCoreSec());
+            statsBuilder.setRemainingCoreSec(
+                    (long) statsBuilder.getPendingFrames() * statsBuilder.getAvgCoreSec());
         }
         else {
             statsBuilder.setAvgFrameSec(0);
@@ -1274,7 +1275,7 @@ public class WhiteboardDaoJdbc extends JdbcDaoSupport implements WhiteboardDao {
                         statsBuilder.setAvgCoreSec(
                                 (int) (statsBuilder.getRenderedCoreSec() / statsBuilder.getRenderedFrameCount()));
                         statsBuilder.setRemainingCoreSec(
-                                statsBuilder.getPendingFrames() * statsBuilder.getAvgCoreSec());
+                                (long) statsBuilder.getPendingFrames() * statsBuilder.getAvgCoreSec());
                     }
                     else {
                         statsBuilder.setAvgFrameSec(0);

--- a/cuebot/src/main/java/com/imageworks/spcue/util/CueUtil.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/util/CueUtil.java
@@ -65,11 +65,11 @@ public final class CueUtil {
     public static final long MB256 = 262144;
     public static final long MB512 = 524288;
     public static final long GB = 1048576;
-    public static final long GB2 = 1048576 * 2;
-    public static final long GB4 = 1048576 * 4;
-    public static final long GB8 = 1048576 * 8;
-    public static final long GB16 = 1048576 * 16;
-    public static final long GB32 = 1048576 * 32;
+    public static final long GB2 = 1048576L * 2;
+    public static final long GB4 = 1048576L * 4;
+    public static final long GB8 = 1048576L * 8;
+    public static final long GB16 = 1048576L * 16;
+    public static final long GB32 = 1048576L * 32;
 
     /**
      * Features that relay on an integer greated than 0 to work


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
#801 

**Summarize your change.**
Flagged by SonarCloud as a bug.

Arithmetic on integers produces integers by default -- when we set them to fields which are `long` we should make the cast explicit.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
