### PR TITLE
Fix %CPU for Windows

### DIFF
--- a/rqd/rqd/rqmachine.py
+++ b/rqd/rqd/rqmachine.py
@@ -222,7 +222,9 @@ class Machine(object):
                     stat = stats[frame.pid]
                     frame.rss = stat["rss"] // 1024
                     frame.maxRss = max(frame.rss, frame.maxRss)
-                    frame.runFrame.attributes["pcpu"] = str(stat["pcpu"])
+                    frame.runFrame.attributes["pcpu"] = str(
+                        stat["pcpu"] * self.__coreInfo.total_cores
+                    )
             return
 
         if platform.system() != 'Linux':


### PR DESCRIPTION
[winps](https://github.com/AcademySoftwareFoundation/OpenCue/tree/master/rqd/winps) stores %CPU to `stat["pcpu"]` in a range of `0.0` to `1.0`.
And `1.0` means that the all of the total CPU cores are 100% busy.

So it is supposed to be multiplied with the number of total CPU cores (x100) to align with the Linux implementation.
E.g. if the number of total cores is 8,  needs to multiply by 800.