### PR TITLE
[cuegui] fix job monitor filter behavior

### DIFF
--- a/cuegui/cuegui/JobMonitorTree.py
+++ b/cuegui/cuegui/JobMonitorTree.py
@@ -238,9 +238,8 @@ class JobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         try:
             if newJobObj:
                 jobKey = cuegui.Utils.getObjectKey(newJobObj)
-                if not self.__groupDependent:
-                    self.__load[jobKey] = newJobObj
-                    self.__jobTimeLoaded[jobKey] = timestamp if timestamp else time.time()
+                self.__load[jobKey] = newJobObj
+                self.__jobTimeLoaded[jobKey] = timestamp if timestamp else time.time()
         finally:
             self.ticksLock.unlock()
 

--- a/cuegui/cuegui/plugins/MonitorJobsPlugin.py
+++ b/cuegui/cuegui/plugins/MonitorJobsPlugin.py
@@ -188,6 +188,8 @@ class MonitorJobsDockWidget(cuegui.AbstractDockWidget.AbstractDockWidget):
         substring = str(self.__regexLoadJobsEditBox.text()).strip()
         load_finished_jobs = self.__loadFinishedJobsCheckBox.isChecked()
 
+        self.jobMonitor.removeAllItems()
+
         if cuegui.Utils.isStringId(substring):
             # If a uuid is provided, load it
             self.jobMonitor.addJob(substring)

--- a/cuegui/cuegui/plugins/MonitorJobsPlugin.py
+++ b/cuegui/cuegui/plugins/MonitorJobsPlugin.py
@@ -89,9 +89,12 @@ class MonitorJobsDockWidget(cuegui.AbstractDockWidget.AbstractDockWidget):
                                      ("columnWidths",
                                       self.jobMonitor.getColumnWidths,
                                       self.jobMonitor.setColumnWidths),
-                                      ("columnOrder",
+                                     ("columnOrder",
                                       self.jobMonitor.getColumnOrder,
-                                      self.jobMonitor.setColumnOrder)])
+                                      self.jobMonitor.setColumnOrder),
+                                     ("loadFinished",
+                                      self.__loadFinishedJobsCheckBox.isChecked,
+                                      self.__loadFinishedJobsCheckBox.setChecked)])
 
     def addJob(self, rpcObject):
         """Adds a job to be monitored."""

--- a/cuegui/cuegui/plugins/MonitorJobsPlugin.py
+++ b/cuegui/cuegui/plugins/MonitorJobsPlugin.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 
 from builtins import str
 from builtins import map
-from datetime import datetime
+import datetime
 import re
 import weakref
 

--- a/cuegui/cuegui/plugins/MonitorJobsPlugin.py
+++ b/cuegui/cuegui/plugins/MonitorJobsPlugin.py
@@ -194,7 +194,7 @@ class MonitorJobsDockWidget(cuegui.AbstractDockWidget.AbstractDockWidget):
         elif load_finished_jobs or re.search(
                 r"^([a-z0-9_]+)\-([a-z0-9\.]+)\-", substring, re.IGNORECASE):
             # If show and shot is provided, or if "load finished" checkbox is checked, load all jobs
-            for job in opencue.api.getJobs(substr=[substring], include_finished=True):
+            for job in opencue.api.getJobs(regex=[substring], include_finished=True):
                 self.jobMonitor.addJob(job)
         else:
             # Otherwise, just load current matching jobs (except for the empty string)


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- Fixes #1121
- Fixes #1122 
- Fixes #1123 

**Summarize your change.**
- Fix previous regressions
- Improve cuegui monitor filter job
  - Allow regex usage in any case
  - Clear all jobs before new job, this is what to expect when doing a new search
  - Save LoadFinished setting in cuetopia preference file

