### PR TITLE
pycue: Raise error if searching with incorrect parameter

### DIFF
--- a/pycue/opencue/search.py
+++ b/pycue/opencue/search.py
@@ -381,4 +381,8 @@ def _setOptions(criteria, options):
             criteria.first_result = int(v)
         elif k == "include_finished":
             criteria.include_finished = v
+        elif len(k) == 0:
+            return criteria
+        else:
+            raise Exception("Criteria for search does not exist")
     return criteria

--- a/pycue/tests/api_test.py
+++ b/pycue/tests/api_test.py
@@ -189,7 +189,7 @@ class JobTests(unittest.TestCase):
             jobs=job_pb2.JobSeq(jobs=[job_pb2.Job(name=TEST_JOB_NAME)]))
         getStubMock.return_value = stubMock
 
-        jobsByShow = opencue.api.getJobs(show=[TEST_SHOW_NAME], all=True)
+        jobsByShow = opencue.api.getJobs(show=[TEST_SHOW_NAME])
 
         stubMock.GetJobs.assert_called_with(
             job_pb2.JobGetJobsRequest(
@@ -205,6 +205,25 @@ class JobTests(unittest.TestCase):
                     jobs=[TEST_JOB_NAME], shows=[TEST_SHOW_NAME])), timeout=mock.ANY)
         self.assertEqual(1, len(jobsByName))
         self.assertEqual(TEST_JOB_NAME, jobsByName[0].name())
+
+    @mock.patch('opencue.cuebot.Cuebot.getStub')
+    def testGetAllJobs(self, getStubMock):
+        stubMock = mock.Mock()
+        stubMock.GetJobs.return_value = job_pb2.JobGetJobsResponse(
+            jobs=job_pb2.JobSeq(jobs=[job_pb2.Job(name=TEST_JOB_NAME)]))
+        getStubMock.return_value = stubMock
+
+        jobs = opencue.api.getJobs()
+
+        stubMock.GetJobs.assert_called_with(
+            job_pb2.JobGetJobsRequest(
+                r=job_pb2.JobSearchCriteria()), timeout=mock.ANY)
+        self.assertEqual(1, len(jobs))
+        self.assertEqual(TEST_JOB_NAME, jobs[0].name())
+
+    def testRaiseExceptionOnBadCriteriaSearch(self):
+        with self.assertRaises(Exception) as context:
+            opencue.api.getJobs(bad_criteria=["00000000-0000-0000-0000-012345678980"])
 
     @mock.patch('opencue.cuebot.Cuebot.getStub')
     def testGetJob(self, getStubMock):


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
When using methods like opecue.api.getJobs and supplying wrong parameters such as ids instead of id, method returns all jobs on the farm. Instead, exception should be thrown in search.py::_setOptions to clearly state that the parameter supplied was wrong.

**Summarize your change.**
Raises error on pycue side (in search.py) when the parameter given is incorrect, i.e. ids instead of id. In case of empty criteria, use empty criteria. So in the case of searching for jobs with empty criteria, all jobs will be returned.


<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
