### PR TITLE
Create feature flag to allow deeding

### DIFF
--- a/cuegui/cuegui/FrameMonitorTree.py
+++ b/cuegui/cuegui/FrameMonitorTree.py
@@ -879,7 +879,6 @@ class FrameContextMenu(QtWidgets.QMenu):
         elif count == 2:
             self.__menuActions.frames().addAction(self, "xdiff2")
 
-        self.__menuActions.frames().addAction(self, "useLocalCores")
         if bool(int(QtGui.qApp.settings.value("AllowDeeding", 0))):
             self.__menuActions.frames().addAction(self, "useLocalCores")
 

--- a/cuegui/cuegui/FrameMonitorTree.py
+++ b/cuegui/cuegui/FrameMonitorTree.py
@@ -212,6 +212,9 @@ class FrameMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
 
         cuegui.AbstractTreeWidget.AbstractTreeWidget.__init__(self, parent)
 
+        # Used to build right click context menus
+        self.__menuActions = cuegui.MenuActions.MenuActions(
+            self, self.updateSoon, self.selectedObjects, self.getJob)
         self.__sortByColumnCache = {}
         self.ticksWithoutUpdate = 999
         self.__lastUpdateTime = None
@@ -877,6 +880,8 @@ class FrameContextMenu(QtWidgets.QMenu):
             self.__menuActions.frames().addAction(self, "xdiff2")
 
         self.__menuActions.frames().addAction(self, "useLocalCores")
+        if bool(int(QtGui.qApp.settings.value("AllowDeeding", 0))):
+            self.__menuActions.frames().addAction(self, "useLocalCores")
 
         # pylint: disable=no-member
         if QtGui.qApp.applicationName() == "CueCommander":

--- a/cuegui/cuegui/JobMonitorTree.py
+++ b/cuegui/cuegui/JobMonitorTree.py
@@ -305,7 +305,9 @@ class JobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         self.__menuActions.jobs().addAction(menu, "view")
         self.__menuActions.jobs().addAction(menu, "emailArtist")
         self.__menuActions.jobs().addAction(menu, "viewComments")
-        self.__menuActions.jobs().addAction(menu, "useLocalCores")
+
+        if bool(int(QtGui.qApp.settings.value("AllowDeeding", 0))):
+            self.__menuActions.jobs().addAction(menu, "useLocalCores")
 
         depend_menu = QtWidgets.QMenu("&Dependencies",self)
         self.__menuActions.jobs().addAction(depend_menu, "viewDepends")

--- a/cuegui/cuegui/LayerMonitorTree.py
+++ b/cuegui/cuegui/LayerMonitorTree.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 from __future__ import division
 
 from PySide2 import QtCore
+from PySide2 import QtGui
 from PySide2 import QtWidgets
 
 from opencue.exception import EntityNotFoundException
@@ -231,7 +232,8 @@ class LayerMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
 
         if len(__selectedObjects) == 1:
             menu.addSeparator()
-            self.__menuActions.layers().addAction(menu, "useLocalCores")
+            if bool(int(QtGui.qApp.settings.value("AllowDeeding", 0))):
+                self.__menuActions.layers().addAction(menu, "useLocalCores")
             if len({layer.data.range for layer in __selectedObjects}) == 1:
                 self.__menuActions.layers().addAction(menu, "reorder")
             self.__menuActions.layers().addAction(menu, "stagger")


### PR DESCRIPTION
**Summarize your change.**
Motivation for disabling using local cores in cuetopia by default (i.e. artist desktops) from rendering was due to firstly, to mitigate slowness affecting artists due to system and network configurations for other services running on the desktop, historically the congestion caused slowness to the artist experience, and decided to avoid this chance for reintroducing congestion. Secondly, due to production management of render farm allocations per shows. Leaving the option to "opt in" and allow users to set the flag: `AllowDeeding=1` in the config file read by cuegui.

- Set AllowDeeding=1 in general config to be able to use local cores
- Use Local Cores option disabled by default


<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
