### PR TITLE
Remove obsolete pyoutline subdir from Dockerfiles.

### DIFF
--- a/cuesubmit/Dockerfile
+++ b/cuesubmit/Dockerfile
@@ -41,7 +41,6 @@ RUN 2to3 -wn -f import pycue/opencue/compiled_proto/*_pb2*.py
 COPY pyoutline/README.md ./pyoutline/
 COPY pyoutline/setup.py ./pyoutline/
 COPY pyoutline/bin ./pyoutline/bin
-COPY pyoutline/etc ./pyoutline/etc
 COPY pyoutline/wrappers ./pyoutline/wrappers
 COPY pyoutline/outline ./pyoutline/outline
 

--- a/pyoutline/Dockerfile
+++ b/pyoutline/Dockerfile
@@ -29,7 +29,6 @@ RUN 2to3 -wn -f import pycue/opencue/compiled_proto/*_pb2*.py
 COPY pyoutline/README.md ./pyoutline/
 COPY pyoutline/setup.py ./pyoutline/
 COPY pyoutline/bin ./pyoutline/bin
-COPY pyoutline/etc ./pyoutline/etc
 COPY pyoutline/tests/ ./pyoutline/tests
 COPY pyoutline/wrappers ./pyoutline/wrappers
 COPY pyoutline/outline ./pyoutline/outline


### PR DESCRIPTION
`etc/` was removed in #1252.