### PR TITLE
Make GRPC ports avaiable in settings file as override

### DIFF
--- a/rqd/rqd/__main__.py
+++ b/rqd/rqd/__main__.py
@@ -130,9 +130,6 @@ def main():
 
     logging.warning('RQD Starting Up')
 
-    if rqd.rqconstants.FACILITY == 'abq':
-        os.environ['TZ'] = 'PST8PDT'
-
     rqCore = rqd.rqcore.RqCore(optNimbyOff)
     rqCore.start()
 

--- a/rqd/rqd/cuerqd.py
+++ b/rqd/rqd/cuerqd.py
@@ -28,8 +28,6 @@ from builtins import object
 import logging as log
 import os
 import random
-import re
-import sys
 
 import grpc
 

--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -28,7 +28,6 @@ import subprocess
 import logging
 import os
 import platform
-import re
 import subprocess
 import sys
 import traceback
@@ -122,43 +121,11 @@ ALLOW_PLAYBLAST = False
 LOAD_MODIFIER = 0 # amount to add/subtract from load
 
 if subprocess.getoutput('/bin/su --help').find('session-command') != -1:
-    SU_ARGUEMENT = '--session-command'
+    SU_ARGUMENT = '--session-command'
 else:
-    SU_ARGUEMENT = '-c'
+    SU_ARGUMENT = '-c'
 
-SP_OS = FACILITY = ''
-proc = None
-# Try to read facility and os from studio environment
-if os.path.isfile('/usr/local/stdenv/.cshrc'):
-    proc = subprocess.Popen(
-        "csh -c 'unsetenv SP_PATH ; setenv CONSOLE 1 ; setenv HOME / ;"
-        " source /usr/local/stdenv/.cshrc ; echo $SP_OS $FACILITY'",
-        shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-elif os.path.isfile('/etc/csh.cshrc'):
-    # For maa on centos
-    proc = subprocess.Popen("csh -c 'source /etc/csh.cshrc ; echo $SP_OS $FACILITY'",
-                            shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-
-# If we have a popen process and it has successfully been run,
-# get os and facility from result.
-if proc:
-    out, err = proc.communicate()
-    if proc.returncode == 0:
-        SP_OS, FACILITY = out.split()[-2:]
-
-if not 3 <= len(SP_OS) <= 10 or not re.match('^[A-Za-z0-9]*$', SP_OS):
-    if SP_OS:
-        logging.warning('SP_OS value of %s is out of allowed range' % SP_OS)
-    SP_OS = platform.system()
-
-if len(FACILITY) != 3 or not re.match('^[A-Za-z0-9]*$', FACILITY):
-    if FACILITY:
-        logging.warning('FACILITY value of %s is out of allowed range' % FACILITY)
-    FACILITY = DEFAULT_FACILITY
-
-# maa is small so decrease the ping in interval
-if FACILITY == 'maa':
-    RQD_MAX_PING_INTERVAL_SEC = 30
+SP_OS = platform.system()
 
 try:
     if os.path.isfile(CONFIG_FILE):
@@ -168,6 +135,11 @@ try:
         config = configparser.RawConfigParser()
         logging.info('Loading config {}'.format(CONFIG_FILE))
         config.read(CONFIG_FILE)
+
+        if config.has_option(__section, "RQD_GRPC_PORT"):
+            RQD_GRPC_PORT = config.getint(__section, "RQD_GRPC_PORT")
+        if config.has_option(__section, "CUEBOT_GRPC_PORT"):
+            CUEBOT_GRPC_PORT = config.getint(__section, "CUEBOT_GRPC_PORT")
         if config.has_option(__section, "OVERRIDE_CORES"):
             OVERRIDE_CORES = config.getint(__section, "OVERRIDE_CORES")
         if config.has_option(__section, "OVERRIDE_PROCS"):

--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -264,7 +264,7 @@ class FrameAttendantThread(threading.Thread):
         rqd.rqutil.permissionsHigh()
         try:
             if rqd.rqconstants.RQD_BECOME_JOB_USER:
-                tempCommand += ["/bin/su", runFrame.user_name, rqd.rqconstants.SU_ARGUEMENT,
+                tempCommand += ["/bin/su", runFrame.user_name, rqd.rqconstants.SU_ARGUMENT,
                                 '"' + self._createCommandFile(runFrame.command) + '"']
             else:
                 tempCommand += [self._createCommandFile(runFrame.command)]

--- a/rqd/rqd/rqmachine.py
+++ b/rqd/rqd/rqmachine.py
@@ -415,7 +415,7 @@ class Machine(object):
         """Updates static machine information during initialization"""
         self.__renderHost.name = self.getHostname()
         self.__renderHost.boot_time = self.getBootTime()
-        self.__renderHost.facility = rqd.rqconstants.FACILITY
+        self.__renderHost.facility = rqd.rqconstants.DEFAULT_FACILITY
         self.__renderHost.attributes['SP_OS'] = rqd.rqconstants.SP_OS
 
         self.updateMachineStats()

--- a/rqd/tests/rqcore_tests.py
+++ b/rqd/tests/rqcore_tests.py
@@ -550,7 +550,7 @@ class RqCoreTests(unittest.TestCase):
 class FrameAttendantThreadTests(pyfakefs.fake_filesystem_unittest.TestCase):
     def setUp(self):
         self.setUpPyfakefs()
-        rqd.rqconstants.SU_ARGUEMENT = '-c'
+        rqd.rqconstants.SU_ARGUMENT = '-c'
 
     @mock.patch('platform.system', new=mock.Mock(return_value='Linux'))
     @mock.patch('tempfile.gettempdir')


### PR DESCRIPTION
- Make GRPC ports available in the settings file as an override
- Remove SPI specific facility checks/overrides hardcoded in RQD
- DEFAULT_FACILITY can now be overridden to set the default facility for a RQD client.
