### PR TITLE
[RQD] Fix gRPC connection

### DIFF
--- a/rqd/rqd/rqnetwork.py
+++ b/rqd/rqd/rqnetwork.py
@@ -238,8 +238,8 @@ class Network(object):
             shuffle(cuebots)
             if len(cuebots) > 0:
                 self.channel = grpc.insecure_channel('%s:%s' % (cuebots[0],
-                                                                rqd.rqconstants.CUEBOT_GRPC_PORT),
-                                                     *interceptors)
+                                                                rqd.rqconstants.CUEBOT_GRPC_PORT))
+                self.channel = grpc.intercept_channel(self.channel, *interceptors)
             atexit.register(self.closeChannel)
 
     def __getReportStub(self):


### PR DESCRIPTION
Fix #1037
wrong usage of API `insecure_channel`. It should have used `intercept_channel`
https://grpc.github.io/grpc/python/grpc.html#grpc.insecure_channel