### PR TITLE
[cuesubmit] Standardize config env var and paths.

### DIFF
--- a/cuesubmit/cuesubmit/Config.py
+++ b/cuesubmit/cuesubmit/Config.py
@@ -27,6 +27,8 @@ from __future__ import absolute_import
 import os
 import yaml
 
+import opencue.config
+
 
 CONFIG_FILE_ENV_VAR = 'CUESUBMIT_CONFIG_FILE'
 
@@ -35,7 +37,9 @@ def getConfigValues():
     """Reads the config file from disk and returns the values it defines."""
     configData = {}
     configFile = os.environ.get(CONFIG_FILE_ENV_VAR)
-    if configFile and os.path.exists(configFile):
+    if not configFile:
+        configFile = os.path.join(opencue.config.config_base_directory(), 'cuesubmit.yaml')
+    if os.path.exists(configFile):
         with open(configFile, 'r') as data:
             try:
                 configData = yaml.load(data, Loader=yaml.SafeLoader)

--- a/cuesubmit/tests/Config_tests.py
+++ b/cuesubmit/tests/Config_tests.py
@@ -21,8 +21,10 @@ from __future__ import division
 from __future__ import absolute_import
 
 import os
-import tempfile
 import unittest
+
+import mock
+import pyfakefs.fake_filesystem_unittest
 
 import cuesubmit.Config
 
@@ -36,28 +38,47 @@ SUBMIT_APP_WINDOW_TITLE : "OpenCue Submit"
 CONFIG_YAML_INVALID = b' " some text in an unclosed quote'
 
 
-class ConfigTests(unittest.TestCase):
+class ConfigTests(pyfakefs.fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+        if 'CUESUBMIT_CONFIG_FILE' in os.environ:
+            del os.environ['CUESUBMIT_CONFIG_FILE']
 
-    def testGetConfigValues(self):
-        with tempfile.NamedTemporaryFile() as fp:
-            fp.write(CONFIG_YAML)
-            fp.flush()
-            os.environ[cuesubmit.Config.CONFIG_FILE_ENV_VAR] = fp.name
+    def test__should_skip_missing_files_without_error(self):
+        configData = cuesubmit.Config.getConfigValues()
 
-            configData = cuesubmit.Config.getConfigValues()
+        self.assertDictEqual({}, configData)
 
-            self.assertEqual('OPENCUESUBMIT', configData.get('UI_NAME'))
-            self.assertEqual('OpenCue Submit', configData.get('SUBMIT_APP_WINDOW_TITLE'))
-            self.assertEqual(None, configData.get('SOME_UNKNOWN_SETTING'))
+    def test__should_load_config_from_env_var(self):
+        config_file_path = '/path/to/config.yaml'
+        self.fs.create_file(config_file_path, contents=CONFIG_YAML)
+        os.environ['CUESUBMIT_CONFIG_FILE'] = config_file_path
 
-    def testFailOnInvalidYaml(self):
-        with tempfile.NamedTemporaryFile() as fp:
-            fp.write(CONFIG_YAML_INVALID)
-            fp.flush()
-            os.environ[cuesubmit.Config.CONFIG_FILE_ENV_VAR] = fp.name
+        configData = cuesubmit.Config.getConfigValues()
 
-            with self.assertRaises(cuesubmit.Config.CuesubmitConfigError):
-                cuesubmit.Config.getConfigValues()
+        self.assertEqual('OPENCUESUBMIT', configData.get('UI_NAME'))
+        self.assertEqual('OpenCue Submit', configData.get('SUBMIT_APP_WINDOW_TITLE'))
+        self.assertEqual(None, configData.get('SOME_UNKNOWN_SETTING'))
+
+    @mock.patch('platform.system', new=mock.Mock(return_value='Linux'))
+    @mock.patch('os.path.expanduser', new=mock.Mock(return_value='/home/username'))
+    def test__should_load_config_from_user_profile(self):
+        config_file_path = '/home/username/.config/opencue/cuesubmit.yaml'
+        self.fs.create_file(config_file_path, contents=CONFIG_YAML)
+
+        configData = cuesubmit.Config.getConfigValues()
+
+        self.assertEqual('OPENCUESUBMIT', configData.get('UI_NAME'))
+        self.assertEqual('OpenCue Submit', configData.get('SUBMIT_APP_WINDOW_TITLE'))
+        self.assertEqual(None, configData.get('SOME_UNKNOWN_SETTING'))
+
+    def test__should_fail_on_invalid_yaml(self):
+        config_file_path = '/path/to/config.yaml'
+        self.fs.create_file(config_file_path, contents=CONFIG_YAML_INVALID)
+        os.environ['CUESUBMIT_CONFIG_FILE'] = config_file_path
+
+        with self.assertRaises(cuesubmit.Config.CuesubmitConfigError):
+            cuesubmit.Config.getConfigValues()
 
 
 if __name__ == '__main__':

--- a/pycue/tests/config_test.py
+++ b/pycue/tests/config_test.py
@@ -61,8 +61,10 @@ class ConfigTests(pyfakefs.fake_filesystem_unittest.TestCase):
         self.setUpPyfakefs()
         self.fs.add_real_file(
             os.path.join(os.path.dirname(opencue.__file__), 'default.yaml'), read_only=True)
-        os.unsetenv('OPENCUE_CONFIG_FILE')
-        os.unsetenv('OPENCUE_CONF')
+        if 'OPENCUE_CONFIG_FILE' in os.environ:
+            del os.environ['OPENCUE_CONFIG_FILE']
+        if 'OPENCUE_CONF' in os.environ:
+            del os.environ['OPENCUE_CONF']
 
     @mock.patch('platform.system', new=mock.Mock(return_value='Linux'))
     @mock.patch('os.path.expanduser', new=mock.Mock(return_value='/home/username'))
@@ -106,7 +108,7 @@ class ConfigTests(pyfakefs.fake_filesystem_unittest.TestCase):
         self.assertEqual(3, config['cuebot.exception_retries'])
 
     def test__should_load_user_config_from_legacy_var(self):
-        config_file_path = '/path/to/config.yaml'
+        config_file_path = '/path/to/legacy/config.yaml'
         self.fs.create_file(config_file_path, contents=USER_CONFIG)
         os.environ['OPENCUE_CONF'] = config_file_path
 


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Advances #785 

**Summarize your change.**
Matches config standardization described in #785. This was implemented for PyCue in #972.

CueSubmit already uses the standard `<COMPONENT>_CONFIG_FILE` format, so this just adds support for automatically loading config from `~/.config/opencue/cuesubmit.yaml` if it exists.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
