### PR TITLE
Cuebot setChannel log supports old Python versions

### DIFF
--- a/pycue/opencue/cuebot.py
+++ b/pycue/opencue/cuebot.py
@@ -187,7 +187,9 @@ class Cuebot(object):
             else:
                 connectStr = '%s:%s' % (
                     host, Cuebot.Config.get('cuebot.grpc_port', DEFAULT_GRPC_PORT))
-            logger.debug('connecting to gRPC at %s', connectStr)
+            # pylint: disable=logging-not-lazy
+            logger.debug('connecting to gRPC at %s' % connectStr)
+            # pylint: enable=logging-not-lazy
             # TODO(bcipriano) Configure gRPC TLS. (Issue #150)
             try:
                 Cuebot.RpcChannel = grpc.intercept_channel(


### PR DESCRIPTION
**Summarize your change.**
Disabling Pylint to support machines running older Py versions which throw exceptions on string formatting.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
