### PR TITLE
[cuebot] Switch to new version of embedded Postgres for unit tests.

### DIFF
--- a/cuebot/build.gradle
+++ b/cuebot/build.gradle
@@ -63,8 +63,11 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.8.0'
-    testCompile group: 'com.opentable.components', name: 'otj-pg-embedded', version: '0.13.3'
+    testCompile group: 'io.zonky.test', name: 'embedded-postgres', version: '1.3.1'
     testCompile group: 'org.flywaydb', name: 'flyway-core', version: '5.2.0'
+
+    // Use newer version of Postgres for tests: https://github.com/zonkyio/embedded-postgres/issues/78
+    implementation enforcedPlatform('io.zonky.test.postgres:embedded-postgres-binaries-bom:11.13.0')
 }
 
 compileJava {

--- a/cuebot/src/test/java/com/imageworks/spcue/test/TestDatabaseSetupPostgres.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/TestDatabaseSetupPostgres.java
@@ -18,7 +18,7 @@ package com.imageworks.spcue.test;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
-import com.opentable.db.postgres.embedded.EmbeddedPostgres;
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
 import org.flywaydb.core.Flyway;
 
 import java.net.URL;


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Fixes #1086.

**Summarize your change.**
The version of the opentable Postgres we were using was not self-contained, and needed files are not available on newer versions of macOS. See https://github.com/AcademySoftwareFoundation/OpenCue/issues/1086#issuecomment-1006886659 for more details.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
