### PR TITLE
Use openjdk:11-jre-slim-buster in Cuebot container

### DIFF
--- a/cuebot/Dockerfile
+++ b/cuebot/Dockerfile
@@ -49,7 +49,7 @@ RUN chmod +x create_rpm.sh && ./create_rpm.sh cuebot "$(cat VERSION)"
 # -----------------
 # RUN
 # -----------------
-FROM openjdk:11-jre-slim
+FROM openjdk:11-jre-slim-buster
 
 # First line after FROM should be unique to avoid --cache-from weirdness.
 RUN echo "Cuebot runtime stage"


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Closes #1067

**Summarize your change.**

Change the tag from openjdk:11-jrd-slim to openjdk:11-jrd-slim-buster, as the original tag is causing errors in the cuebot build.


These community posts mention the same issue and suggest using the buster tag as a work around.
https://github.com/carlossg/docker-maven/issues/221
https://forums.docker.com/t/multiple-projects-stopped-building-on-docker-hub-operation-not-permitted/92570/14



