### PR TITLE
Remove hinv and pexpect

### DIFF
--- a/cuegui/cuegui/HostMonitorTree.py
+++ b/cuegui/cuegui/HostMonitorTree.py
@@ -250,7 +250,6 @@ class HostMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         menu = QtWidgets.QMenu()
         self.__menuActions.hosts().addAction(menu, "viewComments")
         self.__menuActions.hosts().addAction(menu, "viewProc")
-        self.__menuActions.hosts().addAction(menu, "hinv")
         self.__menuActions.hosts().addAction(menu, "lock")
         self.__menuActions.hosts().addAction(menu, "unlock")
         self.__menuActions.hosts().addAction(menu, "addTags")

--- a/cuegui/cuegui/MenuActions.py
+++ b/cuegui/cuegui/MenuActions.py
@@ -30,7 +30,6 @@ import glob
 import subprocess
 import time
 
-import pexpect
 from PySide2 import QtGui
 from PySide2 import QtWidgets
 import six
@@ -1211,19 +1210,6 @@ class HostActions(AbstractActions):
         hosts = list(set([host.data.name for host in hosts]))
         if hosts:
             QtGui.qApp.view_procs.emit(hosts)
-
-    hinv_info = ["View Host Information (hinv)", None, "view"]
-    def hinv(self, rpcObjects=None):
-        hosts = self._getOnlyHostObjects(rpcObjects)
-        for host in hosts:
-            try:
-                lines = pexpect.run("rsh %s hinv" % host.data.name, timeout=10).splitlines()
-                QtWidgets.QMessageBox.information(self._caller,
-                                                  "%s hinv" % host.data.name,
-                                                  "\n".join(lines),
-                                                  QtWidgets.QMessageBox.Ok)
-            except Exception as e:
-                logger.warning("Failed to get host's hinv: %s" % e)
 
     lock_info = ["Lock Host", None, "lock"]
     def lock(self, rpcObjects=None):

--- a/cuegui/setup.py
+++ b/cuegui/setup.py
@@ -61,7 +61,6 @@ setup(
         'future',
         'grpcio',
         'grpcio-tools',
-        'pexpect',
         'PySide2',
         'PyYAML',
     ]

--- a/cuegui/tests/MenuActions_tests.py
+++ b/cuegui/tests/MenuActions_tests.py
@@ -1166,20 +1166,6 @@ class HostActionsTests(unittest.TestCase):
 
         qAppMock.view_procs.emit.assert_called_with([hostName])
 
-    @mock.patch('PySide2.QtWidgets.QMessageBox')
-    @mock.patch('pexpect.run')
-    def test_hinv(self, runMock, qMessageBoxMock):
-        hostName = 'arbitrary-name'
-        host = opencue.wrappers.host.Host(
-            opencue.compiled_proto.host_pb2.Host(id='arbitrary-id', name=hostName))
-        rshResponse = 'response line one\nanother response line'
-        runMock.return_value = rshResponse
-
-        self.host_actions.hinv(rpcObjects=[host])
-
-        qMessageBoxMock.information.assert_called_with(
-            mock.ANY, '%s hinv' % hostName, rshResponse, mock.ANY)
-
     def test_lock(self):
         host = opencue.wrappers.host.Host(
             opencue.compiled_proto.host_pb2.Host(id='arbitrary-id'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ grpcio==1.16.0
 grpcio-tools==1.16.0
 mock==2.0.0
 pathlib==1.0.1;python_version<"3.4"
-pexpect==4.6.0
 psutil==5.6.6
 pyfakefs==3.6
 pylint==2.6.0;python_version>="3.7"


### PR DESCRIPTION
These are not used for most users and aren't part of a standard Linux install