### PR TITLE
fix: Pin pip and setuptools to compatible versions

### DIFF
--- a/connectors/prometheus_metrics/Dockerfile
+++ b/connectors/prometheus_metrics/Dockerfile
@@ -15,10 +15,10 @@ RUN yum -y install \
   python36-devel \
   python36-pip
 
-RUN python -m pip install --upgrade pip
+RUN python -m pip install --upgrade 'pip<21'
 RUN python3.6 -m pip install --upgrade pip
 
-RUN python -m pip install --upgrade setuptools
+RUN python -m pip install --upgrade 'setuptools<45'
 RUN python3.6 -m pip install --upgrade setuptools
 
 COPY LICENSE ./

--- a/cueadmin/Dockerfile
+++ b/cueadmin/Dockerfile
@@ -19,10 +19,10 @@ RUN yum -y install \
   python36-devel \
   python36-pip
 
-RUN python -m pip install --upgrade pip
+RUN python -m pip install --upgrade 'pip<21'
 RUN python3.6 -m pip install --upgrade pip
 
-RUN python -m pip install --upgrade setuptools
+RUN python -m pip install --upgrade 'setuptools<45'
 RUN python3.6 -m pip install --upgrade setuptools
 
 COPY LICENSE ./

--- a/cuegui/Dockerfile
+++ b/cuegui/Dockerfile
@@ -26,10 +26,10 @@ RUN yum -y install \
   python36-devel \
   python36-pip
 
-RUN python -m pip install --upgrade pip
+RUN python -m pip install --upgrade 'pip<21'
 RUN python3.6 -m pip install --upgrade pip
 
-RUN python -m pip install --upgrade setuptools
+RUN python -m pip install --upgrade 'setuptools<45'
 RUN python3.6 -m pip install --upgrade setuptools
 
 RUN dbus-uuidgen > /etc/machine-id

--- a/cuesubmit/Dockerfile
+++ b/cuesubmit/Dockerfile
@@ -20,10 +20,10 @@ RUN yum -y install \
   python36-devel \
   python36-pip
 
-RUN python -m pip install --upgrade pip
+RUN python -m pip install --upgrade 'pip<21'
 RUN python3.6 -m pip install --upgrade pip
 
-RUN python -m pip install --upgrade setuptools
+RUN python -m pip install --upgrade 'setuptools<45'
 RUN python3.6 -m pip install --upgrade setuptools
 
 COPY LICENSE ./

--- a/pycue/Dockerfile
+++ b/pycue/Dockerfile
@@ -19,10 +19,10 @@ RUN yum -y install \
   python36-devel \
   python36-pip
 
-RUN python -m pip install --upgrade pip
+RUN python -m pip install --upgrade 'pip<21'
 RUN python3.6 -m pip install --upgrade pip
 
-RUN python -m pip install --upgrade setuptools
+RUN python -m pip install --upgrade 'setuptools<45'
 RUN python3.6 -m pip install --upgrade setuptools
 
 COPY LICENSE ./

--- a/pyoutline/Dockerfile
+++ b/pyoutline/Dockerfile
@@ -19,10 +19,10 @@ RUN yum -y install \
   python36-devel \
   python36-pip
 
-RUN python -m pip install --upgrade pip
+RUN python -m pip install --upgrade 'pip<21'
 RUN python3.6 -m pip install --upgrade pip
 
-RUN python -m pip install --upgrade setuptools
+RUN python -m pip install --upgrade 'setuptools<45'
 RUN python3.6 -m pip install --upgrade setuptools
 
 COPY LICENSE ./

--- a/rqd/Dockerfile
+++ b/rqd/Dockerfile
@@ -12,10 +12,10 @@ RUN yum -y install \
   python36-devel \
   python36-pip
 
-RUN python -m pip install --upgrade pip
+RUN python -m pip install --upgrade 'pip<21'
 RUN python3.6 -m pip install --upgrade pip
 
-RUN python -m pip install --upgrade setuptools
+RUN python -m pip install --upgrade 'setuptools<45'
 RUN python3.6 -m pip install --upgrade setuptools
 
 WORKDIR /opt/opencue


### PR DESCRIPTION

**Link the Issue(s) this Pull Request is related to.**
Closes #882 

**Summarize your change.**
This pins `pip` and `setuptools` to the last python 2 compatible versions in the various Dockerfiles.
This fixes building the sandbox environment.

