### PR TITLE
Open log files in binary mode for Python 3 comp

### DIFF
--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -459,17 +459,17 @@ def getLastLine(path):
     ansiEscape = r'(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]'
 
     try:
-        fp = open(path, 'r')
+        fp = open(path, 'rb')
         fp.seek(0, 2)
 
         backseek = min(4096, fp.tell())
         fp.seek(-backseek, 1)
         buf = fp.read(4096)
 
-        newline_pos = buf.rfind("\n",0,len(buf)-1)
+        newline_pos = buf.rfind(b'\n', 0, len(buf)-1)
         fp.close()
 
-        line = buf[newline_pos+1:].strip()
+        line = buf[newline_pos+1:].strip().decode("utf-8")
 
         return re.sub(ansiEscape, "", line)
     except IOError:


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
We noticed that last Last Line column was broken on Frame Monitor when running on Python 3. The problem was that you cannot seek with negative integer when reading file default.

**Summarize your change.**
Instead of reading file in default manner, we now use binary mode which allows for negative seeking. This fixes reading the log file and hence fixes Last Line.


<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
