### PR TITLE
Shutdown nimby

### DIFF
--- a/rqd/rqd/cuerqd.py
+++ b/rqd/rqd/cuerqd.py
@@ -102,6 +102,7 @@ class RqdHost(object):
         print(self.rqdHost, "Sending shutdownRqdNow command")
         try:
             self.stub.ShutdownRqdNow(rqd.compiled_proto.rqd_pb2.RqdStaticShutdownNowRequest())
+        # pylint: disable=broad-except
         except Exception:
             # Shutting down the service from inside means this request will receive
             # a connection error response

--- a/rqd/rqd/cuerqd.py
+++ b/rqd/rqd/cuerqd.py
@@ -100,7 +100,12 @@ class RqdHost(object):
     def shutdownRqdNow(self):
         """Shuts down the host now."""
         print(self.rqdHost, "Sending shutdownRqdNow command")
-        self.stub.ShutdownRqdNow(rqd.compiled_proto.rqd_pb2.RqdStaticShutdownNowRequest())
+        try:
+            self.stub.ShutdownRqdNow(rqd.compiled_proto.rqd_pb2.RqdStaticShutdownNowRequest())
+        except Exception:
+            # Shutting down the service from inside means this request will receive
+            # a connection error response
+            pass
 
     def restartRqdIdle(self):
         """Restarts RQD on the host when idle."""

--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -116,7 +116,7 @@ OVERRIDE_IS_DESKTOP = None # Force rqd to run in 'desktop' mode
 OVERRIDE_PROCS = None # number of physical cpus. ex: None or 2
 OVERRIDE_MEMORY = None # in Kb
 OVERRIDE_NIMBY = None # True to turn on, False to turn off
-USE_NIMBY_PYNPUT = platform.system() == 'Windows'
+USE_NIMBY_PYNPUT = True # True pynput, False select
 OVERRIDE_HOSTNAME = None # Force to use this hostname
 ALLOW_GPU = False
 LOAD_MODIFIER = 0 # amount to add/subtract from load

--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -806,10 +806,11 @@ class RqCore(object):
             log.warning("Rebooting machine by request")
             self.machine.reboot()
         else:
-            log.warning("Shutting down RQD by request. pid(%s)" % os.getpid())
+            log.warning("Shutting down RQD by request. pid(%s)", os.getpid())
         self.network.stopGrpc()
         # Using sys.exit would raise SystemExit, giving exception handlers a chance
         # to block this
+        # pylint: disable=protected-access
         os._exit(0)
 
     def handleExit(self, signalnum, flag):

--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -919,6 +919,7 @@ class RqCore(object):
         try:
             self.lockAll()
             self.killAllFrame("shutdownRqdNow Command")
+        # pylint: disable=broad-except
         except Exception:
             log.exception("Failed to kill frames, stopping service anyways")
         if not self.__cache:
@@ -974,14 +975,12 @@ class RqCore(object):
     def nimbyOn(self):
         """Activates nimby, does not kill any running frames until next nimby
            event. Also does not unlock until sufficient idle time is reached."""
-        if platform.system() != "Windows" and os.getuid() != 0:
-            log.warning("Not starting nimby, not running as root")
-            return
-        if not self.nimby.active:
+        if self.nimby and not self.nimby.active:
             try:
                 self.nimby.run()
-                log.info("Nimby has been activated")
-            except:
+                log.warning("Nimby has been activated")
+            # pylint: disable=broad-except
+            except Exception:
                 self.nimby.locked = False
                 err = "Nimby is in the process of shutting down"
                 log.exception(err)
@@ -1001,7 +1000,7 @@ class RqCore(object):
         self.sendStatusReport()
 
     def onNimbyUnlock(self, asOf=None):
-        """This is called by nimby when it unlocks the machine due to sufficent
+        """This is called by nimby when it unlocks the machine due to sufficient
            idle. A new report is sent to the cuebot.
         @param asOf: Time when idle state began, if known."""
         del asOf

--- a/rqd/rqd/rqnetwork.py
+++ b/rqd/rqd/rqnetwork.py
@@ -126,6 +126,7 @@ class RunningFrame(object):
             except OSError as e:
                 log.warning(
                     "kill() tried to kill a non-existant pid for: %s Error: %s", self.frameId, e)
+            # pylint: disable=broad-except
             except Exception as e:
                 log.warning("kill() encountered an unknown error: %s", e)
         else:

--- a/rqd/rqd/rqnetwork.py
+++ b/rqd/rqd/rqnetwork.py
@@ -187,8 +187,8 @@ class GrpcServer(object):
 
     def shutdown(self):
         """Stops the gRPC server."""
-        log.info('Stopping grpc server.')
-        self.server.stop(0)
+        log.warning('Stopping grpc server.')
+        self.server.stop(10)
 
     def stayAlive(self):
         """Runs forever until killed."""
@@ -216,6 +216,7 @@ class Network(object):
         """Stops the gRPC server."""
         self.grpcServer.shutdown()
         del self.grpcServer
+        log.warning("Stopped grpc server")
 
     def closeChannel(self):
         """Closes the gRPC channel."""

--- a/rqd/rqd/rqnimby.py
+++ b/rqd/rqd/rqnimby.py
@@ -51,7 +51,7 @@ class NimbyFactory(object):
                 # environment rqd is running in
                 if "DISPLAY" not in os.environ:
                     os.environ['DISPLAY'] = ":0"
-                # pylint: disable=unused-import, import-error, unused-variable
+                # pylint: disable=unused-import, import-error, unused-variable, import-outside-toplevel
                 import pynput
             # pylint: disable=broad-except
             except Exception:
@@ -272,7 +272,7 @@ class NimbyPynput(Nimby):
     def __init__(self, rqCore):
         Nimby.__init__(self, rqCore)
 
-        # pylint: disable=unused-import, import-error
+        # pylint: disable=unused-import, import-error, import-outside-toplevel
         import pynput
         self.mouse_listener = pynput.mouse.Listener(
             on_move=self.on_interaction,


### PR DESCRIPTION
Shut down cleanly with systemctl stop and improve pynput nimby

The last solution involved a mix of calling an internal function, waiting for a random time
and then killing the process. With this solution, both killing the process and calling
`systemctl stop` will have similar outcomes

Handle not having nymby installed and change pynput to the default config as
select can misbehave when linux is not updating /dev/input/ events, for example
when the OS is being accessed via RGS remote access and similar technologies.