### PR TITLE
Fix rqdconstants assertEqual statement

### DIFF
--- a/rqd/tests/rqconstants_tests.py
+++ b/rqd/tests/rqconstants_tests.py
@@ -128,7 +128,7 @@ DEFAULT_FACILITY =  test_facility
         self.assertEqual(rqd.rqconstants.DEFAULT_FACILITY, "test_facility")
 
         machine = self.makeRqMachine()
-        self.assertEqual(machine.renderHost.facility, "test_facility")
+        self.assertEqual(machine.renderHost.facility, "cloud")
 
     @MockConfig(
         tempdir,
@@ -141,7 +141,6 @@ RQD_TAGS =  test_tag1 test_tag2  test_tag3
         self.assertEqual(rqd.rqconstants.RQD_TAGS, "test_tag1 test_tag2  test_tag3")
 
         machine = self.makeRqMachine()
-        self.assertEqual(machine.renderHost.facility, "cloud")
         self.assertTrue(
             set(["test_tag1", "test_tag2", "test_tag3"]).issubset(
                 machine.renderHost.tags


### PR DESCRIPTION
**Summarize your change.**
The assertEqual statement for `test_facility` should be asserting `"cloud"` which was creating in mock function, moved the correct assert test from `test_tags` to `test_facility`.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
