### PR TITLE
Add dockerignore so that the sandbox env can be run mutliple times.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+ci
+images
+samples
+sandbox/db-data
+tsc
+venv


### PR DESCRIPTION
Exclude a few other directories as well that are not needed during
docker builds.

Closes #878