### PR TITLE
Add balanced mode to dispatch query

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dao/DispatcherDao.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/DispatcherDao.java
@@ -164,18 +164,31 @@ public interface DispatcherDao {
                                               int limit);
 
    /**
-    * Return whether FIFO scheduling is enabled or not in the same priority for unittest.
+    * Return Scheduling Mode selected
     *
     * @return
     */
-   boolean getFifoSchedulingEnabled();
+   SchedulingMode getSchedulingMode();
 
    /**
-    * Set whether FIFO scheduling is enabled or not in the same priority for unittest.
+    * Set Scheduling Mode.
     *
-    * @param fifoSchedulingEnabled
+    * @param schedulingMode
     */
-   void setFifoSchedulingEnabled(boolean fifoSchedulingEnabled);
+   void setSchedulingMode(SchedulingMode schedulingMode);
+
+    /**
+     *  - PRIORITY_ONLY: Sort by priority only
+     *  - FIFO: Whether or not to enable FIFO scheduling in the same priority.
+     *  - BALANCED: Use a rank formula that takes into account time waiting, and number
+     *      of cores required: rank = priority + (100 * (1 - (job.cores/job.int_min_cores))) + age in days
+     */
+    enum SchedulingMode {
+        PRIORITY_ONLY,
+        FIFO,
+        BALANCED
+    }
 }
+
 
 

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatchQuery.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatchQuery.java
@@ -21,8 +21,8 @@ package com.imageworks.spcue.dao.postgres;
 
 public class DispatchQuery {
 
-    public static final String FIND_JOBS_BY_SHOW =
-        "/* FIND_JOBS_BY_SHOW */ " +
+    public static final String FIND_JOBS_BY_SHOW_PRIORITY_MODE =
+        "/* FIND_JOBS_BY_SHOW_PRIORITY_MODE */ " +
         "SELECT pk_job, int_priority, rank FROM ( " +
             "SELECT " +
                 "ROW_NUMBER() OVER (ORDER BY job_resource.int_priority DESC) AS rank, " +
@@ -101,9 +101,76 @@ public class DispatchQuery {
                 ") " +
         ") AS t1 WHERE rank < ?";
 
+    // sort = priority + (100 * (1 - (job.cores/job.int_min_cores))) + (age in days) */
+    public static final String FIND_JOBS_BY_SHOW_BALANCED_MODE =
+            "/* FIND_JOBS_BY_SHOW_BALANCED_MODE */ " +
+            "SELECT pk_job, int_priority, rank FROM ( " +
+            "SELECT " +
+                "ROW_NUMBER() OVER (ORDER BY int_priority DESC) AS rank, " +
+                "pk_job, " +
+                "int_priority " +
+            "FROM ( " +
+            "SELECT DISTINCT " +
+                "job.pk_job as pk_job, " +
+                "CAST( " +
+                        "job_resource.int_priority + ( " +
+                            "100 * (CASE WHEN job_resource.int_min_cores <= 0 THEN 0 " +
+                        "ELSE " +
+                            "CASE WHEN job_resource.int_cores > job_resource.int_min_cores THEN 0 " +
+                            "ELSE 1 - job_resource.int_cores/job_resource.int_min_cores " +
+                            "END " +
+                        "END) " +
+				") + ( " +
+                "(DATE_PART('days', NOW()) - DATE_PART('days', job.ts_updated)) " +
+            ") as INT) as int_priority " +
+            "FROM " +
+                "job            , " +
+                "job_resource   , " +
+                "folder         , " +
+                "folder_resource, " +
+                "point          , " +
+                "layer          , " +
+                "layer_stat     , " +
+                "host             " +
+            "WHERE " +
+                "job.pk_job                 = job_resource.pk_job " +
+                "AND job.pk_folder          = folder.pk_folder " +
+                "AND folder.pk_folder       = folder_resource.pk_folder " +
+                "AND folder.pk_dept         = point.pk_dept " +
+                "AND folder.pk_show         = point.pk_show " +
+                "AND job.pk_job             = layer.pk_job " +
+                "AND job_resource.pk_job    = job.pk_job " +
+                "AND (CASE WHEN layer_stat.int_waiting_count > 0 THEN layer_stat.pk_layer ELSE NULL END) = layer.pk_layer " +
+                "AND " +
+                    "(" +
+                        "folder_resource.int_max_cores = -1 " +
+                    "OR " +
+                        "folder_resource.int_cores + layer.int_cores_min < folder_resource.int_max_cores " +
+                    ") " +
+                "AND job.str_state                  = 'PENDING' " +
+                "AND job.b_paused                   = false " +
+                "AND job.pk_show                    = ? " +
+                "AND job.pk_facility                = ? " +
+                "AND " +
+                    "(" +
+                        "job.str_os IS NULL OR job.str_os = '' " +
+                    "OR " +
+                        "job.str_os = ? " +
+                    ") " +
+                "AND (CASE WHEN layer_stat.int_waiting_count > 0 THEN 1 ELSE NULL END) = 1 " +
+                "AND layer.int_cores_min            <= ? " +
+                "AND layer.int_mem_min              <= ? " +
+                "AND (CASE WHEN layer.b_threadable = true THEN 1 ELSE 0 END) >= ? " +
+                "AND layer.int_gpus_min             <= ? " +
+                "AND layer.int_gpu_mem_min          BETWEEN ? AND ? " +
+                "AND job_resource.int_cores + layer.int_cores_min <= job_resource.int_max_cores " +
+                "AND host.str_tags ~* ('(?x)' || layer.str_tags) " +
+                "AND host.str_name = ? " +
+        ") AS t1 ) AS t2 WHERE rank < ?";
 
-    public static final String FIND_JOBS_BY_GROUP =
-        FIND_JOBS_BY_SHOW
+
+    public static final String FIND_JOBS_BY_GROUP_PRIORITY_MODE =
+        FIND_JOBS_BY_SHOW_PRIORITY_MODE
             .replace(
                 "FIND_JOBS_BY_SHOW",
                 "FIND_JOBS_BY_GROUP")
@@ -111,6 +178,14 @@ public class DispatchQuery {
                 "AND job.pk_show                    = ? ",
                 "AND job.pk_folder                  = ? ");
 
+    public static final String FIND_JOBS_BY_GROUP_BALANCED_MODE =
+        FIND_JOBS_BY_SHOW_BALANCED_MODE
+            .replace(
+                "FIND_JOBS_BY_SHOW",
+                "FIND_JOBS_BY_GROUP")
+            .replace(
+                "AND job.pk_show                    = ? ",
+                "AND job.pk_folder                  = ? ");
 
     private static final String replaceQueryForFifo(String query) {
         return query
@@ -125,8 +200,8 @@ public class DispatchQuery {
                 "WHERE rank < ? ORDER BY rank");
     }
 
-    public static final String FIND_JOBS_FIFO_BY_SHOW = replaceQueryForFifo(FIND_JOBS_BY_SHOW);
-    public static final String FIND_JOBS_FIFO_BY_GROUP = replaceQueryForFifo(FIND_JOBS_BY_GROUP);
+    public static final String FIND_JOBS_BY_SHOW_FIFO_MODE = replaceQueryForFifo(FIND_JOBS_BY_SHOW_PRIORITY_MODE);
+    public static final String FIND_JOBS_BY_GROUP_FIFO_MODE = replaceQueryForFifo(FIND_JOBS_BY_GROUP_PRIORITY_MODE);
 
     /**
      * Dispatch a host in local booking mode.

--- a/cuebot/src/main/resources/opencue.properties
+++ b/cuebot/src/main/resources/opencue.properties
@@ -43,8 +43,13 @@ dispatcher.frame_query_max=20
 dispatcher.job_frame_dispatch_max=8
 # Maximum number of frames to dispatch from a host at one time.
 dispatcher.host_frame_dispatch_max=12
-# Whether or not to enable FIFO scheduling in the same priority.
-dispatcher.fifo_scheduling_enabled=false
+# Choose between different scheduling strategies:
+#  - PRIORITY_ONLY: Sort by priority only
+#  - FIFO: Whether or not to enable FIFO scheduling in the same priority.
+#  - BALANCED: Use a rank formula that takes into account time waiting, and number
+#      of cores required: rank = priority + (100 * (1 - (job.cores/job.int_min_cores))) + age in days
+#      layer limiting is also disabled in this mode for performance reasons
+dispatcher.scheduling_mode=PRIORITY_ONLY
 
 # Number of threads to keep in the pool for launching job.
 dispatcher.launch_queue.core_pool_size=1

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/DispatcherDaoFifoTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/DispatcherDaoFifoTests.java
@@ -131,7 +131,7 @@ public class DispatcherDaoFifoTests extends AbstractTransactionalJUnit4SpringCon
 
     @Before
     public void launchJob() {
-        dispatcherDao.setFifoSchedulingEnabled(true);
+        dispatcherDao.setSchedulingMode(DispatcherDao.SchedulingMode.FIFO);
 
         dispatcher.setTestMode(true);
         jobLauncher.testMode = true;
@@ -139,7 +139,7 @@ public class DispatcherDaoFifoTests extends AbstractTransactionalJUnit4SpringCon
 
     @After
     public void resetFifoScheduling() {
-        dispatcherDao.setFifoSchedulingEnabled(false);
+        dispatcherDao.setSchedulingMode(DispatcherDao.SchedulingMode.PRIORITY_ONLY);
     }
 
     @Before
@@ -171,11 +171,11 @@ public class DispatcherDaoFifoTests extends AbstractTransactionalJUnit4SpringCon
     @Transactional
     @Rollback(true)
     public void testFifoSchedulingEnabled() {
-        assertTrue(dispatcherDao.getFifoSchedulingEnabled());
-        dispatcherDao.setFifoSchedulingEnabled(false);
-        assertFalse(dispatcherDao.getFifoSchedulingEnabled());
-        dispatcherDao.setFifoSchedulingEnabled(true);
-        assertTrue(dispatcherDao.getFifoSchedulingEnabled());
+        assertEquals(dispatcherDao.getSchedulingMode(), DispatcherDao.SchedulingMode.FIFO);
+        dispatcherDao.setSchedulingMode(DispatcherDao.SchedulingMode.PRIORITY_ONLY);
+        assertEquals(dispatcherDao.getSchedulingMode(), DispatcherDao.SchedulingMode.PRIORITY_ONLY);
+        dispatcherDao.setSchedulingMode(DispatcherDao.SchedulingMode.FIFO);
+        assertEquals(dispatcherDao.getSchedulingMode(), DispatcherDao.SchedulingMode.FIFO);
     }
 
     @Test
@@ -213,8 +213,7 @@ public class DispatcherDaoFifoTests extends AbstractTransactionalJUnit4SpringCon
     @Transactional
     @Rollback(true)
     public void testFifoSchedulingDisabled() throws Exception {
-        dispatcherDao.setFifoSchedulingEnabled(false);
-        assertFalse(dispatcherDao.getFifoSchedulingEnabled());
+        dispatcherDao.setSchedulingMode(DispatcherDao.SchedulingMode.PRIORITY_ONLY);
 
         int count = 10;
         launchJobs(count);

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/DispatcherDaoTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/DispatcherDaoTests.java
@@ -522,6 +522,6 @@ public class DispatcherDaoTests extends AbstractTransactionalJUnit4SpringContext
     @Transactional
     @Rollback(true)
     public void testFifoSchedulingEnabled() {
-        assertFalse(dispatcherDao.getFifoSchedulingEnabled());
+        assertEquals(dispatcherDao.getSchedulingMode(), DispatcherDao.SchedulingMode.PRIORITY_ONLY);
     }
 }


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Large studios with multiple shows and nodes can experience resource starving in smaller shows due to the priority model

**Summarize your change.**

Adds a scheduler_mode option to choose between `BALANCED`, `PRIORITY_ONLY` and `FIFO`. 
 - PRIORITY_ONLY was the default mode
 - FIFO replaces the property fifo_scheduling_enabled and uses its logic
 - BALANCED described bellow

The new mode (BALANCED) uses a formula that makes sure smaller jobs don't get starved by large jobs and also takes into account the time a job has been waiting in the queue. This mode also disregards the layer_limit feature for performance implications. The formula takes into account the number of required cores and the time the job has been waiting on queue.  
Formula:
```
  rank = priority + (100 * (1 - (job.cores/job.int_min_cores))) + (age in days)
```
This heuristic favours scenarios with a large amount of jobs and hosts.
