### PR TITLE
Make frames and layers readonly after job is done

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatchQuery.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatchQuery.java
@@ -76,7 +76,7 @@ public class DispatchQuery {
                 "AND layer.int_gpu_mem_min          BETWEEN ? AND ? " +
                 "AND job_resource.int_cores + layer.int_cores_min < job_resource.int_max_cores " +
                 "AND job_resource.int_gpus + layer.int_gpus_min < job_resource.int_max_gpus " +
-                "AND host.str_tags ~* ('(?x)' || layer.str_tags) " +
+                "AND host.str_tags ~* ('(?x)' || layer.str_tags || '\\y') " +
                 "AND host.str_name = ? " +
                 "AND layer.pk_layer IN (" +
                     "SELECT " +
@@ -164,7 +164,7 @@ public class DispatchQuery {
                 "AND layer.int_gpus_min             <= ? " +
                 "AND layer.int_gpu_mem_min          BETWEEN ? AND ? " +
                 "AND job_resource.int_cores + layer.int_cores_min <= job_resource.int_max_cores " +
-                "AND host.str_tags ~* ('(?x)' || layer.str_tags) " +
+                "AND host.str_tags ~* ('(?x)' || layer.str_tags || '\\y') " +
                 "AND host.str_name = ? " +
         ") AS t1 ) AS t2 WHERE rank < ?";
 
@@ -368,7 +368,7 @@ public class DispatchQuery {
                 "AND " +
                     "l.int_gpu_mem_min = ? " +
                 "AND " +
-                    "h.str_tags ~* ('(?x)' || l.str_tags) " +
+                    "h.str_tags ~* ('(?x)' || l.str_tags || '\\y') " +
                 "AND " +
                     "h.str_name = ? " +
                 "AND " +
@@ -471,7 +471,7 @@ public class DispatchQuery {
                     "AND " +
                         "l.int_gpu_mem_min = ? " +
                     "AND " +
-                        "h.str_tags ~* ('(?x)' || l.str_tags) " +
+                        "h.str_tags ~* ('(?x)' || l.str_tags || '\\y') " +
                     "AND " +
                         "h.str_name = ? " +
                     "AND " +
@@ -593,7 +593,7 @@ public class DispatchQuery {
                     "l.pk_layer " +
                 "FROM " +
                     "layer l " +
-                "JOIN host h ON (h.str_tags ~* ('(?x)' || l.str_tags) AND h.str_name = ?) " +
+                "JOIN host h ON (h.str_tags ~* ('(?x)' || l.str_tags || '\\y') AND h.str_name = ?) " +
                 "LEFT JOIN layer_limit ON layer_limit.pk_layer = l.pk_layer " +
                 "LEFT JOIN limit_record ON limit_record.pk_limit_record = layer_limit.pk_limit_record " +
                 "LEFT JOIN (" +
@@ -711,7 +711,7 @@ public class DispatchQuery {
                         "l.pk_layer " +
                     "FROM " +
                         "layer l " +
-                    "JOIN host h ON (h.str_tags ~* ('(?x)' || l.str_tags) AND h.str_name = ?) " +
+                    "JOIN host h ON (h.str_tags ~* ('(?x)' || l.str_tags || '\\y') AND h.str_name = ?) " +
                     "LEFT JOIN layer_limit ON layer_limit.pk_layer = l.pk_layer " +
                     "LEFT JOIN limit_record ON limit_record.pk_limit_record = layer_limit.pk_limit_record " +
                     "LEFT JOIN (" +
@@ -1045,7 +1045,7 @@ public class DispatchQuery {
                     "l.pk_layer " +
                 "FROM " +
                     "layer l " +
-                "JOIN host h ON (h.str_tags ~* ('(?x)' || l.str_tags) AND h.str_name = ?) " +
+                "JOIN host h ON (h.str_tags ~* ('(?x)' || l.str_tags || '\\y') AND h.str_name = ?) " +
                 "LEFT JOIN layer_limit ON layer_limit.pk_layer = l.pk_layer " +
                 "LEFT JOIN limit_record ON limit_record.pk_limit_record = layer_limit.pk_limit_record " +
                 "LEFT JOIN (" +
@@ -1163,7 +1163,7 @@ public class DispatchQuery {
                         "l.pk_layer " +
                     "FROM " +
                         "layer l " +
-                    "JOIN host h ON (h.str_tags ~* ('(?x)' || l.str_tags) AND h.str_name = ?) " +
+                    "JOIN host h ON (h.str_tags ~* ('(?x)' || l.str_tags  || '\\y') AND h.str_name = ?) " +
                     "LEFT JOIN layer_limit ON layer_limit.pk_layer = l.pk_layer " +
                     "LEFT JOIN limit_record ON limit_record.pk_limit_record = layer_limit.pk_limit_record " +
                     "LEFT JOIN (" +

--- a/cuegui/cuegui/MenuActions.py
+++ b/cuegui/cuegui/MenuActions.py
@@ -1576,10 +1576,28 @@ class HostActions(AbstractActions):
                 self._caller, title, body, sorted(allocations.keys()), 0, False)
             if choice:
                 allocation = allocations[str(allocationName)]
+                error_hosts = []
                 for host in hosts:
-                    self.cuebotCall(host.setAllocation,
-                                    "Set Allocation on %s Failed" % host.data.name,
-                                    allocation)
+                    # pylint: disable=broad-except
+                    try:
+                        self.cuebotCall(host.setAllocation,
+                            "Set Allocation on %s Failed" % host.data.name,
+                            allocation)
+                    except Exception as e:
+                        # Handle allocation modification errors separately
+                        # pylint: disable=no-member
+                        if (hasattr(e, "details") and
+                            "EntityModificationError" in str(e.details())):
+                            error_hosts.append(host.name())
+                        else:
+                            raise
+                if error_hosts:
+                    error_msg = "{hosts} not moved.\nHosts with reserved cores " \
+                                "cannot be moved between allocations."
+                    QtWidgets.QMessageBox.warning(self._caller,
+                                "Warning",
+                                error_msg.format(hosts=", ".join(error_hosts)),
+                                QtWidgets.QMessageBox.Ok)
                 self._update()
 
     setRepair_info = ["Set Repair State", None, "configure"]

--- a/cuegui/cuegui/MenuActions.py
+++ b/cuegui/cuegui/MenuActions.py
@@ -164,6 +164,7 @@ class AbstractActions(object):
             self.__actionCache[key] = action
 
         menu.addAction(self.__actionCache[key])
+        return self.__actionCache[key]
 
     def cuebotCall(self, functionToCall, errorMessageTitle, *args):
         """Makes the given call to the Cuebot, displaying exception info if needed.


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Retrying a frame in a finished job will cause the frame to go back into the waiting state and the job will return to the cue. This even bypasses checks on duplicate job names, so two jobs with the same name can be running at the same time. Hence, it should be disallowed to retry frames on finished jobs, and the finished jobs should be read only.

**Summarize your change.**
The cuegui buttons that retry frames, edit dependencies, reorder, etc. are grayed out if the jobs is finished. This should make sure we treat the job as read only once the job is finished.


<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
