### PR TITLE
Fix crash on macOS by GRPC_POLL_STRATEGY=epoll1

### DIFF
--- a/pycue/opencue/cuebot.py
+++ b/pycue/opencue/cuebot.py
@@ -23,6 +23,7 @@ from random import shuffle
 import atexit
 import logging
 import os
+import platform
 import yaml
 
 import grpc
@@ -77,8 +78,9 @@ if os.path.exists(fcnf):
 DEFAULT_MAX_MESSAGE_BYTES = 1024 ** 2 * 10
 DEFAULT_GRPC_PORT = 8443
 
-# Avoid spamming users with epoll fork warning messages
-os.environ["GRPC_POLL_STRATEGY"] = "epoll1"
+if platform.system() != 'Darwin':
+    # Avoid spamming users with epoll fork warning messages
+    os.environ["GRPC_POLL_STRATEGY"] = "epoll1"
 
 class Cuebot(object):
     """Used to manage the connection to the Cuebot.  Normally the connection


### PR DESCRIPTION
> E0628 ... ev_posix.cc:227]                   No event engine could be initialized from epoll1

cuegui crashes on macOS because macOS doesn't support `GRPC_POLL_STRATEGY=epoll1`. Skip it on macOS(`Darwin`).