### PR TITLE
Fix: missed LluTime in WhiteboardDaoJdbc.FRAME_MAPPER

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/WhiteboardDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/WhiteboardDaoJdbc.java
@@ -1424,6 +1424,13 @@ public class WhiteboardDaoJdbc extends JdbcDaoSupport implements WhiteboardDao {
                     else {
                         builder.setStopTime(0);
                     }
+                    java.sql.Timestamp ts_llu = rs.getTimestamp("ts_llu");
+                    if (ts_llu!= null) {
+                        builder.setLluTime((int) (ts_llu.getTime() / 1000));
+                    }
+                    else {
+                        builder.setLluTime(0);
+                    }
 
                     builder.setTotalCoreTime(rs.getInt("int_total_past_core_time"));
                     builder.setTotalGpuTime(rs.getInt("int_total_past_gpu_time"));


### PR DESCRIPTION
LluTime field is missed In WhiteboardDaoJdbc.FRAME_MAPPER.