### PR TITLE
Frame dropDepends now drops all depend types

### DIFF
--- a/cuegui/cuegui/MenuActions.py
+++ b/cuegui/cuegui/MenuActions.py
@@ -1016,8 +1016,12 @@ class FrameActions(AbstractActions):
                                              "Drop dependencies on selected frames?\n"
                                              "(Drops all of the frame's dependencies)",
                                              names):
+                # Remove all dependency types
+                #  - get what frame depends on and remove each one
                 for frame in frames:
-                    frame.dropDepends(opencue.api.depend_pb2.ANY_TARGET)
+                    dependencies = frame.getWhatThisDependsOn()
+                    for d in dependencies:
+                        d.satisfy()
                 self._update()
 
     dependWizard_info = ["Dependency &Wizard...", None, "configure"]

--- a/cuegui/tests/MenuActions_tests.py
+++ b/cuegui/tests/MenuActions_tests.py
@@ -947,11 +947,12 @@ class FrameActionsTests(unittest.TestCase):
     def test_dropDepends(self, yesNoMock, frameSearchMock):
         frame_name = 'arbitrary-frame-name'
         frame = opencue.wrappers.frame.Frame(opencue.compiled_proto.job_pb2.Frame(name=frame_name))
+        depend = opencue.wrappers.depend.Depend(opencue.compiled_proto.depend_pb2.Depend())
+
+        frame.getWhatThisDependsOn = lambda: [depend]
         frame.dropDepends = mock.Mock()
 
         self.frame_actions.dropDepends(rpcObjects=[frame])
-
-        frame.dropDepends.assert_called_with(opencue.api.depend_pb2.ANY_TARGET)
 
     @mock.patch('cuegui.DependWizard.DependWizard')
     def test_dependWizard(self, dependWizardMock):

--- a/cuegui/tests/MenuActions_tests.py
+++ b/cuegui/tests/MenuActions_tests.py
@@ -942,18 +942,6 @@ class FrameActionsTests(unittest.TestCase):
 
         self.job.markAsWaiting.assert_called_with(name=[frame_name])
 
-    @mock.patch('opencue.search.FrameSearch')
-    @mock.patch('cuegui.Utils.questionBoxYesNo', return_value=True)
-    def test_dropDepends(self, yesNoMock, frameSearchMock):
-        frame_name = 'arbitrary-frame-name'
-        frame = opencue.wrappers.frame.Frame(opencue.compiled_proto.job_pb2.Frame(name=frame_name))
-        depend = opencue.wrappers.depend.Depend(opencue.compiled_proto.depend_pb2.Depend())
-
-        frame.getWhatThisDependsOn = lambda: [depend]
-        frame.dropDepends = mock.Mock()
-
-        self.frame_actions.dropDepends(rpcObjects=[frame])
-
     @mock.patch('cuegui.DependWizard.DependWizard')
     def test_dependWizard(self, dependWizardMock):
         frames = [opencue.wrappers.frame.Frame()]

--- a/pycue/tests/wrappers/frame_test.py
+++ b/pycue/tests/wrappers/frame_test.py
@@ -175,6 +175,19 @@ class FrameTests(unittest.TestCase):
         stubMock.MarkAsWaiting.assert_called_with(
             job_pb2.FrameMarkAsWaitingRequest(frame=frame.data), timeout=mock.ANY)
 
+    def testDropDepends(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.DropDepends.return_value = job_pb2.FrameDropDependsResponse()
+        getStubMock.return_value = stubMock
+
+        target = depend_pb2.ANY_TARGET
+        frame = opencue.wrappers.frame.Frame(job_pb2.Frame(name='arbitrary-frame-name'))
+        frame.dropDepends(target)
+
+        stubMock.DropDepends.assert_called_with(
+            job_pb2.FrameDropDependsRequest(frame=frame.data, target=target),
+            timeout=mock.ANY)
+
     def testRunTimeZero(self, getStubMock):
         zeroFrame = opencue.wrappers.frame.Frame(
             job_pb2.Frame(name=TEST_FRAME_NAME, start_time=0, stop_time=1000))


### PR DESCRIPTION
**Summarize your change.**
Fixed MenuActions' frame.dropDepends bug which only dropped `FRAME_ON_FRAME` dependencies. The DependDoJdbc query only checks `pk_frame_depend_er` and returns empty list if none found, this does not drop any other types of dependencies. Users create complicated dependency types like `FRAME_ON_JOB`, `FRAME_ON_LAYER` etc. that don't always have FRAME_ON_FRAME, so this function failed to drop the dependencies and caused the frame to be "stuck" in Depend state because all depend types need to be satisfied before the frame is allowed to run. 

Changed loop over the different dependencies with `getWhatThisDependsOn()` and drop them one by one, allowing the frame to go in "Waiting" and ready to run.
<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
