### PR TITLE
Fix PyOutline test

### DIFF
--- a/pyoutline/tests/specver_test.py
+++ b/pyoutline/tests/specver_test.py
@@ -32,6 +32,8 @@ import outline.modules.shell
 
 class SpecVersiondTest(unittest.TestCase):
     def _makeSpec(self):
+        # Ensure to reset current
+        outline.Outline.current = None
         ol = outline.Outline(name="spec_version_test")
         layer = outline.modules.shell.Shell("test_layer", command=["/bin/ls"])
         layer.set_arg("timeout", 420)


### PR DESCRIPTION
`test_after_init_current` changes global `outline.Outline.current`, eventually it affects other tests badly.
For example, #941 doesn't change Python but failed.
https://github.com/AcademySoftwareFoundation/OpenCue/pull/941/checks?check_run_id=2180764941

Ensure to clear the value.