### PR TITLE
PyOutline: Add facility support for JSON

### DIFF
--- a/pyoutline/outline/loader.py
+++ b/pyoutline/outline/loader.py
@@ -124,6 +124,8 @@ def load_json(json_str):
 
     if "name" in data:
         ol.set_name(data["name"])
+    if "facility" in data:
+        ol.set_facility(data["facility"])
     if "range" in data:
         ol.set_frame_range(data["range"])
 

--- a/pyoutline/tests/json/facility.json
+++ b/pyoutline/tests/json/facility.json
@@ -1,0 +1,12 @@
+{
+  "name": "shell_command",
+  "facility": "test_facility",
+  "range": "1",
+  "layers": [
+    {
+      "name": "shell_layer",
+      "module": "outline.modules.shell.Shell",
+      "command": ["/bin/ls"]
+    }
+  ]
+}

--- a/pyoutline/tests/json_test.py
+++ b/pyoutline/tests/json_test.py
@@ -77,6 +77,12 @@ class JsonTest(unittest.TestCase):
             systemMock.assert_has_calls([mock.call(['/bin/ls'], frame=1000)])
             self.assertEqual('LAYER_VALUE', os.environ['LAYER_KEY'])
 
+    def testFacility(self):
+        """Test facility from JSON"""
+        with open(os.path.join(JSON_DIR, 'facility.json')) as fp:
+            ol = outline.load_json(fp.read())
+            self.assertEqual('test_facility', ol.get_facility())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Allow PyOutline to use `facility` in JSON

    {
      "name": "shell_command",
      "facility": "test_facility",
