### PR TITLE
Add workaround for PowerShell Exitcode

### DIFF
--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -44,6 +44,9 @@ import rqd.rqnimby
 import rqd.rqutil
 
 
+INT32_MAX = 2147483647
+INT32_MIN = -2147483648
+
 class FrameAttendantThread(threading.Thread):
     """Once a frame has been received and checked by RQD, this class handles
        the launching, waiting on, and cleanup work related to running the
@@ -361,6 +364,10 @@ class FrameAttendantThread(threading.Thread):
 
         # Find exitStatus and exitSignal
         returncode = frameInfo.forkedCommand.returncode
+        if returncode < INT32_MIN:
+            returncode = 303
+        if returncode > INT32_MAX:
+            returncode = 304
         frameInfo.exitStatus = returncode
         frameInfo.exitSignal = returncode
 


### PR DESCRIPTION
PowerShell exit code may exceed int32 range. For example, `4294901760`. It causes `ValueError` exception here.

https://github.com/AcademySoftwareFoundation/OpenCue/blob/21bfbfe158fdb0e730a80db3ec2134efc15e0366/rqd/rqd/rqcore.py#L218

> ValueError: Value out of range: 4294901760

This PR adds an workaround to avoid the exception, with arbitrary exit codes, which is better than nothing.