### PR TITLE
Minor log fix

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
@@ -430,7 +430,7 @@ public class HostReportHandler {
                                 + proc.getName() + " was OOM");
                         try {
                             killQueue.execute(new DispatchRqdKillFrame(proc, "The frame required " +
-                                    CueUtil.KbToMb(f.getRss()) + "MB but the machine only has " +
+                                    CueUtil.KbToMb(f.getRss()) + " but the machine only has " +
                                     CueUtil.KbToMb(host.memory), rqdClient));
                         } catch (TaskRejectedException e) {
                             logger.warn("Unable to queue RQD kill, task rejected, " + e);

--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -180,7 +180,8 @@ class FrameAttendantThread(threading.Thread):
         self.endTime = time.time()
         self.frameInfo.runTime = int(self.endTime - self.startTime)
         try:
-            print("\n", "="*59, file=self.rqlog)
+            print("", file=self.rqlog)
+            print("="*59, file=self.rqlog)
             print("RenderQ Job Complete\n", file=self.rqlog)
             print("%-20s%s" % ("exitStatus", self.frameInfo.exitStatus), file=self.rqlog)
             print("%-20s%s" % ("exitSignal", self.frameInfo.exitSignal), file=self.rqlog)


### PR DESCRIPTION
1. The RQD log footer always has an extra space on the separator
    - <img width="202" alt="Screen Shot 2021-09-09 at 10 24 15 PM" src="https://user-images.githubusercontent.com/81904/132804776-7836e181-1bfb-4371-8538-8022951e18df.png">
2. Out of memory error message has an extra "MB", like `20480MBMB but the machine only has` 
    - https://github.com/AcademySoftwareFoundation/OpenCue/blob/21bfbfe158fdb0e730a80db3ec2134efc15e0366/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java#L433
    - `KbToMb` already prints `MB` https://github.com/AcademySoftwareFoundation/OpenCue/blob/21bfbfe158fdb0e730a80db3ec2134efc15e0366/cuebot/src/main/java/com/imageworks/spcue/util/CueUtil.java#L207