### PR TITLE
Only restore jobIds added within last 3 days

### DIFF
--- a/cuegui/cuegui/JobMonitorTree.py
+++ b/cuegui/cuegui/JobMonitorTree.py
@@ -226,7 +226,7 @@ class JobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         @type  value: boolean or QtCore.Qt.Checked or QtCore.Qt.Unchecked"""
         self.__loadMine = (value is True or value == QtCore.Qt.Checked)
 
-    def addJob(self, job):
+    def addJob(self, job, timestamp=None, loading_from_config=False):
         """Adds a job to the list. With locking"
         @param job: Job can be None, a job object, or a job name.
         @type  job: job, string, None"""
@@ -234,15 +234,33 @@ class JobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         self.ticksLock.lock()
         try:
             if newJobObj:
-                objectKey = cuegui.Utils.getObjectKey(newJobObj)
-                self.__load[objectKey] = newJobObj
-                self.__jobTimeLoaded[objectKey] = time.time()
+                jobKey = cuegui.Utils.getObjectKey(newJobObj)
+                if not self.__groupDependent:
+                    self.__load[jobKey] = newJobObj
+                    self.__jobTimeLoaded[jobKey] = timestamp if timestamp else time.time()
         finally:
             self.ticksLock.unlock()
 
     def getJobProxies(self):
-        """Gets a list of IDs of monitored jobs."""
-        return list(self._items.keys())
+        """Get a list of the JobProxies that are being monitored in the session
+         which will be saved to the config file
+
+         Returning a sorted list based on the most recent timestamp - restoring jobs is capped
+         by LOAD_LIMIT, so restore the most recent jobs the user added to their session
+
+        :return: list of tuples of the JobId and timestamp
+        """
+        jobIdsTimeLoaded = []
+
+        for jobProxy in self._items.keys():
+            try:
+                jobIdsTimeLoaded.append((jobProxy, self.__jobTimeLoaded[jobProxy]))
+            except KeyError as e:
+                # set timestamp to epoch time if timestamp not found
+                jobIdsTimeLoaded.append((jobProxy, 0))
+
+        # sort list on recent timestamps, only restoring the first n jobs (defined by LOAD_LIMIT)
+        return list(sorted(jobIdsTimeLoaded, key=lambda x: x[1], reverse=True))
 
     def _removeItem(self, item):
         """Removes an item from the TreeWidget without locking

--- a/cuegui/cuegui/JobMonitorTree.py
+++ b/cuegui/cuegui/JobMonitorTree.py
@@ -229,7 +229,10 @@ class JobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
     def addJob(self, job, timestamp=None):
         """Adds a job to the list. With locking"
         @param job: Job can be None, a job object, or a job name.
-        @type  job: job, string, None"""
+        @type  job: job, string, None
+        @param timestamp: UTC time of the specific date the job was
+                          added to be monitored
+        @type timestamp: float"""
         newJobObj = cuegui.Utils.findJob(job)
         self.ticksLock.lock()
         try:

--- a/cuegui/cuegui/JobMonitorTree.py
+++ b/cuegui/cuegui/JobMonitorTree.py
@@ -226,7 +226,7 @@ class JobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         @type  value: boolean or QtCore.Qt.Checked or QtCore.Qt.Unchecked"""
         self.__loadMine = (value is True or value == QtCore.Qt.Checked)
 
-    def addJob(self, job, timestamp=None, loading_from_config=False):
+    def addJob(self, job, timestamp=None):
         """Adds a job to the list. With locking"
         @param job: Job can be None, a job object, or a job name.
         @type  job: job, string, None"""
@@ -255,7 +255,7 @@ class JobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         for jobProxy in self._items.keys():
             try:
                 jobIdsTimeLoaded.append((jobProxy, self.__jobTimeLoaded[jobProxy]))
-            except KeyError as e:
+            except KeyError:
                 # set timestamp to epoch time if timestamp not found
                 jobIdsTimeLoaded.append((jobProxy, 0))
 

--- a/cuegui/cuegui/JobMonitorTree.py
+++ b/cuegui/cuegui/JobMonitorTree.py
@@ -252,7 +252,7 @@ class JobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         """
         jobIdsTimeLoaded = []
 
-        for jobProxy in self._items.keys():
+        for jobProxy, _ in self._items.items():
             try:
                 jobIdsTimeLoaded.append((jobProxy, self.__jobTimeLoaded[jobProxy]))
             except KeyError:

--- a/cuegui/cuegui/plugins/MonitorJobsPlugin.py
+++ b/cuegui/cuegui/plugins/MonitorJobsPlugin.py
@@ -47,8 +47,8 @@ PLUGIN_CATEGORY = "Cuetopia"
 PLUGIN_DESCRIPTION = "Monitors a list of jobs"
 PLUGIN_PROVIDES = "MonitorJobsDockWidget"
 REGEX_EMPTY_STRING = re.compile("^$")
-TIME_DELTA = 3
-JOB_RESTORE_THRESHOLD_DAYS = 200
+JOB_RESTORE_THRESHOLD_DAYS = 3
+JOB_RESTORE_THRESHOLD_LIMIT = 200
 
 class MonitorJobsDockWidget(cuegui.AbstractDockWidget.AbstractDockWidget):
     """Plugin for listing active jobs and managing them."""
@@ -118,15 +118,15 @@ class MonitorJobsDockWidget(cuegui.AbstractDockWidget.AbstractDockWidget):
         :type jobIds: list[tuples]
         """
         today = datetime.datetime.now()
-        limit = JOB_RESTORE_THRESHOLD_DAYS if len(jobIds) > \
-                                                JOB_RESTORE_THRESHOLD_DAYS else len(jobIds)
+        limit = JOB_RESTORE_THRESHOLD_LIMIT if len(jobIds) > \
+                                                JOB_RESTORE_THRESHOLD_LIMIT else len(jobIds)
         msg = ('Unable to load previously loaded job since it was moved '
                    'to the historical database: {0}')
 
         try:
             for jobId, timestamp in jobIds[:limit]:
                 loggedTime = datetime.datetime.fromtimestamp(timestamp)
-                if (today - loggedTime).days <= TIME_DELTA:
+                if (today - loggedTime).days <= JOB_RESTORE_THRESHOLD_DAYS:
                     try:
                         self.jobMonitor.addJob(jobId, timestamp)
                     except opencue.EntityNotFoundException:

--- a/cuegui/cuegui/plugins/MonitorJobsPlugin.py
+++ b/cuegui/cuegui/plugins/MonitorJobsPlugin.py
@@ -112,15 +112,17 @@ class MonitorJobsDockWidget(cuegui.AbstractDockWidget.AbstractDockWidget):
         Only load jobs that have a timestamp less than or equal to the time a job lives on the farm
         (jobs are moved to historical database)
 
-        :param jobIds: monitored jobs ids and their timestamp from previous working state (loaded from config.ini file)
-        :ptype: list of tuples (ex: [("Job.f156be87-987a-48b9-b9da-774cd58674a3", 1612482716.170947),...
+        :param jobIds: monitored jobs ids and their timestamp from previous working state
+                       (loaded from config.ini file)
+        :ptype: list of tuples ex:
+                [("Job.f156be87-987a-48b9-b9da-774cd58674a3", 1612482716.170947),...
         """
         today = datetime.datetime.now()
         limit = JOB_LOAD_LIMIT if len(jobIds) > JOB_LOAD_LIMIT else len(jobIds)
         msg = """
               Unable to load previously loaded job since
               it was moved to the historical
-              database: {0}
+              database:
               """
 
         try:
@@ -129,15 +131,15 @@ class MonitorJobsDockWidget(cuegui.AbstractDockWidget.AbstractDockWidget):
                 if (today - loggedTime).days <= TIME_DELTA:
                     try:
                         self.jobMonitor.addJob(jobId, timestamp)
-                    except opencue.EntityNotFoundException as e:
-                        logger.info(msg.format(jobId))
-        except ValueError as e:
+                    except opencue.EntityNotFoundException:
+                        logger.info(msg, jobId)
+        except ValueError:
             # load older format
             for jobId in jobIds[:limit]:
                 try:
                     self.jobMonitor.addJob(jobId)
-                except opencue.EntityNotFoundException as e:
-                    logger.info(msg.format(jobId))
+                except opencue.EntityNotFoundException:
+                    logger.info(msg, jobId)
 
     def pluginRestoreState(self, saved_settings):
         """Called on plugin start with any previously saved state.

--- a/cuegui/cuegui/plugins/MonitorJobsPlugin.py
+++ b/cuegui/cuegui/plugins/MonitorJobsPlugin.py
@@ -48,7 +48,7 @@ PLUGIN_DESCRIPTION = "Monitors a list of jobs"
 PLUGIN_PROVIDES = "MonitorJobsDockWidget"
 REGEX_EMPTY_STRING = re.compile("^$")
 TIME_DELTA = 3
-JOB_LOAD_LIMIT = 200
+JOB_RESTORE_THRESHOLD_DAYS = 200
 
 class MonitorJobsDockWidget(cuegui.AbstractDockWidget.AbstractDockWidget):
     """Plugin for listing active jobs and managing them."""
@@ -114,16 +114,14 @@ class MonitorJobsDockWidget(cuegui.AbstractDockWidget.AbstractDockWidget):
 
         :param jobIds: monitored jobs ids and their timestamp from previous working state
                        (loaded from config.ini file)
-        :ptype: list of tuples ex:
-                [("Job.f156be87-987a-48b9-b9da-774cd58674a3", 1612482716.170947),...
+                       ex: [("Job.f156be87-987a-48b9-b9da-774cd58674a3", 1612482716.170947),...
+        :type jobIds: list[tuples]
         """
         today = datetime.datetime.now()
-        limit = JOB_LOAD_LIMIT if len(jobIds) > JOB_LOAD_LIMIT else len(jobIds)
-        msg = """
-              Unable to load previously loaded job since
-              it was moved to the historical
-              database:
-              """
+        limit = JOB_RESTORE_THRESHOLD_DAYS if len(jobIds) > \
+                                                JOB_RESTORE_THRESHOLD_DAYS else len(jobIds)
+        msg = ('Unable to load previously loaded job since it was moved '
+                   'to the historical database: {0}')
 
         try:
             for jobId, timestamp in jobIds[:limit]:


### PR DESCRIPTION
**Summarize your change.**
Common complaint from our users is that if they added 1000s of jobs to their previous Job Monitor Tree session, opencuetopia would _**take a very long time**_ to load, especially if the jobs were moved to the historical database since their last session (they would also receive many warnings in the shell which further bogs down the app). 

To avoid the restore lag for such scenarios:
* Only restore jobs from config.ini that were added within the last 3 days.
* Add a timestamp to the config.ini file for each monitored job. Uses the timestamp of when the user added the job to monitor over the job's database `startTime()` because a job could be running on the farm for 3+ days or be dependent on other jobs, meaning a job could have a db start time > 3 (and hence not restored but could still be in progress and of interest to the user)
*  This change does not prevent the user from adding 1000s of jobs to be monitored, only that it will restore the most recent 200 jobs.


<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
