### PR TITLE
[Cuebot] Add FIFO scheduling capability

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dao/DispatcherDao.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/DispatcherDao.java
@@ -82,7 +82,7 @@ public interface DispatcherDao {
      * @param numJobs
      * @return
      */
-    Set<String> findDispatchJobsForAllShows(DispatchHost host, int numJobs);
+    List<String> findDispatchJobsForAllShows(DispatchHost host, int numJobs);
 
     /**
      * Return a list of jobs which could use resources of the specified
@@ -92,7 +92,7 @@ public interface DispatcherDao {
      * @param numJobs
      * @return
      */
-    Set<String> findDispatchJobs(DispatchHost host, int numJobs);
+    List<String> findDispatchJobs(DispatchHost host, int numJobs);
 
     /**
     * Return a list of jobs which could use resources of the specified
@@ -102,7 +102,7 @@ public interface DispatcherDao {
     * @param numJobs
     * @return
     */
-    Set<String> findDispatchJobs(DispatchHost host, GroupInterface g);
+    List<String> findDispatchJobs(DispatchHost host, GroupInterface g);
 
     /**
      * Finds an under proced job if one exists and returns it,
@@ -131,7 +131,7 @@ public interface DispatcherDao {
     * @param numJobs
     * @return
     */
-   Set<String> findDispatchJobs(DispatchHost host, ShowInterface show, int numJobs);
+   List<String> findDispatchJobs(DispatchHost host, ShowInterface show, int numJobs);
 
    /**
     * Find a list of local dispatch jobs.
@@ -162,6 +162,20 @@ public interface DispatcherDao {
     */
    List<DispatchFrame> findNextDispatchFrames(LayerInterface layer, DispatchHost host,
                                               int limit);
+
+   /**
+    * Return whether FIFO scheduling is enabled or not in the same priority for unittest.
+    *
+    * @return
+    */
+   boolean getFifoSchedulingEnabled();
+
+   /**
+    * Set whether FIFO scheduling is enabled or not in the same priority for unittest.
+    *
+    * @param fifoSchedulingEnabled
+    */
+   void setFifoSchedulingEnabled(boolean fifoSchedulingEnabled);
 }
 
 

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatchQuery.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatchQuery.java
@@ -112,6 +112,22 @@ public class DispatchQuery {
                 "AND job.pk_folder                  = ? ");
 
 
+    private static final String replaceQueryForFifo(String query) {
+        return query
+            .replace(
+                "JOBS_BY",
+                "JOBS_FIFO_BY")
+            .replace(
+                "ORDER BY job_resource.int_priority DESC",
+                "ORDER BY job_resource.int_priority DESC, job.ts_started ASC")
+            .replace(
+                "WHERE rank < ?",
+                "WHERE rank < ? ORDER BY rank");
+    }
+
+    public static final String FIND_JOBS_FIFO_BY_SHOW = replaceQueryForFifo(FIND_JOBS_BY_SHOW);
+    public static final String FIND_JOBS_FIFO_BY_GROUP = replaceQueryForFifo(FIND_JOBS_BY_GROUP);
+
     /**
      * Dispatch a host in local booking mode.
      */

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/CoreUnitDispatcher.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/CoreUnitDispatcher.java
@@ -21,7 +21,6 @@ package com.imageworks.spcue.dispatcher;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.cache.Cache;
@@ -126,7 +125,7 @@ public class CoreUnitDispatcher implements Dispatcher {
     }
 
 
-    private List<VirtualProc> dispatchJobs(DispatchHost host, Set<String> jobs) {
+    private List<VirtualProc> dispatchJobs(DispatchHost host, List<String> jobs) {
         List<VirtualProc> procs = new ArrayList<VirtualProc>();
 
         try {
@@ -170,8 +169,8 @@ public class CoreUnitDispatcher implements Dispatcher {
         return procs;
     }
 
-    private Set<String> getGpuJobs(DispatchHost host, ShowInterface show) {
-        Set<String> jobs = null;
+    private List<String> getGpuJobs(DispatchHost host, ShowInterface show) {
+        List<String> jobs = null;
 
         // TODO: GPU: make index with the 4 components instead of just 3, replace the just 3
 
@@ -200,7 +199,7 @@ public class CoreUnitDispatcher implements Dispatcher {
 
     @Override
     public List<VirtualProc> dispatchHostToAllShows(DispatchHost host) {
-        Set<String> jobs = dispatchSupport.findDispatchJobsForAllShows(
+        List<String> jobs = dispatchSupport.findDispatchJobsForAllShows(
                 host,
                 getIntProperty("dispatcher.job_query_max"));
 
@@ -210,7 +209,7 @@ public class CoreUnitDispatcher implements Dispatcher {
     @Override
     public List<VirtualProc> dispatchHost(DispatchHost host) {
 
-        Set<String> jobs = getGpuJobs(host, null);
+        List<String> jobs = getGpuJobs(host, null);
 
         if (jobs == null)
             jobs = dispatchSupport.findDispatchJobs(host, getIntProperty("dispatcher.job_query_max"));
@@ -221,7 +220,7 @@ public class CoreUnitDispatcher implements Dispatcher {
     @Override
     public List<VirtualProc> dispatchHost(DispatchHost host, ShowInterface show) {
 
-        Set<String> jobs = getGpuJobs(host, show);
+        List<String> jobs = getGpuJobs(host, show);
 
         if (jobs == null)
             jobs = dispatchSupport.findDispatchJobs(host, show,
@@ -233,7 +232,7 @@ public class CoreUnitDispatcher implements Dispatcher {
     @Override
     public List<VirtualProc> dispatchHost(DispatchHost host, GroupInterface group) {
 
-        Set<String> jobs = getGpuJobs(host, null);
+        List<String> jobs = getGpuJobs(host, null);
 
         if (jobs == null)
             jobs = dispatchSupport.findDispatchJobs(host, group);

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupport.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupport.java
@@ -306,7 +306,7 @@ public interface DispatchSupport {
      * @param host
      * @return
      */
-    Set<String> findDispatchJobsForAllShows(DispatchHost host, int numJobs);
+    List<String> findDispatchJobsForAllShows(DispatchHost host, int numJobs);
 
     /**
      * Returns the highest priority job that can utilize
@@ -315,7 +315,7 @@ public interface DispatchSupport {
      * @param host
      * @return
      */
-    Set<String> findDispatchJobs(DispatchHost host, int numJobs);
+    List<String> findDispatchJobs(DispatchHost host, int numJobs);
 
     /**
      * Returns the highest priority jobs that can utilize
@@ -324,7 +324,7 @@ public interface DispatchSupport {
      * @param host
      * @return  A set of unique job ids.
      */
-    Set<String> findDispatchJobs(DispatchHost host, GroupInterface p);
+    List<String> findDispatchJobs(DispatchHost host, GroupInterface p);
 
     /**
      *
@@ -523,14 +523,14 @@ public interface DispatchSupport {
     void determineIdleCores(DispatchHost host, int load);
 
     /**
-     * Return a set of job IDs that can take the given host.
+     * Return a list of job IDs that can take the given host.
      *
      * @param host
      * @param show
      * @param numJobs
      * @return
      */
-    Set<String> findDispatchJobs(DispatchHost host, ShowInterface show, int numJobs);
+    List<String> findDispatchJobs(DispatchHost host, ShowInterface show, int numJobs);
 
     /**
      * Return true of the job has pending frames.

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java
@@ -148,17 +148,17 @@ public class DispatchSupportService implements DispatchSupport {
     }
 
     @Transactional(readOnly = true)
-    public Set<String> findDispatchJobsForAllShows(DispatchHost host, int numJobs) {
+    public List<String> findDispatchJobsForAllShows(DispatchHost host, int numJobs) {
         return dispatcherDao.findDispatchJobsForAllShows(host, numJobs);
     }
 
     @Transactional(readOnly = true)
-    public Set<String> findDispatchJobs(DispatchHost host, int numJobs) {
+    public List<String> findDispatchJobs(DispatchHost host, int numJobs) {
         return dispatcherDao.findDispatchJobs(host, numJobs);
     }
 
     @Transactional(readOnly = true)
-    public Set<String> findDispatchJobs(DispatchHost host, GroupInterface g) {
+    public List<String> findDispatchJobs(DispatchHost host, GroupInterface g) {
         return dispatcherDao.findDispatchJobs(host, g);
     }
 
@@ -170,7 +170,7 @@ public class DispatchSupportService implements DispatchSupport {
 
     @Override
     @Transactional(readOnly = true)
-    public Set<String> findDispatchJobs(DispatchHost host, ShowInterface show,
+    public List<String> findDispatchJobs(DispatchHost host, ShowInterface show,
             int numJobs) {
         return dispatcherDao.findDispatchJobs(host, show, numJobs);
     }

--- a/cuebot/src/main/resources/opencue.properties
+++ b/cuebot/src/main/resources/opencue.properties
@@ -43,6 +43,8 @@ dispatcher.frame_query_max=20
 dispatcher.job_frame_dispatch_max=8
 # Maximum number of frames to dispatch from a host at one time.
 dispatcher.host_frame_dispatch_max=12
+# Whether or not to enable FIFO scheduling in the same priority.
+dispatcher.fifo_scheduling_enabled=false
 
 # Jobs will be archived to the history tables after being completed for this long.
 history.archive_jobs_cutoff_hours=72

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/DispatcherDaoFifoTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/DispatcherDaoFifoTests.java
@@ -1,0 +1,254 @@
+
+/*
+ * Copyright Contributors to the OpenCue Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.imageworks.spcue.test.dao.postgres;
+
+import java.io.File;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import javax.annotation.Resource;
+
+import org.jdom.Document;
+import org.jdom.Element;
+import org.jdom.input.SAXBuilder;
+import org.jdom.output.XMLOutputter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.imageworks.spcue.DispatchHost;
+import com.imageworks.spcue.JobDetail;
+import com.imageworks.spcue.config.TestAppConfig;
+import com.imageworks.spcue.dao.DispatcherDao;
+import com.imageworks.spcue.dao.HostDao;
+import com.imageworks.spcue.dispatcher.Dispatcher;
+import com.imageworks.spcue.grpc.host.HardwareState;
+import com.imageworks.spcue.grpc.report.RenderHost;
+import com.imageworks.spcue.service.AdminManager;
+import com.imageworks.spcue.service.GroupManager;
+import com.imageworks.spcue.service.HostManager;
+import com.imageworks.spcue.service.JobLauncher;
+import com.imageworks.spcue.service.JobManager;
+import com.imageworks.spcue.test.AssumingPostgresEngine;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@Transactional
+@ContextConfiguration(classes=TestAppConfig.class, loader=AnnotationConfigContextLoader.class)
+public class DispatcherDaoFifoTests extends AbstractTransactionalJUnit4SpringContextTests  {
+
+    @Autowired
+    @Rule
+    public AssumingPostgresEngine assumingPostgresEngine;
+
+    @Resource
+    DispatcherDao dispatcherDao;
+
+    @Resource
+    HostDao hostDao;
+
+    @Resource
+    JobManager jobManager;
+
+    @Resource
+    HostManager hostManager;
+
+    @Resource
+    AdminManager adminManager;
+
+    @Resource
+    GroupManager groupManager;
+
+    @Resource
+    Dispatcher dispatcher;
+
+    @Resource
+    JobLauncher jobLauncher;
+
+    private static final String HOSTNAME="beta";
+
+    public DispatchHost getHost() {
+        return hostDao.findDispatchHost(HOSTNAME);
+    }
+
+    private void launchJobs(int count) throws Exception {
+        Document docTemplate = new SAXBuilder(true).build(
+            new File("src/test/resources/conf/jobspec/jobspec_simple.xml"));
+        docTemplate.getDocType().setSystemID("http://localhost:8080/spcue/dtd/cjsl-1.12.dtd");
+        Element root = docTemplate.getRootElement();
+        Element jobTemplate = root.getChild("job");
+        Element depends = root.getChild("depends");
+        assertEquals(jobTemplate.getAttributeValue("name"), "test");
+        root.removeContent(jobTemplate);
+        root.removeContent(depends);
+
+        long t = System.currentTimeMillis();
+        for (int i = 0; i < count; i++) {
+            Document doc = (Document) docTemplate.clone();
+            root = doc.getRootElement();
+            Element job = (Element) jobTemplate.clone();
+            job.setAttribute("name", "job" + i);
+            root.addContent(job);
+            root.addContent((Element) depends.clone());
+            jobLauncher.launch(new XMLOutputter().outputString(doc));
+
+            // Force to set incremental ts_started to the jobs
+            // because current_timestamp is not updated during test.
+            jdbcTemplate.update("UPDATE job SET ts_started = ? WHERE str_name = ?",
+                new Timestamp(t + i), "pipe-default-testuser_job" + i);
+        }
+    }
+
+    @Before
+    public void launchJob() {
+        dispatcherDao.setFifoSchedulingEnabled(true);
+
+        dispatcher.setTestMode(true);
+        jobLauncher.testMode = true;
+    }
+
+    @After
+    public void resetFifoScheduling() {
+        dispatcherDao.setFifoSchedulingEnabled(false);
+    }
+
+    @Before
+    public void createHost() {
+        RenderHost host = RenderHost.newBuilder()
+                .setName(HOSTNAME)
+                .setBootTime(1192369572)
+                .setFreeMcp(76020)
+                .setFreeMem(53500)
+                .setFreeSwap(20760)
+                .setLoad(1)
+                .setTotalMcp(195430)
+                .setTotalMem(8173264)
+                .setTotalSwap(20960)
+                .setNimbyEnabled(false)
+                .setNumProcs(2)
+                .setCoresPerProc(100)
+                .addTags("test")
+                .setState(HardwareState.UP)
+                .setFacility("spi")
+                .putAttributes("SP_OS", "Linux")
+                .build();
+
+        hostManager.createHost(host,
+                adminManager.findAllocationDetail("spi", "general"));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFifoSchedulingEnabled() {
+        assertTrue(dispatcherDao.getFifoSchedulingEnabled());
+        dispatcherDao.setFifoSchedulingEnabled(false);
+        assertFalse(dispatcherDao.getFifoSchedulingEnabled());
+        dispatcherDao.setFifoSchedulingEnabled(true);
+        assertTrue(dispatcherDao.getFifoSchedulingEnabled());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testAllSorted() throws Exception {
+        int count = 10;
+        launchJobs(count);
+
+        List<String> jobs = dispatcherDao.findDispatchJobs(getHost(), count);
+        assertEquals(count, jobs.size());
+        for (int i = 0; i < count; i++) {
+            assertEquals("pipe-default-testuser_job" + i,
+                jobManager.getJob(jobs.get(i)).getName());
+        }
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testPortionSorted() throws Exception {
+        int count = 100;
+        launchJobs(count);
+
+        int portion = 19;
+        List<String> jobs = dispatcherDao.findDispatchJobs(getHost(), (portion + 1) / 10);
+        assertEquals(portion, jobs.size());
+        for (int i = 0; i < portion; i++) {
+            assertEquals("pipe-default-testuser_job" + i,
+                jobManager.getJob(jobs.get(i)).getName());
+        }
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFifoSchedulingDisabled() throws Exception {
+        dispatcherDao.setFifoSchedulingEnabled(false);
+        assertFalse(dispatcherDao.getFifoSchedulingEnabled());
+
+        int count = 10;
+        launchJobs(count);
+
+        List<String> jobs = dispatcherDao.findDispatchJobs(getHost(), count);
+        assertEquals(count, jobs.size());
+
+        List<String> sortedJobs = new ArrayList<String>(jobs);
+        Collections.sort(sortedJobs,
+            Comparator.comparing(jobId -> jobManager.getJob(jobId).getName()));
+        assertNotEquals(jobs, sortedJobs);
+
+        for (int i = 0; i < count; i++) {
+            assertEquals("pipe-default-testuser_job" + i,
+                jobManager.getJob(sortedJobs.get(i)).getName());
+        }
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGroup() throws Exception {
+        int count = 10;
+        launchJobs(count);
+
+        JobDetail job = jobManager.findJobDetail("pipe-default-testuser_job0");
+        assertNotNull(job);
+
+        List<String> jobs = dispatcherDao.findDispatchJobs(getHost(),
+                groupManager.getGroupDetail(job));
+        assertEquals(count, jobs.size());
+        for (int i = 0; i < count; i++) {
+            assertEquals("pipe-default-testuser_job" + i,
+                jobManager.getJob(jobs.get(i)).getName());
+        }
+    }
+}

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/DispatcherDaoTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/DispatcherDaoTests.java
@@ -327,7 +327,7 @@ public class DispatcherDaoTests extends AbstractTransactionalJUnit4SpringContext
         assertTrue(jdbcTemplate.queryForObject(
                 "SELECT COUNT(*) FROM job WHERE str_state='PENDING'", Integer.class) > 0);
 
-        Set<String> jobs = dispatcherDao.findDispatchJobs(host, 10);
+        List<String> jobs = dispatcherDao.findDispatchJobs(host, 10);
         assertTrue(jobs.size() > 0);
     }
 
@@ -341,7 +341,7 @@ public class DispatcherDaoTests extends AbstractTransactionalJUnit4SpringContext
         assertNotNull(job);
         assertNotNull(job.groupId);
 
-        Set<String> jobs = dispatcherDao.findDispatchJobs(host,
+        List<String> jobs = dispatcherDao.findDispatchJobs(host,
                 groupManager.getGroupDetail(job));
         assertTrue(jobs.size() > 0);
     }
@@ -354,7 +354,7 @@ public class DispatcherDaoTests extends AbstractTransactionalJUnit4SpringContext
         final JobDetail job = getJob1();
         assertNotNull(job);
 
-        Set<String> jobs = dispatcherDao.findDispatchJobs(host,
+        List<String> jobs = dispatcherDao.findDispatchJobs(host,
                 adminManager.findShowEntity("pipe"), 5);
         assertTrue(jobs.size() > 0);
     }
@@ -516,5 +516,12 @@ public class DispatcherDaoTests extends AbstractTransactionalJUnit4SpringContext
 
         boolean isHigher = dispatcherDao.higherPriorityJobExists(job1, proc);
         assertFalse(isHigher);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testFifoSchedulingEnabled() {
+        assertFalse(dispatcherDao.getFifoSchedulingEnabled());
     }
 }


### PR DESCRIPTION
This PR will address #1059 `Frame scheduling` by adding FIFO scheduling capability.
What I mean by `FIFO scheduling` is `the oldest frame will run first if the priority is the same`, which is commonly expected in job scheduling system.

# Changes
- Inject `Environment` to `DispatcherDaoJdbc` to set `fifoSchedulingEnabled` variable by `dispatcher.fifo_scheduling_enabled` property. The default value is `false`. So the default scheduling behavior will not change.
- Insert `ORDER BY`s to `FIND_JOBS_BY_SHOW/GROUP` to order/sort if `fifoSchedulingEnabled` is `true`, the highest priority job first, the oldest job next.
- Use `List` instead of `Set` to keep the job order in the SQL Query result.
- Add unittests to make sure the default `fifoSchedulingEnabled` is `false` and the scheduling is not FIFO. If it is set to `true`, verify the FIFO scheduling is working.

# Behavior
The FIFO scheduling behavior would not be 100% perfect. There would be multiple Cuebot instances and multiple threads to schedule frames simultaneously. It cannot guarantee the oldest frame will run first. But this FIFO scheduling is almost working as expected.

The runtime cost should be almost identical with/without FIFO scheduling since the `findDispatchJobs` doesn't use much jobs at the same time.