### PR TITLE
Fix reserveHT

### DIFF
--- a/rqd/tests/rqmachine_tests.py
+++ b/rqd/tests/rqmachine_tests.py
@@ -304,6 +304,9 @@ class MachineTests(pyfakefs.fake_filesystem_unittest.TestCase):
 
     @mock.patch.object(
         rqd.rqmachine.Machine, '_Machine__enabledHT', new=mock.MagicMock(return_value=True))
+    @mock.patch.object(
+        rqd.rqmachine.Machine, '_Machine__getHyperthreadingMultiplier',
+        new=mock.MagicMock(return_value=2))
     def test_getLoadAvgHT(self):
         self.loadavg.set_contents(LOADAVG_HIGH_USAGE)
 


### PR DESCRIPTION
The nature of `reserveHT` is creating a CPU-list for `taskset -c`, it should work without Hyper-threading.
But it assumes `hyperthreadingMultiplier` is 2.
This PR allows non-HT machine (for example, VM) can use `taskset -c`.

(Probably, we can add an extra logic for `hyperthreadingMultiplier=3` or more, but I think not worth it for now)