### PR TITLE
Replace deprecated CI actions.

### DIFF
--- a/.github/workflows/packaging-pipeline.yml
+++ b/.github/workflows/packaging-pipeline.yml
@@ -43,7 +43,7 @@ jobs:
     name: Build ${{ matrix.NAME }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Fetch all Git history, otherwise the current version number will
           # not be correctly calculated.
@@ -101,7 +101,7 @@ jobs:
     name: Create Other Build Artifacts
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Fetch all Git history, otherwise the current version number will
           # not be correctly calculated.

--- a/.github/workflows/packaging-pipeline.yml
+++ b/.github/workflows/packaging-pipeline.yml
@@ -58,6 +58,12 @@ jobs:
           role-to-assume: ${{ secrets.AWS_S3_ROLE }}
           role-duration-seconds: 1800
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+
       - name: Set build ID
         run: |
           set -e
@@ -66,13 +72,11 @@ jobs:
           echo "BUILD_ID=$(cat ./VERSION)" >> ${GITHUB_ENV}
 
       - name: Build Docker image
-        uses: docker/build-push-action@v1
+        uses: docker/build-push-action@v3
         with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASS }}
-          dockerfile: ${{ matrix.component }}/Dockerfile
-          repository: opencuebuild/${{ matrix.component }}
-          tags: ${{ env.BUILD_ID }}
+          file: ${{ matrix.component }}/Dockerfile
+          tags: opencuebuild/${{ matrix.component }}:${{ env.BUILD_ID }}
+          push: true
 
       - name: Extract Artifacts
         run: |

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -12,7 +12,7 @@ jobs:
     name: Preflight
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -45,7 +45,7 @@ jobs:
     name: Release ${{ matrix.component }} Docker image
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/artifacts/"
           aws s3 sync "s3://${S3_BUCKET}/opencue/${BUILD_ID}/" "${GITHUB_WORKSPACE}/artifacts/"
-          echo "::set-output name=filenames::$(ls "${GITHUB_WORKSPACE}/artifacts/" | xargs)"
+          echo "filenames=$(ls "${GITHUB_WORKSPACE}/artifacts/" | xargs)" >> $GITHUB_OUTPUT
 
       - name: List artifacts
         run: |
@@ -116,7 +116,7 @@ jobs:
           commits_since_last_release=$(git log --reverse --pretty="* %H %s" ${last_tagged_version}..HEAD)
           # See https://github.community/t/set-output-truncates-multiline-strings/16852
           commits_since_last_release="${commits_since_last_release//$'\n'/'%0A'}"
-          echo "::set-output name=commits::${commits_since_last_release}"
+          echo "commits=${commits_since_last_release}" >> $GITHUB_OUTPUT
 
       - name: Create release
         id: create_release

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -61,14 +61,18 @@ jobs:
           set -e
           docker pull opencuebuild/${{ matrix.component }}:${BUILD_ID}
 
-      - name: Rebuild and push Docker image
-        uses: docker/build-push-action@v1
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
-          dockerfile: ${{ matrix.component }}/Dockerfile
-          repository: opencue/${{ matrix.component }}
-          tags: ${{ env.BUILD_ID }}, latest
+
+      - name: Rebuild and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          file: ${{ matrix.component }}/Dockerfile
+          tags: opencue/${{ matrix.component }}:${{ env.BUILD_ID }},opencue/${{ matrix.component }}:latest
+          push: true
 
   create_release:
     needs: preflight
@@ -114,9 +118,8 @@ jobs:
         run: |
           last_tagged_version=$(git describe --tags --abbrev=0 $(git rev-list --tags --skip=1 --max-count=1))
           commits_since_last_release=$(git log --reverse --pretty="* %H %s" ${last_tagged_version}..HEAD)
+          # Use a delimiter to preserve the multiline string.
           # See https://github.community/t/set-output-truncates-multiline-strings/16852
-          #commits_since_last_release="${commits_since_last_release//$'\n'/'%0A'}"
-          #echo "commits=${commits_since_last_release}" >> ${GITHUB_OUTPUT}
           delimiter="$(openssl rand -hex 8)"
           echo "commits<<${delimiter}" >> ${GITHUB_OUTPUT}
           echo "${commits_since_last_release}" >> ${GITHUB_OUTPUT}

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/artifacts/"
           aws s3 sync "s3://${S3_BUCKET}/opencue/${BUILD_ID}/" "${GITHUB_WORKSPACE}/artifacts/"
-          echo "filenames=$(ls "${GITHUB_WORKSPACE}/artifacts/" | xargs)" >> $GITHUB_OUTPUT
+          echo "filenames=$(ls "${GITHUB_WORKSPACE}/artifacts/" | xargs)" >> ${GITHUB_OUTPUT}
 
       - name: List artifacts
         run: |
@@ -116,7 +116,7 @@ jobs:
           commits_since_last_release=$(git log --reverse --pretty="* %H %s" ${last_tagged_version}..HEAD)
           # See https://github.community/t/set-output-truncates-multiline-strings/16852
           commits_since_last_release="${commits_since_last_release//$'\n'/'%0A'}"
-          echo "commits=${commits_since_last_release}" >> $GITHUB_OUTPUT
+          echo "commits=${commits_since_last_release}" >> ${GITHUB_OUTPUT}
 
       - name: Create release
         id: create_release

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -115,8 +115,12 @@ jobs:
           last_tagged_version=$(git describe --tags --abbrev=0 $(git rev-list --tags --skip=1 --max-count=1))
           commits_since_last_release=$(git log --reverse --pretty="* %H %s" ${last_tagged_version}..HEAD)
           # See https://github.community/t/set-output-truncates-multiline-strings/16852
-          commits_since_last_release="${commits_since_last_release//$'\n'/'%0A'}"
-          echo "commits=${commits_since_last_release}" >> ${GITHUB_OUTPUT}
+          #commits_since_last_release="${commits_since_last_release//$'\n'/'%0A'}"
+          #echo "commits=${commits_since_last_release}" >> ${GITHUB_OUTPUT}
+          delimiter="$(openssl rand -hex 8)"
+          echo "commits<<${delimiter}" >> ${GITHUB_OUTPUT}
+          echo "${commits_since_last_release}" >> ${GITHUB_OUTPUT}
+          echo "${delimiter}" >> ${GITHUB_OUTPUT}
 
       - name: Create release
         id: create_release

--- a/.github/workflows/sonar-cloud-pipeline.yml
+++ b/.github/workflows/sonar-cloud-pipeline.yml
@@ -12,7 +12,7 @@ jobs:
     name: Analyze Python Components
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Fetch all Git history, otherwise the current version number will
           # not be correctly calculated.
@@ -33,7 +33,7 @@ jobs:
     name: Analyze Cuebot
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Fetch all Git history, otherwise the current version number will
           # not be correctly calculated.

--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -155,8 +155,12 @@ jobs:
           last_tagged_version=$(git describe --tags --abbrev=0 $(git rev-list --tags --skip=1 --max-count=1))
           commits_since_last_release=$(git log --reverse --pretty="* %H %s" ${last_tagged_version}..HEAD)
           # See https://github.community/t/set-output-truncates-multiline-strings/16852
-          commits_since_last_release="${commits_since_last_release//$'\n'/'%0A'}"
-          echo "commits=${commits_since_last_release}" >> ${GITHUB_OUTPUT}
+          #commits_since_last_release="${commits_since_last_release//$'\n'/'%0A'}"
+          #echo "commits=${commits_since_last_release}" >> ${GITHUB_OUTPUT}
+          delimiter="$(openssl rand -hex 8)"
+          echo "commits<<${delimiter}" >> ${GITHUB_OUTPUT}
+          echo "${commits_since_last_release}" >> ${GITHUB_OUTPUT}
+          echo "${delimiter}" >> ${GITHUB_OUTPUT}
 
       - name: List commits
         run: |

--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -139,3 +139,25 @@ jobs:
         uses: tj-actions/changed-files@v35
       - name: Check for Version Change
         run: ci/check_version_bump.py ${{ steps.get_changed_files.outputs.all_changed_and_modified_files }}
+
+  test_escaping:
+    name: Test Multiline Escaping
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Generate release notes
+        id: release_notes
+        run: |
+          last_tagged_version=$(git describe --tags --abbrev=0 $(git rev-list --tags --skip=1 --max-count=1))
+          commits_since_last_release=$(git log --reverse --pretty="* %H %s" ${last_tagged_version}..HEAD)
+          # See https://github.community/t/set-output-truncates-multiline-strings/16852
+          commits_since_last_release="${commits_since_last_release//$'\n'/'%0A'}"
+          echo "commits=${commits_since_last_release}" >> $GITHUB_OUTPUT
+
+      - name: List commits
+        run: |
+          echo ${{ steps.release_notes.outputs.commits }}

--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -156,8 +156,8 @@ jobs:
           commits_since_last_release=$(git log --reverse --pretty="* %H %s" ${last_tagged_version}..HEAD)
           # See https://github.community/t/set-output-truncates-multiline-strings/16852
           commits_since_last_release="${commits_since_last_release//$'\n'/'%0A'}"
-          echo "commits=${commits_since_last_release}" >> $GITHUB_OUTPUT
+          echo "commits=${commits_since_last_release}" >> ${GITHUB_OUTPUT}
 
       - name: List commits
         run: |
-          echo ${{ steps.release_notes.outputs.commits }}
+          echo "${{ steps.release_notes.outputs.commits }}"

--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -139,29 +139,3 @@ jobs:
         uses: tj-actions/changed-files@v35
       - name: Check for Version Change
         run: ci/check_version_bump.py ${{ steps.get_changed_files.outputs.all_changed_and_modified_files }}
-
-  test_escaping:
-    name: Test Multiline Escaping
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Generate release notes
-        id: release_notes
-        run: |
-          last_tagged_version=$(git describe --tags --abbrev=0 $(git rev-list --tags --skip=1 --max-count=1))
-          commits_since_last_release=$(git log --reverse --pretty="* %H %s" ${last_tagged_version}..HEAD)
-          # See https://github.community/t/set-output-truncates-multiline-strings/16852
-          #commits_since_last_release="${commits_since_last_release//$'\n'/'%0A'}"
-          #echo "commits=${commits_since_last_release}" >> ${GITHUB_OUTPUT}
-          delimiter="$(openssl rand -hex 8)"
-          echo "commits<<${delimiter}" >> ${GITHUB_OUTPUT}
-          echo "${commits_since_last_release}" >> ${GITHUB_OUTPUT}
-          echo "${delimiter}" >> ${GITHUB_OUTPUT}
-
-      - name: List commits
-        run: |
-          echo "${{ steps.release_notes.outputs.commits }}"

--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     container: aswf/ci-opencue:2019
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run Python Tests
         run: ci/run_python_tests.sh
 
@@ -22,7 +22,7 @@ jobs:
     container:
       image: aswf/ci-opencue:2019
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build with Gradle
       run: |
         chown -R aswfuser:aswfgroup .
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     container: aswf/ci-opencue:2020
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run Python Tests
         run: ci/run_python_tests.sh
 
@@ -43,7 +43,7 @@ jobs:
     container:
       image: aswf/ci-opencue:2020
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build with Gradle
         run: |
           chown -R aswfuser:aswfgroup .
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     container: aswf/ci-opencue:2021
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run Python Tests
         run: ci/run_python_tests.sh
 
@@ -64,7 +64,7 @@ jobs:
     container:
       image: aswf/ci-opencue:2021
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build with Gradle
         run: |
           chown -R aswfuser:aswfgroup .
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     container: aswf/ci-opencue:2022
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run Python Tests
         run: ci/run_python_tests.sh
 
@@ -85,7 +85,7 @@ jobs:
     container:
       image: aswf/ci-opencue:2022
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build with Gradle
         run: |
           chown -R aswfuser:aswfgroup .
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     container: aswf/ci-opencue:2022
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Lint Python Code
         run: ci/run_python_lint.sh
 
@@ -106,7 +106,7 @@ jobs:
     container:
       image: aswf/ci-opencue:2020
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run Sphinx build
         run: ci/build_sphinx_docs.sh
 
@@ -114,7 +114,7 @@ jobs:
     name: Check Changed Files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get Changed Files
         id: get_changed_files
         uses: jitterbit/get-changed-files@v1
@@ -125,7 +125,7 @@ jobs:
     name: Check Database Migration Files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Check Migration Files
         run: ci/check_database_migrations.py
 
@@ -133,7 +133,7 @@ jobs:
     name: Check for Version Bump
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get Changed Files
         id: get_changed_files
         uses: jitterbit/get-changed-files@v1

--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -117,9 +117,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Get Changed Files
         id: get_changed_files
-        uses: jitterbit/get-changed-files@v1
+        uses: tj-actions/changed-files@v35
       - name: Check for Version Change
-        run: ci/check_changed_files.py ${{ steps.get_changed_files.outputs.modified }} ${{ steps.get_changed_files.outputs.removed }}
+        run: ci/check_changed_files.py ${{ steps.get_changed_files.outputs.modified_files }} ${{ steps.get_changed_files.outputs.deleted_files }}
 
   check_migration_files:
     name: Check Database Migration Files
@@ -136,6 +136,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Get Changed Files
         id: get_changed_files
-        uses: jitterbit/get-changed-files@v1
+        uses: tj-actions/changed-files@v35
       - name: Check for Version Change
-        run: ci/check_version_bump.py ${{ steps.get_changed_files.outputs.all }}
+        run: ci/check_version_bump.py ${{ steps.get_changed_files.outputs.all_changed_and_modified_files }}

--- a/cuebot/src/main/resources/conf/ddl/postgres/migrations/V15__Add_min_memory_increase_service.sql
+++ b/cuebot/src/main/resources/conf/ddl/postgres/migrations/V15__Add_min_memory_increase_service.sql
@@ -2,4 +2,4 @@
 -- Add minimum memory increase - default 2G
 
 ALTER TABLE show_service ADD COLUMN int_min_memory_increase INT DEFAULT 2097152 NOT NULL;
-ALTER TABLE service ADD COLUMN int_min_memory_increase INT DEFAULT 2097152 NOT NULL;
+ALTER TABLE service ADD COLUMN int_min_memory_increase INT DEFAULT 2097153 NOT NULL;

--- a/cuebot/src/main/resources/conf/ddl/postgres/migrations/V15__Add_min_memory_increase_service.sql
+++ b/cuebot/src/main/resources/conf/ddl/postgres/migrations/V15__Add_min_memory_increase_service.sql
@@ -2,4 +2,4 @@
 -- Add minimum memory increase - default 2G
 
 ALTER TABLE show_service ADD COLUMN int_min_memory_increase INT DEFAULT 2097152 NOT NULL;
-ALTER TABLE service ADD COLUMN int_min_memory_increase INT DEFAULT 2097153 NOT NULL;
+ALTER TABLE service ADD COLUMN int_min_memory_increase INT DEFAULT 2097152 NOT NULL;


### PR DESCRIPTION
CI pipelines are functioning but producing several warnings about deprecated features we're using.

* Upgrade to `actions/checkout@v3` which uses Node 16.
* Upgrade to `docker/build-push-action@v3`.
* Replace deprecated `set-output` with new `$GITHUB_OUTPUT` env var. This uses a new method for protecting multiline strings.
* Replace `jitterbit/get-changed-files@v1` with `tj-actions/changed-files@v35`.