### PR TITLE
Add wrapper script for cuegui tests.

### DIFF
--- a/ci/run_gui_test.sh
+++ b/ci/run_gui_test.sh
@@ -7,10 +7,12 @@ echo "#################"
 echo "Done with main test run"
 echo "#################"
 
-
-#ls -l ${test_log}
-#cat ${test_log}
-
 echo "grep"
 grep -Pz 'Ran \d+ tests in [0-9\.]+s\n\nOK' ${test_log}
-echo $?
+if [ $? -eq 0 ]; then
+  echo "Detected passing tests"
+  exit 0
+fi
+
+echo "Detected test failure"
+exit 1

--- a/ci/run_gui_test.sh
+++ b/ci/run_gui_test.sh
@@ -12,7 +12,5 @@ echo "#################"
 #cat ${test_log}
 
 echo "grep"
-grep -Pzl 'Ran \d+ tests in [0-9\.]+s\n\nOK' ${test_log}
-
-echo "pcregrep"
-pcregrep -M 'Ran \d+ tests in [0-9\.]+s\n\nOK' ${test_log}
+grep -Pz 'Ran \d+ tests in [0-9\.]+s\n\nOK' ${test_log}
+echo $?

--- a/ci/run_gui_test.sh
+++ b/ci/run_gui_test.sh
@@ -1,13 +1,22 @@
 #!/bin/bash
 
+# Wrapper script for CueGUI tests.
+#
+# xvfb-run sometimes crashes on exit, we haven't been able to figure out why yet.
+# This means that tests may pass but the xvfb-run crash will generate a non-zero exit code
+# and cause our CI pipeline to fail.
+#
+# We work around this by capturing unit test output and looking for the text that indicates
+# tests have passed:
+#
+# > Ran 209 tests in 4.394s
+# >
+# > OK
+#
+
 test_log="/tmp/cuegui_result.log"
 PYTHONPATH=pycue xvfb-run -d python cuegui/setup.py test | tee ${test_log}
 
-echo "#################"
-echo "Done with main test run"
-echo "#################"
-
-echo "grep"
 grep -Pz 'Ran \d+ tests in [0-9\.]+s\n\nOK' ${test_log}
 if [ $? -eq 0 ]; then
   echo "Detected passing tests"

--- a/ci/run_gui_test.sh
+++ b/ci/run_gui_test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+stderr_log="/tmp/stderr.log"
+PYTHONPATH=pycue xvfb-run -d python cuegui/setup.py test 2> >(tee ${stderr_log} >&2)
+
+echo "#################"
+echo "Done with main test run"
+echo "#################"
+
+cat ${stderr_log}
+

--- a/ci/run_gui_test.sh
+++ b/ci/run_gui_test.sh
@@ -7,6 +7,12 @@ echo "#################"
 echo "Done with main test run"
 echo "#################"
 
-ls -l ${test_log}
-cat ${test_log}
 
+#ls -l ${test_log}
+#cat ${test_log}
+
+echo "grep"
+grep -Pzl 'Ran \d+ tests in [0-9\.]+s\n\nOK' ${test_log}
+
+echo "pcregrep"
+pcregrep -M 'Ran \d+ tests in [0-9\.]+s\n\nOK' ${test_log}

--- a/ci/run_gui_test.sh
+++ b/ci/run_gui_test.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-stderr_log="/tmp/stderr.log"
-PYTHONPATH=pycue xvfb-run -d python cuegui/setup.py test 2> >(tee ${stderr_log} >&2)
+test_log="/tmp/cuegui_result.log"
+PYTHONPATH=pycue xvfb-run -d python cuegui/setup.py test | tee ${test_log}
 
 echo "#################"
 echo "Done with main test run"
 echo "#################"
 
-cat ${stderr_log}
+ls -l ${test_log}
+cat ${test_log}
 

--- a/ci/run_python_tests.sh
+++ b/ci/run_python_tests.sh
@@ -9,18 +9,18 @@ pip install --user -r requirements.txt -r requirements_gui.txt
 
 # Protos need to have their Python code generated in order for tests to pass.
 python -m grpc_tools.protoc -I=proto/ --python_out=pycue/opencue/compiled_proto --grpc_python_out=pycue/opencue/compiled_proto proto/*.proto
-#python -m grpc_tools.protoc -I=proto/ --python_out=rqd/rqd/compiled_proto --grpc_python_out=rqd/rqd/compiled_proto proto/*.proto
+python -m grpc_tools.protoc -I=proto/ --python_out=rqd/rqd/compiled_proto --grpc_python_out=rqd/rqd/compiled_proto proto/*.proto
 
 # Fix imports to work in both Python 2 and 3. See
 # <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
 2to3 -wn -f import pycue/opencue/compiled_proto/*_pb2*.py
-#2to3 -wn -f import rqd/rqd/compiled_proto/*_pb2*.py
+2to3 -wn -f import rqd/rqd/compiled_proto/*_pb2*.py
 
-#python pycue/setup.py test
-#PYTHONPATH=pycue python pyoutline/setup.py test
-#PYTHONPATH=pycue python cueadmin/setup.py test
-#PYTHONPATH=pycue:pyoutline python cuesubmit/setup.py test
-#python rqd/setup.py test
+python pycue/setup.py test
+PYTHONPATH=pycue python pyoutline/setup.py test
+PYTHONPATH=pycue python cueadmin/setup.py test
+PYTHONPATH=pycue:pyoutline python cuesubmit/setup.py test
+python rqd/setup.py test
 
 # Xvfb no longer supports Python 2.
 if [[ "$python_version" =~ "Python 3" ]]; then

--- a/ci/run_python_tests.sh
+++ b/ci/run_python_tests.sh
@@ -9,20 +9,20 @@ pip install --user -r requirements.txt -r requirements_gui.txt
 
 # Protos need to have their Python code generated in order for tests to pass.
 python -m grpc_tools.protoc -I=proto/ --python_out=pycue/opencue/compiled_proto --grpc_python_out=pycue/opencue/compiled_proto proto/*.proto
-python -m grpc_tools.protoc -I=proto/ --python_out=rqd/rqd/compiled_proto --grpc_python_out=rqd/rqd/compiled_proto proto/*.proto
+#python -m grpc_tools.protoc -I=proto/ --python_out=rqd/rqd/compiled_proto --grpc_python_out=rqd/rqd/compiled_proto proto/*.proto
 
 # Fix imports to work in both Python 2 and 3. See
 # <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
 2to3 -wn -f import pycue/opencue/compiled_proto/*_pb2*.py
-2to3 -wn -f import rqd/rqd/compiled_proto/*_pb2*.py
+#2to3 -wn -f import rqd/rqd/compiled_proto/*_pb2*.py
 
-python pycue/setup.py test
-PYTHONPATH=pycue python pyoutline/setup.py test
-PYTHONPATH=pycue python cueadmin/setup.py test
-PYTHONPATH=pycue:pyoutline python cuesubmit/setup.py test
-python rqd/setup.py test
+#python pycue/setup.py test
+#PYTHONPATH=pycue python pyoutline/setup.py test
+#PYTHONPATH=pycue python cueadmin/setup.py test
+#PYTHONPATH=pycue:pyoutline python cuesubmit/setup.py test
+#python rqd/setup.py test
 
 # Xvfb no longer supports Python 2.
 if [[ "$python_version" =~ "Python 3" ]]; then
-  PYTHONPATH=pycue xvfb-run -d python cuegui/setup.py test
+  ci/run_gui_test.sh
 fi

--- a/cuegui/tests/MenuActions_tests.py
+++ b/cuegui/tests/MenuActions_tests.py
@@ -65,7 +65,7 @@ class JobActionsTests(unittest.TestCase):
         self.job_actions = cuegui.MenuActions.JobActions(self.widgetMock, mock.Mock(), None, None)
 
     def test_jobs(self):
-        print(cuegui.MenuActions.MenuActions(self.widgetMock, None, None, None).jobs())
+        cuegui.MenuActions.MenuActions(self.widgetMock, None, None, None).jobs()
 
     def test_unmonitor(self):
         self.job_actions.unmonitor()

--- a/cuegui/tests/Utils_tests.py
+++ b/cuegui/tests/Utils_tests.py
@@ -49,6 +49,7 @@ class UtilsTests(unittest.TestCase):
         invalidJobId = 'arbitrary$String##With*Disallowed@Characters'
 
         self.assertIsNone(cuegui.Utils.findJob(invalidJobId))
+        self.assertTrue(False)
 
     @mock.patch('opencue.api.findJob')
     def test_shouldSearchForJobByName(self, findJobMock):

--- a/cuegui/tests/Utils_tests.py
+++ b/cuegui/tests/Utils_tests.py
@@ -49,7 +49,6 @@ class UtilsTests(unittest.TestCase):
         invalidJobId = 'arbitrary$String##With*Disallowed@Characters'
 
         self.assertIsNone(cuegui.Utils.findJob(invalidJobId))
-        self.assertTrue(False)
 
     @mock.patch('opencue.api.findJob')
     def test_shouldSearchForJobByName(self, findJobMock):


### PR DESCRIPTION
Recently CueGUI unit tests have been crashing intermittently on GitHub because of some issue during `xvfb-run` shutdown:

```
----------------------------------------------------------------------
Ran 209 tests in 4.394s

OK
<cuegui.MenuActions.JobActions object at 0x7f61ae684f70>
/usr/bin/xvfb-run: line 181:   259 Segmentation fault      (core dumped) DISPLAY=:$SERVERNUM XAUTHORITY=$AUTHFILE "$@" 2>&1
```

Unit tests are passing, but because of that segfault the whole pipeline is showing as failed.

I've tried to debug the segfault without any luck, so I'm resorting to creating a wrapper script that can handle this instead.