### PR TITLE
Red text unhighlights once search is cleared

### DIFF
--- a/cuegui/cuegui/plugins/LogViewPlugin.py
+++ b/cuegui/cuegui/plugins/LogViewPlugin.py
@@ -699,7 +699,6 @@ class LogViewWidget(QtWidgets.QWidget):
                                                 QtGui.QTextCursor.KeepAnchor,
                                                 match[-1])
             self._highlight_cursor.setCharFormat(self._format)
-            self._matches_to_highlight.discard(match)
 
     def _clear_search_text(self):
         """
@@ -721,19 +720,27 @@ class LogViewWidget(QtWidgets.QWidget):
                         are also removed.
         """
 
+        if not self._log_file:
+            return
+
+        # find matched text to "unhighlight" red by resetting the char format
+        highlight = self._matches[max(self._current_match - 300, 0):
+                                  min(self._current_match + 300, len(self._matches))]
+        matches = list(set(highlight).intersection(self._matches_to_highlight))
+
+        for match in matches:
+            self._highlight_cursor.setPosition(match[0])
+            self._highlight_cursor.movePosition(QtGui.QTextCursor.Right,
+                                                QtGui.QTextCursor.KeepAnchor,
+                                                match[-1])
+            self._highlight_cursor.setCharFormat(QtGui.QTextCharFormat())
+            self._highlight_cursor.clearSelection()
+
+        # reset text matches
         self._matches = []
         self._matches_to_highlight = set()
         self._search_timestamp = 0
         self._matches_label.setText('')
-        if not self._log_file:
-            return
-
-        charFormat = QtGui.QTextCharFormat()
-        self._highlight_cursor.setPosition(QtGui.QTextCursor.Start)
-        self._highlight_cursor.movePosition(
-            QtGui.QTextCursor.End, mode=QtGui.QTextCursor.KeepAnchor)
-        self._highlight_cursor.setCharFormat(charFormat)
-        self._highlight_cursor.clearSelection()
 
     def _set_scrollbar_value(self, val):
         """


### PR DESCRIPTION
**Summarize your change.**
Bug in pressing the clear button for search text, it did not unhighlight the red text causing the log to be filled with unwanted red text. Changed the `self.matches_to_highlight` to **not** discard the positions of the search text before calling clear_search_data.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
