### PR TITLE
Reinterrupt current thread after InterruptedException.

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/BookingQueue.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/BookingQueue.java
@@ -93,6 +93,7 @@ public class BookingQueue extends ThreadPoolExecutor {
                 Thread.sleep(sleepTime());
             } catch (InterruptedException e) {
                 logger.info("booking queue was interrupted.");
+                Thread.currentThread().interrupt();
             }
         }
     }

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchQueue.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchQueue.java
@@ -105,6 +105,7 @@ public class DispatchQueue {
                     }
                     Thread.sleep(250);
                 } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
                     break;
                 }
             }

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportQueue.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportQueue.java
@@ -73,6 +73,7 @@ public class HostReportQueue extends ThreadPoolExecutor {
                     }
                     Thread.sleep(250);
                 } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
                     break;
                 }
             }

--- a/cuebot/src/main/java/com/imageworks/spcue/service/JobManagerSupport.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/service/JobManagerSupport.java
@@ -100,6 +100,7 @@ public class JobManagerSupport {
                 } catch (InterruptedException e1) {
                     logger.info(job.getName() + "/" + job.getId() +
                             " shutdown thread was interrupted.");
+                    Thread.currentThread().interrupt();
                 }
 
                 FrameSearchInterface search = frameSearchFactory.create(job);


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
#801 

**Summarize your change.**
Flagged by SonarCloud.

When catching `InterruptedException`, you should always either a) rethrow the exception, or b) reinterrupt the current thread (as `InterruptedException` clears the interrupted state) so downstream code can deal with it.

In these cases, it looks like it's best to just reinterrupt the threads so Spring can deal with the interruption as needed.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
