### PR TITLE
Shellout check_call uses string input

### DIFF
--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -285,7 +285,7 @@ def checkShellOut(cmdList, lockGui=False):
     if not lockGui and platform.system() != "Windows":
         cmdList.append('&')
     try:
-        subprocess.check_call(cmdList)
+        subprocess.check_call(" ".join(cmdList), shell=True)
     except subprocess.CalledProcessError as e:
         text = 'Command {cmd} failed with returncode {code}. {msg}.\n' \
                'Please check your EDITOR environment variable and the ' \


### PR DESCRIPTION
**Summarize your change.**
Fixed bug with check_call input parameters when cmdList appends '&', if user has the environment variable EDITOR set in shell (for example like nedit), it caused the shell out to fail. Once cmdList is changed to string inputs over list, all editors work including custom overrides like nedit.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
