### PR TITLE
Introduce RQD_TAGS for setting tags to RQD host

### DIFF
--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -68,6 +68,7 @@ RQD_RETRY_CRITICAL_REPORT_DELAY = 30
 RQD_USE_IP_AS_HOSTNAME = True
 RQD_BECOME_JOB_USER = True
 RQD_CREATE_USER_IF_NOT_EXISTS = True
+RQD_TAGS = ''
 
 KILL_SIGNAL = 9
 if platform.system() == 'Linux':
@@ -185,6 +186,8 @@ try:
             RQD_USE_IP_AS_HOSTNAME = config.getboolean(__section, "RQD_USE_IP_AS_HOSTNAME")
         if config.has_option(__section, "RQD_BECOME_JOB_USER"):
             RQD_BECOME_JOB_USER = config.getboolean(__section, "RQD_BECOME_JOB_USER")
+        if config.has_option(__section, "RQD_TAGS"):
+            RQD_TAGS = config.getint(__section, "RQD_TAGS")
         if config.has_option(__section, "DEFAULT_FACILITY"):
             DEFAULT_FACILITY = config.get(__section, "DEFAULT_FACILITY")
         if config.has_option(__section, "LAUNCH_FRAME_USER_GID"):

--- a/rqd/rqd/rqmachine.py
+++ b/rqd/rqd/rqmachine.py
@@ -385,6 +385,10 @@ class Machine(object):
         """Sets the hosts tags"""
         self.__renderHost.tags.append("rqdv-%s" % rqd.rqconstants.VERSION)
 
+        if rqd.rqconstants.RQD_TAGS:
+            for tag in rqd.rqconstants.RQD_TAGS.split():
+                self.__renderHost.tags.append(tag)
+
         # Tag with desktop if it is a desktop
         if self.isDesktop():
             self.__renderHost.tags.append("desktop")

--- a/rqd/tests/rqmachine_tests.py
+++ b/rqd/tests/rqmachine_tests.py
@@ -430,6 +430,13 @@ class MachineTests(pyfakefs.fake_filesystem_unittest.TestCase):
 
         self.assertEqual({0, 1, 2, 3, 4, 5, 6, 7}, self.machine._Machine__tasksets)
 
+    def test_tags(self):
+        tags = ["test1", "test2", "test3"]
+        rqd.rqconstants.RQD_TAGS = " ".join(tags)
+
+        machine = rqd.rqmachine.Machine(self.rqCore, self.coreDetail)
+
+        self.assertTrue(all(tag in machine.__dict__['_Machine__renderHost'].tags for tag in tags))
 
 class CpuinfoTests(unittest.TestCase):
 


### PR DESCRIPTION
RQD container build script usually knows which tags should be assigned to the RQD container.
This PR allows the build script can generate `rqd.conf` file with `RQD_TAGS` to set the tags to the RQD.