### PR TITLE
Fix AllocationDao

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/AllocationDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/AllocationDaoJdbc.java
@@ -109,7 +109,7 @@ public class AllocationDaoJdbc extends JdbcDaoSupport  implements AllocationDao 
                  Integer.class, new_alloc_name) > 0) {
 
              getJdbcTemplate().update(
-                     "UPDATE alloc SET b_enabled=1 WHERE str_name=?",
+                     "UPDATE alloc SET b_enabled = true WHERE str_name=?",
                      new_alloc_name);
          }
          else {
@@ -196,8 +196,8 @@ public class AllocationDaoJdbc extends JdbcDaoSupport  implements AllocationDao 
      }
 
      public void setDefaultAllocation(AllocationInterface a) {
-         getJdbcTemplate().update("UPDATE alloc SET b_default = 0 WHERE b_default = 1");
-         getJdbcTemplate().update("UPDATE alloc SET b_default = 1 WHERe pk_alloc=?",
+         getJdbcTemplate().update("UPDATE alloc SET b_default = false WHERE b_default = true");
+         getJdbcTemplate().update("UPDATE alloc SET b_default = true WHERE pk_alloc=?",
                  a.getAllocationId());
      }
 

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/AllocationDaoTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/AllocationDaoTests.java
@@ -182,6 +182,26 @@ public class AllocationDaoTests extends AbstractTransactionalJUnit4SpringContext
                 "SELECT b_billable FROM alloc WHERE pk_alloc=?",
                 Boolean.class, alloc.getId()));
     }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testSetDefaultAllocation() {
+        AllocationEntity newAlloc = new AllocationEntity();
+        newAlloc.name = "spi.new_alloc";
+        newAlloc.tag = "new_alloc";
+        allocDao.insertAllocation(
+                facilityDao.getFacility("spi"),  newAlloc);
+
+        allocDao.setDefaultAllocation(newAlloc);
+        AllocationEntity defaultAlloc = allocDao.getDefaultAllocationEntity();
+        assertEquals(newAlloc.getAllocationId(), defaultAlloc.getAllocationId());
+        assertEquals(newAlloc.name, defaultAlloc.name);
+        assertEquals(newAlloc.tag, defaultAlloc.tag);
+        assertEquals(
+                facilityDao.getFacility("spi").getFacilityId(),
+                defaultAlloc.getFacilityId());
+    }
 }
 
 


### PR DESCRIPTION
`setDefaultAllocation` fails due to type mismatch. fix it.

> org.springframework.jdbc.BadSqlGrammarException: StatementCallback; bad SQL grammar [UPDATE alloc SET b_default = 0 WHERE b_default = 1]; nested exception is org.postgresql.util.PSQLException: ERROR: operator does not exist: boolean = integer
  Hint: No operator matches the given name and argument type(s). You might need to add explicit type casts.
