### PR TITLE
Fix scroll bar position from jumping back to the top

### DIFF
--- a/cuegui/cuegui/JobMonitorTree.py
+++ b/cuegui/cuegui/JobMonitorTree.py
@@ -411,7 +411,7 @@ class JobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
 
         self._itemsLock.lockForWrite()
 
-        # include rpcObjects from self._items that are not in jobObjects
+        # include rpcObjects from self._items that are not in rpcObjects
         for proxy, item in list(self._items.items()):
             if not proxy in rpcObjects:
                 rpcObjects[proxy] = item.rpcObject
@@ -435,7 +435,7 @@ class JobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                 if proxy in self.__userColors:
                     self._items[proxy].setUserColor(self.__userColors[proxy])
 
-            self.verticalScrollBar().setRange(scrolled, len(jobObjects.keys() - scrolled))
+            self.verticalScrollBar().setRange(scrolled, len(rpcObjects.keys()) - scrolled)
             list(map(lambda key: self._items[key].setSelected(True),
                      [key for key in selectedKeys if key in self._items]))
 

--- a/cuegui/cuegui/JobMonitorTree.py
+++ b/cuegui/cuegui/JobMonitorTree.py
@@ -435,7 +435,7 @@ class JobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                 if proxy in self.__userColors:
                     self._items[proxy].setUserColor(self.__userColors[proxy])
 
-            self.verticalScrollBar().setValue(scrolled)
+            self.verticalScrollBar().setRange(scrolled, len(jobObjects.keys() - scrolled))
             list(map(lambda key: self._items[key].setSelected(True),
                      [key for key in selectedKeys if key in self._items]))
 


### PR DESCRIPTION
**Summarize your change.**
A common minor annoyance we heard from our users is that when scrolling through many jobs (500+), as they scrolled down the list and double clicked on a job to see it's layers, the scroll bar would jump back up to the top, forcing the user to re-scroll back down the list if they needed to view the other jobs in that scope, ideally the scroll position should remain in the most recent position.
**Solution:** Changed scroll position using the `setVerticalBar().setRange(...)` and created a small scroll area between scroll position and the number of jobs monitored.



<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
