### PR TITLE
Add a new property max_show_stale_days to control show expiration rule

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/ShowDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/ShowDaoJdbc.java
@@ -251,7 +251,7 @@ public class ShowDaoJdbc extends JdbcDaoSupport implements ShowDao {
                             "  (DATE_PART('days', NOW()) - DATE_PART('days', dt_last_modified)) < ? " +
                             "GROUP BY pk_show HAVING COUNT(pk_job) > 0) pk_show) " +
                             "  AND str_name NOT IN (?)",
-                    protectedShows, maxShowStaleDays);
+                   maxShowStaleDays, protectedShows);
         }
     }
 

--- a/cuebot/src/main/resources/opencue.properties
+++ b/cuebot/src/main/resources/opencue.properties
@@ -136,8 +136,13 @@ maintenance.auto_delete_down_hosts=false
 # Set hostname/IP of the smtp host. Will be used for mailing
 smtp_host=smtp
 
-# These shows won't be deactivated by the scheduled tasks
-protected_shows=pipe,swtest,edu
+# Flags related to a job that runs periodically to deactivate shows that haven't been
+#  receiving jobs.
+# A comma separated list of shows that won't be deactivated by the scheduled tasks
+protected_shows=testing
+# Number of days a show needs to be stale before it gets deactivated.
+#  -1 means shows should not get deactivated at all.
+max_show_stale_days=-1
 
 # These flags determine whether or not layers/frames will be readonly when job is finished.
 # If flags are set as true, layers/frames cannot be retried, eaten, edited dependency on, etc.


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Fixes #1205 caused by #1151 

**Summarize your change.**
The recently introduced PR #1151 ended up changing the default behaviour of the system, where shows would only be marked as inactive manually. This PR keeps the functionally but adds a new property entry to set the number of days a show needs to be stale (No new jobs) to be marked as inactive and sets the default to -1, which deactivates the feature.
