### PR TITLE
Support logging path windows linux

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/util/JobLogUtil.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/util/JobLogUtil.java
@@ -38,9 +38,9 @@ public class JobLogUtil {
         return f.isDirectory();
     }
 
-    public String getJobLogDir(String show, String shot) {
+    public String getJobLogDir(String show, String shot, String os) {
         StringBuilder sb = new StringBuilder(512);
-        sb.append(getJobLogRootDir());
+        sb.append(getJobLogRootDir(os));
         sb.append("/");
         sb.append(show);
         sb.append("/");
@@ -51,7 +51,7 @@ public class JobLogUtil {
 
     public String getJobLogPath(JobDetail job) {
         StringBuilder sb = new StringBuilder(512);
-        sb.append(getJobLogDir(job.showName, job.shot));
+        sb.append(getJobLogDir(job.showName, job.shot, job.os));
         sb.append("/");
         sb.append(job.name);
         sb.append("--");
@@ -59,8 +59,12 @@ public class JobLogUtil {
         return sb.toString();
     }
 
-    public String getJobLogRootDir() {
-        return env.getRequiredProperty("log.frame-log-root", String.class);
+    public String getJobLogRootDir(String os) {
+        try {
+            return env.getRequiredProperty(String.format("log.frame-log-root.%s", os), String.class);
+        } catch (IllegalStateException e) {
+            return env.getRequiredProperty("log.frame-log-root.default_os", String.class);
+        }
     }
 }
 

--- a/cuebot/src/main/resources/opencue.properties
+++ b/cuebot/src/main/resources/opencue.properties
@@ -35,10 +35,13 @@ grpc.rqd_cache_expiration=30
 # Set to a boolean value. See com/imageworks/spcue/services/JmsMover.java.
 messaging.enabled=false
 
-# Root directory for which logs will be stored. See com/imageworks/spcue/util/JobLogUtil.java.
+# Default root directory for which logs will be stored no other OS is defined.
+# See com/imageworks/spcue/util/JobLogUtil.java.
 # Override this via environment variable (CUE_FRAME_LOG_DIR) or command line flag
-# (--log.frame-log-root). Command line flag will be preferred if both are provided.
-log.frame-log-root=${CUE_FRAME_LOG_DIR:/shots}
+# (--log.frame-log-root.default_os). Command line flag will be preferred if both are provided.
+log.frame-log-root.default_os=${CUE_FRAME_LOG_DIR:/shots}
+# To set up root directories for other OS, like Windows, create new environment
+# variable as `log.frame-log-root.[OS] where OS relates to str_os on the job table
 
 # Maximum number of jobs to query.
 dispatcher.job_query_max=20

--- a/cuebot/src/test/java/com/imageworks/spcue/test/util/JobLogUtilTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/util/JobLogUtilTests.java
@@ -36,32 +36,33 @@ public class JobLogUtilTests extends AbstractTransactionalJUnit4SpringContextTes
     @Resource
     private JobLogUtil jobLogUtil;
 
-    private String logRoot;
+    private String logRootDefault;
 
     @Before
     public void setUp() {
-        // This value should match what's defined in test/resources/opencue.properties.
-        logRoot = "/arbitraryLogDirectory";
+        // The values should match what's defined in test/resources/opencue.properties.
+        logRootDefault = "/arbitraryLogDirectory";
     }
 
     @Test
-    public void testGetJobLogRootDir() {
-        assertEquals(logRoot, jobLogUtil.getJobLogRootDir());
+    public void testGetJobLogRootDirDefault() {
+        assertEquals(logRootDefault, jobLogUtil.getJobLogRootDir("someUndefinedOs"));
     }
 
     @Test
-    public void testGetJobLogDir() {
-        assertEquals(logRoot + "/show/shot/logs", jobLogUtil.getJobLogDir("show", "shot"));
+    public void testGetJobLogDirDefault() {
+        assertEquals(logRootDefault + "/show/shot/logs", jobLogUtil.getJobLogDir("show", "shot", "someUndefinedOs"));
     }
 
     @Test
-    public void testGetJobLogPath() {
+    public void testGetJobLogPathDefault() {
         JobDetail jobDetail = new JobDetail();
         jobDetail.id = "id";
         jobDetail.name = "name";
         jobDetail.showName = "show";
         jobDetail.shot = "shot";
-        assertEquals(logRoot + "/show/shot/logs/name--id", jobLogUtil.getJobLogPath(jobDetail));
+        jobDetail.os = "someUndefinedOs";
+        assertEquals(logRootDefault + "/show/shot/logs/name--id", jobLogUtil.getJobLogPath(jobDetail));
     }
 }
 

--- a/cuebot/src/test/resources/opencue.properties
+++ b/cuebot/src/test/resources/opencue.properties
@@ -19,7 +19,7 @@ grpc.rqd_cache_size=500
 # RQD Channel Cache Expiration in Minutes
 grpc.rqd_cache_expiration=30
 
-log.frame-log-root=/arbitraryLogDirectory
+log.frame-log-root.default_os=/arbitraryLogDirectory
 
 dispatcher.job_query_max=20
 dispatcher.job_lock_expire_seconds=2

--- a/cuegui/cuegui/CloudGroupDialog.py
+++ b/cuegui/cuegui/CloudGroupDialog.py
@@ -1,0 +1,147 @@
+#  Copyright Contributors to the OpenCue Project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+"""
+Helps create a cloud group from the cloud manager interface
+"""
+
+from PySide2 import QtCore
+from PySide2 import QtGui
+from PySide2 import QtWidgets
+
+import cuegui.Utils
+import opencue.cloud.api
+
+
+class CloudGroupCreateDialog(QtWidgets.QDialog):
+    def __init__(self, parent=None):
+        QtWidgets.QDialog.__init__(self, parent)
+
+        self.setWindowTitle("Create Cloud Group")
+        self.resize(500, 200)
+
+        layout = QtWidgets.QGridLayout(self)
+        layout.setSpacing(10)
+
+        layout.addWidget(QtWidgets.QLabel("Service: ", self), 0, 0, 1, 2)
+        self.__services_dropdown = CloudServicesCombo(selected="google", parent=self)
+        layout.addWidget(self.__services_dropdown, 0, 2, 1, 2)
+
+        layout.addWidget(QtWidgets.QLabel("Select Template/Image: ", self), 2, 0, 1, 2)
+        self.__templates_dropdown = CloudGroupTemplatesCombo(self)
+        layout.addWidget(self.__templates_dropdown, 2, 2, 1, 2)
+
+        layout.addWidget(QtWidgets.QLabel("Group Details: ", self), 3, 0, 1, 2)
+
+        layout.addWidget(QtWidgets.QLabel("Name of group: ", self), 4, 0, 1, 1)
+        self.__groupname_text_input = QtWidgets.QLineEdit()
+        layout.addWidget(self.__groupname_text_input, 4, 2, 1, 2)
+
+        layout.addWidget(QtWidgets.QLabel("Number of Instances: ", self), 5, 0, 1, 1)
+        self.__number_of_instances = QtWidgets.QLineEdit()
+        layout.addWidget(self.__number_of_instances, 5, 2, 1, 2)
+
+        self.__btnCreateGroup = QtWidgets.QPushButton("Create Group")
+        layout.addWidget(self.__btnCreateGroup, 6, 1, 1, 2)
+
+        self.__templates_dropdown.refresh(cloud_group=self.__services_dropdown.get_provider())
+        self.__services_dropdown.currentIndexChanged.connect(self._populateTemplates)
+        self.__btnCreateGroup.clicked.connect(self._createCloudGroup)
+
+    def _populateTemplates(self):
+        # TODO: When another provider is added, check this functionality
+        """
+        Use to query the templates associated with a particular cloud provider when the dropdown of
+        cloud providers is switched
+        :return:
+        """
+        pass
+
+    def _createCloudGroup(self):
+        """
+        Calls the associated cloud manager's group creation method
+        """
+        group_name = self.__groupname_text_input.text()
+        instances = self.__number_of_instances.text()
+        template = self.__templates_dropdown.get_template_data()
+        try:
+            request = self.__services_dropdown.get_provider().create_managed_group(name=group_name, size=instances,
+                                                                                   template=template)
+            if request:
+                self.close()
+        except opencue.cloud.api.CloudProviderException as e:
+            cuegui.Utils.showErrorMessageBox(text="{} {} request error!".format(e.provider, e.error_code),
+                                             detailedText=e.message)
+
+
+class CloudServicesCombo(QtWidgets.QComboBox):
+    """
+    A combo box for cloud services selection
+    """
+    def __init__(self, selected="google", parent=None):
+        QtWidgets.QComboBox.__init__(self, parent)
+        self._cloud_providers = {}
+        self.refresh()
+        self.setCurrentIndex(self.findText(selected))
+
+    def refresh(self):
+        self.clear()
+        cloud_providers = opencue.cloud.api.CloudManager.get_registered_providers()
+        # Connect for all the registered providers
+        for provider in cloud_providers:
+            provider.connect(cloud_resources_config=self.get_cloud_resources_config())
+        for provider in cloud_providers:
+            self.addItem(provider.signature())
+            self._cloud_providers[provider.signature()] = provider
+
+    def get_provider(self):
+        """
+        :return: Manager object of the chosen cloud provider
+        """
+        return self._cloud_providers[str(self.currentText())]
+
+    def get_cloud_resources_config(self):
+        """
+        :return: YAML cloud resources config returned as a dict
+        """
+        cloud_config_resources_path = "{}/cloud_plugin_resources.yaml".format(cuegui.Constants.DEFAULT_INI_PATH)
+        cloud_resources_config = cuegui.Utils.getResourceConfig(cloud_config_resources_path)
+        return cloud_resources_config
+
+
+class CloudGroupTemplatesCombo(QtWidgets.QComboBox):
+    """
+    Combo box for listing the available templates/images in the service provider
+    """
+    def __init__(self, parent=None):
+        QtWidgets.QComboBox.__init__(self, parent)
+        self._templates = {}
+
+    def refresh(self, cloud_group):
+        """
+        :type cloud_group: opencue.cloud.api.CloudInstanceGroup
+        :param cloud_group: Cloud group object used to query the list of image templates and populate the combobox with
+        """
+        self.clear()
+        templates = cloud_group.list_templates()
+        for template in templates:
+            self.addItem(template["name"])
+            self._templates[template["name"]] = template
+
+    def get_template(self):
+        return str(self.currentText())
+
+    def get_template_data(self):
+        return self._templates[self.get_template()]

--- a/cuegui/cuegui/CloudManagerWidget.py
+++ b/cuegui/cuegui/CloudManagerWidget.py
@@ -1,0 +1,135 @@
+#  Copyright Contributors to the OpenCue Project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+
+from PySide2 import QtCore
+from PySide2 import QtWidgets
+
+import cuegui.AbstractTreeWidget
+import cuegui.AbstractWidgetItem
+import cuegui.CloudGroupDialog
+import cuegui.Constants
+import cuegui.Logger
+import cuegui.Utils
+import cuegui.MenuActions
+import opencue.cloud.api
+
+
+logger = cuegui.Logger.getLogger(__file__)
+
+
+class CloudManagerWidget(QtWidgets.QWidget):
+    def __init__(self, parent):
+        QtWidgets.QWidget.__init__(self, parent)
+
+        self.__btnAddCloudGroup = QtWidgets.QPushButton("Add Cloud Group", self)
+        self.__btnAddCloudGroup.setFocusPolicy(QtCore.Qt.NoFocus)
+
+        self.__viewCloudGroups = CloudManagerTreeWidget(self)
+
+        layout = QtWidgets.QGridLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        layout.addWidget(self.__btnAddCloudGroup, 0, 3)
+        layout.addWidget(self.__viewCloudGroups, 2, 0, 3, 4)
+
+        self.__btnAddCloudGroup.clicked.connect(self._onAddCloudGroupClicked)
+
+    def _onAddCloudGroupClicked(self):
+        cuegui.CloudGroupDialog.CloudGroupCreateDialog(self).show()
+
+    def getColumnVisibility(self):
+        self.__viewCloudGroups.getColumnVisibility()
+
+    def setColumnVisibility(self):
+        self.__viewCloudGroups.setColumnVisibility()
+
+
+class CloudManagerTreeWidget(cuegui.AbstractTreeWidget.AbstractTreeWidget):
+    def __init__(self, parent):
+        self.startColumnsForType(cuegui.Constants.TYPE_CLOUDGROUP)
+        self.addColumn("Cloud Group Name", 250, id=1,
+                       data=lambda cig: cig.name())
+        self.addColumn("Cloud Provider", 100, id=2,
+                       data=lambda cig: cig.__signature__)
+        self.addColumn("Number of instances", 160, id=3,
+                       data=lambda cig: cig.current_group_size_info())
+        self.addColumn("Status", 60, id=4,
+                       data=lambda cig: (cig.status()))
+        cuegui.AbstractTreeWidget.AbstractTreeWidget.__init__(self, parent)
+
+        # New manager objects instantiated here
+        self.__registeredCloudProviders = opencue.cloud.api.CloudManager.get_registered_providers()
+
+        # Connect for all the registered providers
+        for provider in self.__registeredCloudProviders:
+            provider.connect(cloud_resources_config=self.get_cloud_resources_config())
+
+        self.__menuActions = cuegui.MenuActions.MenuActions(
+            self, self.updateSoon, self.selectedObjects)
+
+        self.setUpdateInterval(30)
+
+    def _createItem(self, object):
+        """Creates and returns the proper item"""
+        item = CloudManagerWidgetItem(object, self)
+        return item
+
+    def _getUpdate(self):
+        """
+        Queries all the cloud groups associated with all the registered cloud providers
+        :return: opencue.cloud.api.CloudInstanceGroup child
+        """
+        cloud_groups = []
+
+        for manager_instance in self.__registeredCloudProviders:
+            cloud_groups.extend(manager_instance.get_all_groups())
+
+        return cloud_groups
+
+    def tick(self):
+        pass
+
+    def contextMenuEvent(self, e):
+        """
+        Context menu for cloudgroup widget
+        """
+
+        count = len(self.selectedObjects())
+        menu = QtWidgets.QMenu()
+
+        if count:
+            self.__menuActions.cloudgroups().addAction(menu, "removeGroup")
+            if count == 1:
+                self.__menuActions.cloudgroups().addAction(menu, "editInstances")
+
+            menu.exec_(QtCore.QPoint(e.globalX(), e.globalY()))
+
+    def get_cloud_resources_config(self):
+        """
+        :return: dict : YAML cloud resources config returned as a dict
+        """
+        cloud_config_resources_path = "{}/cloud_plugin_resources.yaml".format(cuegui.Constants.DEFAULT_INI_PATH)
+        cloud_resources_config = cuegui.Utils.getResourceConfig(cloud_config_resources_path)
+        return cloud_resources_config
+
+
+class CloudManagerWidgetItem(cuegui.AbstractWidgetItem.AbstractWidgetItem):
+    def __init__(self, object, parent):
+        cuegui.AbstractWidgetItem.AbstractWidgetItem.__init__(
+            self, cuegui.Constants.TYPE_CLOUDGROUP, object, parent)

--- a/cuegui/cuegui/Constants.py
+++ b/cuegui/cuegui/Constants.py
@@ -117,6 +117,7 @@ TYPE_DEPEND = QtWidgets.QTreeWidgetItem.UserType + 13
 TYPE_SUB = QtWidgets.QTreeWidgetItem.UserType + 14
 TYPE_TASK = QtWidgets.QTreeWidgetItem.UserType + 15
 TYPE_LIMIT = QtWidgets.QTreeWidgetItem.UserType + 16
+TYPE_CLOUDGROUP = QtWidgets.QTreeWidgetItem.UserType + 17
 
 COLUMN_INFO_DISPLAY = 2
 

--- a/cuegui/cuegui/config/cloud_plugin_resources.yaml
+++ b/cuegui/cuegui/config/cloud_plugin_resources.yaml
@@ -1,0 +1,6 @@
+
+
+# Google cloud plugin resource
+
+gce_project_name: ""
+gce_project_zone_name: ""

--- a/cuegui/cuegui/plugins/CloudManagerPlugin.py
+++ b/cuegui/cuegui/plugins/CloudManagerPlugin.py
@@ -1,0 +1,39 @@
+#  Copyright Contributors to the OpenCue Project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+import cuegui.AbstractDockWidget
+import cuegui.CloudManagerWidget
+
+
+PLUGIN_NAME = "CloudManager"
+PLUGIN_CATEGORY = "Cuecommander"
+PLUGIN_DESCRIPTION = "An interface to manage cloud groups and hosts"
+PLUGIN_REQUIRES = "CueCommander"
+PLUGIN_PROVIDES = "CloudManagerDockWidget"
+
+
+class CloudManagerDockWidget(cuegui.AbstractDockWidget.AbstractDockWidget):
+    """This builds what is displayed on the dock widget"""
+
+    def __init__(self, parent):
+        super(CloudManagerDockWidget, self).__init__(parent, PLUGIN_NAME)
+
+        self.__cloudManagerWidget = cuegui.CloudManagerWidget.CloudManagerWidget(self)
+
+        self.layout().addWidget(self.__cloudManagerWidget)

--- a/cuegui/tests/MenuActions_tests.py
+++ b/cuegui/tests/MenuActions_tests.py
@@ -49,6 +49,7 @@ import opencue.wrappers.proc
 import opencue.wrappers.show
 import opencue.wrappers.subscription
 import opencue.wrappers.task
+import opencue.cloud.api
 
 
 _GB_TO_KB = 1024 * 1024
@@ -1599,6 +1600,40 @@ class LimitActionsTests(unittest.TestCase):
         self.limit_actions.rename(rpcObjects=[limit])
 
         limit.rename.assert_called_with(newName)
+
+
+class CloudGroupActionsTests(unittest.TestCase):
+    def setUp(self):
+        self.widgetMock = mock.Mock()
+        self.cloud_group_actions = cuegui.MenuActions.CloudGroupActions(
+            self.widgetMock, mock.Mock(), None, None
+        )
+        # Testing with the abstract group class instead of a specific provider
+        self.test_group_data = {
+            "name": "main-group",
+            "id": 1234
+        }
+
+    @mock.patch('cuegui.Utils.questionBoxYesNo', new=mock.Mock(return_value=True))
+    def test_removeGroup(self):
+        cloud_group = opencue.cloud.api.CloudInstanceGroup(data=self.test_group_data)
+        cloud_group.delete_cloud_group = mock.MagicMock()
+
+        self.cloud_group_actions.removeGroup(cloudGroupObjects=[cloud_group])
+
+        cloud_group.delete_cloud_group.assert_called()
+
+    @mock.patch('PySide2.QtWidgets.QInputDialog.getInt')
+    def test_editInstances(self, getIntMock):
+        cloud_group = opencue.cloud.api.CloudInstanceGroup(data=self.test_group_data)
+        cloud_group.resize = mock.MagicMock()
+
+        resize_target_number = 4
+        getIntMock.return_value = (resize_target_number, True)
+
+        self.cloud_group_actions.editInstances(cloudGroupObjects=[cloud_group])
+
+        cloud_group.resize.assert_called_with(size=resize_target_number)
 
 
 @mock.patch('opencue.cuebot.Cuebot.getStub', new=mock.Mock())

--- a/pycue/opencue/cloud/__init__.py
+++ b/pycue/opencue/cloud/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright Contributors to the OpenCue Project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/pycue/opencue/cloud/api.py
+++ b/pycue/opencue/cloud/api.py
@@ -1,0 +1,141 @@
+#  Copyright Contributors to the OpenCue Project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import abc
+
+
+class CloudInstanceGroup(object):
+    def __init__(self, data):
+        self.data = data
+        self.instances = []
+
+    @abc.abstractmethod
+    def get_instances(self):
+        """
+        Gets all instances of the current group
+        :return: (list) List of instances
+        """
+
+    @abc.abstractmethod
+    def resize(self, size=None):
+        """
+        Resizes the group to the given number of instances
+        :type size: int
+        :param size: The target size of group to be scaled up/down to
+        """
+
+    @abc.abstractmethod
+    def name(self):
+        """
+        :return: Name of the cloud group
+        """
+
+    @abc.abstractmethod
+    def status(self):
+        """
+        :return: Returns the status of any operation made on the group. By default "STABLE"
+        Each provider has it's own way of implementing status of a particular group
+        """
+
+    @abc.abstractmethod
+    def id(self):
+        """
+        :return: Used to treat a CloudInstanceGroup object similar to a gRPC object for threadpool usage
+        """
+
+    @abc.abstractmethod
+    def delete_cloud_group(self):
+        """
+        Delete the cloud group from the provider
+        """
+
+    @abc.abstractmethod
+    def current_group_size_info(self):
+        """
+        Implement this method to show the state of the instances for the group
+        If resizing ongoing: current_size -> target_size
+        If not: current_size (or) just the len(instances)
+        :return:
+        """
+
+
+class CloudManager(object):
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def get_registered_providers():
+        """
+        :return: (list) Returns the list of registered cloud provider's manager classes
+        """
+        # TODO : Better way to register plugins
+        # For now just return the GCE group class
+        from .gce_api import GoogleCloudManager
+        providers = [GoogleCloudManager]
+        managers_instances = []
+        for provider in providers:
+            manager_object = provider()
+            managers_instances.append(manager_object)
+
+        return managers_instances
+
+    @abc.abstractmethod
+    def signature(self):
+        """
+        :return: Returns the name of the provider
+        """
+
+    @abc.abstractmethod
+    def create_managed_group(self, name, size, template):
+        """
+        Creates a cloud group with the given template/image from cloud
+        :type name: str
+        :param name: A unique name that is to be associated with the cloud group
+        :type size: int
+        :param size: The initial number of instances for the cloud group
+        :type: template: str/template/vm image object according to the implementation API
+        :param template: Template/Image needed to create the group
+        """
+
+    @abc.abstractmethod
+    def get_all_groups(self):
+        """
+        Get all the cloud groups associated with the provider
+        :return: list of cloud provider's instance group objects
+        """
+
+    @abc.abstractmethod
+    def connect(self, cloud_resources_config):
+        """
+        Abstract method that will implement connecting to the cloud provider
+        :type cloud_resources_config: dict
+        :param cloud_resources_config: YAML config object as a dictionary to access cloud API setup information
+        """
+
+
+class CloudProviderException(Exception):
+    """
+    Base class for handling exceptions when making cloud requests
+    """
+
+    def __init__(self, error_code, message, provider=None):
+        self.provider = provider
+        self.message = message
+        self.error_code = error_code
+
+    def __str__(self):
+        return self.__repr__()
+
+    def __repr__(self):
+        return "<Cloud Provider: {} {} exception: {}".format(self.provider, self.error_code, self.message)

--- a/pycue/opencue/cloud/gce_api.py
+++ b/pycue/opencue/cloud/gce_api.py
@@ -1,0 +1,200 @@
+#  Copyright Contributors to the OpenCue Project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import googleapiclient.discovery
+import oauth2client.client
+
+import opencue.cloud.api
+import opencue.cloud.gce_exception_util
+
+
+class GoogleCloudGroup(opencue.cloud.api.CloudInstanceGroup):
+    __signature__ = "google"
+
+    def __init__(self, data, connection_manager):
+        super(GoogleCloudGroup, self).__init__(data=data)
+        self.current_instances_size = 0
+        self.target_size = 0
+        self.connection_manager = connection_manager
+
+    @opencue.cloud.gce_exception_util.googleRequestExceptionParser
+    def delete_cloud_group(self):
+        """
+        Delete the google cloud instance group
+        """
+        request = self.connection_manager.service.instanceGroupManagers().delete(
+            project=self.connection_manager.project, zone=self.connection_manager.zone,
+            instanceGroupManager=self.name())
+        response = request.execute()
+
+    @opencue.cloud.gce_exception_util.googleRequestExceptionParser
+    def get_instances(self):
+        """
+        Updates the instances attributes with a list of dictionaries. Currently only the size of the list matters
+        """
+        request = self.connection_manager.service.instanceGroupManagers().listManagedInstances(
+            project=self.connection_manager.project, zone=self.connection_manager.zone,
+            instanceGroupManager=self.name())
+        response = request.execute()
+        self.instances = response.get("managedInstances", [])
+
+    def current_group_size_info(self):
+        """
+        Used by the widget to show the current state of the number of instances
+        Default : len(self.instances)
+        If currentActions has "creating" key more than 0 -> Resizing up
+        If currentActions has "deleting" key more than 0 -> Resizing down
+        :return:
+        """
+
+        if self.data["currentActions"]["creating"] > 0:
+            self.current_instances_size = self.data["currentActions"]["none"]
+        elif self.data["currentActions"]["deleting"] > 0:
+            self.current_instances_size = 0
+            for action in self.data["currentActions"]:
+                self.current_instances_size += self.data["currentActions"][action]
+        else:
+            self.current_instances_size = len(self.instances)
+
+        self.target_size = self.data["targetSize"]
+
+        if self.current_instances_size == self.target_size:
+            return self.current_instances_size
+        else:
+            return "{current_size} -> {target_size}".format(current_size=self.current_instances_size,
+                                                            target_size=self.target_size)
+
+    @opencue.cloud.gce_exception_util.googleRequestExceptionParser
+    def resize(self, size=None):
+        """
+        :type size: int
+        :param size: Size of the group/ Number of instances to be resized to
+        """
+        request = self.connection_manager.service.instanceGroupManagers().resize(
+            project=self.connection_manager.project, zone=self.connection_manager.zone,
+            instanceGroupManager=self.name(), size=size)
+        response = request.execute()
+
+    def name(self):
+        """
+
+        :return: str of the name of the cloud instance group
+        """
+        return self.data["name"]
+
+    def status(self):
+        """
+        Use the info gained from group size info to customize status column
+        :return: (str) Of the descriptive status
+        """
+        if self.data["status"].get("isStable"):
+            return "STABLE"
+        else:
+            if self.target_size > self.current_instances_size:
+                return "BUSY: SCALING UP"
+            elif self.target_size < self.current_instances_size:
+                return "BUSY: SCALING DOWN"
+
+            return "BUSY: IN OPERATION"
+
+    def id(self):
+        return self.data["id"]
+
+
+class GoogleCloudManager(opencue.cloud.api.CloudManager):
+
+    def __init__(self):
+        super(GoogleCloudManager, self).__init__()
+        self.project = None
+        self.zone = None
+        self.credentials = None
+        self.service = None
+
+    def signature(self):
+        return "google"
+
+    @opencue.cloud.gce_exception_util.googleRequestExceptionParser
+    def connect(self, cloud_resources_config):
+        """
+        Connect to the GCE : For now with application defaults
+        :type cloud_resources_config: dict
+        :param cloud_resources_config: YAML config resource for the cloud plugin
+        """
+
+        self.project = cloud_resources_config.get('gce_project_name', '')
+        self.zone = cloud_resources_config.get('gce_project_zone_name', '')
+        self.credentials = oauth2client.client.GoogleCredentials.get_application_default()
+        self.service = googleapiclient.discovery.build('compute', 'v1', credentials=self.credentials)
+
+    @opencue.cloud.gce_exception_util.googleRequestExceptionParser
+    def get_all_groups(self):
+        """
+        Queries the instance groups available in the project
+        :return: (list) of GoogleCloudGroup objects
+        """
+        cigs = []
+        request = self.service.instanceGroupManagers().list(project=self.project, zone=self.zone)
+        while request is not None:
+            response = request.execute()
+            for instance_group_manager in response['items']:
+                new_cig = GoogleCloudGroup(data=instance_group_manager, connection_manager=self)
+                # Call get_instances to update the actual
+                # number of instances running for the group
+                new_cig.get_instances()
+                cigs.append(new_cig)
+            request = self.service.instanceGroupManagers().list_next(previous_request=request,
+                                                                     previous_response=response)
+
+        return cigs
+
+    @opencue.cloud.gce_exception_util.googleRequestExceptionParser
+    def create_managed_group(self, name, size, template):
+        """
+        :type name: str
+        :param name: name of cloud group from input
+        :type size: int
+        :param size: size/capacity of the group to start with
+        :type template: dict
+        :param template: Dictionary of the template object
+        :return: Response of the creation API call
+        """
+        template_url = template.get("selfLink")
+        request_body = {
+            "baseInstanceName": "{}-instance".format(name),
+            "name": name,
+            "targetSize": size,
+            "instanceTemplate": template_url
+        }
+        request = self.service.instanceGroupManagers().insert(project=self.project, zone=self.zone, body=request_body)
+        response = request.execute()
+        return response
+
+    @opencue.cloud.gce_exception_util.googleRequestExceptionParser
+    def list_templates(self):
+        """
+        List the instance templates available in the project
+        :return: (list) of template objects
+        """
+        templates = []
+        request = self.service.instanceTemplates().list(project=self.project)
+        while request is not None:
+            response = request.execute()
+
+            for instance_template in response['items']:
+                templates.append(instance_template)
+
+            request = self.service.instanceTemplates().list_next(previous_request=request, previous_response=response)
+
+        return templates
+

--- a/pycue/opencue/cloud/gce_exception_util.py
+++ b/pycue/opencue/cloud/gce_exception_util.py
@@ -1,0 +1,45 @@
+#  Copyright Contributors to the OpenCue Project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import ast
+import functools
+
+import googleapiclient.errors
+
+import opencue.cloud.api
+
+
+class GoogleCloudRequestException(opencue.cloud.api.CloudProviderException):
+    """
+    Handle all google cloud request related exceptions
+    """
+
+    def __init__(self, error_code, message):
+        self.error_code = error_code
+        self.message = message
+        self.provider = "google"
+        super(GoogleCloudRequestException, self).__init__(self.error_code, self.message, self.provider)
+
+
+def googleRequestExceptionParser(request_function):
+
+    def _decorator(*args, **kwargs):
+        try:
+            return request_function(*args, **kwargs)
+        except googleapiclient.errors.HttpError as exception:
+            content = ast.literal_eval(exception.content.decode("UTF-8"))
+            raise GoogleCloudRequestException(error_code=content["error"]["code"],
+                                              message=content["error"]["message"])
+
+    return functools.wraps(request_function)(_decorator)

--- a/pycue/tests/cloud/__init__.py
+++ b/pycue/tests/cloud/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright Contributors to the OpenCue Project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/pycue/tests/cloud/gce_api_test.py
+++ b/pycue/tests/cloud/gce_api_test.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python
+
+#  Copyright Contributors to the OpenCue Project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import mock
+import unittest
+
+import opencue
+import opencue.cloud.gce_api
+
+TEST_CLOUD_GROUP_NAME = "test-group-main"
+TEST_CLOUD_GROUP_NAME_SECOND = "test-group-main-second"
+TEST_INSTANCE_TEMPLATE_NAME = "test-instance-template"
+TEST_TEMPLATE_SELF_LINK = "https://mock-template-link.com/template-name"
+
+
+class GoogleCloudManagerTest(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_get_all_groups(self):
+        # __getitem__.side_effect is used to make the return value of mock
+        # list call subscriptable since the actual code uses it like a dictionary
+        test_response = {
+            "items": [
+                {
+                    "name": TEST_CLOUD_GROUP_NAME,
+                    "id": 1234
+                },
+                {
+                    "name": TEST_CLOUD_GROUP_NAME_SECOND,
+                    "id": 4321
+                }
+            ]
+        }
+        manager = opencue.cloud.gce_api.GoogleCloudManager()
+        manager.service = mock.MagicMock()
+        manager.service.instanceGroupManagers().list.return_value.execute().__getitem__.side_effect =\
+            test_response.__getitem__
+        manager.service.instanceGroupManagers().list_next.return_value = None
+        groups = manager.get_all_groups()
+
+        for group in groups:
+            self.assertIsInstance(group, opencue.cloud.gce_api.GoogleCloudGroup)
+        self.assertListEqual([TEST_CLOUD_GROUP_NAME, TEST_CLOUD_GROUP_NAME_SECOND], [g.name for g in groups])
+        self.assertListEqual([1234, 4321], [g.id() for g in groups])
+
+    def test_list_templates(self):
+        # Accessing the 'name' key should be possible
+        test_response = {
+            "items": [
+                {
+                    "name": "rqd-test"
+                }
+            ]
+        }
+        manager = opencue.cloud.gce_api.GoogleCloudManager()
+        manager.service = mock.MagicMock()
+        manager.service.instanceTemplates().list.return_value.execute().__getitem__.side_effect =\
+            test_response.__getitem__
+        manager.service.instanceTemplates().list_next.return_value = None
+        templates = manager.list_templates()
+
+        self.assertEqual(["rqd-test"], [t["name"] for t in templates])
+
+    def test_create_managed_group(self):
+        test_group_name_input = TEST_CLOUD_GROUP_NAME
+        test_group_size = 3
+        test_template_object = {
+            "selfLink": TEST_TEMPLATE_SELF_LINK
+        }
+        expected_request_body = {
+            "baseInstanceName": "{}-instance".format(test_group_name_input),
+            "name": test_group_name_input,
+            "targetSize": test_group_size,
+            "instanceTemplate": test_template_object["selfLink"]
+        }
+
+        manager = opencue.cloud.gce_api.GoogleCloudManager()
+        manager.service = mock.MagicMock()
+
+        manager.create_managed_group(name=test_group_name_input,
+                                     size=test_group_size,
+                                     template=test_template_object)
+
+        manager.service.instanceGroupManagers().insert.assert_called_with(
+            project=mock.ANY, zone=mock.ANY,
+            body=expected_request_body
+        )
+
+
+class GoogleCloudGroupTest(unittest.TestCase):
+
+    def setUp(self):
+        self.connection_manager_mock = mock.MagicMock()
+        self.test_group_data = {
+            "name": TEST_CLOUD_GROUP_NAME,
+            "id": 1234
+        }
+
+    def test_get_instances(self):
+        test_managed_instances_data = [
+            {
+                "name": "instance-1",
+                "id": 4321
+            },
+            {
+                "name": "instance-2",
+                "id": 9876
+            }
+        ]
+
+        self.connection_manager_mock.service.instanceGroupManagers().listManagedInstances.return_value.execute.\
+            return_value.get.return_value = test_managed_instances_data
+
+        test_group = opencue.cloud.gce_api.GoogleCloudGroup(data=self.test_group_data,
+                                                            connection_manager=self.connection_manager_mock)
+        test_group.get_instances()
+
+        self.assertEqual(2, len(test_group.instances))
+        self.assertEqual(["instance-1", "instance-2"], [i["name"] for i in test_group.instances])
+        self.connection_manager_mock.service.instanceGroupManagers().listManagedInstances.assert_called_with(
+            project=mock.ANY, zone=mock.ANY, instanceGroupManager=TEST_CLOUD_GROUP_NAME
+        )
+
+    def test_delete_cloud_group(self):
+
+        test_group = opencue.cloud.gce_api.GoogleCloudGroup(data=self.test_group_data,
+                                                            connection_manager=self.connection_manager_mock)
+
+        test_group.delete_cloud_group()
+
+        self.connection_manager_mock.service.instanceGroupManagers().delete.assert_called_with(
+            project=mock.ANY, zone=mock.ANY, instanceGroupManager=TEST_CLOUD_GROUP_NAME
+        )
+
+    def test_resize(self):
+        test_group = opencue.cloud.gce_api.GoogleCloudGroup(data=self.test_group_data,
+                                                            connection_manager=self.connection_manager_mock)
+
+        test_group.resize(size=3)
+
+        self.connection_manager_mock.service.instanceGroupManagers().resize.assert_called_with(
+            project=mock.ANY, zone=mock.ANY, instanceGroupManager=TEST_CLOUD_GROUP_NAME, size=3
+        )
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,11 @@
 enum34==1.1.6
 future==0.17.1
 futures==3.2.0;python_version<"3.0"
+google-api-python-client==1.9.1
 grpcio==1.16.0
 grpcio-tools==1.16.0
 mock==2.0.0
+oauth2client==4.1.3
 pathlib==1.0.1;python_version<"3.4"
 pexpect==4.6.0
 psutil==5.6.6


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
[Opencue should support different logging paths for Windows and Linux #1096](https://github.com/AcademySoftwareFoundation/OpenCue/issues/1096)

**Summarize your change.**
The logging paths now can be different based on OS. The path can be set up by creating a new env variable like this: `log.frame-log-root.[OS]` where `[OS]` is related to `str_os` on the job table. If no environment variable is set up, it will default to the path described in `
cuebot/src/main/resources/opencue.properties` 

This change will allow OpenCue to be more adaptable to any system

The change was tested using unit tests and by running docker image.
<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
