### PR TITLE
Fix NIMBY lock and refactor Nimby to Factory

### DIFF
--- a/rqd/rqd/__main__.py
+++ b/rqd/rqd/__main__.py
@@ -61,15 +61,13 @@ import rqd.rqutil
 
 def setupLogging():
     """Sets up the logging for RQD.
+       Logs to /var/log/messages"""
 
-    Logs to /var/log/messages"""
-    # TODO(bcipriano) These should be config based. (Issue #72)
-    consoleFormat = '%(asctime)s %(levelname)-9s rqd3-%(module)-10s %(message)s'
-    consoleLevel = logging.DEBUG
-    fileFormat = '%(asctime)s %(levelname)-9s rqd3-%(module)-10s %(message)s'
-    fileLevel = logging.WARNING  # Equal to or greater than the consoleLevel
+    consolehandler = logging.StreamHandler()
+    consolehandler.setLevel(rqd.rqconstants.CONSOLE_LOG_LEVEL)
+    consolehandler.setFormatter(logging.Formatter(rqd.rqconstants.LOG_FORMAT))
+    logging.getLogger('').addHandler(consolehandler)
 
-    logging.basicConfig(level=consoleLevel, format=consoleFormat)
     if platform.system() in ('Linux', 'Darwin'):
         if platform.system() == 'Linux':
             syslogAddress = '/dev/log'
@@ -83,9 +81,10 @@ def setupLogging():
         logfile = logging.FileHandler(os.path.expandvars('%TEMP%/openrqd.log'))
     else:
         logfile = logging.handlers.SysLogHandler()
-    logfile.setLevel(fileLevel)
-    logfile.setFormatter(logging.Formatter(fileFormat))
+    logfile.setLevel(rqd.rqconstants.FILE_LOG_LEVEL)
+    logfile.setFormatter(logging.Formatter(rqd.rqconstants.LOG_FORMAT))
     logging.getLogger('').addHandler(logfile)
+    logging.getLogger('').setLevel(logging.DEBUG)
 
 
 def usage():

--- a/rqd/rqd/cuerqd.py
+++ b/rqd/rqd/cuerqd.py
@@ -60,13 +60,13 @@ class RqdHost(object):
 
     def nimbyOff(self):
         """Disables Nimby on the host."""
-        print(self.rqdHost, "Turning off Nimby")
+        log.info(self.rqdHost, "Turning off Nimby")
         log.info("rqd nimbyoff by %s", os.environ.get("USER"))
         self.stub.NimbyOff(rqd.compiled_proto.rqd_pb2.RqdStaticNimbyOffRequest())
 
     def nimbyOn(self):
         """Enables Nimby on the host."""
-        print(self.rqdHost, "Turning on Nimby")
+        log.info(self.rqdHost, "Turning on Nimby")
         log.info("rqd nimbyon by %s", os.environ.get("USER"))
         self.stub.NimbyOn(rqd.compiled_proto.rqd_pb2.RqdStaticNimbyOnRequest())
 

--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -116,9 +116,14 @@ OVERRIDE_IS_DESKTOP = None # Force rqd to run in 'desktop' mode
 OVERRIDE_PROCS = None # number of physical cpus. ex: None or 2
 OVERRIDE_MEMORY = None # in Kb
 OVERRIDE_NIMBY = None # True to turn on, False to turn off
+USE_NIMBY_PYNPUT = platform.system() == 'Windows'
 OVERRIDE_HOSTNAME = None # Force to use this hostname
 ALLOW_GPU = False
 LOAD_MODIFIER = 0 # amount to add/subtract from load
+
+LOG_FORMAT = '%(asctime)s %(levelname)-9s openrqd-%(module)-10s %(message)s'
+CONSOLE_LOG_LEVEL = logging.DEBUG
+FILE_LOG_LEVEL = logging.WARNING  # Equal to or greater than the consoleLevel
 
 if subprocess.getoutput('/bin/su --help').find('session-command') != -1:
     SU_ARGUMENT = '--session-command'
@@ -138,8 +143,8 @@ try:
         else:
             ConfigParser = configparser.RawConfigParser
         config = ConfigParser()
-        logging.info('Loading config %s', CONFIG_FILE)
         config.read(CONFIG_FILE)
+        logging.warning('Loading config %s', CONFIG_FILE)
 
         if config.has_option(__section, "RQD_GRPC_PORT"):
             RQD_GRPC_PORT = config.getint(__section, "RQD_GRPC_PORT")
@@ -173,8 +178,16 @@ try:
             DEFAULT_FACILITY = config.get(__section, "DEFAULT_FACILITY")
         if config.has_option(__section, "LAUNCH_FRAME_USER_GID"):
             LAUNCH_FRAME_USER_GID = config.getint(__section, "LAUNCH_FRAME_USER_GID")
+        if config.has_option(__section, "CONSOLE_LOG_LEVEL"):
+            level = config.get(__section, "CONSOLE_LOG_LEVEL")
+            CONSOLE_LOG_LEVEL = logging.getLevelName(level)
+        if config.has_option(__section, "FILE_LOG_LEVEL"):
+            level = config.get(__section, "FILE_LOG_LEVEL")
+            FILE_LOG_LEVEL = logging.getLevelName(level)
 # pylint: disable=broad-except
 except Exception as e:
     logging.warning(
         "Failed to read values from config file %s due to %s at %s",
         CONFIG_FILE, e, traceback.extract_tb(sys.exc_info()[2]))
+
+logging.warning("CUEBOT_HOSTNAME: " + CUEBOT_HOSTNAME)

--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -190,4 +190,4 @@ except Exception as e:
         "Failed to read values from config file %s due to %s at %s",
         CONFIG_FILE, e, traceback.extract_tb(sys.exc_info()[2]))
 
-logging.warning("CUEBOT_HOSTNAME: " + CUEBOT_HOSTNAME)
+logging.warning("CUEBOT_HOSTNAME: %s", CUEBOT_HOSTNAME)

--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -847,8 +847,6 @@ class RqCore(object):
             err = "Not launching, rqd is lockNimby and User is Active"
             log.info(err)
             raise rqd.rqexceptions.CoreReservationFailureException(err)
-        else:
-            log.info("rqd.rqconstants.OVERRIDE_NIMBY and self.nimby.isUserActive() is FALSE")
 
         if runFrame.frame_id in self.__cache:
             err = "Not launching, frame is already running on this proc %s" % runFrame.frame_id

--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -22,7 +22,7 @@ from __future__ import division
 
 from builtins import str
 from builtins import object
-import logging as log
+import logging
 import os
 import platform
 import random
@@ -46,6 +46,8 @@ import rqd.rqutil
 
 INT32_MAX = 2147483647
 INT32_MIN = -2147483648
+log = logging.getLogger(__name__)
+
 
 class FrameAttendantThread(threading.Thread):
     """Once a frame has been received and checked by RQD, this class handles
@@ -582,7 +584,7 @@ class RqCore(object):
             booked_cores=0,
         )
 
-        self.nimby = rqd.rqnimby.Nimby(self)
+        self.nimby = rqd.rqnimby.NimbyFactory.getNimby(self)
 
         self.machine = rqd.rqmachine.Machine(self, self.cores)
 
@@ -614,6 +616,7 @@ class RqCore(object):
                     log.warning('OVERRIDE_NIMBY is False, Nimby startup has been disabled')
             else:
                 self.nimbyOn()
+                self.onNimbyLock()
         elif rqd.rqconstants.OVERRIDE_NIMBY:
             log.warning('Nimby startup has been triggered by OVERRIDE_NIMBY')
             self.nimbyOn()
@@ -836,9 +839,16 @@ class RqCore(object):
             raise rqd.rqexceptions.CoreReservationFailureException(err)
 
         if self.nimby.locked and not runFrame.ignore_nimby:
-            err = "Not launching, rqd is lockNimby"
+            err = "Not launching, rqd is lockNimby and not Ignore Nimby"
             log.info(err)
             raise rqd.rqexceptions.CoreReservationFailureException(err)
+
+        if rqd.rqconstants.OVERRIDE_NIMBY and self.nimby.isNimbyActive():
+            err = "Not launching, rqd is lockNimby and User is Active"
+            log.info(err)
+            raise rqd.rqexceptions.CoreReservationFailureException(err)
+        else:
+            log.info("rqd.rqconstants.OVERRIDE_NIMBY and self.nimby.isUserActive() is FALSE")
 
         if runFrame.frame_id in self.__cache:
             err = "Not launching, frame is already running on this proc %s" % runFrame.frame_id
@@ -913,6 +923,7 @@ class RqCore(object):
 
     def shutdownRqdIdle(self):
         """When machine is idle, shutdown RQD"""
+        log.info("shutdownRqdIdle")
         self.lockAll()
         self.__whenIdle = True
         self.sendStatusReport()
@@ -921,11 +932,13 @@ class RqCore(object):
 
     def restartRqdNow(self):
         """Kill all running frames and restart RQD"""
+        log.info("RestartRqdNow")
         self.__respawn = True
         self.shutdownRqdNow()
 
     def restartRqdIdle(self):
         """When machine is idle, restart RQD"""
+        log.info("RestartRqdIdle")
         self.lockAll()
         self.__whenIdle = True
         self.__respawn = True

--- a/rqd/rqd/rqdservicers.py
+++ b/rqd/rqd/rqdservicers.py
@@ -20,12 +20,15 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
 
-import logging as log
+import logging
 
 import grpc
 
 import rqd.compiled_proto.rqd_pb2
 import rqd.compiled_proto.rqd_pb2_grpc
+
+
+log = logging.getLogger(__name__)
 
 
 class RqdInterfaceServicer(rqd.compiled_proto.rqd_pb2_grpc.RqdInterfaceServicer):

--- a/rqd/rqd/rqmachine.py
+++ b/rqd/rqd/rqmachine.py
@@ -31,7 +31,7 @@ from builtins import object
 
 import ctypes
 import errno
-import logging as log
+import logging
 import math
 import os
 import platform
@@ -64,6 +64,7 @@ import rqd.rqswap
 import rqd.rqutil
 
 
+log = logging.getLogger(__name__)
 KILOBYTE = 1024
 
 

--- a/rqd/rqd/rqnetwork.py
+++ b/rqd/rqd/rqnetwork.py
@@ -25,7 +25,7 @@ from concurrent import futures
 from random import shuffle
 import abc
 import atexit
-import logging as log
+import logging
 import os
 import platform
 import subprocess
@@ -39,6 +39,9 @@ import rqd.compiled_proto.rqd_pb2_grpc
 import rqd.rqconstants
 import rqd.rqdservicers
 import rqd.rqutil
+
+
+log = logging.getLogger(__name__)
 
 
 class RunningFrame(object):
@@ -101,7 +104,7 @@ class RunningFrame(object):
 
     def kill(self, message=""):
         """Kills the frame"""
-        log.info("Request recieved: kill")
+        log.info("Request received: kill")
         if self.frameAttendantThread is None:
             log.warning(
                 "Kill requested before frameAttendantThread is created for: %s", self.frameId)

--- a/rqd/rqd/rqnimby.py
+++ b/rqd/rqd/rqnimby.py
@@ -20,18 +20,33 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
 
+from abc import ABCMeta, abstractmethod
 import os
 import select
 import time
 import signal
 import threading
-import logging as log
+import logging
 
 import rqd.rqconstants
 import rqd.rqutil
 
 
-class Nimby(threading.Thread):
+log = logging.getLogger(__name__)
+
+# compatible with Python 2 and 3:
+ABC = ABCMeta('ABC', (object,), {'__slots__': ()})
+
+class NimbyFactory(object):
+    @staticmethod
+    def getNimby(rqCore):
+        if rqd.rqconstants.USE_NIMBY_PYNPUT:
+            return NimbyPynput(rqCore)
+        else:
+            return NimbySelect(rqCore)
+
+
+class Nimby(threading.Thread, ABC):
     """Nimby == Not In My Back Yard.
        If enabled, nimby will lock and kill all frames running on the host if
        keyboard or mouse activity is detected. If sufficient idle time has
@@ -45,14 +60,17 @@ class Nimby(threading.Thread):
         threading.Thread.__init__(self)
 
         self.rqCore = rqCore
-
         self.locked = False
         self.active = False
+        log.warn("Locked state :%s", self.locked)
+        log.warn("Active state :%s", self.active)
 
         self.fileObjList = []
         self.results = [[]]
 
         self.thread = None
+
+        self.interaction_detected = False
 
         signal.signal(signal.SIGINT, self.signalHandler)
 
@@ -77,71 +95,77 @@ class Nimby(threading.Thread):
             log.info("Unlocked nimby")
             self.rqCore.onNimbyUnlock(asOf=asOf)
 
-    def _openEvents(self):
-        """Opens the /dev/input/event* files so nimby can monitor them"""
-        self._closeEvents()
+    def run(self):
+        """Starts the Nimby thread"""
+        log.warn("Nimby Run")
+        self.active = True
+        self.locked = True
+        self.startListener()
+        self.unlockedIdle()
 
         rqd.rqutil.permissionsHigh()
         try:
             for device in os.listdir("/dev/input/"):
                 if device.startswith("event") or device.startswith("mice"):
-                    log.debug("Found device: %s", device)
                     try:
                         self.fileObjList.append(open("/dev/input/%s" % device, "rb"))
                     except IOError as e:
                         # Bad device found
-                        log.debug("IOError: Failed to open %s, %s", "/dev/input/%s" % device, e)
+                        log.warning("IOError: Failed to open %s, %s", "/dev/input/%s" % device, e)
         finally:
             rqd.rqutil.permissionsLow()
 
-    def _closeEvents(self):
-        """Closes the /dev/input/event* files"""
-        log.debug("_closeEvents")
-        if self.fileObjList:
-            for fileObj in self.fileObjList:
-                try:
-                    fileObj.close()
-                # pylint: disable=broad-except
-                except Exception:
-                    pass
-            self.fileObjList = []
+    def stop(self):
+        """Stops the Nimby thread"""
+        log.warn("Stop Nimby")
+        if self.thread:
+            self.thread.cancel()
+        self.active = False
+        self.stopListener()
+        self.unlockNimby()
+
+    @abstractmethod
+    def startListener(self):
+        pass
+
+    @abstractmethod
+    def stopListener(self):
+        pass
+
+    @abstractmethod
+    def lockedInUse(self):
+        pass
+
+    @abstractmethod
+    def lockedIdle(self):
+        pass
+
+    @abstractmethod
+    def unlockedIdle(self):
+        pass
+
+
+class NimbySelect(Nimby):
+    def startListener(self):
+        pass
+
+    def stopListener(self):
+        self.closeEvents()
 
     def lockedInUse(self):
         """Nimby State: Machine is in use, host is locked,
                         waiting for sufficient idle time"""
-        log.debug("lockedInUse")
-        self._openEvents()
+        log.warn("lockedInUse")
+        self.openEvents()
         try:
             self.results = select.select(self.fileObjList, [], [], 5)
         # pylint: disable=broad-except
-        except Exception:
-            pass
+        except Exception as e:
+            log.warn(e)
         if self.active and self.results[0] == []:
             self.lockedIdle()
         elif self.active:
-            self._closeEvents()
-            self.thread = threading.Timer(rqd.rqconstants.CHECK_INTERVAL_LOCKED,
-                                          self.lockedInUse)
-            self.thread.start()
-
-    def lockedIdle(self):
-        """Nimby State: Machine is idle,
-                        waiting for sufficient idle time to unlock"""
-        self._openEvents()
-        waitStartTime = time.time()
-        try:
-            self.results = select.select(self.fileObjList, [], [],
-                                         rqd.rqconstants.MINIMUM_IDLE)
-        # pylint: disable=broad-except
-        except Exception:
-            pass
-        if self.active and self.results[0] == [] and \
-           self.rqCore.machine.isNimbySafeToUnlock():
-            self._closeEvents()
-            self.unlockNimby(asOf=waitStartTime)
-            self.unlockedIdle()
-        elif self.active:
-            self._closeEvents()
+            self.closeEvents()
             self.thread = threading.Timer(rqd.rqconstants.CHECK_INTERVAL_LOCKED,
                                           self.lockedInUse)
             self.thread.start()
@@ -149,11 +173,12 @@ class Nimby(threading.Thread):
     def unlockedIdle(self):
         """Nimby State: Machine is idle, host is unlocked,
                         waiting for user activity"""
+        log.warn("UnlockedIdle Nimby")
         while self.active and \
-              self.results[0] == [] and \
-              self.rqCore.machine.isNimbySafeToRunJobs():
+                self.results[0] == [] and \
+                self.rqCore.machine.isNimbySafeToRunJobs():
             try:
-                self._openEvents()
+                self.openEvents()
                 self.results = select.select(self.fileObjList, [], [], 5)
             # pylint: disable=broad-except
             except Exception:
@@ -163,21 +188,141 @@ class Nimby(threading.Thread):
                 self.active = True
 
         if self.active:
-            self._closeEvents()
+            log.warn("Is active, locking Nimby")
+            self.closeEvents()
             self.lockNimby()
             self.thread = threading.Timer(rqd.rqconstants.CHECK_INTERVAL_LOCKED,
                                           self.lockedInUse)
             self.thread.start()
 
-    def run(self):
-        """Starts the Nimby thread"""
-        self.active = True
-        self.unlockedIdle()
+    def lockedIdle(self):
+        """Nimby State: Machine is idle,
+                        waiting for sufficient idle time to unlock"""
+        log.warn("lockedIdle")
+        self.openEvents()
+        waitStartTime = time.time()
+        try:
+            self.results = select.select(self.fileObjList, [], [],
+                                         rqd.rqconstants.MINIMUM_IDLE)
+        # pylint: disable=broad-except
+        except Exception as e:
+            log.warn(e)
+        if self.active and self.results[0] == [] and \
+                self.rqCore.machine.isNimbySafeToUnlock():
+            self.closeEvents()
+            self.unlockNimby(asOf=waitStartTime)
+            self.unlockedIdle()
+        elif self.active:
+            self.closeEvents()
+            self.thread = threading.Timer(rqd.rqconstants.CHECK_INTERVAL_LOCKED,
+                                          self.lockedInUse)
+            self.thread.start()
 
-    def stop(self):
-        """Stops the Nimby thread"""
-        if self.thread:
-            self.thread.cancel()
-        self.active = False
-        self._closeEvents()
-        self.unlockNimby()
+    def openEvents(self):
+        """Opens the /dev/input/event* files so nimby can monitor them"""
+        log.warn("openEvents")
+        self.closeEvents()
+
+        rqd.rqutil.permissionsHigh()
+        try:
+            for device in os.listdir("/dev/input/"):
+                if device.startswith("event") or device.startswith("mice"):
+                    try:
+                        self.fileObjList.append(open("/dev/input/%s" % device, "rb"))
+                    except IOError as e:
+                        # Bad device found
+                        log.warning("IOError: Failed to open %s, %s" % ("/dev/input/%s" % device, e))
+        finally:
+            rqd.rqutil.permissionsLow()
+
+    def closeEvents(self):
+        """Closes the /dev/input/event* files"""
+        log.warning("closeEvents")
+        if self.fileObjList:
+            for fileObj in self.fileObjList:
+                try:
+                    fileObj.close()
+                # pylint: disable=broad-except
+                except Exception:
+                    pass
+            self.fileObjList = []
+
+    def isNimbyActive(self):
+        """ Check if user is active
+        :return: boolean if events are logged and Nimby is active
+        """
+        return self.active and self.results[0] == []
+
+class NimbyPynput(Nimby):
+    def __init__(self, rqCore):
+        Nimby.__init__(self, rqCore)
+
+        import pynput
+        self.mouse_listener = pynput.mouse.Listener(
+            on_move=self.on_interaction,
+            on_click=self.on_interaction,
+            on_scroll=self.on_interaction)
+        self.keyboard_listener = pynput.keyboard.Listener(on_press=self.on_interaction)
+
+    def on_interaction(self, *args):
+        self.interaction_detected = True
+
+    def startListener(self):
+        self.mouse_listener.start()
+        self.keyboard_listener.start()
+
+    def stopListener(self):
+        self.mouse_listener.stop()
+        self.keyboard_listener.stop()
+
+    def lockedInUse(self):
+        self.interaction_detected = False
+
+        time.sleep(5)
+        if self.active and self.interaction_detected == False:
+            self.lockedIdle()
+        elif self.active:
+
+            self.thread = threading.Timer(rqd.rqconstants.CHECK_INTERVAL_LOCKED,
+                                          self.lockedInUse)
+            self.thread.start()
+
+    def unlockedIdle(self):
+        log.warn("unlockedIdle")
+        while self.active and \
+                self.interaction_detected == False and \
+                self.rqCore.machine.isNimbySafeToRunJobs():
+
+            time.sleep(5)
+
+            if not self.rqCore.machine.isNimbySafeToRunJobs():
+                log.warning("memory threshold has been exceeded, locking nimby")
+                self.active = True
+
+        if self.active:
+            log.warning("Is active, lock Nimby")
+            self.lockNimby()
+            self.thread = threading.Timer(rqd.rqconstants.CHECK_INTERVAL_LOCKED,
+                                          self.lockedInUse)
+            log.warn("starting Thread")
+            self.thread.start()
+
+    def lockedIdle(self):
+        log.warn("lockedIdle")
+        waitStartTime = time.time()
+
+        time.sleep(rqd.rqconstants.MINIMUM_IDLE)
+
+        if self.active and self.interaction_detected == False and \
+                self.rqCore.machine.isNimbySafeToUnlock():
+            log.warn("Start wait time: %s", waitStartTime)
+            self.unlockNimby(asOf=waitStartTime)
+            self.unlockedIdle()
+        elif self.active:
+
+            self.thread = threading.Timer(rqd.rqconstants.CHECK_INTERVAL_LOCKED,
+                                          self.lockedInUse)
+            self.thread.start()
+
+    def isNimbyActive(self):
+        return not self.active and self.interaction_detected

--- a/rqd/rqd/rqnimby.py
+++ b/rqd/rqd/rqnimby.py
@@ -32,13 +32,16 @@ import platform
 import rqd.rqconstants
 import rqd.rqutil
 
+log = logging.getLogger(__name__)
+
 if platform.system() == 'Windows':
+    pynputIsAvailable = False
     try:
         import pynput
-    except ImportError:
-        pass
+        pynputIsAvailable = True
+    except ImportError as e:
+        log.error(e)
 
-log = logging.getLogger(__name__)
 
 # compatible with Python 2 and 3:
 ABC = ABCMeta('ABC', (object,), {'__slots__': ()})
@@ -49,7 +52,7 @@ class NimbyFactory(object):
     def getNimby(rqCore):
         """ assign platform dependent Nimby instance """
         nimbyInstance = None
-        if rqd.rqconstants.USE_NIMBY_PYNPUT:
+        if rqd.rqconstants.USE_NIMBY_PYNPUT and pynputIsAvailable:
             nimbyInstance = NimbyPynput(rqCore)
         else:
             nimbyInstance = NimbySelect(rqCore)

--- a/rqd/rqd/rqswap.py
+++ b/rqd/rqd/rqswap.py
@@ -24,12 +24,13 @@ from __future__ import absolute_import
 from builtins import str
 from builtins import range
 from builtins import object
-import logging as log
+import logging
 import re
 import threading
 import time
 
 
+log = logging.getLogger(__name__)
 PGPGOUT_RE = re.compile(r"^pgpgout (\d+)")
 
 

--- a/rqd/rqd/rqutil.py
+++ b/rqd/rqd/rqutil.py
@@ -24,7 +24,7 @@ from __future__ import division
 from builtins import str
 from builtins import object
 import functools
-import logging as log
+import logging
 import os
 import platform
 import socket
@@ -40,6 +40,7 @@ if platform.system() != 'Windows':
 
     PERMISSIONS = threading.Lock()
     HIGH_PERMISSION_GROUPS = os.getgroups()
+log = logging.getLogger(__name__)
 
 
 class Memoize(object):

--- a/rqd/tests/rqcore_tests.py
+++ b/rqd/tests/rqcore_tests.py
@@ -40,7 +40,7 @@ import rqd.rqnimby
 
 class RqCoreTests(unittest.TestCase):
 
-    @mock.patch('rqd.rqnimby.Nimby', autospec=True)
+    @mock.patch('rqd.rqnimby.NimbySelect', autospec=True)
     @mock.patch('rqd.rqnetwork.Network', autospec=True)
     @mock.patch('rqd.rqmachine.Machine', autospec=True)
     def setUp(self, machineMock, networkMock, nimbyMock):
@@ -314,7 +314,7 @@ class RqCoreTests(unittest.TestCase):
         frame = rqd.compiled_proto.rqd_pb2.RunFrame(uid=22, num_cores=10)
         frameIgnoreNimby = rqd.compiled_proto.rqd_pb2.RunFrame(
             uid=22, num_cores=10, ignore_nimby=True)
-        self.rqcore.nimby = mock.create_autospec(rqd.rqnimby.Nimby)
+        self.rqcore.nimby = mock.create_autospec(rqd.rqnimby.NimbySelect)
         self.rqcore.nimby.locked = True
 
         with self.assertRaises(rqd.rqexceptions.CoreReservationFailureException):

--- a/rqd/tests/rqmachine_tests.py
+++ b/rqd/tests/rqmachine_tests.py
@@ -173,7 +173,7 @@ class MachineTests(pyfakefs.fake_filesystem_unittest.TestCase):
         self.meminfo = self.fs.create_file('/proc/meminfo', contents=MEMINFO_MODERATE_USAGE)
 
         self.rqCore = mock.MagicMock(spec=rqd.rqcore.RqCore)
-        self.nimby = mock.MagicMock(spec=rqd.rqnimby.Nimby)
+        self.nimby = mock.MagicMock(spec=rqd.rqnimby.NimbySelect)
         self.rqCore.nimby = self.nimby
         self.nimby.active = False
         self.nimby.locked = False

--- a/rqd/tests/rqnimby_tests.py
+++ b/rqd/tests/rqnimby_tests.py
@@ -41,10 +41,10 @@ class RqNimbyTests(pyfakefs.fake_filesystem_unittest.TestCase):
         self.rqMachine = mock.MagicMock(spec=rqd.rqmachine.Machine)
         self.rqCore = mock.MagicMock(spec=rqd.rqcore.RqCore)
         self.rqCore.machine = self.rqMachine
-        self.nimby = rqd.rqnimby.Nimby(self.rqCore)
+        self.nimby = rqd.rqnimby.NimbyFactory.getNimby(self.rqCore)
         self.nimby.daemon = True
 
-    @mock.patch.object(rqd.rqnimby.Nimby, 'unlockedIdle')
+    @mock.patch.object(rqd.rqnimby.NimbySelect, 'unlockedIdle')
     def test_initialState(self, unlockedIdleMock):
         self.nimby.daemon = True
 
@@ -70,7 +70,7 @@ class RqNimbyTests(pyfakefs.fake_filesystem_unittest.TestCase):
         timerMock.return_value.start.assert_called()
 
     @mock.patch('select.select', new=mock.MagicMock(return_value=[[], [], []]))
-    @mock.patch.object(rqd.rqnimby.Nimby, 'unlockedIdle')
+    @mock.patch.object(rqd.rqnimby.NimbySelect, 'unlockedIdle')
     @mock.patch('threading.Timer')
     def test_lockedIdleWhenIdle(self, timerMock, unlockedIdleMock):
         self.nimby.active = True
@@ -96,7 +96,7 @@ class RqNimbyTests(pyfakefs.fake_filesystem_unittest.TestCase):
         timerMock.return_value.start.assert_called()
 
     @mock.patch('select.select', new=mock.MagicMock(return_value=[[], [], []]))
-    @mock.patch.object(rqd.rqnimby.Nimby, 'lockedIdle')
+    @mock.patch.object(rqd.rqnimby.NimbySelect, 'lockedIdle')
     @mock.patch('threading.Timer')
     def test_lockedInUseWhenIdle(self, timerMock, lockedIdleMock):
         self.nimby.active = True


### PR DESCRIPTION
**Summarize your change.**
Refactor Nimby to a Factory, now has two modes, Select and Pynput. Windows hosts will activate the Pynput mode by default. Fixed Nimby lock override, revamped logging removed print statements. 

Nimby lock was reverting irregardless if the user was using the desktop, turning Nimby into a Factory for Windows capability.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
