### PR TITLE
Fix username string comparison.

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/service/JobSpec.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/service/JobSpec.java
@@ -202,7 +202,7 @@ public class JobSpec {
         uid = Optional.ofNullable(rootElement.getChildTextTrim("uid")).map(Integer::parseInt);
         email = rootElement.getChildTextTrim("email");
 
-        if (user == "root" || uid.equals(Optional.of(0))) {
+        if (user.equals("root") || uid.equals(Optional.of(0))) {
             throw new SpecBuilderException("Cannot launch jobs as root.");
         }
     }


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
#801 

**Summarize your change.**
Flagged by SonarCloud.

Use `.equals` instead of `==` for the string comparison.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
