### PR TITLE
MonitorCue displays all jobs/groups to move

### DIFF
--- a/cuegui/cuegui/CueJobMonitorTree.py
+++ b/cuegui/cuegui/CueJobMonitorTree.py
@@ -863,8 +863,12 @@ class MoveDialog(QtWidgets.QDialog):
         _hlayout.addWidget(_btn_cancel)
         _vlayout.addLayout(_hlayout)
 
-        _btn_accept.clicked.connect(self._move_items)
-        _btn_cancel.clicked.connect(self.reject)
+        self.connect(_btn_accept,
+                     QtCore.SIGNAL("clicked()"),
+                     self._move_items)
+        self.connect(_btn_cancel,
+                     QtCore.SIGNAL("clicked()"),
+                     self.reject)
 
     def _move_items(self):
         if not self.send_to_groups:

--- a/cuegui/cuegui/CueJobMonitorTree.py
+++ b/cuegui/cuegui/CueJobMonitorTree.py
@@ -871,7 +871,10 @@ class MoveDialog(QtWidgets.QDialog):
                      self.reject)
 
     def move_items(self):
+<<<<<<< HEAD
         """Reparent jobs to new group"""
+=======
+>>>>>>> 898db171 (Fix unittests for sendToGroups)
         if not self.send_to_groups:
             if self.items.job_ids:
                 jobs = [opencue.api.getJob(id_) for id_ in self.items.job_ids]

--- a/cuegui/cuegui/CueJobMonitorTree.py
+++ b/cuegui/cuegui/CueJobMonitorTree.py
@@ -865,12 +865,13 @@ class MoveDialog(QtWidgets.QDialog):
 
         self.connect(_btn_accept,
                      QtCore.SIGNAL("clicked()"),
-                     self._move_items)
+                     self.move_items)
         self.connect(_btn_cancel,
                      QtCore.SIGNAL("clicked()"),
                      self.reject)
 
-    def _move_items(self):
+    def move_items(self):
+        """Reparent jobs to new group"""
         if not self.send_to_groups:
             if self.items.job_ids:
                 jobs = [opencue.api.getJob(id_) for id_ in self.items.job_ids]

--- a/cuegui/cuegui/CueJobMonitorTree.py
+++ b/cuegui/cuegui/CueJobMonitorTree.py
@@ -871,6 +871,8 @@ class MoveDialog(QtWidgets.QDialog):
                      self.reject)
 
     def move_items(self):
+        """Reparent jobs to new group"""
+
         if not self.send_to_groups:
             if self.items.job_ids:
                 jobs = [opencue.api.getJob(id_) for id_ in self.items.job_ids]

--- a/cuegui/cuegui/MenuActions.py
+++ b/cuegui/cuegui/MenuActions.py
@@ -528,17 +528,21 @@ class JobActions(AbstractActions):
             return
 
         title = "Send jobs to group"
-        groups = {
-            group.data.name: group for group in opencue.api.findShow(jobs[0].data.show).getGroups()}
-        body = "What group should these jobs move to?\n" + \
-               "\n".join([job.data.name for job in jobs])
+        groups = {group.data.name: group for group in opencue.api.findShow(
+                                                      jobs[0].data.show).getGroups()}
 
-        (group, choice) = QtWidgets.QInputDialog.getItem(
-            self._caller, title, body, sorted(groups.keys()), 0, False)
-        if not choice:
-            return
+        body_content = cuegui.CueJobMonitorTree.Body(group_names=[],
+                                                     group_ids=[],
+                                                     job_names=[job.name() for job in jobs],
+                                                     job_ids=jobs)
 
-        groups[str(group)].reparentJobs(jobs)
+        dialog = cuegui.CueJobMonitorTree.MoveDialog(title=title,
+                                                     text="What group should these jobs move to?",
+                                                     event_item=None,
+                                                     items=body_content,
+                                                     dst_groups=groups,
+                                                     send_to_groups=True)
+        dialog.exec_()
         self._update()
 
     useLocalCores_info = [

--- a/cuegui/tests/MenuActions_tests.py
+++ b/cuegui/tests/MenuActions_tests.py
@@ -443,34 +443,55 @@ class JobActionsTests(unittest.TestCase):
         unbookDialogMock.assert_called_with(jobs, self.widgetMock)
         unbookDialogMock.return_value.exec_.assert_called()
 
-    @mock.patch('PySide2.QtWidgets.QInputDialog.getItem')
+    @mock.patch('cuegui.CueJobMonitorTree.MoveDialog.move_items')
     @mock.patch('opencue.api.findShow')
-    def test_sendToGroup(self, findShowMock, getItemMock):
+    def test_sendToGroup(self, findShowMock, move_itemsMock):
+
+        move_dialogMock = mock.Mock()
+
+        move_dialogMock.open()
         group_name = 'arbitrary-group-name'
         job = opencue.wrappers.job.Job(
             opencue.compiled_proto.job_pb2.Job(
                 name='arbitrary-job-name', show='arbitrary-show-name'))
-        show = opencue.wrappers.show.Show()
+        body_content = cuegui.CueJobMonitorTree.Body(group_names=[],
+                                                     group_ids=[],
+                                                     job_names=[job.name()],
+                                                     job_ids=[job])
+
         group = opencue.wrappers.group.Group(opencue.compiled_proto.job_pb2.Group(name=group_name))
         group.reparentJobs = mock.Mock()
+
+        show = opencue.wrappers.show.Show()
         findShowMock.return_value = show
         show.getGroups = mock.Mock(return_value=[group])
-        getItemMock.return_value = (group_name, True)
 
-        self.job_actions.sendToGroup(rpcObjects=[job])
+        move_dialogMock.dst_groups = {str(group_name): group}
+        move_itemsMock.return_value = move_dialogMock.dst_groups[str(group_name)].reparentJobs(
+                body_content.job_ids)
+        move_dialogMock.accept()
 
-        group.reparentJobs.assert_called_with([job])
+        group.reparentJobs.assert_called_with(body_content.job_ids)
 
-    @mock.patch('PySide2.QtWidgets.QInputDialog.getItem')
+    @mock.patch('cuegui.CueJobMonitorTree.MoveDialog.move_items')
     @mock.patch('opencue.api.findShow')
-    def test_sendToGroupCanceled(self, findShowMock, getItemMock):
-        job = opencue.wrappers.job.Job(opencue.compiled_proto.job_pb2.Job(name='job-name'))
-        group = opencue.wrappers.group.Group()
-        group.reparentJobs = mock.Mock()
-        findShowMock.getGroups.return_value = []
-        getItemMock.return_value = (None, False)
+    def test_sendToGroupCanceled(self, findShowMock, move_itemsMock):
 
-        self.job_actions.sendToGroup(rpcObjects=[job])
+        move_dialogMock = mock.Mock()
+
+        move_dialogMock.open()
+        group_name = 'arbitrary-group-name'
+        job = opencue.wrappers.job.Job(
+            opencue.compiled_proto.job_pb2.Job(
+                name='arbitrary-job-name', show='arbitrary-show-name'))
+        group = opencue.wrappers.group.Group(opencue.compiled_proto.job_pb2.Group(name=group_name))
+        group.reparentJobs = mock.Mock()
+
+        show = opencue.wrappers.show.Show()
+        findShowMock.return_value = show
+        show.getGroups = mock.Mock(return_value=[group])
+        move_itemsMock.return_value = (None, False)
+        move_dialogMock.reject()
 
         group.reparentJobs.assert_not_called()
 


### PR DESCRIPTION
**Summarize your change.**
When moving a lot of jobs to a different cue group, the confirmation popup cuts off at the bottom, changed to an expandable dialog with a scrollbar to allow user to view large number of jobs.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
