### PR TITLE
Skip tests needing xvfb-run in Python 2.

### DIFF
--- a/ci/run_python_tests.sh
+++ b/ci/run_python_tests.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+python_version=$(python3 -V)
+echo "Will run tests using ${python_version}"
+
+
+
 pip install --user -r requirements.txt -r requirements_gui.txt
 
 # Protos need to have their Python code generated in order for tests to pass.
@@ -16,9 +21,13 @@ python -m grpc_tools.protoc -I=proto/ --python_out=rqd/rqd/compiled_proto --grpc
 python pycue/setup.py test
 PYTHONPATH=pycue python pyoutline/setup.py test
 PYTHONPATH=pycue python cueadmin/setup.py test
-PYTHONPATH=pycue xvfb-run -d python cuegui/setup.py test
 PYTHONPATH=pycue:pyoutline python cuesubmit/setup.py test
 python rqd/setup.py test
+
+# Xvfb no longer supports Python 2.
+if [[ "$python_version" =~ "Python 3" ]]; then
+  PYTHONPATH=pycue xvfb-run -d python cuegui/setup.py test
+fi
 
 # Some environments don't have pylint available, for ones that do they should pass this flag.
 if [[ "$1" == "--lint" ]]; then

--- a/ci/run_python_tests.sh
+++ b/ci/run_python_tests.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-python_version=$(python3 -V)
+python_version=$(python -V)
 echo "Will run tests using ${python_version}"
 
 pip install --user -r requirements.txt -r requirements_gui.txt

--- a/ci/run_python_tests.sh
+++ b/ci/run_python_tests.sh
@@ -5,8 +5,6 @@ set -e
 python_version=$(python3 -V)
 echo "Will run tests using ${python_version}"
 
-
-
 pip install --user -r requirements.txt -r requirements_gui.txt
 
 # Protos need to have their Python code generated in order for tests to pass.

--- a/cuegui/Dockerfile
+++ b/cuegui/Dockerfile
@@ -26,10 +26,8 @@ RUN yum -y install \
   python36-devel \
   python36-pip
 
-RUN python -m pip install --upgrade 'pip<21'
 RUN python3.6 -m pip install --upgrade pip
 
-RUN python -m pip install --upgrade 'setuptools<45'
 RUN python3.6 -m pip install --upgrade setuptools
 
 RUN dbus-uuidgen > /etc/machine-id
@@ -38,7 +36,6 @@ COPY LICENSE ./
 COPY requirements.txt ./
 COPY requirements_gui.txt ./
 
-RUN python -m pip install -r requirements.txt -r requirements_gui.txt
 RUN python3.6 -m pip install -r requirements.txt -r requirements_gui.txt
 
 COPY proto/ ./proto
@@ -47,7 +44,7 @@ COPY pycue/setup.py ./pycue/
 COPY pycue/FileSequence ./pycue/FileSequence
 COPY pycue/opencue ./pycue/opencue
 
-RUN python -m grpc_tools.protoc \
+RUN python3.6 -m grpc_tools.protoc \
   -I=./proto \
   --python_out=./pycue/opencue/compiled_proto \
   --grpc_python_out=./pycue/opencue/compiled_proto \
@@ -65,13 +62,7 @@ COPY cuegui/cuegui ./cuegui/cuegui
 COPY VERSION.in VERSIO[N] ./
 RUN test -e VERSION || echo "$(cat VERSION.in)-custom" | tee VERSION
 
-RUN cd pycue && python setup.py install
-
 RUN cd pycue && python3.6 setup.py install
-
-# TODO(bcipriano) Lint the code here. (Issue #78)
-
-RUN cd cuegui && xvfb-run -d python setup.py test
 
 RUN cd cuegui && xvfb-run -d python3.6 setup.py test
 


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
#964 

**Summarize your change.**
Based on updates in their [bug tracker](https://bugs.python.org/issue34095#msg360911), Xvfb no longer supports Python 2. CueGUI tests, when running in headless environments like our CI pipelines, require `xvfb-run` to mimic an X Server for PySide to use.

I've gone through all of the past Xvfb versions available through `yum` and they all present the same bug.

Unfortunately that means, for now at least, we'll need to disable CueGUI automated tests using Python 2.

Python 3 tests still appear to run normally.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
