### PR TITLE
Remove special case for playblast

### DIFF
--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -118,7 +118,6 @@ OVERRIDE_MEMORY = None # in Kb
 OVERRIDE_NIMBY = None # True to turn on, False to turn off
 OVERRIDE_HOSTNAME = None # Force to use this hostname
 ALLOW_GPU = False
-ALLOW_PLAYBLAST = False
 LOAD_MODIFIER = 0 # amount to add/subtract from load
 
 if subprocess.getoutput('/bin/su --help').find('session-command') != -1:
@@ -182,8 +181,6 @@ try:
             OVERRIDE_HOSTNAME = config.get(__section, "OVERRIDE_HOSTNAME")
         if config.has_option(__section, "GPU"):
             ALLOW_GPU = config.getboolean(__section, "GPU")
-        if config.has_option(__section, "PLAYBLAST"):
-            ALLOW_PLAYBLAST = config.getboolean(__section, "PLAYBLAST")
         if config.has_option(__section, "LOAD_MODIFIER"):
             LOAD_MODIFIER = config.getint(__section, "LOAD_MODIFIER")
         if config.has_option(__section, "RQD_USE_IP_AS_HOSTNAME"):

--- a/rqd/rqd/rqmachine.py
+++ b/rqd/rqd/rqmachine.py
@@ -317,8 +317,6 @@ class Machine(object):
         if not hasattr(self, 'gpuNotSupported'):
             if not hasattr(self, 'gpuResults'):
                 self.gpuResults = {'total': 0, 'free': 0, 'updated': 0}
-            if rqd.rqconstants.ALLOW_PLAYBLAST and not rqd.rqconstants.ALLOW_GPU:
-                return {'total': 262144, 'free': 262144, 'updated': 0}
             if not rqd.rqconstants.ALLOW_GPU:
                 self.gpuNotSupported = True
                 return self.gpuResults


### PR DESCRIPTION
Unless still used by SPI it seems like a special case we should remove.