### PR TITLE
Support different logging paths based on OS

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/util/JobLogUtil.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/util/JobLogUtil.java
@@ -38,9 +38,9 @@ public class JobLogUtil {
         return f.isDirectory();
     }
 
-    public String getJobLogDir(String show, String shot) {
+    public String getJobLogDir(String show, String shot, String os) {
         StringBuilder sb = new StringBuilder(512);
-        sb.append(getJobLogRootDir());
+        sb.append(getJobLogRootDir(os));
         sb.append("/");
         sb.append(show);
         sb.append("/");
@@ -51,7 +51,7 @@ public class JobLogUtil {
 
     public String getJobLogPath(JobDetail job) {
         StringBuilder sb = new StringBuilder(512);
-        sb.append(getJobLogDir(job.showName, job.shot));
+        sb.append(getJobLogDir(job.showName, job.shot, job.os));
         sb.append("/");
         sb.append(job.name);
         sb.append("--");
@@ -59,8 +59,12 @@ public class JobLogUtil {
         return sb.toString();
     }
 
-    public String getJobLogRootDir() {
-        return env.getRequiredProperty("log.frame-log-root", String.class);
+    public String getJobLogRootDir(String os) {
+        try {
+            return env.getRequiredProperty(String.format("log.frame-log-root.%s", os), String.class);
+        } catch (IllegalStateException e) {
+            return env.getRequiredProperty("log.frame-log-root.default_os", String.class);
+        }
     }
 }
 

--- a/cuebot/src/main/resources/opencue.properties
+++ b/cuebot/src/main/resources/opencue.properties
@@ -1,6 +1,10 @@
 cue.proxy = tcp -h cuetest01-vm -p 9019 -t 10000:tcp -h cuetest02-vm -p 9019 -t 10000:tcp -h cuetest03-vm -p 9019 -t 10000
 spring.velocity.checkTemplateLocation=false
 
+# Oracle versions of config values will look like:
+# datasource.cueDataSource.driverClassName=oracle.jdbc.OracleDriver
+# datasource.cueDataSource.jdbc-url=jdbc:oracle:oci:@dbname
+
 datasource.cue-data-source.driver-class-name=org.postgresql.Driver
 datasource.cue-data-source.jdbc-url=jdbc:postgresql://dbhost/dbname
 datasource.cue-data-source.username=cue
@@ -9,26 +13,35 @@ datasource.cue-data-source.password=password
 # connection rebalancing.
 datasource.cue-data-source.maxAge=21600000
 
+cue.trackit.enabled=false
+# If using Oracle trackit, ensure the drivers are installed and use the following config value:
+# datasource.trackit-data-source.driver-class-name=oracle.jdbc.OracleDriver
+datasource.trackit-data-source.jdbc-url=jdbc:oracle:oci:@dbname
+datasource.trackit-data-source.username=element_ro
+datasource.trackit-data-source.password=password
+# Discard connections after 6 hours, this allows for gradual
+# connection rebalancing.
+datasource.trackit-data-source.max-age=21600000
+
 grpc.cue_port=${CUEBOT_GRPC_CUE_PORT:8443}
 grpc.rqd_server_port=${CUEBOT_GRPC_RQD_SERVER_PORT:8444}
 grpc.max_message_bytes=104857600
 # Number of entries allowed in the RQD channel cache
-grpc.rqd_cache_size=2000
+grpc.rqd_cache_size=500
 # RQD Channel Cache Expiration in Minutes
-grpc.rqd_cache_expiration=5
-# RQD Channel Cache expected concurrency
-grpc.rqd_cache_concurrency=20
-# RQD Channel task deadline in seconds
-grpc.rqd_task_deadline=10
+grpc.rqd_cache_expiration=30
 
 # Whether or not to enable publishing to a messaging topic.
 # Set to a boolean value. See com/imageworks/spcue/services/JmsMover.java.
 messaging.enabled=false
 
-# Root directory for which logs will be stored. See com/imageworks/spcue/util/JobLogUtil.java.
+# Default root directory for which logs will be stored no other OS is defined.
+# See com/imageworks/spcue/util/JobLogUtil.java.
 # Override this via environment variable (CUE_FRAME_LOG_DIR) or command line flag
-# (--log.frame-log-root). Command line flag will be preferred if both are provided.
-log.frame-log-root=${CUE_FRAME_LOG_DIR:/shots}
+# (--log.frame-log-root.default_os). Command line flag will be preferred if both are provided.
+log.frame-log-root.default_os=${CUE_FRAME_LOG_DIR:/shots}
+# To set up root directories for other OS, like Windows, create new environment
+# variable as `log.frame-log-root.[OS] where OS relates to str_os on the job table
 
 # Maximum number of jobs to query.
 dispatcher.job_query_max=20
@@ -43,56 +56,3 @@ dispatcher.frame_query_max=20
 dispatcher.job_frame_dispatch_max=8
 # Maximum number of frames to dispatch from a host at one time.
 dispatcher.host_frame_dispatch_max=12
-# Whether or not to enable FIFO scheduling in the same priority.
-dispatcher.fifo_scheduling_enabled=false
-
-# Number of threads to keep in the pool for launching job.
-dispatcher.launch_queue.core_pool_size=1
-# Maximum number of threads to allow in the pool for launching job.
-dispatcher.launch_queue.max_pool_size=1
-# Queue capacity for launching job.
-dispatcher.launch_queue.queue_capacity=100
-
-# Number of threads to keep in the pool for various operation.
-dispatcher.dispatch_pool.core_pool_size=4
-# Maximum number of threads to allow in the pool for various operation.
-dispatcher.dispatch_pool.max_pool_size=4
-# Queue capacity for various operation.
-dispatcher.dispatch_pool.queue_capacity=500
-
-# Number of threads to keep in the pool for management operation.
-dispatcher.manage_pool.core_pool_size=8
-# Maximum number of threads to allow in the pool for management operation.
-dispatcher.manage_pool.max_pool_size=8
-# Queue capacity for management operation.
-dispatcher.manage_pool.queue_capacity=250
-
-# Number of threads to keep in the pool for handling Host Report.
-dispatcher.report_queue.core_pool_size=6
-# Maximum number of threads to allow in the pool for handling Host Report.
-dispatcher.report_queue.max_pool_size=8
-# Queue capacity for handling Host Report.
-dispatcher.report_queue.queue_capacity=1000
-
-# Number of threads to keep in the pool for kill frame operation.
-dispatcher.kill_queue.core_pool_size=6
-# Maximum number of threads to allow in the pool for kill frame operation.
-dispatcher.kill_queue.max_pool_size=8
-# Queue capacity for kill frame operation.
-dispatcher.kill_queue.queue_capacity=1000
-
-# Number of threads to keep in the pool for booking.
-dispatcher.booking_queue.core_pool_size=6
-# Maximum number of threads to allow in the pool for booking.
-dispatcher.booking_queue.max_pool_size=6
-# Queue capacity for booking.
-dispatcher.booking_queue.queue_capacity=1000
-
-# Whether or not to satisfy dependents (*_ON_FRAME and *_ON_LAYER) only on Frame success
-depend.satisfy_only_on_frame_success=true
-
-# Jobs will be archived to the history tables after being completed for this long.
-history.archive_jobs_cutoff_hours=72
-
-# Delete down hosts automatically.
-maintenance.auto_delete_down_hosts=false

--- a/cuebot/src/test/java/com/imageworks/spcue/test/util/JobLogUtilTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/util/JobLogUtilTests.java
@@ -36,32 +36,56 @@ public class JobLogUtilTests extends AbstractTransactionalJUnit4SpringContextTes
     @Resource
     private JobLogUtil jobLogUtil;
 
-    private String logRoot;
+    private String logRootDefault;
+    private String logRootSomeOs;
 
     @Before
     public void setUp() {
-        // This value should match what's defined in test/resources/opencue.properties.
-        logRoot = "/arbitraryLogDirectory";
+        // The values should match what's defined in test/resources/opencue.properties.
+        logRootDefault = "/arbitraryLogDirectory";
+        logRootSomeOs = "/arbitrarySomeOsDirectory";
     }
 
     @Test
-    public void testGetJobLogRootDir() {
-        assertEquals(logRoot, jobLogUtil.getJobLogRootDir());
+    public void testGetJobLogRootDirDefault() {
+        assertEquals(logRootDefault, jobLogUtil.getJobLogRootDir("someUndefinedOs"));
     }
 
     @Test
-    public void testGetJobLogDir() {
-        assertEquals(logRoot + "/show/shot/logs", jobLogUtil.getJobLogDir("show", "shot"));
+    public void testGetJobLogRootDirSomeOs() {
+        assertEquals(logRootSomeOs, jobLogUtil.getJobLogRootDir("some_os"));
     }
 
     @Test
-    public void testGetJobLogPath() {
+    public void testGetJobLogDirDefault() {
+        assertEquals(logRootDefault + "/show/shot/logs", jobLogUtil.getJobLogDir("show", "shot", "someUndefinedOs"));
+    }
+
+    @Test
+    public void testGetJobLogDirSomeOs() {
+        assertEquals(logRootSomeOs + "/show/shot/logs", jobLogUtil.getJobLogDir("show", "shot", "some_os"));
+    }
+
+    @Test
+    public void testGetJobLogPathDefault() {
         JobDetail jobDetail = new JobDetail();
         jobDetail.id = "id";
         jobDetail.name = "name";
         jobDetail.showName = "show";
         jobDetail.shot = "shot";
-        assertEquals(logRoot + "/show/shot/logs/name--id", jobLogUtil.getJobLogPath(jobDetail));
+        jobDetail.os = "someUndefinedOs";
+        assertEquals(logRootDefault + "/show/shot/logs/name--id", jobLogUtil.getJobLogPath(jobDetail));
+    }
+
+    @Test
+    public void testGetJobLogPathSomeOs() {
+        JobDetail jobDetail = new JobDetail();
+        jobDetail.id = "id";
+        jobDetail.name = "name";
+        jobDetail.showName = "show";
+        jobDetail.shot = "shot";
+        jobDetail.os = "some_os";
+        assertEquals(logRootSomeOs + "/show/shot/logs/name--id", jobLogUtil.getJobLogPath(jobDetail));
     }
 }
 

--- a/cuebot/src/test/resources/opencue.properties
+++ b/cuebot/src/test/resources/opencue.properties
@@ -1,6 +1,16 @@
 cue.proxy = tcp -h cuetest01-vm -p 9019 -t 10000:tcp -h cuetest02-vm -p 9019 -t 10000:tcp -h cuetest03-vm -p 9019 -t 10000
 spring.velocity.checkTemplateLocation=false
 
+cue.trackit.enabled=false
+# If using Oracle trackit, ensure the drivers are installed and use the following config value:
+# datasource.trackit-data-source.driver-class-name=oracle.jdbc.OracleDriver
+datasource.trackit-data-source.jdbc-url=jdbc:oracle:oci:@dbname
+datasource.trackit-data-source.username=element_ro
+datasource.trackit-data-source.password=password
+# Discard connections after 6 hours, this allows for gradual
+# connection rebalancing.
+datasource.trackit-data-source.max-age=21600000
+
 grpc.cue_port=8453
 grpc.rqd_server_port=${CUEBOT_GRPC_RQD_SERVER_PORT:50051}
 grpc.max_message_bytes=104857600
@@ -8,12 +18,9 @@ grpc.max_message_bytes=104857600
 grpc.rqd_cache_size=500
 # RQD Channel Cache Expiration in Minutes
 grpc.rqd_cache_expiration=30
-# RQD Channel Cache expected concurrency
-grpc.rqd_cache_concurrency=20
-# RQD Channel task deadline in seconds
-grpc.rqd_task_deadline=10
 
-log.frame-log-root=/arbitraryLogDirectory
+log.frame-log-root.default_os=/arbitraryLogDirectory
+log.frame-log-root.some_os=/arbitrarySomeOsDirectory
 
 dispatcher.job_query_max=20
 dispatcher.job_lock_expire_seconds=2
@@ -21,27 +28,3 @@ dispatcher.job_lock_concurrency_level=3
 dispatcher.frame_query_max=10
 dispatcher.job_frame_dispatch_max=2
 dispatcher.host_frame_dispatch_max=12
-
-dispatcher.launch_queue.core_pool_size=1
-dispatcher.launch_queue.max_pool_size=1
-dispatcher.launch_queue.queue_capacity=100
-
-dispatcher.dispatch_pool.core_pool_size=4
-dispatcher.dispatch_pool.max_pool_size=4
-dispatcher.dispatch_pool.queue_capacity=500
-
-dispatcher.manage_pool.core_pool_size=8
-dispatcher.manage_pool.max_pool_size=8
-dispatcher.manage_pool.queue_capacity=250
-
-dispatcher.report_queue.core_pool_size=6
-dispatcher.report_queue.max_pool_size=8
-dispatcher.report_queue.queue_capacity=1000
-
-dispatcher.kill_queue.core_pool_size=6
-dispatcher.kill_queue.max_pool_size=8
-dispatcher.kill_queue.queue_capacity=1000
-
-dispatcher.booking_queue.core_pool_size=6
-dispatcher.booking_queue.max_pool_size=6
-dispatcher.booking_queue.queue_capacity=1000


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
[Opencue should support different logging paths for Windows and Linux #1096](https://github.com/AcademySoftwareFoundation/OpenCue/issues/1096)

**Summarize your change.**
The logging paths now can be different based on OS. The path can be set up by creating a new env variable like this: `log.frame-log-root.[OS]` where `[OS]` is related to `str_os` on the job table. If no environment variable is set up, it will default to the path described in `
cuebot/src/main/resources/opencue.properties` 

This change will allow OpenCue to be more adaptable to any system

The change was tested using unit tests and by running docker image.
<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
