### PR TITLE
Simplify docker compose setup.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: postgres
     environment:
       - POSTGRES_USER=cuebot
-      - POSTGRES_PASSWORD=$POSTGRES_PASSWORD
+      - POSTGRES_PASSWORD=cuebot_password
       - POSTGRES_DB=cuebot
     ports:
       - "5432:5432"
@@ -22,7 +22,7 @@ services:
       - db
     environment:
       - PGUSER=cuebot
-      - PGPASSWORD=$POSTGRES_PASSWORD
+      - PGPASSWORD=cuebot_password
       - PGDATABASE=cuebot
       - PGHOST=db
       - PGPORT=5432
@@ -39,8 +39,8 @@ services:
       - flyway
     restart: always
     environment:
-      - CUE_FRAME_LOG_DIR=$CUE_FRAME_LOG_DIR
-    command: --datasource.cue-data-source.jdbc-url=jdbc:postgresql://db/cuebot --datasource.cue-data-source.username=cuebot --datasource.cue-data-source.password=$POSTGRES_PASSWORD
+      - CUE_FRAME_LOG_DIR=/tmp/rqd/logs
+    command: --datasource.cue-data-source.jdbc-url=jdbc:postgresql://db/cuebot --datasource.cue-data-source.username=cuebot --datasource.cue-data-source.password=cuebot_password
 
   rqd:
     image: opencue/rqd

--- a/sandbox/docker-compose.monitoring.yml
+++ b/sandbox/docker-compose.monitoring.yml
@@ -13,7 +13,7 @@ services:
     environment:
       - DATA_SOURCE_URI=db:5432/postgres?sslmode=disable
       - DATA_SOURCE_USER=cuebot
-      - DATA_SOURCE_PASS=$POSTGRES_PASSWORD
+      - DATA_SOURCE_PASS=cuebot_password
       - PG_EXPORTER_AUTO_DISCOVER_DATABASES=true
     ports:
       - 9187:9187


### PR DESCRIPTION
Place docker-compose at the root of the project.

Remove some of the variable user needed to setup with defaults.
We can assume a person is running this as a test and not in production
with docker-compose.

process to start is now.

`docker-compose up` in the root of the project.