### PR TITLE
Sortlambda works on all rpcObject types

### DIFF
--- a/cuegui/cuegui/AbstractWidgetItem.py
+++ b/cuegui/cuegui/AbstractWidgetItem.py
@@ -27,9 +27,6 @@ from builtins import str
 from PySide2 import QtCore
 from PySide2 import QtWidgets
 
-import opencue
-import opencue.wrappers.job
-
 import cuegui.Constants
 import cuegui.Logger
 import cuegui.Style
@@ -92,14 +89,15 @@ class AbstractWidgetItem(QtWidgets.QTreeWidgetItem):
         return cuegui.Constants.QVARIANT_NULL
 
     def __lt__(self, other):
-        """Custom sorting for columns that have a function defined for sorting"""
+        """Custom sorting for columns that have a function defined for sorting
+           (uses the sort lambda function defined in the subclasses' addColumn definition)"""
         sortLambda = self.column_info[self.treeWidget().sortColumn()][SORT_LAMBDA]
         column = self.treeWidget().sortColumn()
 
-        if sortLambda and isinstance(other.rpcObject, opencue.wrappers.job.Job):
+        if sortLambda:
             # pylint: disable=broad-except
             try:
                 return sortLambda(self.rpcObject) < sortLambda(other.rpcObject)
             except Exception:
-                logger.warning("Sort failed on column %s, using text sort.", column)
+                logger.info("Sort failed on column %s, using text sort.", column)
         return str(self.text(column)) < str(other.text(column))

--- a/cuegui/cuegui/AbstractWidgetItem.py
+++ b/cuegui/cuegui/AbstractWidgetItem.py
@@ -90,7 +90,7 @@ class AbstractWidgetItem(QtWidgets.QTreeWidgetItem):
 
     def __lt__(self, other):
         """Custom sorting for columns that have a function defined for sorting
-           (uses the sort lambda function defined in the subclasses' addColumn definition)"""
+           (uses the sort lambda function defined in the subclasses' addColumn definition)."""
         sortLambda = self.column_info[self.treeWidget().sortColumn()][SORT_LAMBDA]
         column = self.treeWidget().sortColumn()
 


### PR DESCRIPTION
**Summarize your change.**
Bug fix `sortLambda` if statement which only worked for `rpcObject` of type "job" (`if sortLambda and isinstance(other.rpcObject, opencue.wrappers.job.Job`) which failed to call the `sortLambda` for the rest of the `rpcObject` types, this caused an issue with numerical sorting (for example it resorted to text sort and would sort numbered columns like 70000, 7, 6000, 5000, 3, 2). Once changed and all the sort lambda functions are called and work correctly (including the numerical sorting for Allocations, Host, Subscription and Show plugins).

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
