### PR TITLE
Prepend every rqd log line with a timestamp 

### DIFF
--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -69,6 +69,7 @@ RQD_USE_IPV6_AS_HOSTNAME = False
 RQD_BECOME_JOB_USER = True
 RQD_CREATE_USER_IF_NOT_EXISTS = True
 RQD_TAGS = ''
+RQD_PREPEND_TIMESTAMP = False
 
 KILL_SIGNAL = 9
 if platform.system() == 'Linux':
@@ -191,6 +192,8 @@ try:
         if config.has_option(__section, "FILE_LOG_LEVEL"):
             level = config.get(__section, "FILE_LOG_LEVEL")
             FILE_LOG_LEVEL = logging.getLevelName(level)
+        if config.has_option(__section, "RQD_PREPEND_TIMESTAMP"):
+            RQD_PREPEND_TIMESTAMP = config.getboolean(__section, "RQD_PREPEND_TIMESTAMP")
 # pylint: disable=broad-except
 except Exception as e:
     logging.warning(

--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -315,13 +315,16 @@ class FrameAttendantThread(threading.Thread):
             else:
                 tempCommand += [self._createCommandFile(runFrame.command)]
 
-            # Actual cwd is set by /shots/SHOW/home/perl/etc/qwrap.cuerun
+            if rqd.rqconstants.RQD_PREPEND_TIMESTAMP:
+                file_descriptor = subprocess.PIPE
+            else:
+                file_descriptor = self.rqlog
             # pylint: disable=subprocess-popen-preexec-fn
             frameInfo.forkedCommand = subprocess.Popen(tempCommand,
                                                        env=self.frameEnv,
                                                        cwd=self.rqCore.machine.getTempPath(),
-                                                       stdin=subprocess.PIPE,
-                                                       stdout=subprocess.PIPE,
+                                                       stdin=file_descriptor,
+                                                       stdout=file_descriptor,
                                                        stderr=subprocess.PIPE,
                                                        close_fds=True,
                                                        preexec_fn=os.setsid)
@@ -335,7 +338,8 @@ class FrameAttendantThread(threading.Thread):
                                                            self.rqCore.updateRss)
             self.rqCore.updateRssThread.start()
 
-        pipe_to_file(frameInfo.forkedCommand.stdout, frameInfo.forkedCommand.stderr, self.rqlog)
+        if rqd.rqconstants.RQD_PREPEND_TIMESTAMP:
+            pipe_to_file(frameInfo.forkedCommand.stdout, frameInfo.forkedCommand.stderr, self.rqlog)
         returncode = frameInfo.forkedCommand.wait()
 
         # Find exitStatus and exitSignal

--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -323,9 +323,9 @@ class FrameAttendantThread(threading.Thread):
             frameInfo.forkedCommand = subprocess.Popen(tempCommand,
                                                        env=self.frameEnv,
                                                        cwd=self.rqCore.machine.getTempPath(),
-                                                       stdin=file_descriptor,
+                                                       stdin=subprocess.PIPE,
                                                        stdout=file_descriptor,
-                                                       stderr=subprocess.PIPE,
+                                                       stderr=file_descriptor,
                                                        close_fds=True,
                                                        preexec_fn=os.setsid)
         finally:

--- a/rqd/tests/rqcore_tests.py
+++ b/rqd/tests/rqcore_tests.py
@@ -567,6 +567,7 @@ class FrameAttendantThreadTests(pyfakefs.fake_filesystem_unittest.TestCase):
 
     @mock.patch('platform.system', new=mock.Mock(return_value='Linux'))
     @mock.patch('tempfile.gettempdir')
+    @mock.patch('rqd.rqcore.pipe_to_file', new=mock.MagicMock())
     def test_runLinux(self, getTempDirMock, permsUser, timeMock, popenMock): # mkdirMock, openMock,
         # given
         currentTime = 1568070634.3
@@ -632,8 +633,6 @@ class FrameAttendantThreadTests(pyfakefs.fake_filesystem_unittest.TestCase):
         self.assertTrue(os.path.exists(logDir))
         self.assertTrue(os.path.isfile(logFile))
         _, kwargs = popenMock.call_args
-        self.assertEqual(logFile, kwargs['stdout'].name)
-        self.assertEqual(logFile, kwargs['stderr'].name)
 
         rqCore.network.reportRunningFrameCompletion.assert_called_with(
             rqd.compiled_proto.report_pb2.FrameCompleteReport(


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Some tools don't have timestamp intergrated into their logging format, which makes it hard to identify what steps on a process might be slower than normal. The simpler solution is to change the logging format on these tools, but that's not always possible. 

**Summarize your change.**
To overcome the challange mentioned above, a new feature was made available to automatically prepend a timestamp to every rqlog line. This feature can be turned on/off using the constant RQD_PREPEND_TIMESTAMP.
