### PR TITLE
cuegui: Make frames and layers readonly after job is done

### DIFF
--- a/cuegui/cuegui/FrameMonitorTree.py
+++ b/cuegui/cuegui/FrameMonitorTree.py
@@ -383,7 +383,7 @@ class FrameMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         @type  job: job, string, None"""
         self.frameSearch = opencue.search.FrameSearch()
         self.__job = job
-        self.__jobState = None
+        self.__jobState = job.state()
         self.removeAllItems()
         self.__sortByColumnLoad()
         self._lastUpdate = 0
@@ -576,7 +576,8 @@ class FrameMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
 
     def contextMenuEvent(self, e):
         """When right clicking on an item, this raises a context menu"""
-        menu = FrameContextMenu(self, self._actionFilterSelectedLayers)
+        menu = FrameContextMenu(self, self._actionFilterSelectedLayers,
+                                allow_edit=self.__jobState != opencue.api.job_pb2.FINISHED)
         menu.exec_(e.globalPos())
 
     def _actionFilterSelectedLayers(self):
@@ -860,7 +861,7 @@ class FrameEtaDataBuffer(object):
 class FrameContextMenu(QtWidgets.QMenu):
     """Context menu for frames."""
 
-    def __init__(self, widget, filterSelectedLayersCallback):
+    def __init__(self, widget, filterSelectedLayersCallback, allow_edit=False):
         super(FrameContextMenu, self).__init__()
 
         self.__menuActions = cuegui.MenuActions.MenuActions(
@@ -903,13 +904,13 @@ class FrameContextMenu(QtWidgets.QMenu):
 
         self.__menuActions.frames().createAction(self, "Filter Selected Layers", None,
                                                  filterSelectedLayersCallback, "stock-filters")
-        self.__menuActions.frames().addAction(self, "reorder")
+        self.__menuActions.frames().addAction(self, "reorder").setEnabled(allow_edit)
         self.addSeparator()
         self.__menuActions.frames().addAction(self, "previewMain")
         self.__menuActions.frames().addAction(self, "previewAovs")
         self.addSeparator()
-        self.__menuActions.frames().addAction(self, "retry")
-        self.__menuActions.frames().addAction(self, "eat")
-        self.__menuActions.frames().addAction(self, "kill")
-        self.__menuActions.frames().addAction(self, "eatandmarkdone")
+        self.__menuActions.frames().addAction(self, "retry").setEnabled(allow_edit)
+        self.__menuActions.frames().addAction(self, "eat").setEnabled(allow_edit)
+        self.__menuActions.frames().addAction(self, "kill").setEnabled(allow_edit)
+        self.__menuActions.frames().addAction(self, "eatandmarkdone").setEnabled(allow_edit)
         self.__menuActions.frames().addAction(self, "viewProcesses")

--- a/cuegui/cuegui/LayerMonitorTree.py
+++ b/cuegui/cuegui/LayerMonitorTree.py
@@ -20,8 +20,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
 
-import logging
-
 from PySide2 import QtCore
 from PySide2 import QtGui
 from PySide2 import QtWidgets
@@ -36,6 +34,7 @@ import cuegui.MenuActions
 import cuegui.Utils
 
 logger = cuegui.Logger.getLogger(__file__)
+
 
 
 def displayRange(layer):

--- a/cuegui/cuegui/MenuActions.py
+++ b/cuegui/cuegui/MenuActions.py
@@ -164,6 +164,7 @@ class AbstractActions(object):
             self.__actionCache[key] = action
 
         menu.addAction(self.__actionCache[key])
+        return self.__actionCache[key]
 
     def cuebotCall(self, functionToCall, errorMessageTitle, *args):
         """Makes the given call to the Cuebot, displaying exception info if needed.


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Retrying a frame in a finished job will cause the frame to go back into the waiting state and the job will return to the cue.  This even bypasses checks on duplicate job names, so two jobs with the same name can be running at the same time. Hence, it should be disallowed to retry frames on finished jobs, and the finished jobs should be read only.

**Summarize your change.**
The cuegui buttons that retry frames, edit dependencies, reorder, etc. are grayed out if the jobs is finished. This should make sure we treat the job as read only once the job is finished.


<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
