### PR TITLE
Ignore compiled protobuf code in Cuebot docker build.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 ci
+cuebot/src/compiled_protobuf
 images
 samples
 sandbox/db-data


### PR DESCRIPTION
Cuebot should always generate fresh protobuf code from the protos that were copied in at build time. This happens during the `gradle build` process, but if `src/compiled_protobuf` has code in it already, this code may be reused.

Developer machines may already contain this generated code; if copied into the build machine this can produce unexpected results if generated code is stale.