### PR TITLE
Fix pynput import error in RQD docker

### DIFF
--- a/rqd/Dockerfile
+++ b/rqd/Dockerfile
@@ -53,7 +53,7 @@ RUN versioned_name="rqd-$(cat ./VERSION)-all" \
   && ln -s $versioned_name rqd
 
 RUN mkdir -p /etc/opencue
-RUN echo "[Override]" >> /etc/opencue/rqd.conf
+RUN echo "[Override]" > /etc/opencue/rqd.conf
 RUN echo "USE_NIMBY_PYNPUT=false" >> /etc/opencue/rqd.conf
 
 # RQD gRPC server

--- a/rqd/Dockerfile
+++ b/rqd/Dockerfile
@@ -52,6 +52,10 @@ RUN versioned_name="rqd-$(cat ./VERSION)-all" \
   && tar -cvzf $versioned_name.tar.gz $versioned_name/* \
   && ln -s $versioned_name rqd
 
+RUN mkdir -p /etc/opencue
+RUN echo "[Override]" >> /etc/opencue/rqd.conf
+RUN echo "USE_NIMBY_PYNPUT=false" >> /etc/opencue/rqd.conf
+
 # RQD gRPC server
 EXPOSE 8444
 

--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -172,6 +172,8 @@ try:
             CUEBOT_HOSTNAME = config.get(__section, "OVERRIDE_CUEBOT")
         if config.has_option(__section, "OVERRIDE_NIMBY"):
             OVERRIDE_NIMBY = config.getboolean(__section, "OVERRIDE_NIMBY")
+        if config.has_option(__section, "USE_NIMBY_PYNPUT"):
+            USE_NIMBY_PYNPUT = config.getboolean(__section, "USE_NIMBY_PYNPUT")
         if config.has_option(__section, "OVERRIDE_HOSTNAME"):
             OVERRIDE_HOSTNAME = config.get(__section, "OVERRIDE_HOSTNAME")
         if config.has_option(__section, "GPU"):


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
https://github.com/AcademySoftwareFoundation/OpenCue/issues/1301

**Summarize your change.**
Building and running RQD on docker results in a `ERROR:rqd.rqnimby:Failed to import pynput` caused by `ImportError: this platform is not supported`. 

This is caused by `pynput` expecting an X11 server for the GUI which docker does not have or require. 
Further details referenced in the pynput platform limitations [doc](https://pynput.readthedocs.io/en/latest/limitations.html).

This was resolved via the following steps:

1. Amend **rqconstants.py** to accept `USE_NIMBY_PYNPUT` changes via rqd.conf
2. Update the RQD Dockerfile to setup rqd.conf configuration during setup as described [here](https://www.opencue.io/docs/other-guides/configuring-opencue/#rqd).
