### PR TITLE
Fix number of GPU units in RunningFrameInfo

### DIFF
--- a/rqd/rqd/rqnetwork.py
+++ b/rqd/rqd/rqnetwork.py
@@ -62,7 +62,6 @@ class RunningFrame(object):
         self.vsize = 0
         self.maxVsize = 0
 
-        self.numGpus = 0
         self.usedGpuMemory = 0
         self.maxUsedGpuMemory = 0
 
@@ -89,7 +88,7 @@ class RunningFrame(object):
             vsize=self.vsize,
             attributes=self.runFrame.attributes,
             llu_time=self.lluTime,
-            num_gpus=self.numGpus,
+            num_gpus=self.runFrame.num_gpus,
             max_used_gpu_memory=self.maxUsedGpuMemory,
             used_gpu_memory=self.usedGpuMemory
         )


### PR DESCRIPTION
Fix a bug introduced in #924
- rqnetwork.py numGpus is always 0 😞 
- It can just use `runFrame.num_gpus`.
  - Because this code block is working correctly https://github.com/AcademySoftwareFoundation/OpenCue/blob/c22fe12721bed24b814184ea78c5e447b3b6a477/rqd/rqd/rqcore.py#L865-L868