### PR TITLE
[Cuebot] Fix inconsistent depend behavior

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/FrameCompleteHandler.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/FrameCompleteHandler.java
@@ -25,6 +25,8 @@ import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.dao.EmptyResultDataAccessException;
 
 import com.imageworks.spcue.DispatchFrame;
@@ -91,6 +93,25 @@ public class FrameCompleteHandler {
      * Boolean to toggle if this class is accepting data or not.
      */
     private boolean shutdown = false;
+
+    /**
+     * Whether or not to satisfy dependents (*_ON_FRAME and *_ON_LAYER) only on Frame success
+     */
+    private boolean satisfyDependOnlyOnFrameSuccess;
+
+    public boolean getSatisfyDependOnlyOnFrameSuccess() {
+        return satisfyDependOnlyOnFrameSuccess;
+    }
+
+    public void setSatisfyDependOnlyOnFrameSuccess(boolean satisfyDependOnlyOnFrameSuccess) {
+        this.satisfyDependOnlyOnFrameSuccess = satisfyDependOnlyOnFrameSuccess;
+    }
+
+    @Autowired
+    public FrameCompleteHandler(Environment env) {
+        satisfyDependOnlyOnFrameSuccess = env.getProperty(
+            "depend.satisfy_only_on_frame_success", Boolean.class, true);
+    }
 
     /**
      * Handle the given FrameCompleteReport from RQD.
@@ -235,19 +256,26 @@ public class FrameCompleteHandler {
 
             dispatchSupport.updateUsageCounters(frame, report.getExitStatus());
 
-            if (newFrameState.equals(FrameState.SUCCEEDED)) {
+            boolean isLayerComplete = false;
+
+            if (newFrameState.equals(FrameState.SUCCEEDED)
+                    || (!satisfyDependOnlyOnFrameSuccess
+                        && newFrameState.equals(FrameState.EATEN))) {
                 jobManagerSupport.satisfyWhatDependsOn(frame);
-                if (jobManager.isLayerComplete(frame)) {
+                isLayerComplete = jobManager.isLayerComplete(frame);
+                if (isLayerComplete) {
                     jobManagerSupport.satisfyWhatDependsOn((LayerInterface) frame);
-                } else {
-                    /*
-                     * If the layer meets some specific criteria then try to
-                     * update the minimum memory and tags so it can run on a
-                     * wider variety of cores, namely older hardware.
-                     */
-                    jobManager.optimizeLayer(frame, report.getFrame().getNumCores(),
-                            report.getFrame().getMaxRss(), report.getRunTime());
                 }
+            }
+
+            if (newFrameState.equals(FrameState.SUCCEEDED) && !isLayerComplete) {
+                /*
+                 * If the layer meets some specific criteria then try to
+                 * update the minimum memory and tags so it can run on a
+                 * wider variety of cores, namely older hardware.
+                 */
+                jobManager.optimizeLayer(frame, report.getFrame().getNumCores(),
+                        report.getFrame().getMaxRss(), report.getRunTime());
             }
 
             /*

--- a/cuebot/src/main/resources/opencue.properties
+++ b/cuebot/src/main/resources/opencue.properties
@@ -88,6 +88,9 @@ dispatcher.booking_queue.max_pool_size=6
 # Queue capacity for booking.
 dispatcher.booking_queue.queue_capacity=1000
 
+# Whether or not to satisfy dependents (*_ON_FRAME and *_ON_LAYER) only on Frame success
+depend.satisfy_only_on_frame_success=true
+
 # Jobs will be archived to the history tables after being completed for this long.
 history.archive_jobs_cutoff_hours=72
 

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HistoryControlTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HistoryControlTests.java
@@ -169,7 +169,7 @@ public class HistoryControlTests extends TransactionalTest {
 
         launchAndDeleteJob();
 
-        assertEquals(Integer.valueOf(3), jdbcTemplate.queryForObject(
+        assertEquals(Integer.valueOf(4), jdbcTemplate.queryForObject(
                 "SELECT COUNT(*) FROM job_history", Integer.class));
         assertEquals(Integer.valueOf(1), jdbcTemplate.queryForObject(
                 "SELECT COUNT(*) FROM frame_history", Integer.class));

--- a/cuebot/src/test/resources/conf/jobspec/jobspec_gpus_test.xml
+++ b/cuebot/src/test/resources/conf/jobspec/jobspec_gpus_test.xml
@@ -73,4 +73,39 @@
             </layer>
         </layers>
     </job>
+
+    <job name="test_depend">
+        <paused>True</paused>
+        <layers>
+            <layer name="layer_first" type="Render">
+                <cmd>true</cmd>
+                <range>0</range>
+                <chunk>1</chunk>
+                <gpus>1</gpus>
+                <gpu_memory>1</gpu_memory>
+                <services>
+                    <service>shell</service>
+                </services>
+            </layer>
+            <layer name="layer_second" type="Render">
+                <cmd>true</cmd>
+                <range>0</range>
+                <chunk>1</chunk>
+                <gpus>1</gpus>
+                <gpu_memory>1</gpu_memory>
+                <services>
+                    <service>shell</service>
+                </services>
+            </layer>
+        </layers>
+    </job>
+
+    <depends>
+        <depend type="LAYER_ON_LAYER" anyframe="False">
+            <depjob>test_depend</depjob>
+            <deplayer>layer_second</deplayer>
+            <onjob>test_depend</onjob>
+            <onlayer>layer_first</onlayer>
+        </depend>
+    </depends>
 </spec>


### PR DESCRIPTION
Fix #1081

- Introduce `depend.satisfy_only_on_frame_success` property to keep the current behavior by default (`true`)
- Setting `false` to `depend.satisfy_only_on_frame_success` makes Frame and Layer dependency (`*_ON_FRAME` and `*_ON_LAYER`) behavior same with Job dependency (`*_ON_JOB`), satisfies regardless the result, succeeded or failed.