### PR TITLE
Set protobuf version 3.17.3 for CY2019

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ grpcio-tools==1.39.0;python_version>="3.0"
 mock==2.0.0
 packaging==20.9
 pathlib==1.0.1;python_version<"3.4"
+protobuf==3.17.3;python_version<"3.0"
 psutil==5.6.6
 pyfakefs==3.6
 pylint==2.6.0;python_version>="3.7"


### PR DESCRIPTION
Python2.7 is not happy with protobuf-3.18.0.
https://github.com/AcademySoftwareFoundation/OpenCue/runs/3898137962

      File "/__w/OpenCue/OpenCue/pycue/opencue/compiled_proto/comment_pb2.py", line 7, in <module>
        from google.protobuf import descriptor as _descriptor
      File "/github/home/.local/lib/python2.7/site-packages/google/protobuf/descriptor.py", line 113
        class DescriptorBase(metaclass=DescriptorMetaclass):
                                  ^
    SyntaxError: invalid syntax
