### PR TITLE
Fix: gRPC GetHost method

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageHost.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageHost.java
@@ -140,7 +140,7 @@ public class ManageHost extends HostInterfaceGrpc.HostInterfaceImplBase {
                          StreamObserver<HostGetHostResponse> responseObserver) {
         try {
             responseObserver.onNext(HostGetHostResponse.newBuilder()
-                    .setHost(whiteboard.findHost(request.getId()))
+                    .setHost(whiteboard.getHost(request.getId()))
                     .build());
             responseObserver.onCompleted();
         } catch (EmptyResultDataAccessException e) {


### PR DESCRIPTION
In gRPC server method GetHost used incorrect method that tried to find host by name instead of id.