### PR TITLE
Remove compiled python from tar.gz releases.

### DIFF
--- a/sandbox/install-client-archives.sh
+++ b/sandbox/install-client-archives.sh
@@ -38,6 +38,12 @@ for PACKAGE in "${CLIENT_PACKAGES[@]}"; do
         pip install -r ${REQUIREMENTS_GUI}
     fi
     cd ${PACKAGE}-${VERSION}-all
+
+    # remove *.pyc files and __pycache__ folders contained on
+    # <PACKAGE-VERSION>-all.tar.gz file
+    find . -path '*/__pycache__*' -delete
+    find . -name '*.pyc'  -type f -delete
+
     python setup.py install
     cd ..
 done

--- a/sandbox/install-client-archives.sh
+++ b/sandbox/install-client-archives.sh
@@ -40,7 +40,11 @@ for PACKAGE in "${CLIENT_PACKAGES[@]}"; do
     cd ${PACKAGE}-${VERSION}-all
 
     # remove *.pyc files and __pycache__ folders contained on
-    # <PACKAGE-VERSION>-all.tar.gz file
+    # <PACKAGE-VERSION>-all.tar.gz. As these files might be generated from
+    # a different operating system and/or python version than current host has
+    # `python setup.py install` may raise a `ValueError: bad marshal data` error.
+    # Removing these files before invoking `setup.py` prevent this error.
+    # NOTE: Temporary solution until pip distribution is ready.
     find . -path '*/__pycache__*' -delete
     find . -name '*.pyc'  -type f -delete
 


### PR DESCRIPTION
Fix #925 

After downloading and unzipping an OpenCue release `tar.gz` file, it removes all compiled python files fixing `python setup.py install` error. This fix is needed to execute with success OpenCue's quick-start-mac guide from: https://www.opencue.io/docs/quick-starts/quick-start-mac/ - which fails up until release 0.8.8.

Tested on a mac with python-3.7.9. 