### PR TITLE
Optimize FIND_JOBS_BY_SHOW

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dao/DispatcherDao.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/DispatcherDao.java
@@ -176,6 +176,34 @@ public interface DispatcherDao {
     * @param fifoSchedulingEnabled
     */
    void setFifoSchedulingEnabled(boolean fifoSchedulingEnabled);
+
+   /**
+    * Return whether FIND_JOBS optimization is enabled or not.
+    *
+    * @return
+    */
+   boolean getFindJobsOptimizationEnabled();
+
+   /**
+     * Set whether FIND_JOBS optimization is enabled or not.
+     *
+     * @param findJobsOptimizationEnabled
+     */
+   void setFindJobsOptimizationEnabled(boolean findJobsOptimizationEnabled);
+
+   /**
+     * Get FIND_JOBS_BY_SHOW query
+     *
+     * @return
+     */
+   String getFindJobsByShowQuery();
+
+   /**
+     * Get FIND_JOBS_BY_GROUP query
+     *
+     * @return
+     */
+   String getFindJobsByGroupQuery();
 }
 
 

--- a/cuebot/src/main/resources/opencue.properties
+++ b/cuebot/src/main/resources/opencue.properties
@@ -45,6 +45,8 @@ dispatcher.job_frame_dispatch_max=8
 dispatcher.host_frame_dispatch_max=12
 # Whether or not to enable FIFO scheduling in the same priority.
 dispatcher.fifo_scheduling_enabled=false
+# Whether or not to enable FIND_JOB optimization.
+dispatcher.find_jobs_optimization_enabled=false
 
 # Number of threads to keep in the pool for launching job.
 dispatcher.launch_queue.core_pool_size=1


### PR DESCRIPTION
This is an experiment to optimize `FIND_JOBS_BY_SHOW` which is the heaviest query in our use-case.

## Environment / Test data
- CentOS8 VM, Broadwell 24 cores, PostgreSQL13 1 instance
- ~8K jobs, ~8K layers, ~10M frames (1 layer per job, 1K/10K frames per layer)
- extract 500 jobs sorted with `int_priority` and `ts_started`

## Original FIND_JOBS_BY_SHOW
- SQL https://gist.github.com/splhack/6905e35defd6bcbd92aeb82c7e645e41
- Analyze result 249ms https://gist.github.com/splhack/bd7c5221acb43e095dffb3e8ddafd472

## Optimized FIND_JOBS_BY_SHOW (~7 times faster than original)
- SQL https://gist.github.com/splhack/8faead2d482f3dde2cba8226f6115dda
- Analyze result 36ms https://gist.github.com/splhack/f93f4e784649a94bd9fdfc50129a9349

## Explanation
- Use CTE to sort `job` and `job_resource` first with some light filters (job state, pause, os, show ID, facility ID) and add `ROW_NUMBER` as `rank`
- Filter with job, folder and layer calculation on the "sorted" jobs

## Caveat
- There are no guarantees that CTE provides the "sorted" result to outer query, thus the outer query should have had `ORDER BY rank`, and it makes the query slow.

## Theory
- Sort jobs with priority (and ts_started for FIFO #1060)
  - O(N x log N) merge sort if we do everytime
  - O(log N) binary search for insert if we can keep sorted list
- Filter jobs
  - Worst case O(N) linear search on the sorted jobs to check whether the utilization of job, folder and layer exceeds the maximum number of cores and gpus or not