### PR TITLE
Expand supported Python and VFX Reference Platform versions.

### DIFF
--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -37,15 +37,6 @@ jobs:
       - name: Run Python Tests
         run: ci/run_python_tests.sh
 
-  lint_python_2020:
-    name: Lint Python Code (CY2020)
-    runs-on: ubuntu-latest
-    container: aswf/ci-opencue:2020
-    steps:
-      - uses: actions/checkout@v2
-      - name: Lint Python Code
-        run: ci/run_python_lint.sh
-
   test_cuebot_2020:
     name: Build Cuebot and Run Unit Tests (CY2020)
     runs-on: ubuntu-latest
@@ -57,6 +48,36 @@ jobs:
         run: |
           chown -R aswfuser:aswfgroup .
           su -c "cd cuebot && ./gradlew build --stacktrace --info" aswfuser
+
+  test_python_2021:
+    name: Run Python Unit Tests (CY2021)
+    runs-on: ubuntu-latest
+    container: aswf/ci-opencue:2021
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Python Tests
+        run: ci/run_python_tests.sh
+
+  test_cuebot_2021:
+    name: Build Cuebot and Run Unit Tests (CY2021)
+    runs-on: ubuntu-latest
+    container:
+      image: aswf/ci-opencue:2021
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build with Gradle
+        run: |
+          chown -R aswfuser:aswfgroup .
+          su -c "cd cuebot && ./gradlew build --stacktrace --info" aswfuser
+
+  lint_python:
+    name: Lint Python Code
+    runs-on: ubuntu-latest
+    container: aswf/ci-opencue:2020
+    steps:
+      - uses: actions/checkout@v2
+      - name: Lint Python Code
+        run: ci/run_python_lint.sh
 
   test_sphinx:
     name: Test Documentation Build

--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -73,7 +73,7 @@ jobs:
   lint_python:
     name: Lint Python Code
     runs-on: ubuntu-latest
-    container: aswf/ci-opencue:2020
+    container: aswf/ci-opencue:2021
     steps:
       - uses: actions/checkout@v2
       - name: Lint Python Code

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![OpenCue](/images/opencue_logo_with_text.png)
 
-[![Supported VFX Platform Versions](https://img.shields.io/badge/vfx%20platform-2019--2020-lightgrey.svg)](http://www.vfxplatform.com/)
-![Supported Python Versions](https://img.shields.io/badge/python-2.7%2C%203.6%2C%203.7-blue.svg)
+[![Supported VFX Platform Versions](https://img.shields.io/badge/vfx%20platform-2019--2021-lightgrey.svg)](http://www.vfxplatform.com/)
+![Supported Python Versions](https://img.shields.io/badge/python-2.7%2C%203.6%2C%203.9-blue.svg)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2837/badge)](https://bestpractices.coreinfrastructure.org/projects/2837)
 
 - [Introduction](#Introduction)

--- a/cueadmin/setup.py
+++ b/cueadmin/setup.py
@@ -46,6 +46,8 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     packages=find_packages(),
     entry_points={

--- a/cuegui/setup.py
+++ b/cuegui/setup.py
@@ -46,6 +46,8 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     packages=find_packages(),
     package_data={

--- a/cuesubmit/setup.py
+++ b/cuesubmit/setup.py
@@ -43,6 +43,11 @@ setup(
 
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     packages=find_packages(),
     package_data={

--- a/pycue/setup.py
+++ b/pycue/setup.py
@@ -46,6 +46,8 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     packages=find_packages(exclude=['tests']),
     package_data={

--- a/pyoutline/setup.py
+++ b/pyoutline/setup.py
@@ -46,6 +46,8 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     packages=find_packages(exclude=['tests']),
     data_files=[

--- a/rqd/setup.py
+++ b/rqd/setup.py
@@ -43,6 +43,11 @@ setup(
 
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     packages=find_packages(),
     entry_points={


### PR DESCRIPTION
Now that gRPC and PySide dependencies are updated, I've been able to install and test on newer Python versions i.e. 3.9.

- Run testing pipeline against CY2021 images.
- Update README with new supported Python and Reference Platform versions.
- Update all `setup.py` files with the current supported version list.