### PR TITLE
Support different logging paths based on OS

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/util/JobLogUtil.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/util/JobLogUtil.java
@@ -38,9 +38,9 @@ public class JobLogUtil {
         return f.isDirectory();
     }
 
-    public String getJobLogDir(String show, String shot) {
+    public String getJobLogDir(String show, String shot, String os) {
         StringBuilder sb = new StringBuilder(512);
-        sb.append(getJobLogRootDir());
+        sb.append(getJobLogRootDir(os));
         sb.append("/");
         sb.append(show);
         sb.append("/");
@@ -51,7 +51,7 @@ public class JobLogUtil {
 
     public String getJobLogPath(JobDetail job) {
         StringBuilder sb = new StringBuilder(512);
-        sb.append(getJobLogDir(job.showName, job.shot));
+        sb.append(getJobLogDir(job.showName, job.shot, job.os));
         sb.append("/");
         sb.append(job.name);
         sb.append("--");
@@ -59,8 +59,11 @@ public class JobLogUtil {
         return sb.toString();
     }
 
-    public String getJobLogRootDir() {
-        return env.getRequiredProperty("log.frame-log-root", String.class);
+    public String getJobLogRootDir(String os) {
+        try {
+            return env.getRequiredProperty(String.format("log.frame-log-root.%s", os), String.class);
+        } catch (IllegalStateException e) {
+            return env.getRequiredProperty("log.frame-log-root.default_os", String.class);
+        }
     }
 }
-

--- a/cuebot/src/main/resources/opencue.properties
+++ b/cuebot/src/main/resources/opencue.properties
@@ -25,10 +25,17 @@ grpc.rqd_task_deadline=10
 # Set to a boolean value. See com/imageworks/spcue/services/JmsMover.java.
 messaging.enabled=false
 
-# Root directory for which logs will be stored. See com/imageworks/spcue/util/JobLogUtil.java.
+# Default root directory for which logs will be stored no other OS is defined.
+# See com/imageworks/spcue/util/JobLogUtil.java.
 # Override this via environment variable (CUE_FRAME_LOG_DIR) or command line flag
-# (--log.frame-log-root). Command line flag will be preferred if both are provided.
-log.frame-log-root=${CUE_FRAME_LOG_DIR:/shots}
+# (--log.frame-log-root.default_os). Command line flag will be preferred if both are provided.
+log.frame-log-root.default_os=${CUE_FRAME_LOG_DIR:/shots}
+# To set up root directories for other OS create new environment
+# variable as `log.frame-log-root.[OS] where OS relates to str_os on the job table
+# For example:
+# log.frame-log-root.Windows=arbitraryWindowsDirectory
+# log.frame-log-root.linux=arbitraryLinuxDirectory
+
 
 # Maximum number of jobs to query.
 dispatcher.job_query_max=20

--- a/cuebot/src/test/java/com/imageworks/spcue/test/util/JobLogUtilTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/util/JobLogUtilTests.java
@@ -36,32 +36,56 @@ public class JobLogUtilTests extends AbstractTransactionalJUnit4SpringContextTes
     @Resource
     private JobLogUtil jobLogUtil;
 
-    private String logRoot;
+    private String logRootDefault;
+    private String logRootSomeOs;
 
     @Before
     public void setUp() {
-        // This value should match what's defined in test/resources/opencue.properties.
-        logRoot = "/arbitraryLogDirectory";
+        // The values should match what's defined in test/resources/opencue.properties.
+        logRootDefault = "/arbitraryLogDirectory";
+        logRootSomeOs = "/arbitrarySomeOsLogDirectory";
     }
 
     @Test
-    public void testGetJobLogRootDir() {
-        assertEquals(logRoot, jobLogUtil.getJobLogRootDir());
+    public void testGetJobLogRootDirDefault() {
+        assertEquals(logRootDefault, jobLogUtil.getJobLogRootDir("someUndefinedOs"));
     }
 
     @Test
-    public void testGetJobLogDir() {
-        assertEquals(logRoot + "/show/shot/logs", jobLogUtil.getJobLogDir("show", "shot"));
+    public void testGetJobLogRootSomeOs() {
+        assertEquals(logRootSomeOs, jobLogUtil.getJobLogRootDir("Windows"));
     }
 
     @Test
-    public void testGetJobLogPath() {
+    public void testGetJobLogDirDefault() {
+        assertEquals(logRootDefault + "/show/shot/logs", jobLogUtil.getJobLogDir("show", "shot", "someUndefinedOs"));
+    }
+
+    @Test
+    public void testGetJobLogDirSomeOs() {
+        assertEquals(logRootSomeOs + "/show/shot/logs", jobLogUtil.getJobLogDir("show", "shot", "Windows"));
+    }
+
+    @Test
+    public void testGetJobLogPathDefault() {
         JobDetail jobDetail = new JobDetail();
         jobDetail.id = "id";
         jobDetail.name = "name";
         jobDetail.showName = "show";
         jobDetail.shot = "shot";
-        assertEquals(logRoot + "/show/shot/logs/name--id", jobLogUtil.getJobLogPath(jobDetail));
+        jobDetail.os = "someUndefinedOs";
+        assertEquals(logRootDefault + "/show/shot/logs/name--id", jobLogUtil.getJobLogPath(jobDetail));
+    }
+
+    @Test
+    public void testGetJobLogPathSomeOs() {
+        JobDetail jobDetail = new JobDetail();
+        jobDetail.id = "id";
+        jobDetail.name = "name";
+        jobDetail.showName = "show";
+        jobDetail.shot = "shot";
+        jobDetail.os = "some_os";
+        assertEquals(logRootSomeOs + "/show/shot/logs/name--id", jobLogUtil.getJobLogPath(jobDetail));
     }
 }
 

--- a/cuebot/src/test/resources/opencue.properties
+++ b/cuebot/src/test/resources/opencue.properties
@@ -13,7 +13,8 @@ grpc.rqd_cache_concurrency=20
 # RQD Channel task deadline in seconds
 grpc.rqd_task_deadline=10
 
-log.frame-log-root=/arbitraryLogDirectory
+log.frame-log-root.default_os=/arbitraryLogDirectory
+log.frame-log-root.some_os=/arbitrarySomeOsLogDirectory
 
 dispatcher.job_query_max=20
 dispatcher.job_lock_expire_seconds=2


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
[Opencue should support different logging paths for Windows and Linux #1096](https://github.com/AcademySoftwareFoundation/OpenCue/issues/1096)

**Summarize your change.**
The logging paths now can be different based on OS. The path can be set up by creating a new env variable like this: `log.frame-log-root.[OS]` where `[OS]` is related to `str_os` on the job table. If no environment variable is set up, it will default to the path described in `
cuebot/src/main/resources/opencue.properties` 

This change will allow OpenCue to be more adaptable to any system

The change was tested using unit tests and by running docker image.
<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
