### PR TITLE
PyOutline: Support layer 'cores'

### DIFF
--- a/pyoutline/outline/backend/cue.py
+++ b/pyoutline/outline/backend/cue.py
@@ -308,7 +308,12 @@ def _serialize(launcher, use_pycuerun):
         sub_element(spec_layer, "chunk", str(layer.get_chunk_size()))
 
         # opencue specific options
-        if layer.get_arg("threads"):
+        # Keeping 'threads' for backward compatibility
+        if layer.get_arg("cores"):
+            if layer.get_arg("threads"):
+                logger.warning("%s has both cores and threads. Use cores.", layer.get_name())
+            sub_element(spec_layer, "cores", "%0.1f" % (layer.get_arg("cores")))
+        elif layer.get_arg("threads"):
             sub_element(spec_layer, "cores", "%0.1f" % (layer.get_arg("threads")))
 
         if layer.is_arg_set("threadable"):

--- a/pyoutline/tests/backend/cue_test.py
+++ b/pyoutline/tests/backend/cue_test.py
@@ -92,6 +92,42 @@ class SerializeTest(unittest.TestCase):
         self.assertEqual(0, len(list(outlineXml.find('depends'))))
 
 
+class CoresTest(unittest.TestCase):
+    def setUp(self):
+        # Ensure to reset current
+        outline.Outline.current = None
+
+    def create(self):
+        ol = outline.Outline()
+        layer = outline.Layer("test")
+        ol.add_layer(layer)
+        return ol, layer
+
+    def assertCores(self, ol, v):
+        launcher = outline.cuerun.OutlineLauncher(ol, user=TEST_USER)
+        outlineXml = ET.fromstring(outline.backend.cue.serialize(launcher))
+        job = outlineXml.find('job')
+        layer = job.find('layers').find('layer')
+        self.assertEqual(v, layer.find('cores').text)
+
+    def testCores(self):
+        ol, layer = self.create()
+        layer.set_arg("cores", 42)
+        self.assertCores(ol, "42.0")
+
+    def testThreads(self):
+        ol, layer = self.create()
+        layer.set_arg("threads", 4)
+        self.assertCores(ol, "4.0")
+
+    def testCoresAndThreads(self):
+        ol, layer = self.create()
+        layer.set_arg("cores", 8)
+        layer.set_arg("threads", 4)
+        # cores overrides threads
+        self.assertCores(ol, "8.0")
+
+
 class BuildCommandTest(unittest.TestCase):
     def setUp(self):
         path = os.path.join(SCRIPTS_DIR, 'shell.outline')


### PR DESCRIPTION
PyOutline uses `threads` to set `cores` to XML job spec layer element. It's confusing. Allow to use `cores` as well.