### PR TITLE
Fix Group GPU APIs

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/GroupDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/GroupDaoJdbc.java
@@ -437,6 +437,10 @@ public class GroupDaoJdbc extends JdbcDaoSupport implements GroupDao {
                 group.jobMaxGpus = rs.getInt("int_job_max_gpus");
                 group.jobMinGpus = rs.getInt("int_job_min_gpus");
                 group.jobPriority = rs.getInt("int_job_priority");
+                group.minCores = rs.getInt("int_min_cores");
+                group.maxCores = rs.getInt("int_max_cores");
+                group.minGpus = rs.getInt("int_min_gpus");
+                group.maxGpus = rs.getInt("int_max_gpus");
                 group.name = rs.getString("str_name");
                 group.parentId = rs.getString("pk_parent_folder");
                 group.showId = rs.getString("pk_show");

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/GroupDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/GroupDaoJdbc.java
@@ -235,11 +235,6 @@ public class GroupDaoJdbc extends JdbcDaoSupport implements GroupDao {
     @Override
     public void updateDefaultJobMaxGpus(GroupInterface group, int value) {
         if (value <= 0) { value = CueUtil.FEATURE_DISABLED; }
-        if (value < CueUtil.ONE_CORE && value != CueUtil.FEATURE_DISABLED) {
-            String msg = "The default max cores for a job must " +
-                    "be greater than a single core";
-            throw new IllegalArgumentException(msg);
-        }
         getJdbcTemplate().update(
                 "UPDATE folder SET int_job_max_gpus=? WHERE pk_folder=?",
                 value, group.getId());
@@ -248,11 +243,6 @@ public class GroupDaoJdbc extends JdbcDaoSupport implements GroupDao {
     @Override
     public void updateDefaultJobMinGpus(GroupInterface group, int value) {
         if (value <= 0) { value = CueUtil.FEATURE_DISABLED; }
-        if (value < CueUtil.ONE_CORE && value != CueUtil.FEATURE_DISABLED) {
-            String msg = "The default min cores for a job must " +
-                    "be greater than a single core";
-            throw new IllegalArgumentException(msg);
-        }
         getJdbcTemplate().update(
                 "UPDATE folder SET int_job_min_gpus=? WHERE pk_folder=?",
                 value, group.getId());
@@ -261,11 +251,6 @@ public class GroupDaoJdbc extends JdbcDaoSupport implements GroupDao {
     @Override
     public void updateMaxGpus(GroupInterface group, int value) {
         if (value < 0) { value = CueUtil.FEATURE_DISABLED; }
-        if (value < CueUtil.ONE_CORE && value != CueUtil.FEATURE_DISABLED) {
-            String msg = "The group max cores feature must " +
-                    "be a whole core or greater, pass in: " + value;
-            throw new IllegalArgumentException(msg);
-        }
 
         getJdbcTemplate().update(
                 "UPDATE folder_resource SET int_max_gpus=? WHERE pk_folder=?",


### PR DESCRIPTION
Group GPU APIs should have not used CPU Cores check logic
(Those codes were copy-and-pasted in #924)

Also GROUP_DETAIL_MAPPER did not get min/max cores/gpus.