### PR TITLE
cuebot: Handle exceptions when moving hosts with running cores

### DIFF
--- a/pycue/opencue/wrappers/host.py
+++ b/pycue/opencue/wrappers/host.py
@@ -19,6 +19,7 @@ import os
 import time
 
 from opencue import Cuebot
+from opencue import util
 from opencue.compiled_proto import comment_pb2
 from opencue.compiled_proto import host_pb2
 import opencue.wrappers.comment
@@ -149,6 +150,7 @@ class Host(object):
             host_pb2.HostRenameTagRequest(host=self.data, old_tag=oldTag, new_tag=newTag),
             timeout=Cuebot.Timeout)
 
+    @util.grpcExceptionParser
     def setAllocation(self, allocation):
         """Sets the host to the given allocation.
 


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
When you attempt to change allocation of a hoist with running cores, cuebot will throw an error that is not handled properly on cuegui side. This will render the application unusable until you relaunch it. 

**Summarize your change.**
When we make a cuebot call, there is a second layer for exception that will take every possible exception. Just like with `CueException`, an error message will appear with explanaition and the user can continue using the application after pressing OK. This will make sure it takes into account any unexpected error thrown by cuebot.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
