### PR TITLE
Fix reading stats from /proc/{pid}/statm

### DIFF
--- a/rqd/rqd/rqmachine.py
+++ b/rqd/rqd/rqmachine.py
@@ -216,7 +216,9 @@ class Machine(object):
 
     def _getStatFields(self, pidFilePath):
         with open(pidFilePath, "r") as statFile:
-            return [None, None] + statFile.read().rsplit(")", 1)[-1].split()
+            stats = statFile.read().split()
+            stats[1] = stats[1].strip('()')
+            return stats
 
     def rssUpdate(self, frames):
         """Updates the rss and maxrss for all running frames"""


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
https://github.com/AcademySoftwareFoundation/OpenCue/issues/1307

**Summarize your change.**
Before, `Machine._getStatFields()` was always returning [None. None] as the first 2 values, which were used later for `statm_size` and `statm_rss` and would always fail.
