### PR TITLE
Post jobs should inherit parent environment variables

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/service/JobSpec.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/service/JobSpec.java
@@ -23,7 +23,13 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/cuebot/src/main/java/com/imageworks/spcue/service/JobSpec.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/service/JobSpec.java
@@ -23,13 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -341,6 +335,12 @@ public class JobSpec {
             job.priority = Integer.valueOf(jobTag.getChildTextTrim("priority"));
         }
 
+
+        Element envTag = jobTag.getChild("env");
+        if (envTag != null) {
+            handleEnvironmentTag(envTag, buildableJob.env);
+        }
+
         handleLayerTags(buildableJob, jobTag);
 
         if (buildableJob.getBuildableLayers().size() > MAX_LAYERS) {
@@ -351,11 +351,6 @@ public class JobSpec {
         if (buildableJob.getBuildableLayers().size() < 1) {
             throw new SpecBuilderException("The job " + job.name
                     + " has no layers");
-        }
-
-        Element envTag = jobTag.getChild("env");
-        if (envTag != null) {
-            handleEnvironmentTag(envTag, buildableJob.env);
         }
 
         return buildableJob;
@@ -958,6 +953,11 @@ public class JobSpec {
         job.deptName = parent.detail.deptName;
 
         BuildableJob postJob = new BuildableJob(job);
+
+        for (String key : parent.env.keySet()) {
+            postJob.env.put(key, parent.env.get(key));
+        }
+
         return postJob;
     }
 


### PR DESCRIPTION
Environment variables set to parent jobs can be useful for post job frames.

**Link the Issue(s) this Pull Request is related to.**
We have a scenario where post jobs require having access to the same environments from the parent. As post_jobs are use to run postProcess jobs, it's invisible to pyoutline module developers that those layers will be passed to a different job (_post_job_), so they expect to have the same environment as the job they are binding postProcess layers to. 

**Summarize your change.**
The change simple copies all environment variables set at the spec level to the postJob object.