### PR TITLE
Suppress warnings

### DIFF
--- a/pyoutline/outline/config.py
+++ b/pyoutline/outline/config.py
@@ -26,9 +26,14 @@ standard_library.install_aliases()
 import getpass
 import os
 import pathlib
+import six
 import tempfile
 
-from six.moves.configparser import SafeConfigParser
+from six.moves import configparser
+if six.PY2:
+    ConfigParser = configparser.SafeConfigParser
+else:
+    ConfigParser = configparser.ConfigParser
 
 
 __all__ = ["config"]
@@ -37,7 +42,7 @@ __file_path__ = pathlib.Path(__file__)
 PYOUTLINE_ROOT_DIR = __file_path__.parent.parent
 DEFAULT_USER_DIR = pathlib.Path(tempfile.gettempdir()) / 'opencue' / 'outline' / getpass.getuser()
 
-config = SafeConfigParser()
+config = ConfigParser()
 
 default_config_paths = [__file_path__.parent.parent.parent / 'etc' / 'outline.cfg',
                         __file_path__.parent.parent / 'etc' / 'outline.cfg']

--- a/pyoutline/outline/config.py
+++ b/pyoutline/outline/config.py
@@ -30,8 +30,9 @@ standard_library.install_aliases()
 import getpass
 import os
 import pathlib
-import six
 import tempfile
+
+import six
 
 from six.moves import configparser
 if six.PY2:

--- a/pyoutline/outline/io.py
+++ b/pyoutline/outline/io.py
@@ -40,7 +40,7 @@ from .exception import ShellCommandFailureException
 logger = logging.getLogger("outline.io")
 
 # Used to match version number in paths
-VERSION_REGEX = re.compile("_v([\d+])")
+VERSION_REGEX = re.compile(r"_v([\d+])")
 
 
 def prep_shell_command(cmd, frame=None):


### PR DESCRIPTION
Suppress warnings by Python 3.7.

    config.py:40: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
    io.py:43: DeprecationWarning: invalid escape sequence \d
