### PR TITLE
Changed psutil to 5.6.7 due to critical compilation error on Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ mock==2.0.0
 packaging==20.9
 pathlib==1.0.1;python_version<"3.4"
 protobuf==3.17.3;python_version<"3.0"
-psutil==5.6.6
+psutil==5.6.7
 pyfakefs==3.6
 pylint==2.6.0;python_version>="3.7"
 PyYAML==5.1


### PR DESCRIPTION
**Summarize your change.**
psutil 5.6.6 fails to install on Windows due to a compile error. This is fixed in 5.6.7.

