### PR TITLE
[PyOutline] Add spec_version

### DIFF
--- a/pyoutline/etc/outline.cfg
+++ b/pyoutline/etc/outline.cfg
@@ -5,6 +5,7 @@ wrapper_dir = %(home)s/wrappers
 user_dir =
 bin_dir = %(home)s/bin
 backend = cue
+spec_version = 1.11
 facility = local
 domain = example.com
 maxretries = 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ futures==3.2.0;python_version<"3.0"
 grpcio==1.16.0
 grpcio-tools==1.16.0
 mock==2.0.0
+packaging==20.9
 pathlib==1.0.1;python_version<"3.4"
 psutil==5.6.6
 pyfakefs==3.6


### PR DESCRIPTION
Fix #918

It allows deploying clients (PyOutline) before updating Cuebot, with specifying spec_version in outline.cfg.