### PR TITLE
Debugging xvfb segfault in testing pipeline.

### DIFF
--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -77,7 +77,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run Python Tests
-        run: ci/run_python_tests.sh
+        run: |
+          chown -R aswfuser:aswfgroup .
+          su -c "ci/run_python_tests.sh" aswfuser
 
   test_cuebot_2022:
     name: Build Cuebot and Run Unit Tests (CY2022)

--- a/ci/run_python_tests.sh
+++ b/ci/run_python_tests.sh
@@ -24,6 +24,6 @@ python rqd/setup.py test
 
 # Xvfb no longer supports Python 2.
 if [[ "$python_version" =~ "Python 3" ]]; then
-  xvfb-run --help
+  echo "DISPLAY: ${DISPLAY}"
   PYTHONPATH=pycue xvfb-run -d python cuegui/setup.py test
 fi

--- a/ci/run_python_tests.sh
+++ b/ci/run_python_tests.sh
@@ -24,5 +24,6 @@ python rqd/setup.py test
 
 # Xvfb no longer supports Python 2.
 if [[ "$python_version" =~ "Python 3" ]]; then
+  xvfb-run --help
   PYTHONPATH=pycue xvfb-run -d python cuegui/setup.py test
 fi


### PR DESCRIPTION
Testing pipeline is failing on CY2022 image only. Tests are succeeding but xvfb/xvfb-run is producing a segault:

```
----------------------------------------------------------------------
Ran 209 tests in 3.721s

OK
<cuegui.MenuActions.JobActions object at 0x7f5943a9fc10>
/usr/bin/xvfb-run: line 181:   256 Segmentation fault      (core dumped) DISPLAY=:$SERVERNUM XAUTHORITY=$AUTHFILE "$@" 2>&1
```

Example: https://github.com/AcademySoftwareFoundation/OpenCue/actions/runs/3715944745/jobs/6301701573