### PR TITLE
Split Python linting into its own CI job.

### DIFF
--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -35,7 +35,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run Python Tests
-        run: ci/run_python_tests.sh --lint
+        run: ci/run_python_tests.sh
+
+  lint_python_2020:
+    name: Lint Python Code (CY2020)
+    runs-on: ubuntu-latest
+    container: aswf/ci-opencue:2020
+    steps:
+      - uses: actions/checkout@v2
+      - name: Lint Python Code
+        run: ci/run_python_lint.sh
 
   test_cuebot_2020:
     name: Build Cuebot and Run Unit Tests (CY2020)

--- a/ci/run_python_lint.sh
+++ b/ci/run_python_lint.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -e
+
+python_version=$(python -V)
+echo "Will run Python lint using ${python_version}"
+
+pip install --user -r requirements.txt -r requirements_gui.txt
+
+# Protos need to have their Python code generated in order for tests to pass.
+python -m grpc_tools.protoc -I=proto/ --python_out=pycue/opencue/compiled_proto --grpc_python_out=pycue/opencue/compiled_proto proto/*.proto
+python -m grpc_tools.protoc -I=proto/ --python_out=rqd/rqd/compiled_proto --grpc_python_out=rqd/rqd/compiled_proto proto/*.proto
+
+# Fix imports to work in both Python 2 and 3. See
+# <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
+2to3 -wn -f import pycue/opencue/compiled_proto/*_pb2*.py
+2to3 -wn -f import rqd/rqd/compiled_proto/*_pb2*.py
+
+cd pycue
+python -m pylint --rcfile=../ci/pylintrc_main FileSequence
+python -m pylint --rcfile=../ci/pylintrc_main opencue --ignore=opencue/compiled_proto
+python -m pylint --rcfile=../ci/pylintrc_test tests
+cd ..
+
+cd pyoutline
+PYTHONPATH=../pycue python -m pylint --rcfile=../ci/pylintrc_main outline
+PYTHONPATH=../pycue python -m pylint --rcfile=../ci/pylintrc_test tests
+cd ..
+
+cd cueadmin
+PYTHONPATH=../pycue python -m pylint --rcfile=../ci/pylintrc_main cueadmin
+PYTHONPATH=../pycue python -m pylint --rcfile=../ci/pylintrc_test tests
+cd ..
+
+cd cuegui
+PYTHONPATH=../pycue python -m pylint --rcfile=../ci/pylintrc_main cuegui --ignore=cuegui/images,cuegui/images/crystal
+PYTHONPATH=../pycue python -m pylint --rcfile=../ci/pylintrc_test tests
+cd ..
+
+cd cuesubmit
+PYTHONPATH=../pycue:../pyoutline python -m pylint --rcfile=../ci/pylintrc_main cuesubmit
+PYTHONPATH=../pycue:../pyoutline python -m pylint --rcfile=../ci/pylintrc_test tests
+cd ..
+
+cd rqd
+python -m pylint --rcfile=../ci/pylintrc_main rqd --ignore=rqd/compiled_proto
+python -m pylint --rcfile=../ci/pylintrc_test tests
+cd ..

--- a/ci/run_python_tests.sh
+++ b/ci/run_python_tests.sh
@@ -26,26 +26,3 @@ python rqd/setup.py test
 if [[ "$python_version" =~ "Python 3" ]]; then
   PYTHONPATH=pycue xvfb-run -d python cuegui/setup.py test
 fi
-
-# Some environments don't have pylint available, for ones that do they should pass this flag.
-if [[ "$1" == "--lint" ]]; then
-  cd pycue && python -m pylint --rcfile=../ci/pylintrc_main FileSequence && cd ..
-  cd pycue && python -m pylint --rcfile=../ci/pylintrc_main opencue --ignore=opencue/compiled_proto && cd ..
-  cd pycue && python -m pylint --rcfile=../ci/pylintrc_test tests && cd ..
-
-  cd pyoutline && PYTHONPATH=../pycue python -m pylint --rcfile=../ci/pylintrc_main outline && cd ..
-  cd pyoutline && PYTHONPATH=../pycue python -m pylint --rcfile=../ci/pylintrc_test tests && cd ..
-
-  cd cueadmin && PYTHONPATH=../pycue python -m pylint --rcfile=../ci/pylintrc_main cueadmin && cd ..
-  cd cueadmin && PYTHONPATH=../pycue python -m pylint --rcfile=../ci/pylintrc_test tests && cd ..
-
-  cd cuegui && PYTHONPATH=../pycue python -m pylint --rcfile=../ci/pylintrc_main cuegui --ignore=cuegui/images,cuegui/images/crystal && cd ..
-  cd cuegui && PYTHONPATH=../pycue python -m pylint --rcfile=../ci/pylintrc_test tests && cd ..
-
-  cd cuesubmit && PYTHONPATH=../pycue:../pyoutline python -m pylint --rcfile=../ci/pylintrc_main cuesubmit && cd ..
-  cd cuesubmit && PYTHONPATH=../pycue:../pyoutline python -m pylint --rcfile=../ci/pylintrc_test tests && cd ..
-
-  cd rqd && python -m pylint --rcfile=../ci/pylintrc_main rqd --ignore=rqd/compiled_proto && cd ..
-  cd rqd && python -m pylint --rcfile=../ci/pylintrc_test tests && cd ..
-fi
-


### PR DESCRIPTION
Linting is currently running as part of one of the Python unit test jobs. This is confusing, it makes people think unit tests are failing, and the output of the combined tests / lint is so large it can be difficult to see the actual source of failure.

Also restructures the linting to avoid use of `cd X && lint && cd ..`. In that model, when the lint check fails it is not caught by the bash `set -e` so the script keeps running but from the wrong directory, which would also create confusing results.