### PR TITLE
add .envrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ venv*/
 coverage.xml
 htmlcov/
 /.env
+.envrc


### PR DESCRIPTION
Signed-off-by: Mark Sisson <5761292+marksisson@users.noreply.github.com>

**Link the Issue(s) this Pull Request is related to.**

Fixes #1206

**Summarize your change.**

direnv (https://github.com/direnv/direnv) can be used for local developer workflow enhancements.  direnv uses .envrc file for configuration.  Because .envrc is usually specific to a developer workflow, it is generally not committed.
