### PR TITLE
Lock evdev dependency for Python 2.

### DIFF
--- a/ci/run_python_tests.sh
+++ b/ci/run_python_tests.sh
@@ -6,8 +6,6 @@ python_version=$(python -V 2>&1)
 echo "Will run tests using ${python_version}"
 
 pip install --user -r requirements.txt -r requirements_gui.txt
-pip install pipdeptree
-pipdeptree
 
 # Protos need to have their Python code generated in order for tests to pass.
 python -m grpc_tools.protoc -I=proto/ --python_out=pycue/opencue/compiled_proto --grpc_python_out=pycue/opencue/compiled_proto proto/*.proto

--- a/ci/run_python_tests.sh
+++ b/ci/run_python_tests.sh
@@ -2,10 +2,12 @@
 
 set -e
 
-python_version=$(python -V)
+python_version=$(python -V 2>&1)
 echo "Will run tests using ${python_version}"
 
 pip install --user -r requirements.txt -r requirements_gui.txt
+pip install pipdeptree
+pipdeptree
 
 # Protos need to have their Python code generated in order for tests to pass.
 python -m grpc_tools.protoc -I=proto/ --python_out=pycue/opencue/compiled_proto --grpc_python_out=pycue/opencue/compiled_proto proto/*.proto

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 2to3==1.0
 enum34==1.1.6
-evdev==1.4.0;python_version<"3.0" and sys_platform=="linux"
+evdev==1.4.0;python_version<"3.0" and "linux" in sys_platform
 future==0.17.1
 futures==3.2.0;python_version<"3.0"
 grpcio==1.26.0;python_version<"3.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 2to3==1.0
 enum34==1.1.6
+evdev==1.4.0;python_version<"3.0" and sys_platform=="linux"
 future==0.17.1
 futures==3.2.0;python_version<"3.0"
 grpcio==1.26.0;python_version<"3.0"


### PR DESCRIPTION
Installing dependencies is currently failing for Python 2:

```
Collecting evdev>=1.3; "linux" in sys_platform
  Downloading evdev-1.6.1.tar.gz (26 kB)
    ERROR: Command errored out with exit status 1:
     command: /usr/local/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-6TVjAa/evdev/setup.py'"'"'; __file__='"'"'/tmp/pip-install-6TVjAa/evdev/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-bH2XrD
         cwd: /tmp/pip-install-6TVjAa/evdev/
    Complete output (6 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-6TVjAa/evdev/setup.py", line 103
        cmd = [sys.executable, 'evdev/genecodes.py', *headers]
```

The `evdev` is used by our recently added `pynput` dependency, but only on Linux.

The evdev project dropped Python 2 support in v1.5.0, however it continued to work until now. The recent v1.6.1 release uses a syntax that is no longer compatible with Python 2.

On Linux, lock `evdev` to 1.4.0, the last version to support Python 2. This still satisfies pynput's requirement of `evdev >= 1.3`.