### PR TITLE
Auto-delete the down state hosts

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dao/HostDao.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/HostDao.java
@@ -66,6 +66,11 @@ public interface HostDao {
     void deleteHost(HostInterface host);
 
     /**
+     * deletes the down state hosts
+     */
+    void deleteDownHosts();
+
+    /**
      * updates a host with the passed hardware state
      *
      * @param host  HostInterface

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/oracle/HostDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/oracle/HostDaoJdbc.java
@@ -489,6 +489,11 @@ public class HostDaoJdbc extends JdbcDaoSupport implements HostDao {
     }
 
     @Override
+    public void deleteDownHosts() {
+        // Not implemented.
+    }
+
+    @Override
     public void updateHostState(HostInterface host, HardwareState state) {
         getJdbcTemplate().update(
                 "UPDATE host_stat SET str_state=? WHERE pk_host=?",

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/HostDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/HostDaoJdbc.java
@@ -489,6 +489,34 @@ public class HostDaoJdbc extends JdbcDaoSupport implements HostDao {
                 "DELETE FROM host WHERE pk_host=?",host.getHostId());
     }
 
+    private static final String DELETE_DOWN_HOST_COMMENTS =
+        "DELETE " +
+        "FROM " +
+            "comments " +
+        "USING " +
+            "host_stat " +
+        "WHERE " +
+            "comments.pk_host = host_stat.pk_host " +
+        "AND " +
+            "host_stat.str_state = ?";
+
+    private static final String DELETE_DOWN_HOSTS =
+        "DELETE " +
+        "FROM " +
+            "host " +
+        "USING " +
+            "host_stat " +
+        "WHERE " +
+            "host.pk_host = host_stat.pk_host " +
+        "AND " +
+            "host_stat.str_state=?";
+
+    @Override
+    public void deleteDownHosts() {
+        getJdbcTemplate().update(DELETE_DOWN_HOST_COMMENTS, HardwareState.DOWN.toString());
+        getJdbcTemplate().update(DELETE_DOWN_HOSTS, HardwareState.DOWN.toString());
+    }
+
     @Override
     public void updateHostState(HostInterface host, HardwareState state) {
         getJdbcTemplate().update(

--- a/cuebot/src/main/resources/conf/spring/applicationContext-service.xml
+++ b/cuebot/src/main/resources/conf/spring/applicationContext-service.xml
@@ -342,6 +342,7 @@
     <property name="dispatchSupport" ref="dispatchSupport" />
     <property name="procDao" ref="procDao" />
     <property name="frameDao" ref="frameDao" />
+    <property name="hostDao" ref="hostDao" />
     <property name="maintenanceDao" ref="maintenanceDao" />
     <property name="historicalSupport" ref="historicalSupport" />
     <property name="departmentManager" ref="departmentManager" />

--- a/cuebot/src/main/resources/opencue.properties
+++ b/cuebot/src/main/resources/opencue.properties
@@ -56,3 +56,6 @@ dispatcher.host_frame_dispatch_max=12
 
 # Jobs will be archived to the history tables after being completed for this long.
 history.archive_jobs_cutoff_hours=72
+
+# Delete down hosts automatically.
+maintenance.auto_delete_down_hosts=false

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/HostDaoTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/HostDaoTests.java
@@ -392,6 +392,30 @@ public class HostDaoTests extends AbstractTransactionalJUnit4SpringContextTests 
     @Test
     @Transactional
     @Rollback(true)
+    public void testDeleteDownHosts() {
+        for (int i = 0; i < 3; i++) {
+            String name = TEST_HOST + i;
+            hostDao.insertRenderHost(buildRenderHost(name),
+                    hostManager.getDefaultAllocationDetail(),
+                    false);
+            if (i != 1) {
+                HostEntity host = hostDao.findHostDetail(name);
+                assertEquals(name, host.name);
+                hostDao.updateHostState(host, HardwareState.DOWN);
+            }
+        }
+
+        hostDao.deleteDownHosts();
+
+        for (int i = 0; i < 3; i++) {
+            String name = TEST_HOST + i;
+            assertEquals(hostDao.hostExists(name), i == 1);
+        }
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
     public void testUpdateHostRebootWhenIdle() {
         hostDao.insertRenderHost(buildRenderHost(TEST_HOST),
                 hostManager.getDefaultAllocationDetail(),


### PR DESCRIPTION
Cuebot automatically deletes hosts when
- It detects the down state on the hosts
- And `maintenance.auto_delete_down_hosts` property is set to `true`

This is very useful when RQD hosts are using dynamic IP address or hostname, some hosts will be never connected again.