### PR TITLE
Delete CORE_POINTS_RESERVED_MAX check logic

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/Dispatcher.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/Dispatcher.java
@@ -34,9 +34,6 @@ import com.imageworks.spcue.util.CueUtil;
 
 public interface Dispatcher {
 
-    // Maximum number of core points that can be assigned to a frame
-    public static final int CORE_POINTS_RESERVED_MAX = 2400;
-
     // The default number of core points assigned to a frame, if no core
     // point value is specified
     public static final int CORE_POINTS_RESERVED_DEFAULT = 100;

--- a/cuebot/src/main/java/com/imageworks/spcue/service/JobSpec.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/service/JobSpec.java
@@ -606,8 +606,7 @@ public class JobSpec {
             corePoints = Integer.valueOf(cores);
         }
 
-        if (corePoints < Dispatcher.CORE_POINTS_RESERVED_MIN
-                || corePoints > Dispatcher.CORE_POINTS_RESERVED_MAX) {
+        if (corePoints < Dispatcher.CORE_POINTS_RESERVED_MIN) {
             corePoints = Dispatcher.CORE_POINTS_RESERVED_DEFAULT;
         }
 


### PR DESCRIPTION
This PR will address #1026
For example, it blocks to reserve an entire machine which has 40 cores.