### PR TITLE
Copy frame name to middle click clipboard

### DIFF
--- a/cuegui/cuegui/FrameMonitorTree.py
+++ b/cuegui/cuegui/FrameMonitorTree.py
@@ -299,7 +299,8 @@ class FrameMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         selected = [
             frame.data.name for frame in self.selectedObjects() if cuegui.Utils.isFrame(frame)]
         if selected:
-            QtWidgets.QApplication.clipboard().setText(" ".join(selected))
+            QtWidgets.QApplication.clipboard().setText(" ".join(selected),
+                                                       QtGui.QClipboard.Selection)
 
     def __itemSingleClickedViewLog(self, item, col):
         """Called when an item is clicked on. Views the log file contents


### PR DESCRIPTION
**Summarize your change.**
A common complaint from our users is that their workflow requires single click frame name selection in the `FrameMonitorTree` to copy to the QtGui clipboard, updated to allow users this capability.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
