### PR TITLE
Use findAllocationDetail for setDefault

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageAllocation.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageAllocation.java
@@ -240,7 +240,7 @@ public class ManageAllocation extends AllocationInterfaceGrpc.AllocationInterfac
     public void setDefault(
             AllocSetDefaultRequest request,
             StreamObserver<AllocSetDefaultResponse> responseObserver) {
-        AllocationEntity alloc = adminManager.findAllocationDetail(
+        AllocationEntity alloc = findAllocationDetail(
                 request.getAllocation().getFacility(), request.getAllocation().getName());
         adminManager.setDefaultAllocation(alloc);
         responseObserver.onNext(AllocSetDefaultResponse.newBuilder().build());


### PR DESCRIPTION
Use local `findAllocationDetail` function instead of `adminManager.findAllocationDetail` direct call for gRPC API consistency. All other call sites (delete, setBillable, setName, and setTag) already did that.
