### PR TITLE
[cuegui] fix cue monitor gpu min/max

### DIFF
--- a/cuegui/cuegui/CueJobMonitorTree.py
+++ b/cuegui/cuegui/CueJobMonitorTree.py
@@ -559,8 +559,8 @@ class CueJobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
             menu.addSeparator()
             self.__menuActions.jobs().addAction(menu, "setMinCores")
             self.__menuActions.jobs().addAction(menu, "setMaxCores")
-            self.__menuActions.jobs().addAction(menu, "setMinGpu")
-            self.__menuActions.jobs().addAction(menu, "setMaxGpu")
+            self.__menuActions.jobs().addAction(menu, "setMinGpus")
+            self.__menuActions.jobs().addAction(menu, "setMaxGpus")
             self.__menuActions.jobs().addAction(menu, "setPriority")
             self.__menuActions.jobs().addAction(menu, "setMaxRetries")
             if counts["job"] == 1:


### PR DESCRIPTION
Signed-off-by: Oblet Alexis <alexis@theyard-vfx.com>

**Summarize your change.**
- Fix regression on cue monitor view

```bash
Traceback (most recent call last):
  File "/tmp/OpenCue/cuegui/cuegui/CueJobMonitorTree.py", line 562, in contextMenuEvent
    self.__menuActions.jobs().addAction(menu, "setMinGpu")
  File "/tmp/OpenCue/cuegui/cuegui/MenuActions.py", line 139, in addAction
    info = getattr(self, "%s_info" % actionName)
AttributeError: 'JobActions' object has no attribute 'setMinGpu_info'
```
