### PR TITLE
Configure test logging for gradle --info and --debug.

### DIFF
--- a/cuebot/build.gradle
+++ b/cuebot/build.gradle
@@ -1,4 +1,7 @@
 
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+
 buildscript {
     repositories {
         mavenCentral()
@@ -166,4 +169,27 @@ sonarqube {
 tasks.withType(AbstractArchiveTask) {
     preserveFileTimestamps = false
     reproducibleFileOrder = true
+}
+
+tasks.withType(Test) {
+    // Configure logging when running Gradle with --info or --debug.
+    testLogging {
+        info {
+            // Don't show STANDARD_OUT messages, these clutter up the output
+            // and make it hard to find actual failures.
+            events TestLogEvent.FAILED
+            exceptionFormat TestExceptionFormat.FULL
+            showStandardStreams false
+        }
+        debug {
+            // Show everything.
+            events TestLogEvent.STARTED,
+                   TestLogEvent.FAILED,
+                   TestLogEvent.PASSED,
+                   TestLogEvent.SKIPPED,
+                   TestLogEvent.STANDARD_ERROR,
+                   TestLogEvent.STANDARD_OUT
+            exceptionFormat TestExceptionFormat.FULL
+        }
+   }
 }


### PR DESCRIPTION
Our Docker images uses `gradle build --info` to build Cuebot and run tests. `--info` produces a lot of useful output, but by default it includes many `STANDARD_OUT` messages from various tests. These messages are not useful, and they clutter up the test logs making it hard to find test failures when they happen.

Define `testLogging` in `build.gradle` to only show failure message when using `--info`.

`--debug` will enable logging of all messages if this is needed for some reason.