### PR TITLE
Serialize layer env

### DIFF
--- a/pyoutline/outline/backend/cue.py
+++ b/pyoutline/outline/backend/cue.py
@@ -294,6 +294,11 @@ def _serialize(launcher, use_pycuerun):
                 limit = Et.SubElement(limits, "limit")
                 limit.text = limit_name
 
+        layer_env = Et.SubElement(spec_layer, "env")
+        for env_k, env_v in layer.get_envs().items():
+            pair = Et.SubElement(layer_env, "key", {"name": env_k})
+            pair.text = env_v
+
         services = Et.SubElement(spec_layer, "services")
         service = Et.SubElement(services, "service")
         try:

--- a/pyoutline/outline/backend/cue.py
+++ b/pyoutline/outline/backend/cue.py
@@ -296,7 +296,7 @@ def _serialize(launcher, use_pycuerun):
 
         layer_env = Et.SubElement(spec_layer, "env")
         for env_k, env_v in layer.get_envs().items():
-            pair = Et.SubElement(layer_env, "key", {"name": env_k})
+            pair = Et.SubElement(layer_env, "key", {"name": "{}".format(env_k)})
             pair.text = env_v
 
         services = Et.SubElement(spec_layer, "services")

--- a/pyoutline/outline/layer.py
+++ b/pyoutline/outline/layer.py
@@ -304,7 +304,11 @@ class Layer(with_metaclass(LayerType, object)):
 
     def get_env(self, key, default=None):
         """Get the value of the env var that will be set before execute."""
-        self.__env.get(key, default)
+        return self.__env.get(key, default)
+
+    def get_envs(self):
+        """Return all env."""
+        return self.__env
 
     def get_name(self):
         """Return the layer name."""

--- a/pyoutline/tests/json/shell.outline
+++ b/pyoutline/tests/json/shell.outline
@@ -5,6 +5,7 @@
     {
       "name": "shell_layer",
       "module": "outline.modules.shell.Shell",
+      "env": {"LAYER_KEY": "LAYER_VALUE"},
       "command": ["/bin/ls"]
     }
   ]

--- a/pyoutline/tests/json_test.py
+++ b/pyoutline/tests/json_test.py
@@ -42,7 +42,7 @@ class JsonTest(unittest.TestCase):
                  '"layers": [{'
                     '"name": "layer_1", '
                     '"module": "outline.modules.shell.Shell", '
-                    '"env": {"LAYER_KEY": "LAYER_VALUE"}, '
+                    '"env": {"LAYER_KEY1": "LAYER_VALUE1"}, '
                     '"command": ["/bin/ls"]'
                  '}]'
              '}')
@@ -50,11 +50,16 @@ class JsonTest(unittest.TestCase):
         ol = load_json(s)
         self.assertEqual('test_job', ol.get_name())
         self.assertEqual('1-10', ol.get_frame_range())
+        self.assertEqual('LAYER_VALUE1', ol.get_layer('layer_1').get_env('LAYER_KEY1'))
+
+        ol.get_layer('layer_1').set_env('LAYER_KEY2', 'LAYER_VALUE2')
 
         l = outline.cuerun.OutlineLauncher(ol)
         root = Et.fromstring(l.serialize())
-        env = root.find('job/layers/layer/env/key[@name="LAYER_KEY"]')
-        self.assertEqual('LAYER_VALUE', env.text)
+        env1 = root.find('job/layers/layer/env/key[@name="LAYER_KEY1"]')
+        self.assertEqual('LAYER_VALUE1', env1.text)
+        env2 = root.find('job/layers/layer/env/key[@name="LAYER_KEY2"]')
+        self.assertEqual('LAYER_VALUE2', env2.text)
 
     @mock.patch('outline.layer.Layer.system')
     @mock.patch.dict(os.environ, {}, clear=True)


### PR DESCRIPTION
Fix #547 

- Layer env can be set from JSON, but it doesn't propagate. Serialize it into XML.
- Fix layer get_env.