### PR TITLE
Swap RE with empty string in MonitorJobPlugin

### DIFF
--- a/cuegui/cuegui/plugins/MonitorJobsPlugin.py
+++ b/cuegui/cuegui/plugins/MonitorJobsPlugin.py
@@ -46,7 +46,6 @@ PLUGIN_NAME = "Monitor Jobs"
 PLUGIN_CATEGORY = "Cuetopia"
 PLUGIN_DESCRIPTION = "Monitors a list of jobs"
 PLUGIN_PROVIDES = "MonitorJobsDockWidget"
-REGEX_EMPTY_STRING = re.compile("^$")
 JOB_RESTORE_THRESHOLD_DAYS = 3
 JOB_RESTORE_THRESHOLD_LIMIT = 200
 
@@ -199,7 +198,7 @@ class MonitorJobsDockWidget(cuegui.AbstractDockWidget.AbstractDockWidget):
                 self.jobMonitor.addJob(job)
         else:
             # Otherwise, just load current matching jobs (except for the empty string)
-            if not re.search(REGEX_EMPTY_STRING, substring):
+            if substring:
                 for job in opencue.api.getJobs(regex=[substring]):
                     self.jobMonitor.addJob(job)
 


### PR DESCRIPTION
**Summarize your change.**
Simplifies check in _regex_loadJobsHandle, if substring is not None, then load current matching jobs.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
