### PR TITLE
[Cuebot] Avoid NullPointerException

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/SortableShow.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/SortableShow.java
@@ -77,7 +77,9 @@ public class SortableShow implements Comparable<SortableShow> {
     }
 
     public void skip(String tags, long cores, long memory) {
-        failed.put(tags, new long[] { cores, memory});
+        if (tags != null) {
+            failed.put(tags, new long[] { cores, memory});
+        }
     }
 
     /**


### PR DESCRIPTION
Not entirely sure but Cuebot got `NullPointerException` time to time on `SortableShow.java:80`. The only possible explanation of this exception would be that the `tags` was `null` sometimes. Maybe some race condition during populating Host entity, but we are not aware of any other issues except this `NullPointerException`.

    java.lang.NullPointerException
    	at java.base/java.util.concurrent.ConcurrentHashMap.putVal(ConcurrentHashMap.java:1011)
    	at java.base/java.util.concurrent.ConcurrentHashMap.put(ConcurrentHashMap.java:1006)
    	at com.imageworks.spcue.SortableShow.skip(SortableShow.java:80)
    	at com.imageworks.spcue.dao.postgres.DispatcherDaoJdbc.findDispatchJobs(DispatcherDaoJdbc.java:199)