### PR TITLE
Fix FRAME_DETAIL_MAPPER for Max RSS

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/FrameDetail.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/FrameDetail.java
@@ -30,7 +30,7 @@ public class FrameDetail extends FrameEntity implements FrameInterface {
     public int dependCount;
     public int retryCount;
     public int exitStatus;
-    public int maxRss;
+    public long maxRss;
     public int dispatchOrder;
     public String lastResource;
 

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/FrameDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/FrameDaoJdbc.java
@@ -400,7 +400,7 @@ public class FrameDaoJdbc extends JdbcDaoSupport  implements FrameDao {
             frame.jobId = rs.getString("pk_job");
             frame.layerId = rs.getString("pk_layer");
             frame.showId = rs.getString("pk_show");
-            frame.maxRss = rs.getInt("int_mem_max_used");
+            frame.maxRss = rs.getLong("int_mem_max_used");
             frame.name = rs.getString("str_name");
             frame.number = rs.getInt("int_number");
             frame.dispatchOrder = rs.getInt("int_dispatch_order");


### PR DESCRIPTION
Max RSS can exceed `int` range.
(Database schema uses already `bigint`, and gRPC proto also uses `int64`)

    Caused by: org.springframework.dao.DataIntegrityViolationException: PreparedStatementCallback; SQL [SELECT frame.*, job.pk_facility,job.pk_show FROM frame,layer,job,show WHERE frame.pk_job = job.pk_job AND frame.pk_layer = layer.pk_layer AND job.pk_show = show.pk_show  AND pk_frame=?]; Bad value for type int : 10733502280; nested exception is org.postgresql.util.PSQLException: Bad value for type int : 10733502280
        at org.springframework.jdbc.support.SQLStateSQLExceptionTranslator.doTranslate(SQLStateSQLExceptionTranslator.java:104)
        at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:72)
        at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:81)
        at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:81)
        at org.springframework.jdbc.core.JdbcTemplate.translateException(JdbcTemplate.java:1443)
        at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:633)
        at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:669)
        at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:700)
        at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:712)
        at org.springframework.jdbc.core.JdbcTemplate.queryForObject(JdbcTemplate.java:790)
        at com.imageworks.spcue.dao.postgres.FrameDaoJdbc.getFrameDetail(FrameDaoJdbc.java: