### PR TITLE
cuebot: Make frames and layers readonly after job is done

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageJob.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageJob.java
@@ -363,11 +363,7 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
     public void setMaxCores(JobSetMaxCoresRequest request, StreamObserver<JobSetMaxCoresResponse> responseObserver) {
         try{
             setupJobData(request.getJob());
-            if (isJobFinished()) {
-                responseObserver.onError(Status.FAILED_PRECONDITION
-                        .withDescription("Finished jobs are readonly")
-                        .asRuntimeException());
-            } else {
+            if (attemptChange(responseObserver)) {
                 jobDao.updateMaxCores(job, Convert.coresToWholeCoreUnits(request.getVal()));
                 responseObserver.onNext(JobSetMaxCoresResponse.newBuilder().build());
                 responseObserver.onCompleted();
@@ -429,11 +425,7 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
     public void setPriority(JobSetPriorityRequest request, StreamObserver<JobSetPriorityResponse> responseObserver) {
         try{
             setupJobData(request.getJob());
-            if (isJobFinished()) {
-                responseObserver.onError(Status.FAILED_PRECONDITION
-                        .withDescription("Finished jobs are readonly")
-                        .asRuntimeException());
-            } else {
+            if (attemptChange(responseObserver)) {
                 jobDao.updatePriority(job, request.getVal());
                 responseObserver.onNext(JobSetPriorityResponse.newBuilder().build());
                 responseObserver.onCompleted();
@@ -467,11 +459,7 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
     public void eatFrames(JobEatFramesRequest request, StreamObserver<JobEatFramesResponse> responseObserver) {
         try {
             setupJobData(request.getJob());
-            if (isJobFinished()) {
-                responseObserver.onError(Status.FAILED_PRECONDITION
-                        .withDescription("Finished jobs are readonly")
-                        .asRuntimeException());
-            } else {
+            if (attemptChange(responseObserver)) {
                 manageQueue.execute(
                         new DispatchEatFrames(
                                 frameSearchFactory.create(job, request.getReq()),
@@ -492,11 +480,7 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
     public void killFrames(JobKillFramesRequest request, StreamObserver<JobKillFramesResponse> responseObserver) {
         try {
             setupJobData(request.getJob());
-            if (isJobFinished()) {
-                responseObserver.onError(Status.FAILED_PRECONDITION
-                        .withDescription("Finished jobs are readonly")
-                        .asRuntimeException());
-            } else {
+            if (attemptChange(responseObserver)) {
                 manageQueue.execute(
                         new DispatchKillFrames(
                                 frameSearchFactory.create(job, request.getReq()),
@@ -518,11 +502,7 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
                                StreamObserver<JobMarkDoneFramesResponse> responseObserver) {
         try{
             setupJobData(request.getJob());
-            if (isJobFinished()) {
-                responseObserver.onError(Status.FAILED_PRECONDITION
-                        .withDescription("Finished jobs are readonly")
-                        .asRuntimeException());
-            } else {
+            if (attemptChange(responseObserver)) {
                 manageQueue.execute(
                         new DispatchSatisfyDepends(
                                 frameSearchFactory.create(job, request.getReq()), jobManagerSupport));
@@ -541,11 +521,7 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
     public void retryFrames(JobRetryFramesRequest request, StreamObserver<JobRetryFramesResponse> responseObserver) {
         try {
             setupJobData(request.getJob());
-            if (isJobFinished()) {
-                responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("Finished jobs are readonly")
-                    .asRuntimeException());
-            } else {
+            if (attemptChange(responseObserver)) {
                 manageQueue.execute(
                         new DispatchRetryFrames(
                                 frameSearchFactory.create(job, request.getReq()),
@@ -566,11 +542,7 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
     public void setAutoEat(JobSetAutoEatRequest request, StreamObserver<JobSetAutoEatResponse> responseObserver) {
         try {
             setupJobData(request.getJob());
-            if (isJobFinished()) {
-                responseObserver.onError(Status.FAILED_PRECONDITION
-                        .withDescription("Finished jobs are readonly")
-                        .asRuntimeException());
-            } else {
+            if (attemptChange(responseObserver)) {
                 jobDao.updateAutoEat(job, request.getValue());
                 responseObserver.onNext(JobSetAutoEatResponse.newBuilder().build());
                 responseObserver.onCompleted();
@@ -588,11 +560,7 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
                                         StreamObserver<JobCreateDependencyOnFrameResponse> responseObserver) {
         try {
             setupJobData(request.getJob());
-            if (isJobFinished()) {
-                responseObserver.onError(Status.FAILED_PRECONDITION
-                        .withDescription("Finished jobs are readonly")
-                        .asRuntimeException());
-            } else {
+            if (attemptChange(responseObserver)) {
                 JobOnFrame depend = new JobOnFrame(job,
                         jobManager.getFrameDetail(request.getFrame().getId()));
                 dependManager.createDepend(depend);
@@ -614,11 +582,7 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
                                       StreamObserver<JobCreateDependencyOnJobResponse> responseObserver) {
         try {
             setupJobData(request.getJob());
-            if (isJobFinished()) {
-                responseObserver.onError(Status.FAILED_PRECONDITION
-                        .withDescription("Finished jobs are readonly")
-                        .asRuntimeException());
-            } else {
+            if (attemptChange(responseObserver)) {
                 JobOnJob depend = new JobOnJob(job,
                         jobManager.getJobDetail(request.getOnJob().getId()));
                 dependManager.createDepend(depend);
@@ -640,11 +604,7 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
                                         StreamObserver<JobCreateDependencyOnLayerResponse> responseObserver) {
         try {
             setupJobData(request.getJob());
-            if (isJobFinished()) {
-                responseObserver.onError(Status.FAILED_PRECONDITION
-                        .withDescription("Finished jobs are readonly")
-                        .asRuntimeException());
-            } else {
+            if (attemptChange(responseObserver)) {
                 JobOnLayer depend = new JobOnLayer(job,
                         jobManager.getLayerDetail(request.getLayer().getId()));
                 dependManager.createDepend(depend);
@@ -737,11 +697,7 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
     public void setMaxRetries(JobSetMaxRetriesRequest request, StreamObserver<JobSetMaxRetriesResponse> responseObserver) {
         try {
             setupJobData(request.getJob());
-            if (isJobFinished()) {
-                responseObserver.onError(Status.FAILED_PRECONDITION
-                        .withDescription("Finished jobs are readonly")
-                        .asRuntimeException());
-            } else {
+            if (attemptChange(responseObserver)) {
                 jobDao.updateMaxFrameRetries(job, request.getMaxRetries());
                 responseObserver.onNext(JobSetMaxRetriesResponse.newBuilder().build());
                 responseObserver.onCompleted();
@@ -795,11 +751,7 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
     public void dropDepends(JobDropDependsRequest request, StreamObserver<JobDropDependsResponse> responseObserver) {
         try {
             setupJobData(request.getJob());
-            if (isJobFinished()) {
-                responseObserver.onError(Status.FAILED_PRECONDITION
-                        .withDescription("Finished jobs are readonly")
-                        .asRuntimeException());
-            } else {
+            if (attemptChange(responseObserver)) {
                 manageQueue.execute(new DispatchDropDepends(job, request.getTarget(), dependManager));
                 responseObserver.onNext(JobDropDependsResponse.newBuilder().build());
                 responseObserver.onCompleted();
@@ -816,11 +768,7 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
     public void setGroup(JobSetGroupRequest request, StreamObserver<JobSetGroupResponse> responseObserver) {
         try {
             setupJobData(request.getJob());
-            if (isJobFinished()) {
-                responseObserver.onError(Status.FAILED_PRECONDITION
-                        .withDescription("Finished jobs are readonly")
-                        .asRuntimeException());
-            } else {
+            if (attemptChange(responseObserver)) {
                 jobDao.updateParent(job, groupManager.getGroupDetail(request.getGroupId()));
                 responseObserver.onNext(JobSetGroupResponse.newBuilder().build());
                 responseObserver.onCompleted();
@@ -838,11 +786,7 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
                               StreamObserver<JobMarkAsWaitingResponse> responseObserver) {
         try {
             setupJobData(request.getJob());
-            if (isJobFinished()) {
-                responseObserver.onError(Status.FAILED_PRECONDITION
-                        .withDescription("Finished jobs are readonly")
-                        .asRuntimeException());
-            } else {
+            if (attemptChange(responseObserver)) {
                 jobManagerSupport.markFramesAsWaiting(
                         frameSearchFactory.create(job, request.getReq()), new Source(request.toString()));
                 responseObserver.onNext(JobMarkAsWaitingResponse.newBuilder().build());
@@ -861,11 +805,7 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
                               StreamObserver<JobReorderFramesResponse> responseObserver) {
         try {
             setupJobData(request.getJob());
-            if (isJobFinished()) {
-                responseObserver.onError(Status.FAILED_PRECONDITION
-                        .withDescription("Finished jobs are readonly")
-                        .asRuntimeException());
-            } else {
+            if (attemptChange(responseObserver)) {
                 manageQueue.execute(new DispatchReorderFrames(job,
                         new FrameSet(request.getRange()), request.getOrder(), jobManagerSupport));
                 responseObserver.onNext(JobReorderFramesResponse.newBuilder().build());
@@ -900,11 +840,7 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
                               StreamObserver<JobStaggerFramesResponse> responseObserver) {
         try {
             setupJobData(request.getJob());
-            if (isJobFinished()) {
-                responseObserver.onError(Status.FAILED_PRECONDITION
-                        .withDescription("Finished jobs are readonly")
-                        .asRuntimeException());
-            } else {
+            if (attemptChange(responseObserver)) {
                 manageQueue.execute(
                         new DispatchStaggerFrames(job, request.getRange(), request.getStagger(), jobManagerSupport));
                 responseObserver.onNext(JobStaggerFramesResponse.newBuilder().build());
@@ -922,11 +858,7 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
     public void addRenderPartition(JobAddRenderPartRequest request, StreamObserver<JobAddRenderPartResponse> responseObserver) {
         try {
             setupJobData(request.getJob());
-            if (isJobFinished()) {
-                responseObserver.onError(Status.FAILED_PRECONDITION
-                        .withDescription("Finished jobs are readonly")
-                        .asRuntimeException());
-            } else {
+            if (attemptChange(responseObserver)) {
                 LocalHostAssignment lha = new LocalHostAssignment();
                 lha.setJobId(job.getId());
                 lha.setThreads(request.getThreads());
@@ -966,11 +898,7 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
     public void runFilters(JobRunFiltersRequest request, StreamObserver<JobRunFiltersResponse> responseObserver) {
         try {
             setupJobData(request.getJob());
-            if (isJobFinished()) {
-                responseObserver.onError(Status.FAILED_PRECONDITION
-                        .withDescription("Finished jobs are readonly")
-                        .asRuntimeException());
-            } else {
+            if (attemptChange(responseObserver)) {
                 JobDetail jobDetail = jobManager.getJobDetail(job.getJobId());
                 filterManager.runFiltersOnJob(jobDetail);
                 responseObserver.onNext(JobRunFiltersResponse.newBuilder().build());
@@ -1109,6 +1037,16 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
             return jobDetail.state == JobState.FINISHED;
         }
         return false;
+    }
+
+    private <T> boolean attemptChange(StreamObserver<T> responseObserver) {
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+            return false;
+        }
+        return true;
     }
 }
 

--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageJob.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageJob.java
@@ -422,6 +422,36 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
     }
 
     @Override
+    public void setMaxGpus(JobSetMaxGpusRequest request, StreamObserver<JobSetMaxGpusResponse> responseObserver) {
+        try{
+            setupJobData(request.getJob());
+            jobDao.updateMaxGpus(job, request.getVal());
+            responseObserver.onNext(JobSetMaxGpusResponse.newBuilder().build());
+            responseObserver.onCompleted();
+        }
+        catch (EmptyResultDataAccessException e) {
+            responseObserver.onError(Status.INTERNAL
+                    .withDescription("Failed to find job data")
+                    .asRuntimeException());
+        }
+    }
+
+    @Override
+    public void setMinGpus(JobSetMinGpusRequest request, StreamObserver<JobSetMinGpusResponse> responseObserver) {
+        try{
+            setupJobData(request.getJob());
+            jobDao.updateMinGpus(job, request.getVal());
+            responseObserver.onNext(JobSetMinGpusResponse.newBuilder().build());
+            responseObserver.onCompleted();
+        }
+        catch (EmptyResultDataAccessException e) {
+            responseObserver.onError(Status.INTERNAL
+                    .withDescription("Failed to find job data")
+                    .asRuntimeException());
+        }
+    }
+
+    @Override
     public void setPriority(JobSetPriorityRequest request, StreamObserver<JobSetPriorityResponse> responseObserver) {
         try{
             setupJobData(request.getJob());
@@ -811,6 +841,22 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
                 responseObserver.onNext(JobReorderFramesResponse.newBuilder().build());
                 responseObserver.onCompleted();
             }
+        }
+        catch (EmptyResultDataAccessException e) {
+            responseObserver.onError(Status.INTERNAL
+                    .withDescription("Failed to find job data")
+                    .asRuntimeException());
+        }
+    }
+
+    @Override
+    public void shutdownIfCompleted(JobShutdownIfCompletedRequest request,
+                                    StreamObserver<JobShutdownIfCompletedResponse> responseObserver) {
+        try {
+            setupJobData(request.getJob());
+            manageQueue.execute(new DispatchShutdownJobIfCompleted(job, jobManagerSupport));
+            responseObserver.onNext(JobShutdownIfCompletedResponse.newBuilder().build());
+            responseObserver.onCompleted();
         }
         catch (EmptyResultDataAccessException e) {
             responseObserver.onError(Status.INTERNAL

--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageJob.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageJob.java
@@ -21,10 +21,13 @@ package com.imageworks.spcue.servant;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.dao.EmptyResultDataAccessException;
 
 import com.imageworks.spcue.BuildableJob;
@@ -174,6 +177,8 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
     private JobInterface job;
     private FrameSearchFactory frameSearchFactory;
     private JobSearchFactory jobSearchFactory;
+    @Autowired
+    private Environment env;
 
     @Override
     public void findJob(JobFindJobRequest request, StreamObserver<JobFindJobResponse> responseObserver) {
@@ -1098,8 +1103,12 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
     }
 
     private boolean isJobFinished() {
-        JobDetail jobDetail = this.jobManager.getJobDetail(this.job.getJobId());
-        return jobDetail.state == JobState.FINISHED;
+        if (env.getProperty("frame.finished_jobs_readonly", String.class) != null &&
+                Objects.equals(env.getProperty("frame.finished_jobs_readonly", String.class), "true")) {
+            JobDetail jobDetail = this.jobManager.getJobDetail(this.job.getJobId());
+            return jobDetail.state == JobState.FINISHED;
+        }
+        return false;
     }
 }
 

--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageLayer.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageLayer.java
@@ -20,6 +20,7 @@ package com.imageworks.spcue.servant;
 import java.util.HashSet;
 
 import com.google.protobuf.Descriptors;
+import com.imageworks.spcue.JobDetail;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -44,6 +45,7 @@ import com.imageworks.spcue.dispatcher.commands.DispatchSatisfyDepends;
 import com.imageworks.spcue.dispatcher.commands.DispatchStaggerFrames;
 import com.imageworks.spcue.grpc.job.FrameSearchCriteria;
 import com.imageworks.spcue.grpc.job.FrameSeq;
+import com.imageworks.spcue.grpc.job.JobState;
 import com.imageworks.spcue.grpc.job.Layer;
 import com.imageworks.spcue.grpc.job.LayerAddLimitRequest;
 import com.imageworks.spcue.grpc.job.LayerAddLimitResponse;
@@ -169,10 +171,16 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     @Override
     public void eatFrames(LayerEatFramesRequest request, StreamObserver<LayerEatFramesResponse> responseObserver) {
         updateLayer(request.getLayer());
-        manageQueue.execute(new DispatchEatFrames(frameSearch,
-                new Source(request.toString()), jobManagerSupport));
-        responseObserver.onNext(LayerEatFramesResponse.newBuilder().build());
-        responseObserver.onCompleted();
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+        } else {
+            manageQueue.execute(new DispatchEatFrames(frameSearch,
+                    new Source(request.toString()), jobManagerSupport));
+            responseObserver.onNext(LayerEatFramesResponse.newBuilder().build());
+            responseObserver.onCompleted();
+        }
     }
 
     @Override
@@ -188,118 +196,190 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     @Override
     public void killFrames(LayerKillFramesRequest request, StreamObserver<LayerKillFramesResponse> responseObserver) {
         updateLayer(request.getLayer());
-        manageQueue.execute(new DispatchKillFrames(frameSearch,
-                new Source(request.toString()), jobManagerSupport));
-        responseObserver.onNext(LayerKillFramesResponse.newBuilder().build());
-        responseObserver.onCompleted();
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+        } else {
+            manageQueue.execute(new DispatchKillFrames(frameSearch,
+                    new Source(request.toString()), jobManagerSupport));
+            responseObserver.onNext(LayerKillFramesResponse.newBuilder().build());
+            responseObserver.onCompleted();
+        }
     }
 
     @Override
     public void markdoneFrames(LayerMarkdoneFramesRequest request,
                                StreamObserver<LayerMarkdoneFramesResponse> responseObserver) {
         updateLayer(request.getLayer());
-        manageQueue.execute(new DispatchSatisfyDepends(layer, jobManagerSupport));
-        responseObserver.onNext(LayerMarkdoneFramesResponse.newBuilder().build());
-        responseObserver.onCompleted();
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+        } else {
+            manageQueue.execute(new DispatchSatisfyDepends(layer, jobManagerSupport));
+            responseObserver.onNext(LayerMarkdoneFramesResponse.newBuilder().build());
+            responseObserver.onCompleted();
+        }
     }
 
     @Override
     public void retryFrames(LayerRetryFramesRequest request,
                             StreamObserver<LayerRetryFramesResponse> responseObserver) {
         updateLayer(request.getLayer());
-        manageQueue.execute(new DispatchRetryFrames(frameSearch,
-                new Source(request.toString()), jobManagerSupport));
-        responseObserver.onNext(LayerRetryFramesResponse.newBuilder().build());
-        responseObserver.onCompleted();
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+        } else {
+            manageQueue.execute(new DispatchRetryFrames(frameSearch,
+                    new Source(request.toString()), jobManagerSupport));
+            responseObserver.onNext(LayerRetryFramesResponse.newBuilder().build());
+            responseObserver.onCompleted();
+        }
     }
 
     @Override
     public void setTags(LayerSetTagsRequest request, StreamObserver<LayerSetTagsResponse> responseObserver) {
         updateLayer(request.getLayer());
-        layerDao.updateLayerTags(layer, new HashSet<>(request.getTagsList()));
-        responseObserver.onNext(LayerSetTagsResponse.newBuilder().build());
-        responseObserver.onCompleted();
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+        } else {
+            layerDao.updateLayerTags(layer, new HashSet<>(request.getTagsList()));
+            responseObserver.onNext(LayerSetTagsResponse.newBuilder().build());
+            responseObserver.onCompleted();
+        }
     }
 
     @Override
     public void setMinCores(LayerSetMinCoresRequest request, StreamObserver<LayerSetMinCoresResponse> responseObserver) {
         updateLayer(request.getLayer());
-        jobManager.setLayerMinCores(layer, Convert.coresToCoreUnits(request.getCores()));
-        responseObserver.onNext(LayerSetMinCoresResponse.newBuilder().build());
-        responseObserver.onCompleted();
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+        } else {
+            jobManager.setLayerMinCores(layer, Convert.coresToCoreUnits(request.getCores()));
+            responseObserver.onNext(LayerSetMinCoresResponse.newBuilder().build());
+            responseObserver.onCompleted();
+        }
     }
 
     @Override
     public void setMinGpus(LayerSetMinGpusRequest request, StreamObserver<LayerSetMinGpusResponse> responseObserver) {
         updateLayer(request.getLayer());
-        jobManager.setLayerMinGpus(layer, request.getMinGpus());
-        responseObserver.onNext(LayerSetMinGpusResponse.newBuilder().build());
-        responseObserver.onCompleted();
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+        } else {
+            jobManager.setLayerMinGpus(layer, request.getMinGpus());
+            responseObserver.onNext(LayerSetMinGpusResponse.newBuilder().build());
+            responseObserver.onCompleted();
+        }
     }
 
     @Override
     public void setMinMemory(LayerSetMinMemoryRequest request, StreamObserver<LayerSetMinMemoryResponse> responseObserver) {
         updateLayer(request.getLayer());
-        layerDao.updateLayerMinMemory(layer, request.getMemory());
-        responseObserver.onNext(LayerSetMinMemoryResponse.newBuilder().build());
-        responseObserver.onCompleted();
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+        } else {
+            layerDao.updateLayerMinMemory(layer, request.getMemory());
+            responseObserver.onNext(LayerSetMinMemoryResponse.newBuilder().build());
+            responseObserver.onCompleted();
+        }
     }
 
     @Override
     public void setMinGpuMemory(LayerSetMinGpuMemoryRequest request,
                                 StreamObserver<LayerSetMinGpuMemoryResponse> responseObserver) {
         updateLayer(request.getLayer());
-        layerDao.updateLayerMinGpuMemory(layer, request.getGpuMemory());
-        responseObserver.onNext(LayerSetMinGpuMemoryResponse.newBuilder().build());
-        responseObserver.onCompleted();
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+        } else {
+            layerDao.updateLayerMinGpuMemory(layer, request.getGpuMemory());
+            responseObserver.onNext(LayerSetMinGpuMemoryResponse.newBuilder().build());
+            responseObserver.onCompleted();
+        }
     }
 
     @Override
     public void createDependencyOnFrame(LayerCreateDependOnFrameRequest request,
                                         StreamObserver<LayerCreateDependOnFrameResponse> responseObserver) {
         updateLayer(request.getLayer());
-        LayerOnFrame depend = new LayerOnFrame(layer, jobManager.getFrameDetail(request.getFrame().getId()));
-        dependManager.createDepend(depend);
-        responseObserver.onNext(LayerCreateDependOnFrameResponse.newBuilder()
-                .setDepend(whiteboard.getDepend(depend))
-                .build());
-        responseObserver.onCompleted();
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+        } else {
+            LayerOnFrame depend = new LayerOnFrame(layer, jobManager.getFrameDetail(request.getFrame().getId()));
+            dependManager.createDepend(depend);
+            responseObserver.onNext(LayerCreateDependOnFrameResponse.newBuilder()
+                    .setDepend(whiteboard.getDepend(depend))
+                    .build());
+            responseObserver.onCompleted();
+        }
     }
 
     @Override
     public void createDependencyOnJob(LayerCreateDependOnJobRequest request,
                                       StreamObserver<LayerCreateDependOnJobResponse> responseObserver) {
         updateLayer(request.getLayer());
-        LayerOnJob depend = new LayerOnJob(layer, jobManager.getJobDetail(request.getJob().getId()));
-        dependManager.createDepend(depend);
-        responseObserver.onNext(LayerCreateDependOnJobResponse.newBuilder()
-                .setDepend(whiteboard.getDepend(depend))
-                .build());
-        responseObserver.onCompleted();
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+        } else {
+            LayerOnJob depend = new LayerOnJob(layer, jobManager.getJobDetail(request.getJob().getId()));
+            dependManager.createDepend(depend);
+            responseObserver.onNext(LayerCreateDependOnJobResponse.newBuilder()
+                    .setDepend(whiteboard.getDepend(depend))
+                    .build());
+            responseObserver.onCompleted();
+        }
     }
 
     @Override
     public void createDependencyOnLayer(LayerCreateDependOnLayerRequest request,
                                         StreamObserver<LayerCreateDependOnLayerResponse> responseObserver) {
         updateLayer(request.getLayer());
-        LayerOnLayer depend = new LayerOnLayer(layer, jobManager.getLayerDetail(request.getDependOnLayer().getId()));
-        dependManager.createDepend(depend);
-        responseObserver.onNext(LayerCreateDependOnLayerResponse.newBuilder()
-                .setDepend(whiteboard.getDepend(depend))
-                .build());
-        responseObserver.onCompleted();
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+        } else {
+            LayerOnLayer depend = new LayerOnLayer(layer, jobManager.getLayerDetail(request.getDependOnLayer().getId()));
+            dependManager.createDepend(depend);
+            responseObserver.onNext(LayerCreateDependOnLayerResponse.newBuilder()
+                    .setDepend(whiteboard.getDepend(depend))
+                    .build());
+            responseObserver.onCompleted();
+        }
     }
 
     @Override
     public void createFrameByFrameDependency(LayerCreateFrameByFrameDependRequest request,
                                              StreamObserver<LayerCreateFrameByFrameDependResponse> responseObserver) {
         updateLayer(request.getLayer());
-        FrameByFrame depend = new FrameByFrame(layer, jobManager.getLayerDetail(request.getDependLayer().getId()));
-        dependManager.createDepend(depend);
-        responseObserver.onNext(LayerCreateFrameByFrameDependResponse.newBuilder()
-                .setDepend(whiteboard.getDepend(depend))
-                .build());
-        responseObserver.onCompleted();
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+        } else {
+            FrameByFrame depend = new FrameByFrame(layer, jobManager.getLayerDetail(request.getDependLayer().getId()));
+            dependManager.createDepend(depend);
+            responseObserver.onNext(LayerCreateFrameByFrameDependResponse.newBuilder()
+                    .setDepend(whiteboard.getDepend(depend))
+                    .build());
+            responseObserver.onCompleted();
+        }
     }
 
     @Override
@@ -326,94 +406,148 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     public void dropDepends(LayerDropDependsRequest request,
                             StreamObserver<LayerDropDependsResponse> responseObserver) {
         updateLayer(request.getLayer());
-        manageQueue.execute(new DispatchDropDepends(layer, request.getTarget(), dependManager));
-        responseObserver.onNext(LayerDropDependsResponse.newBuilder().build());
-        responseObserver.onCompleted();
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+        } else {
+            manageQueue.execute(new DispatchDropDepends(layer, request.getTarget(), dependManager));
+            responseObserver.onNext(LayerDropDependsResponse.newBuilder().build());
+            responseObserver.onCompleted();
+        }
     }
 
     @Override
     public void dropLimit(LayerDropLimitRequest request,
                          StreamObserver<LayerDropLimitResponse> responseObserver) {
         updateLayer(request.getLayer());
-        layerDao.dropLimit(layer, request.getLimitId());
-        responseObserver.onNext(LayerDropLimitResponse.newBuilder().build());
-        responseObserver.onCompleted();
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+        } else {
+            layerDao.dropLimit(layer, request.getLimitId());
+            responseObserver.onNext(LayerDropLimitResponse.newBuilder().build());
+            responseObserver.onCompleted();
+        }
     }
 
     @Override
     public void reorderFrames(LayerReorderFramesRequest request,
                               StreamObserver<LayerReorderFramesResponse> responseObserver) {
         updateLayer(request.getLayer());
-        manageQueue.execute(new DispatchReorderFrames(layer, new FrameSet(request.getRange()), request.getOrder(),
-                jobManagerSupport));
-        responseObserver.onNext(LayerReorderFramesResponse.newBuilder().build());
-        responseObserver.onCompleted();
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+        } else {
+            manageQueue.execute(new DispatchReorderFrames(layer, new FrameSet(request.getRange()), request.getOrder(),
+                    jobManagerSupport));
+            responseObserver.onNext(LayerReorderFramesResponse.newBuilder().build());
+            responseObserver.onCompleted();
+        }
     }
 
     @Override
     public void staggerFrames(LayerStaggerFramesRequest request,
                               StreamObserver<LayerStaggerFramesResponse> responseObserver) {
         updateLayer(request.getLayer());
-        manageQueue.execute(new DispatchStaggerFrames(layer, request.getRange(), request.getStagger(),
-                jobManagerSupport));
-        responseObserver.onNext(LayerStaggerFramesResponse.newBuilder().build());
-        responseObserver.onCompleted();
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+        } else {
+            manageQueue.execute(new DispatchStaggerFrames(layer, request.getRange(), request.getStagger(),
+                    jobManagerSupport));
+            responseObserver.onNext(LayerStaggerFramesResponse.newBuilder().build());
+            responseObserver.onCompleted();
+        }
     }
 
     @Override
     public void setThreadable(LayerSetThreadableRequest request, StreamObserver<LayerSetThreadableResponse> responseObserver) {
         updateLayer(request.getLayer());
-        layerDao.updateThreadable(layer, request.getThreadable());
-        responseObserver.onNext(LayerSetThreadableResponse.newBuilder().build());
-        responseObserver.onCompleted();
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+        } else {
+            layerDao.updateThreadable(layer, request.getThreadable());
+            responseObserver.onNext(LayerSetThreadableResponse.newBuilder().build());
+            responseObserver.onCompleted();
+        }
     }
 
     @Override
     public void setTimeout(LayerSetTimeoutRequest request, StreamObserver<LayerSetTimeoutResponse> responseObserver) {
         updateLayer(request.getLayer());
-        layerDao.updateTimeout(layer, request.getTimeout());
-        responseObserver.onNext(LayerSetTimeoutResponse.newBuilder().build());
-        responseObserver.onCompleted();
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+        } else {
+            layerDao.updateTimeout(layer, request.getTimeout());
+            responseObserver.onNext(LayerSetTimeoutResponse.newBuilder().build());
+            responseObserver.onCompleted();
+        }
     }
 
     @Override
     public void setTimeoutLLU(LayerSetTimeoutLLURequest request, StreamObserver<LayerSetTimeoutLLUResponse> responseObserver) {
         updateLayer(request.getLayer());
-        layerDao.updateTimeoutLLU(layer, request.getTimeoutLlu());
-        responseObserver.onNext(LayerSetTimeoutLLUResponse.newBuilder().build());
-        responseObserver.onCompleted();
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+        } else {
+            layerDao.updateTimeoutLLU(layer, request.getTimeoutLlu());
+            responseObserver.onNext(LayerSetTimeoutLLUResponse.newBuilder().build());
+            responseObserver.onCompleted();
+        }
     }
 
     @Override
     public void addLimit(LayerAddLimitRequest request,
                          StreamObserver<LayerAddLimitResponse> responseObserver) {
         updateLayer(request.getLayer());
-        layerDao.addLimit(layer, request.getLimitId());
-        responseObserver.onNext(LayerAddLimitResponse.newBuilder().build());
-        responseObserver.onCompleted();
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+        } else {
+            layerDao.addLimit(layer, request.getLimitId());
+            responseObserver.onNext(LayerAddLimitResponse.newBuilder().build());
+            responseObserver.onCompleted();
+        }
     }
 
     @Override
     public void addRenderPartition(LayerAddRenderPartitionRequest request,
                                    StreamObserver<LayerAddRenderPartitionResponse> responseObserver) {
         updateLayer(request.getLayer());
-        LocalHostAssignment lha = new LocalHostAssignment();
-        lha.setThreads(request.getThreads());
-        lha.setMaxCoreUnits(request.getMaxCores() * 100);
-        lha.setMaxMemory(request.getMaxMemory());
-        lha.setMaxGpuUnits(request.getMaxGpus());
-        lha.setMaxGpuMemory(request.getMaxGpuMemory());
-        lha.setType(RenderPartitionType.LAYER_PARTITION);
-        if (localBookingSupport.bookLocal(layer, request.getHost(), request.getUsername(), lha)) {
-            RenderPartition partition = whiteboard.getRenderPartition(lha);
-            responseObserver.onNext(LayerAddRenderPartitionResponse.newBuilder()
-                    .setRenderPartition(partition)
-                    .build());
-            responseObserver.onCompleted();
-        } else {
-            responseObserver.onError(Status.INTERNAL
-                    .withDescription("Failed to find suitable frames.")
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
                     .asRuntimeException());
+        } else {
+            LocalHostAssignment lha = new LocalHostAssignment();
+            lha.setThreads(request.getThreads());
+            lha.setMaxCoreUnits(request.getMaxCores() * 100);
+            lha.setMaxMemory(request.getMaxMemory());
+            lha.setMaxGpuUnits(request.getMaxGpus());
+            lha.setMaxGpuMemory(request.getMaxGpuMemory());
+            lha.setType(RenderPartitionType.LAYER_PARTITION);
+            if (localBookingSupport.bookLocal(layer, request.getHost(), request.getUsername(), lha)) {
+                RenderPartition partition = whiteboard.getRenderPartition(lha);
+                responseObserver.onNext(LayerAddRenderPartitionResponse.newBuilder()
+                        .setRenderPartition(partition)
+                        .build());
+                responseObserver.onCompleted();
+            } else {
+                responseObserver.onError(Status.INTERNAL
+                        .withDescription("Failed to find suitable frames.")
+                        .asRuntimeException());
+            }
         }
 
     }
@@ -422,9 +556,15 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     public void registerOutputPath(LayerRegisterOutputPathRequest request,
                                    StreamObserver<LayerRegisterOutputPathResponse> responseObserver) {
         updateLayer(request.getLayer());
-        jobManager.registerLayerOutput(layer, request.getSpec());
-        responseObserver.onNext(LayerRegisterOutputPathResponse.newBuilder().build());
-        responseObserver.onCompleted();
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+        } else {
+            jobManager.registerLayerOutput(layer, request.getSpec());
+            responseObserver.onNext(LayerRegisterOutputPathResponse.newBuilder().build());
+            responseObserver.onCompleted();
+        }
     }
 
     @Override
@@ -450,17 +590,29 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     public void enableMemoryOptimizer(LayerEnableMemoryOptimizerRequest request,
                                       StreamObserver<LayerEnableMemoryOptimizerResponse> responseObserver) {
         updateLayer(request.getLayer());
-        jobManager.enableMemoryOptimizer(layer, request.getValue());
-        responseObserver.onNext(LayerEnableMemoryOptimizerResponse.newBuilder().build());
-        responseObserver.onCompleted();
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+        } else {
+            jobManager.enableMemoryOptimizer(layer, request.getValue());
+            responseObserver.onNext(LayerEnableMemoryOptimizerResponse.newBuilder().build());
+            responseObserver.onCompleted();
+        }
     }
 
     @Override
     public void setMaxCores(LayerSetMaxCoresRequest request, StreamObserver<LayerSetMaxCoresResponse> responseObserver) {
         updateLayer(request.getLayer());
-        jobManager.setLayerMaxCores(layer, Convert.coresToWholeCoreUnits(request.getCores()));
-        responseObserver.onNext(LayerSetMaxCoresResponse.newBuilder().build());
-        responseObserver.onCompleted();
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+        } else {
+            jobManager.setLayerMaxCores(layer, Convert.coresToWholeCoreUnits(request.getCores()));
+            responseObserver.onNext(LayerSetMaxCoresResponse.newBuilder().build());
+            responseObserver.onCompleted();
+        }
     }
 
     @Override
@@ -549,5 +701,9 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
         layer = layerDao.getLayerDetail(layerData.getId());
         frameSearch = frameSearchFactory.create(layer);
     }
-}
+
+    private boolean isJobFinished() {
+        JobDetail jobDetail = this.jobManager.getJobDetail(this.layer.getJobId());
+        return jobDetail.state == JobState.FINISHED;
+    }}
 

--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageLayer.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageLayer.java
@@ -176,11 +176,7 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     @Override
     public void eatFrames(LayerEatFramesRequest request, StreamObserver<LayerEatFramesResponse> responseObserver) {
         updateLayer(request.getLayer());
-        if (isJobFinished()) {
-            responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("Finished jobs are readonly")
-                    .asRuntimeException());
-        } else {
+        if (attemptChange(responseObserver)) {
             manageQueue.execute(new DispatchEatFrames(frameSearch,
                     new Source(request.toString()), jobManagerSupport));
             responseObserver.onNext(LayerEatFramesResponse.newBuilder().build());
@@ -201,11 +197,7 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     @Override
     public void killFrames(LayerKillFramesRequest request, StreamObserver<LayerKillFramesResponse> responseObserver) {
         updateLayer(request.getLayer());
-        if (isJobFinished()) {
-            responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("Finished jobs are readonly")
-                    .asRuntimeException());
-        } else {
+        if (attemptChange(responseObserver)) {
             manageQueue.execute(new DispatchKillFrames(frameSearch,
                     new Source(request.toString()), jobManagerSupport));
             responseObserver.onNext(LayerKillFramesResponse.newBuilder().build());
@@ -217,11 +209,7 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     public void markdoneFrames(LayerMarkdoneFramesRequest request,
                                StreamObserver<LayerMarkdoneFramesResponse> responseObserver) {
         updateLayer(request.getLayer());
-        if (isJobFinished()) {
-            responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("Finished jobs are readonly")
-                    .asRuntimeException());
-        } else {
+        if (attemptChange(responseObserver)) {
             manageQueue.execute(new DispatchSatisfyDepends(layer, jobManagerSupport));
             responseObserver.onNext(LayerMarkdoneFramesResponse.newBuilder().build());
             responseObserver.onCompleted();
@@ -232,11 +220,7 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     public void retryFrames(LayerRetryFramesRequest request,
                             StreamObserver<LayerRetryFramesResponse> responseObserver) {
         updateLayer(request.getLayer());
-        if (isJobFinished()) {
-            responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("Finished jobs are readonly")
-                    .asRuntimeException());
-        } else {
+        if (attemptChange(responseObserver)) {
             manageQueue.execute(new DispatchRetryFrames(frameSearch,
                     new Source(request.toString()), jobManagerSupport));
             responseObserver.onNext(LayerRetryFramesResponse.newBuilder().build());
@@ -247,11 +231,7 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     @Override
     public void setTags(LayerSetTagsRequest request, StreamObserver<LayerSetTagsResponse> responseObserver) {
         updateLayer(request.getLayer());
-        if (isJobFinished()) {
-            responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("Finished jobs are readonly")
-                    .asRuntimeException());
-        } else {
+        if (attemptChange(responseObserver)) {
             layerDao.updateLayerTags(layer, new HashSet<>(request.getTagsList()));
             responseObserver.onNext(LayerSetTagsResponse.newBuilder().build());
             responseObserver.onCompleted();
@@ -261,11 +241,7 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     @Override
     public void setMinCores(LayerSetMinCoresRequest request, StreamObserver<LayerSetMinCoresResponse> responseObserver) {
         updateLayer(request.getLayer());
-        if (isJobFinished()) {
-            responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("Finished jobs are readonly")
-                    .asRuntimeException());
-        } else {
+        if (attemptChange(responseObserver)) {
             jobManager.setLayerMinCores(layer, Convert.coresToCoreUnits(request.getCores()));
             responseObserver.onNext(LayerSetMinCoresResponse.newBuilder().build());
             responseObserver.onCompleted();
@@ -289,11 +265,7 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     @Override
     public void setMinMemory(LayerSetMinMemoryRequest request, StreamObserver<LayerSetMinMemoryResponse> responseObserver) {
         updateLayer(request.getLayer());
-        if (isJobFinished()) {
-            responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("Finished jobs are readonly")
-                    .asRuntimeException());
-        } else {
+        if (attemptChange(responseObserver)) {
             layerDao.updateLayerMinMemory(layer, request.getMemory());
             responseObserver.onNext(LayerSetMinMemoryResponse.newBuilder().build());
             responseObserver.onCompleted();
@@ -304,11 +276,7 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     public void setMinGpuMemory(LayerSetMinGpuMemoryRequest request,
                                 StreamObserver<LayerSetMinGpuMemoryResponse> responseObserver) {
         updateLayer(request.getLayer());
-        if (isJobFinished()) {
-            responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("Finished jobs are readonly")
-                    .asRuntimeException());
-        } else {
+        if (attemptChange(responseObserver)) {
             layerDao.updateLayerMinGpuMemory(layer, request.getGpuMemory());
             responseObserver.onNext(LayerSetMinGpuMemoryResponse.newBuilder().build());
             responseObserver.onCompleted();
@@ -319,11 +287,7 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     public void createDependencyOnFrame(LayerCreateDependOnFrameRequest request,
                                         StreamObserver<LayerCreateDependOnFrameResponse> responseObserver) {
         updateLayer(request.getLayer());
-        if (isJobFinished()) {
-            responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("Finished jobs are readonly")
-                    .asRuntimeException());
-        } else {
+        if (attemptChange(responseObserver)) {
             LayerOnFrame depend = new LayerOnFrame(layer, jobManager.getFrameDetail(request.getFrame().getId()));
             dependManager.createDepend(depend);
             responseObserver.onNext(LayerCreateDependOnFrameResponse.newBuilder()
@@ -337,11 +301,7 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     public void createDependencyOnJob(LayerCreateDependOnJobRequest request,
                                       StreamObserver<LayerCreateDependOnJobResponse> responseObserver) {
         updateLayer(request.getLayer());
-        if (isJobFinished()) {
-            responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("Finished jobs are readonly")
-                    .asRuntimeException());
-        } else {
+        if (attemptChange(responseObserver)) {
             LayerOnJob depend = new LayerOnJob(layer, jobManager.getJobDetail(request.getJob().getId()));
             dependManager.createDepend(depend);
             responseObserver.onNext(LayerCreateDependOnJobResponse.newBuilder()
@@ -355,11 +315,7 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     public void createDependencyOnLayer(LayerCreateDependOnLayerRequest request,
                                         StreamObserver<LayerCreateDependOnLayerResponse> responseObserver) {
         updateLayer(request.getLayer());
-        if (isJobFinished()) {
-            responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("Finished jobs are readonly")
-                    .asRuntimeException());
-        } else {
+        if (attemptChange(responseObserver)) {
             LayerOnLayer depend = new LayerOnLayer(layer, jobManager.getLayerDetail(request.getDependOnLayer().getId()));
             dependManager.createDepend(depend);
             responseObserver.onNext(LayerCreateDependOnLayerResponse.newBuilder()
@@ -373,11 +329,7 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     public void createFrameByFrameDependency(LayerCreateFrameByFrameDependRequest request,
                                              StreamObserver<LayerCreateFrameByFrameDependResponse> responseObserver) {
         updateLayer(request.getLayer());
-        if (isJobFinished()) {
-            responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("Finished jobs are readonly")
-                    .asRuntimeException());
-        } else {
+        if (attemptChange(responseObserver)) {
             FrameByFrame depend = new FrameByFrame(layer, jobManager.getLayerDetail(request.getDependLayer().getId()));
             dependManager.createDepend(depend);
             responseObserver.onNext(LayerCreateFrameByFrameDependResponse.newBuilder()
@@ -411,11 +363,7 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     public void dropDepends(LayerDropDependsRequest request,
                             StreamObserver<LayerDropDependsResponse> responseObserver) {
         updateLayer(request.getLayer());
-        if (isJobFinished()) {
-            responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("Finished jobs are readonly")
-                    .asRuntimeException());
-        } else {
+        if (attemptChange(responseObserver)) {
             manageQueue.execute(new DispatchDropDepends(layer, request.getTarget(), dependManager));
             responseObserver.onNext(LayerDropDependsResponse.newBuilder().build());
             responseObserver.onCompleted();
@@ -426,11 +374,7 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     public void dropLimit(LayerDropLimitRequest request,
                          StreamObserver<LayerDropLimitResponse> responseObserver) {
         updateLayer(request.getLayer());
-        if (isJobFinished()) {
-            responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("Finished jobs are readonly")
-                    .asRuntimeException());
-        } else {
+        if (attemptChange(responseObserver)) {
             layerDao.dropLimit(layer, request.getLimitId());
             responseObserver.onNext(LayerDropLimitResponse.newBuilder().build());
             responseObserver.onCompleted();
@@ -441,11 +385,7 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     public void reorderFrames(LayerReorderFramesRequest request,
                               StreamObserver<LayerReorderFramesResponse> responseObserver) {
         updateLayer(request.getLayer());
-        if (isJobFinished()) {
-            responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("Finished jobs are readonly")
-                    .asRuntimeException());
-        } else {
+        if (attemptChange(responseObserver)) {
             manageQueue.execute(new DispatchReorderFrames(layer, new FrameSet(request.getRange()), request.getOrder(),
                     jobManagerSupport));
             responseObserver.onNext(LayerReorderFramesResponse.newBuilder().build());
@@ -457,11 +397,7 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     public void staggerFrames(LayerStaggerFramesRequest request,
                               StreamObserver<LayerStaggerFramesResponse> responseObserver) {
         updateLayer(request.getLayer());
-        if (isJobFinished()) {
-            responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("Finished jobs are readonly")
-                    .asRuntimeException());
-        } else {
+        if (attemptChange(responseObserver)) {
             manageQueue.execute(new DispatchStaggerFrames(layer, request.getRange(), request.getStagger(),
                     jobManagerSupport));
             responseObserver.onNext(LayerStaggerFramesResponse.newBuilder().build());
@@ -472,11 +408,7 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     @Override
     public void setThreadable(LayerSetThreadableRequest request, StreamObserver<LayerSetThreadableResponse> responseObserver) {
         updateLayer(request.getLayer());
-        if (isJobFinished()) {
-            responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("Finished jobs are readonly")
-                    .asRuntimeException());
-        } else {
+        if (attemptChange(responseObserver)) {
             layerDao.updateThreadable(layer, request.getThreadable());
             responseObserver.onNext(LayerSetThreadableResponse.newBuilder().build());
             responseObserver.onCompleted();
@@ -486,11 +418,7 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     @Override
     public void setTimeout(LayerSetTimeoutRequest request, StreamObserver<LayerSetTimeoutResponse> responseObserver) {
         updateLayer(request.getLayer());
-        if (isJobFinished()) {
-            responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("Finished jobs are readonly")
-                    .asRuntimeException());
-        } else {
+        if (attemptChange(responseObserver)) {
             layerDao.updateTimeout(layer, request.getTimeout());
             responseObserver.onNext(LayerSetTimeoutResponse.newBuilder().build());
             responseObserver.onCompleted();
@@ -500,11 +428,7 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     @Override
     public void setTimeoutLLU(LayerSetTimeoutLLURequest request, StreamObserver<LayerSetTimeoutLLUResponse> responseObserver) {
         updateLayer(request.getLayer());
-        if (isJobFinished()) {
-            responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("Finished jobs are readonly")
-                    .asRuntimeException());
-        } else {
+        if (attemptChange(responseObserver)) {
             layerDao.updateTimeoutLLU(layer, request.getTimeoutLlu());
             responseObserver.onNext(LayerSetTimeoutLLUResponse.newBuilder().build());
             responseObserver.onCompleted();
@@ -515,11 +439,7 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     public void addLimit(LayerAddLimitRequest request,
                          StreamObserver<LayerAddLimitResponse> responseObserver) {
         updateLayer(request.getLayer());
-        if (isJobFinished()) {
-            responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("Finished jobs are readonly")
-                    .asRuntimeException());
-        } else {
+        if (attemptChange(responseObserver)) {
             layerDao.addLimit(layer, request.getLimitId());
             responseObserver.onNext(LayerAddLimitResponse.newBuilder().build());
             responseObserver.onCompleted();
@@ -530,11 +450,7 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     public void addRenderPartition(LayerAddRenderPartitionRequest request,
                                    StreamObserver<LayerAddRenderPartitionResponse> responseObserver) {
         updateLayer(request.getLayer());
-        if (isJobFinished()) {
-            responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("Finished jobs are readonly")
-                    .asRuntimeException());
-        } else {
+        if (attemptChange(responseObserver)) {
             LocalHostAssignment lha = new LocalHostAssignment();
             lha.setThreads(request.getThreads());
             lha.setMaxCoreUnits(request.getMaxCores() * 100);
@@ -561,11 +477,7 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     public void registerOutputPath(LayerRegisterOutputPathRequest request,
                                    StreamObserver<LayerRegisterOutputPathResponse> responseObserver) {
         updateLayer(request.getLayer());
-        if (isJobFinished()) {
-            responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("Finished jobs are readonly")
-                    .asRuntimeException());
-        } else {
+        if (attemptChange(responseObserver)) {
             jobManager.registerLayerOutput(layer, request.getSpec());
             responseObserver.onNext(LayerRegisterOutputPathResponse.newBuilder().build());
             responseObserver.onCompleted();
@@ -595,11 +507,7 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     public void enableMemoryOptimizer(LayerEnableMemoryOptimizerRequest request,
                                       StreamObserver<LayerEnableMemoryOptimizerResponse> responseObserver) {
         updateLayer(request.getLayer());
-        if (isJobFinished()) {
-            responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("Finished jobs are readonly")
-                    .asRuntimeException());
-        } else {
+        if (attemptChange(responseObserver)) {
             jobManager.enableMemoryOptimizer(layer, request.getValue());
             responseObserver.onNext(LayerEnableMemoryOptimizerResponse.newBuilder().build());
             responseObserver.onCompleted();
@@ -609,11 +517,7 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
     @Override
     public void setMaxCores(LayerSetMaxCoresRequest request, StreamObserver<LayerSetMaxCoresResponse> responseObserver) {
         updateLayer(request.getLayer());
-        if (isJobFinished()) {
-            responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("Finished jobs are readonly")
-                    .asRuntimeException());
-        } else {
+        if (attemptChange(responseObserver)) {
             jobManager.setLayerMaxCores(layer, Convert.coresToWholeCoreUnits(request.getCores()));
             responseObserver.onNext(LayerSetMaxCoresResponse.newBuilder().build());
             responseObserver.onCompleted();
@@ -714,6 +618,16 @@ public class ManageLayer extends LayerInterfaceGrpc.LayerInterfaceImplBase {
             return jobDetail.state == JobState.FINISHED;
         }
         return false;
+    }
+
+    private <T> boolean attemptChange(StreamObserver<T> responseObserver) {
+        if (isJobFinished()) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("Finished jobs are readonly")
+                    .asRuntimeException());
+            return false;
+        }
+        return true;
     }
 }
 

--- a/cuebot/src/main/resources/opencue.properties
+++ b/cuebot/src/main/resources/opencue.properties
@@ -138,3 +138,9 @@ smtp_host=smtp
 
 # These shows won't be deactivated by the scheduled tasks
 protected_shows=pipe,swtest,edu
+
+# These flags determine whether or not layers/frames will be readonly when job is finished.
+# If flags are set as true, layers/frames cannot be retried, eaten, edited dependency on, etc.
+# In order to toggle the same functionility on cuegui side, set flags in cue_resources.yaml
+layer.finished_jobs_readonly=false
+frame.finished_jobs_readonly=false


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Retrying a frame in a finished job will cause the frame to go back into the waiting state and the job will return to the cue. This even bypasses checks on duplicate job names, so two jobs with the same name can be running at the same time. Hence, it should be disallowed to retry frames on finished jobs, and the finished jobs should be read only.


**Summarize your change.**
Endpoints that edit layers or frames now check whether or not the job is finished. If it is finished, then an error is returned. This will make sure the job is readonly from cuebot side.


<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
