### PR TITLE
Add FindLimit to pycue API

### DIFF
--- a/pycue/opencue/api.py
+++ b/pycue/opencue/api.py
@@ -794,3 +794,14 @@ def getLimits():
     :return: a list of Limit objects"""
     return [Limit(limit) for limit in Cuebot.getStub('limit').GetAll(
         limit_pb2.LimitGetAllRequest(), timeout=Cuebot.Timeout).limits]
+
+@util.grpcExceptionParser
+def findLimit(name):
+    """Returns the Limit object that matches the name.
+
+    :type  name: str
+    :param name: a string that represents a limit to return
+    :rtype:  Limit
+    :return: the matching Limit object"""
+    return Limit(Cuebot.getStub('limit').Find(
+        limit_pb2.LimitFindRequest(name=name), timeout=Cuebot.Timeout).limit)

--- a/pycue/tests/api_test.py
+++ b/pycue/tests/api_test.py
@@ -832,6 +832,21 @@ class LimitTests(unittest.TestCase):
         self.assertEqual(len(limits), 1)
         self.assertEqual(limits[0].name(), TEST_LIMIT_NAME)
 
+    @mock.patch('opencue.cuebot.Cuebot.getStub')
+    def testFindLimit(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.Find.return_value = limit_pb2.LimitFindResponse(
+            limit=limit_pb2.Limit(name=TEST_LIMIT_NAME, max_value=42))
+        getStubMock.return_value = stubMock
+
+        limit = opencue.api.findLimit(TEST_LIMIT_NAME)
+        self.assertEqual(TEST_LIMIT_NAME, limit.name())
+        self.assertEqual(42, limit.maxValue())
+
+        stubMock.Find.assert_called_with(
+            limit_pb2.LimitFindRequest(name=TEST_LIMIT_NAME),
+            timeout=mock.ANY)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
pycue has already `find` API but it is under `Limit` wrapper.
https://github.com/AcademySoftwareFoundation/OpenCue/blob/847ee50c1732b268d55cd645d1d7c2d9e9e039da/pycue/opencue/wrappers/limit.py#L42-L43
Which means user needs to get `Limit` instance somehow (`getLimits()` or `createLimit()`) first to find a `Limit`. It is not efficient.
