### PR TITLE
fix: some SQL queries were malformed

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatchQuery.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatchQuery.java
@@ -230,7 +230,7 @@ public class DispatchQuery {
             "AND " +
                 "job.pk_facility =  ? " +
             "AND " +
-                "(job.str_os = ? OR job.str_os IS NULL)" +
+                "(job.str_os = ? OR job.str_os IS NULL) " +
             "AND " +
                 "job.pk_job IN ( " +
                     "SELECT " +
@@ -256,7 +256,7 @@ public class DispatchQuery {
                     "AND " +
                         "j.pk_facility = ? " +
                     "AND " +
-                        "(j.str_os = ? OR j.str_os IS NULL)" +
+                        "(j.str_os = ? OR j.str_os IS NULL) " +
                     "AND " +
                         "(CASE WHEN lst.int_waiting_count > 0 THEN lst.pk_layer ELSE NULL END) = l.pk_layer " +
                     "AND " +
@@ -333,7 +333,7 @@ public class DispatchQuery {
         "AND " +
             "job.pk_facility = ? " +
         "AND " +
-            "(job.str_os = ? OR job.str_os IS NULL)" +
+            "(job.str_os = ? OR job.str_os IS NULL) " +
         "AND " +
             "job.pk_job IN ( " +
                 "SELECT /* index (h i_str_host_tag) */ " +
@@ -354,7 +354,7 @@ public class DispatchQuery {
                 "AND " +
                     "j.pk_facility = ? " +
                 "AND " +
-                    "(j.str_os = ? OR j.str_os IS NULL)" +
+                    "(j.str_os = ? OR j.str_os IS NULL) " +
                 "AND " +
                     "(CASE WHEN lst.int_waiting_count > 0 THEN lst.pk_layer ELSE NULL END) = l.pk_layer " +
                 "AND " +
@@ -426,7 +426,7 @@ public class DispatchQuery {
             "AND " +
                 "(folder_resource.int_max_gpus = -1 OR folder_resource.int_gpus < folder_resource.int_max_gpus) " +
             "AND " +
-                "job_resource.int_priority > ?" +
+                "job_resource.int_priority > ? " +
             "AND " +
                 "job_resource.int_cores < job_resource.int_max_cores " +
             "AND " +
@@ -438,7 +438,7 @@ public class DispatchQuery {
             "AND " +
                 "job.pk_facility = ? " +
             "AND " +
-                "(job.str_os = ? OR job.str_os IS NULL)" +
+                "(job.str_os = ? OR job.str_os IS NULL) " +
             "AND " +
                 "job.pk_job IN ( " +
                     "SELECT /* index (h i_str_host_tag) */ " +
@@ -457,7 +457,7 @@ public class DispatchQuery {
                     "AND " +
                         "j.pk_facility = ? " +
                     "AND " +
-                        "(j.str_os = ? OR j.str_os IS NULL)" +
+                        "(j.str_os = ? OR j.str_os IS NULL) " +
                     "AND " +
                         "(CASE WHEN lst.int_waiting_count > 0 THEN lst.pk_layer ELSE NULL END) = l.pk_layer " +
                     "AND " +

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/FilterDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/FilterDaoJdbc.java
@@ -54,7 +54,7 @@ public class FilterDaoJdbc extends JdbcDaoSupport implements FilterDao {
 
     private static final String GET_ACTIVE_FILTERS =
         "SELECT " +
-            "filter.*" +
+            "filter.* " +
         "FROM " +
             "filter " +
         "WHERE " +
@@ -66,7 +66,7 @@ public class FilterDaoJdbc extends JdbcDaoSupport implements FilterDao {
 
     private static final String GET_FILTERS =
         "SELECT " +
-            "filter.*" +
+            "filter.* " +
         "FROM " +
             "filter " +
         "WHERE " +

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/JobDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/JobDaoJdbc.java
@@ -437,7 +437,7 @@ public class JobDaoJdbc extends JdbcDaoSupport implements JobDao {
             "str_visible_name = NULL, " +
             "ts_stopped = current_timestamp "+
         "WHERE " +
-            "str_state = 'PENDING'" +
+            "str_state = 'PENDING' " +
         "AND " +
             "pk_job = ?";
 
@@ -945,7 +945,7 @@ public class JobDaoJdbc extends JdbcDaoSupport implements JobDao {
         "AND " +
             "job.b_auto_book = true " +
         "AND " +
-            "job_stat.int_waiting_count != 0" +
+            "job_stat.int_waiting_count != 0 " +
         "AND " +
             "job_resource.int_cores < job_resource.int_max_cores " +
         "AND " +

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/ShowDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/ShowDaoJdbc.java
@@ -147,7 +147,7 @@ public class ShowDaoJdbc extends JdbcDaoSupport implements ShowDao {
         "SELECT " +
             "COUNT(show.pk_show) " +
         "FROM " +
-            "show LEFT JOIN show_alias ON (show.pk_show = show_alias.pk_show )" +
+            "show LEFT JOIN show_alias ON (show.pk_show = show_alias.pk_show) " +
         "WHERE " +
             "(show.str_name = ? OR show_alias.str_name = ?) ";
     public boolean showExists(String name) {

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/LayerDaoTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/LayerDaoTests.java
@@ -522,7 +522,7 @@ public class LayerDaoTests extends AbstractTransactionalJUnit4SpringContextTests
                 layer.getLayerId());
 
         jdbcTemplate.update(
-                "UPDATE layer_usage SET int_core_time_success = 3600 * 6" +
+                "UPDATE layer_usage SET int_core_time_success = 3600 * 6 " +
                 "WHERE pk_layer=?", layer.getLayerId());
 
         assertFalse(layerDao.isOptimizable(layer, 5, 3600));
@@ -532,7 +532,7 @@ public class LayerDaoTests extends AbstractTransactionalJUnit4SpringContextTests
          * Assert True
          */
         jdbcTemplate.update(
-                "UPDATE layer_usage SET int_core_time_success = 3500 * 5" +
+                "UPDATE layer_usage SET int_core_time_success = 3500 * 5 " +
                 "WHERE pk_layer=?", layer.getLayerId());
 
         assertTrue(layerDao.isOptimizable(layer, 5, 3600));


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Fixes #1221

**Summarize your change.**
Some SQL query strings were missing spaces and, when appending the strings together, the resulting query had syntax issue.

The main issue was in `cuebot\src\main\java\com\imageworks\spcue\dao\postgres\JobDaoJdbc.java:948` where we had this code:
```java
            "job_stat.int_waiting_count != 0" +
        "AND " +
```

Which would result with that faulty string: `job_stat.int_waiting_count != 0AND`.

Then I searched in the code if there were other issues like this one and found a few.

See also this message in the mailing-list: https://lists.aswf.io/g/opencue-user/topic/95205474#494