### PR TITLE
Encode Cuegui email MIMEText with plain utf-8

### DIFF
--- a/cuegui/cuegui/EmailDialog.py
+++ b/cuegui/cuegui/EmailDialog.py
@@ -281,7 +281,7 @@ class EmailWidget(QtWidgets.QWidget):
 
     def email_body(self):
         """Get the email body text."""
-        return "%s" % self.__email_body.toPlainText().toAscii()
+        return "%s" % self.__email_body.toPlainText()
 
     def appendToBody(self, txt):
         """Appends text to the email body."""
@@ -295,8 +295,8 @@ class EmailWidget(QtWidgets.QWidget):
         """Sends the email."""
         self.send.emit()
 
-        msg = MIMEText(self.email_body())
-        msg["Subject"] = Header(self.email_subject(), continuation_ws=' ')
+        msg = MIMEText(self.email_body(), 'plain', 'utf-8')
+        msg["Subject"] = Header(self.email_subject(), 'utf-8', continuation_ws=' ')
         msg["To"] = self.email_to()
         msg["From"] = self.email_from()
         msg["Cc"] = self.email_cc()


### PR DESCRIPTION
**Summarize your change.**
Fixed bug with email_body, PySide.QEdit.toPlainText() returns a unicode object which threw an attribute error with toAscii(). Also, encoded MIMEText to handle high bit characters (extended ascii table).

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
