### PR TITLE
Enable editing existing comments

### DIFF
--- a/cuegui/cuegui/Comments.py
+++ b/cuegui/cuegui/Comments.py
@@ -109,6 +109,8 @@ class CommentListDialog(QtWidgets.QDialog):
     def __textEdited(self, text=None):
         """Called when the text boxes are modified, enables the save button"""
         del text
+        self.__textSubject.setReadOnly(False)
+        self.__textMessage.setReadOnly(False)
         self.__btnSave.setEnabled(True)
 
     def __close(self):


### PR DESCRIPTION
**Summarize your change.**
User workflow require checking and editing **existing** comments' subject and body, updated `__textEdited` fn to allow users to edit both.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
