### PR TITLE
Fix HostSearch substring for loose search

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dao/criteria/postgres/HostSearch.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/criteria/postgres/HostSearch.java
@@ -44,7 +44,7 @@ public class HostSearch extends Criteria implements HostSearchInterface {
     public void buildWhereClause() {
         addPhrase("host.pk_host", criteria.getIdsList());
         addPhrase("host.str_name", criteria.getHostsList());
-        addPhrase("host.str_name", new HashSet<>(criteria.getSubstrList()));
+        addLikePhrase("host.str_name", new HashSet<>(criteria.getSubstrList()));
         addRegexPhrase("host.str_name", new HashSet<>(criteria.getRegexList()));
         addPhrase("alloc.str_name", criteria.getAllocsList());
         Set<String> items = new HashSet<>(criteria.getStates().getStateCount());


### PR DESCRIPTION
**Summarize your change.**
Bug with cueadmin arg handler -lh, it should allow a substring match for the hosts being searched, but user
was trying `-lh PARTIAL_HOST_NAME -alloc location.general`, api.getHosts uses search.HostSearch.byOptions but Criteria.java sql search was not returning any results, substring in HostSearch.java was calling addPhrase which does NOT do a SQL loose match, changed HostSearch.java to use `addLikePhrase`, this will search substrings in sql (just like JobSearch.java which uses addLikePhrase for SQL substring searches.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
