### PR TITLE
Add GRPC_POLL_STRATEGY to avoid spamming users

### DIFF
--- a/pycue/opencue/cuebot.py
+++ b/pycue/opencue/cuebot.py
@@ -77,6 +77,9 @@ if os.path.exists(fcnf):
 DEFAULT_MAX_MESSAGE_BYTES = 1024 ** 2 * 10
 DEFAULT_GRPC_PORT = 8443
 
+# Avoid spamming users with epoll fork warning messages
+os.environ["GRPC_POLL_STRATEGY"] = "epoll1"
+
 class Cuebot(object):
     """Used to manage the connection to the Cuebot.  Normally the connection
        to the Cuebot is made automatically as needed so you don't have to explicitly


### PR DESCRIPTION
**Summarize your change.**
Not defining the poll strategy generates a warning message on every fork that includes a opencue environment

**why**
Common source of confusion for users was the appearance of the e-poll strategy warning in the logs when forking, opting to handle the strategy to avoid spamming users.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
