### PR TITLE
Fix bug in Monitor Job Details due to setShortcut arg type.

### DIFF
--- a/cuegui/cuegui/FrameMonitor.py
+++ b/cuegui/cuegui/FrameMonitor.py
@@ -25,6 +25,7 @@ from copy import deepcopy
 import math
 
 from PySide2 import QtCore
+from PySide2 import QtGui
 from PySide2 import QtWidgets
 
 import FileSequence
@@ -440,7 +441,7 @@ class FrameMonitor(QtWidgets.QWidget):
                 if item[0] != "Clear":
                     a.setCheckable(True)
                 if item[1]:
-                    a.setShortcut(item[1])
+                    a.setShortcut(QtGui.QKeySequence(item[1]))
                 menu.addAction(a)
             else:
                 menu.addSeparator()


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Fixes #1005 

**Summarize your change.**
In a Python 3 environment, this works fine as-is. However in Python 2 you get the error

```
TypeError: 'PySide2.QtWidgets.QAction.setShortcut' called with wrong argument types:
  PySide2.QtWidgets.QAction.setShortcut(long)
Supported signatures:
  PySide2.QtWidgets.QAction.setShortcut(PySide2.QtGui.QKeySequence)
```

Adding the explicit use of `QKeySequence` gets this working again in both Python 2 and 3.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
