### PR TITLE
Draft: Dynamically plug values for facility and os

### DIFF
--- a/rqd/tests/facility_config.py
+++ b/rqd/tests/facility_config.py
@@ -1,0 +1,2 @@
+def getValue():
+    return "test_facility_name_dynamic"

--- a/rqd/tests/rqconstants_tests.py
+++ b/rqd/tests/rqconstants_tests.py
@@ -123,11 +123,40 @@ class RqConstantTests(pyfakefs.fake_filesystem_unittest.TestCase):
 DEFAULT_FACILITY =  test_facility
 """,
     )
-    def test_facility(self):
+    def test_default_facility(self):
         self.assertEqual(rqd.rqconstants.DEFAULT_FACILITY, "test_facility")
 
         machine = self.makeRqMachine()
         self.assertEqual(machine.renderHost.facility, "test_facility")
+
+    @MockConfig(
+        tempdir,
+        """
+[Override]
+OVERRIDE_FACILITY_MODULE =  tests.facility_config
+OVERRIDE_FACILITY_FUNC = getValue
+DEFAULT_FACILITY =  test_facility
+""",
+    )
+    def test_facility(self):
+        self.assertEqual(rqd.rqconstants.FACILITY, "test_facility_name_dynamic")
+
+        machine = self.makeRqMachine()
+        self.assertEqual(machine.renderHost.facility, "test_facility")
+
+    @MockConfig(
+        tempdir,
+        """
+[Override]
+OVERRIDE_SP_OS_MODULE =  tests.sp_os_config
+OVERRIDE_SP_OS_FUNC = getValue
+""",
+    )
+    def test_sp_os(self):
+        self.assertEqual(rqd.rqconstants.SP_OS, "test_sp_os_dynamic")
+
+        machine = self.makeRqMachine()
+        self.assertEqual(machine.renderHost.attributes['SP_OS'], "test_sp_os_dynamic")
 
     @MockConfig(
         tempdir,

--- a/rqd/tests/sp_os_config.py
+++ b/rqd/tests/sp_os_config.py
@@ -1,0 +1,2 @@
+def getValue():
+    return "test_sp_os_dynamic"


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Current version uses DEFAULT_FACILITY value for every machine. Hence, in order to use a different value based on a machine, people have to edit and plug new logic into the code base. Same goes for SP_OS.

**Summarize your change.**
It is now possible to define `OVERRIDE_FACILITY_MODULE` and `OVERRIDE_FACILITY_FUNC` which will represent a module and a function that define FACILITY value. The same can be done for SP_OS. The module will be imported dynamically within `rqconstants.py`.
Unit tests were created within `rqconstants_tests.py`.
This change should allow for a better flexibility when using values that can require different logic based on studios.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
