### PR TITLE
Keep staggerFrames interleaving start frame static

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/util/FrameRange.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/util/FrameRange.java
@@ -62,7 +62,7 @@ public class FrameRange {
      * set of frames unique from the first set. This process is repeated until interleaveSize
      * reaches 1.
      *
-     * Example: 1-10:5 == 1, 6, 2, 4, 8, 10, 3, 5, 7, 9.
+     * Example: 1-10:5 == 1, 6, 3, 5 ,7 ,9, 2, 4, 8, 10.
      */
     public FrameRange(String frameRange) {
         frameList = parseFrameRange(frameRange);
@@ -166,10 +166,9 @@ public class FrameRange {
     private static ImmutableList<Integer> getInterleavedRange(Integer start, Integer end, Integer step) {
         validateStepSign(start, end, step);
         Set<Integer> interleavedFrames = new LinkedHashSet<>();
-        int incrValue = step / abs(step);
+
         while (abs(step) > 0) {
             interleavedFrames.addAll(getIntRange(start, end, step));
-            start += incrValue;
             step /= 2;
         }
         return ImmutableList.copyOf(interleavedFrames);

--- a/cuebot/src/test/java/com/imageworks/spcue/test/util/FrameRangeTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/util/FrameRangeTests.java
@@ -103,14 +103,14 @@ public class FrameRangeTests {
     public void testInterleave() {
         FrameRange result = new FrameRange("1-10:5");
 
-        assertThat(result.getAll()).containsExactly(1, 6, 2, 4, 8, 10, 3, 5, 7, 9);
+        assertThat(result.getAll()).containsExactly(1, 6, 3, 5, 7, 9, 2, 4, 8, 10);
     }
 
     @Test
     public void testNegativeInterleave() {
         FrameRange result = new FrameRange("10-1:-5");
 
-        assertThat(result.getAll()).containsExactly(10, 5, 9, 7, 3, 1, 8, 6, 4, 2);
+        assertThat(result.getAll()).containsExactly(10, 5, 8, 6, 4, 2, 9, 7, 3, 1);
     }
 
     @Test

--- a/cuebot/src/test/java/com/imageworks/spcue/test/util/FrameSetTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/util/FrameSetTests.java
@@ -12,7 +12,7 @@ public class FrameSetTests {
         FrameSet result = new FrameSet("57,1-3,4-2,12-15x2,76-70x-3,5-12y3,1-7:5");
 
         assertThat(result.getAll()).containsExactly(
-            57, 1, 2, 3, 4, 3, 2, 12, 14, 76, 73, 70, 6, 7, 9, 10, 12, 1, 6, 2, 4, 3, 5, 7);
+            57, 1, 2, 3, 4, 3, 2, 12, 14, 76, 73, 70, 6, 7, 9, 10, 12, 1, 6, 3, 5, 7, 2, 4);
     }
 
     @Test


### PR DESCRIPTION
**Summarize your change.**
There was a implementation bug with the logic of the start frame 
incrementing after each Nth step iteration, causing the interleaving
to be incorrect because the step was operating on a subset of the 
frame range and not the entire range for each Nth step. The start 
index needs to remain static after each iter for interleaving to work 
correctly on the entire range. Ex, 1-10:5. N=5, results in 
1,6,3,5,7,9,2,4,8,10 1st iter: N=5, [1,6], 2nd iter: N=2, [1,6,3,5,7,9], 
3rd iter: N=1 [1,6,3,5,7,9,2,4,8,10].

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
