### PR TITLE
Add scheduled task to update show statuses

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dao/ShowDao.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/ShowDao.java
@@ -146,5 +146,11 @@ public interface ShowDao {
      * @param emails
      */
     void updateShowCommentEmail(ShowInterface s, String[] emails);
+
+    /**
+     * Scheduled task to update shows. Set show as inactive if it has at
+     * least 1 job in job_history service th
+     */
+    void updateShowsStatus();
 }
 

--- a/cuebot/src/main/java/com/imageworks/spcue/service/AdminManager.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/service/AdminManager.java
@@ -40,6 +40,7 @@ public interface AdminManager {
     ShowEntity getShowEntity(String id);
     void setShowActive(ShowInterface show, boolean value);
     void updateShowCommentEmail(ShowInterface s, String[] emails);
+    void updateShowsStatus();
 
     /*
      * Facilities

--- a/cuebot/src/main/java/com/imageworks/spcue/service/AdminManagerService.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/service/AdminManagerService.java
@@ -135,6 +135,11 @@ public class AdminManagerService implements AdminManager {
         showDao.updateShowCommentEmail(s, emails);
     }
 
+    @Override
+    public void updateShowsStatus() {
+        showDao.updateShowsStatus();
+    }
+
     public SubscriptionInterface createSubscription(SubscriptionEntity sub) {
         subscriptionDao.insertSubscription(sub);
         return sub;

--- a/cuebot/src/main/resources/conf/spring/applicationContext-service.xml
+++ b/cuebot/src/main/resources/conf/spring/applicationContext-service.xml
@@ -543,6 +543,19 @@
     <property name="repeatInterval" value="43200000" />
   </bean>
 
+  <bean id="updateShowsStatus" class="org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean">
+    <property name="targetObject" ref="adminManager" />
+    <property name="targetMethod" value="updateShowsStatus" />
+  </bean>
+
+  <bean id="updateShowsStatusTrigger" class="org.springframework.scheduling.quartz.SimpleTriggerFactoryBean">
+    <property name="jobDetail" ref="updateShowsStatus" />
+    <!-- delay 60 seconds -->
+    <property name="startDelay" value="60000" />
+    <!-- repeat once a week -->
+    <property name="repeatInterval" value="604800000" />
+  </bean>
+
   <bean class="org.springframework.scheduling.quartz.SchedulerFactoryBean" destroy-method="destroy">
    <property name="waitForJobsToCompleteOnShutdown"><value>false</value></property>
     <property name="triggers">
@@ -557,6 +570,7 @@
         <ref bean="dispatchQueueSchedule" />
         <ref bean="manageQueueSchedule" />
         <ref bean="killQueueSchedule" />
+        <ref bean="updateShowsStatusTrigger"/>
       </list>
     </property>
   </bean>

--- a/cuebot/src/main/resources/opencue.properties
+++ b/cuebot/src/main/resources/opencue.properties
@@ -135,3 +135,6 @@ maintenance.auto_delete_down_hosts=false
 
 # Set hostname/IP of the smtp host. Will be used for mailing
 smtp_host=smtp
+
+# These shows won't be deactivated by the scheduled tasks
+protected_shows=pipe,swtest,edu


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Automate show deactivation.

**Summarize your change.**
Currently the only way to deactivate the shows so they don't clog up UI is by directly updating DB. This attempts to automate this task by querrying for the shows that haven't had any jobs in the past 30 days.

It is also possible to ignore some shows by modifying properties.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
