### PR TITLE
Oom protection

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/FrameInterface.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/FrameInterface.java
@@ -1,4 +1,3 @@
-
 /*
  * Copyright Contributors to the OpenCue Project
  *

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/FrameDao.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/FrameDao.java
@@ -206,7 +206,7 @@ public interface FrameDao {
      * Sets a frame exitStatus to EXIT_STATUS_MEMORY_FAILURE
      *
      * @param frame
-     * @return
+     * @return whether the frame has been updated
      */
     boolean updateFrameMemoryError(FrameInterface frame);
 

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/FrameDao.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/FrameDao.java
@@ -202,6 +202,13 @@ public interface FrameDao {
      * @return
      */
     boolean updateFrameCleared(FrameInterface frame);
+    /**
+     * Sets a frame exitStatus to EXIT_STATUS_MEMORY_FAILURE
+     *
+     * @param frame
+     * @return
+     */
+    boolean updateFrameMemoryError(FrameInterface frame);
 
     /**
      * Sets a frame to an unreserved waiting state.

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/HostDao.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/HostDao.java
@@ -253,15 +253,6 @@ public interface HostDao {
     void updateThreadMode(HostInterface host, ThreadMode mode);
 
     /**
-     * When a host is in kill mode that means its 256MB+ into the swap and the
-     * the worst memory offender is killed.
-     *
-     * @param h HostInterface
-     * @return boolean
-     */
-    boolean isKillMode(HostInterface h);
-
-    /**
      * Update the specified host's hardware information.
      *
      * @param host        HostInterface

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/FrameDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/FrameDaoJdbc.java
@@ -155,6 +155,24 @@ public class FrameDaoJdbc extends JdbcDaoSupport  implements FrameDao {
         return updateFrame(frame, Dispatcher.EXIT_STATUS_FRAME_CLEARED) > 0;
     }
 
+    private static final String UPDATE_FRAME_MEMORY_ERROR =
+            "UPDATE "+
+                "frame "+
+            "SET " +
+                 "int_exit_status = ?, " +
+                 "int_version = int_version + 1 " +
+                 "WHERE " +
+                 "frame.pk_frame = ? ";
+    @Override
+    public boolean updateFrameMemoryError(FrameInterface frame) {
+        int result =  getJdbcTemplate().update(
+                UPDATE_FRAME_MEMORY_ERROR,
+                Dispatcher.EXIT_STATUS_MEMORY_FAILURE,
+                frame.getFrameId());
+
+        return result > 0;
+    }
+
     private static final String UPDATE_FRAME_STARTED =
         "UPDATE " +
             "frame " +

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/HostDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/HostDaoJdbc.java
@@ -613,15 +613,6 @@ public class HostDaoJdbc extends JdbcDaoSupport implements HostDao {
     }
 
     @Override
-    public boolean isKillMode(HostInterface h) {
-        return getJdbcTemplate().queryForObject(
-                "SELECT COUNT(1) FROM host_stat WHERE pk_host = ? " +
-                "AND int_swap_total - int_swap_free > ? AND int_mem_free < ?",
-                Integer.class, h.getHostId(), Dispatcher.KILL_MODE_SWAP_THRESHOLD,
-                Dispatcher.KILL_MODE_MEM_THRESHOLD) > 0;
-    }
-
-    @Override
     public int getStrandedCoreUnits(HostInterface h) {
         try {
             int idle_cores =  getJdbcTemplate().queryForObject(

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/ProcDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/ProcDaoJdbc.java
@@ -564,7 +564,7 @@ public class ProcDaoJdbc extends JdbcDaoSupport implements ProcDao {
                     value, p.getProcId(), value) == 1;
         } catch (Exception e) {
             // check by trigger erify_host_resources
-            throw new ResourceReservationFailureException("failed to increase memory reserveration for proc "
+            throw new ResourceReservationFailureException("failed to increase memory reservation for proc "
                     + p.getProcId() + " to " + value + ", proc does not have that much memory to spare.");
         }
       }

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupport.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupport.java
@@ -420,7 +420,7 @@ public interface DispatchSupport {
      *
      * @param frame
      */
-    void updateFrameMemoryError(FrameInterface frame);
+    boolean updateFrameMemoryError(FrameInterface frame);
 
     /**
      * Update Memory usage data and LLU time for the given frame.

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupport.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupport.java
@@ -416,6 +416,13 @@ public interface DispatchSupport {
     void clearFrame(DispatchFrame frame);
 
     /**
+     * Sets the frame state exitStatus to EXIT_STATUS_MEMORY_FAILURE
+     *
+     * @param frame
+     */
+    void updateFrameMemoryError(FrameInterface frame);
+
+    /**
      * Update Memory usage data and LLU time for the given frame.
      *
      * @param frame

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupport.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupport.java
@@ -419,6 +419,7 @@ public interface DispatchSupport {
      * Sets the frame state exitStatus to EXIT_STATUS_MEMORY_FAILURE
      *
      * @param frame
+     * @return whether the frame has been updated
      */
     boolean updateFrameMemoryError(FrameInterface frame);
 

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java
@@ -42,6 +42,7 @@ import com.imageworks.spcue.VirtualProc;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.dao.DataAccessException;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -184,7 +185,11 @@ public class DispatchSupportService implements DispatchSupport {
 
     @Override
     public boolean clearVirtualProcAssignement(ProcInterface proc) {
-        return procDao.clearVirtualProcAssignment(proc);
+        try {
+            return procDao.clearVirtualProcAssignment(proc);
+        } catch (DataAccessException e) {
+            return false;
+        }
     }
 
     @Transactional(propagation = Propagation.REQUIRED)
@@ -345,8 +350,8 @@ public class DispatchSupportService implements DispatchSupport {
 
     @Override
     @Transactional(propagation = Propagation.REQUIRED)
-    public void updateFrameMemoryError(FrameInterface frame) {
-        frameDao.updateFrameMemoryError(frame);
+    public boolean updateFrameMemoryError(FrameInterface frame) {
+        return frameDao.updateFrameMemoryError(frame);
     }
 
     @Transactional(propagation = Propagation.SUPPORTS)

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java
@@ -343,6 +343,12 @@ public class DispatchSupportService implements DispatchSupport {
         frameDao.updateFrameCleared(frame);
     }
 
+    @Override
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void updateFrameMemoryError(FrameInterface frame) {
+        frameDao.updateFrameMemoryError(frame);
+    }
+
     @Transactional(propagation = Propagation.SUPPORTS)
     public RunFrame prepareRqdRunFrame(VirtualProc proc, DispatchFrame frame) {
         int threads =  proc.coresReserved / 100;

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/Dispatcher.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/Dispatcher.java
@@ -108,13 +108,11 @@ public interface Dispatcher {
     // without being penalized for it.
     public static final long VIRTUAL_MEM_THRESHHOLD = CueUtil.GB2;
 
-    // The amount of swap that must be used before a host can go
-    // into kill mode.
-    public static final long KILL_MODE_SWAP_THRESHOLD = CueUtil.MB128;
+    // Percentage of used memory to consider a risk for triggering oom-killer
+    public static final double OOM_MAX_SAFE_USED_MEMORY_THRESHOLD = 0.95;
 
-    // When the amount of free memory drops below this point, the
-    // host can go into kill mode.
-    public static final long KILL_MODE_MEM_THRESHOLD = CueUtil.MB512;
+    // How much can a frame exceed its reserved memory
+    public static final double OOM_FRAME_OVERBOARD_ALLOWED_THRESHOLD = 0.25;
 
     // A higher number gets more deep booking but less spread on the cue.
     public static final int DEFAULT_MAX_FRAMES_PER_PASS = 4;

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/Dispatcher.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/Dispatcher.java
@@ -107,13 +107,8 @@ public interface Dispatcher {
     // without being penalized for it.
     public static final long VIRTUAL_MEM_THRESHHOLD = CueUtil.GB2;
 
-    // Percentage of used memory to consider a risk for triggering oom-killer
-    public static final double OOM_MAX_SAFE_USED_MEMORY_THRESHOLD = 0.95;
-
-    // How much can a frame exceed its reserved memory.
-    //  - 0.5 means 50% above reserve
-    //  - -1.0 makes the feature inactive
-    public static final double OOM_FRAME_OVERBOARD_ALLOWED_THRESHOLD = 0.6;
+    // How long to keep track of a frame kill request
+    public static final int FRAME_KILL_CACHE_EXPIRE_AFTER_WRITE_MINUTES = 3;
 
     // A higher number gets more deep booking but less spread on the cue.
     public static final int DEFAULT_MAX_FRAMES_PER_PASS = 4;

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/Dispatcher.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/Dispatcher.java
@@ -1,4 +1,3 @@
-
 /*
  * Copyright Contributors to the OpenCue Project
  *
@@ -111,8 +110,10 @@ public interface Dispatcher {
     // Percentage of used memory to consider a risk for triggering oom-killer
     public static final double OOM_MAX_SAFE_USED_MEMORY_THRESHOLD = 0.95;
 
-    // How much can a frame exceed its reserved memory
-    public static final double OOM_FRAME_OVERBOARD_ALLOWED_THRESHOLD = 0.25;
+    // How much can a frame exceed its reserved memory.
+    //  - 0.5 means 50% above reserve
+    //  - -1.0 makes the feature inactive
+    public static final double OOM_FRAME_OVERBOARD_ALLOWED_THRESHOLD = 0.6;
 
     // A higher number gets more deep booking but less spread on the cue.
     public static final int DEFAULT_MAX_FRAMES_PER_PASS = 4;

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/FrameCompleteHandler.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/FrameCompleteHandler.java
@@ -33,6 +33,7 @@ import org.springframework.dao.EmptyResultDataAccessException;
 import com.imageworks.spcue.DispatchFrame;
 import com.imageworks.spcue.DispatchHost;
 import com.imageworks.spcue.DispatchJob;
+import com.imageworks.spcue.FrameDetail;
 import com.imageworks.spcue.JobDetail;
 import com.imageworks.spcue.LayerDetail;
 import com.imageworks.spcue.LayerInterface;

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
@@ -21,7 +21,6 @@ package com.imageworks.spcue.dispatcher;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +40,7 @@ import com.imageworks.spcue.FrameInterface;
 import com.imageworks.spcue.JobEntity;
 import com.imageworks.spcue.LayerEntity;
 import com.imageworks.spcue.LayerDetail;
+import com.imageworks.spcue.FrameDetail;
 import com.imageworks.spcue.LocalHostAssignment;
 import com.imageworks.spcue.Source;
 import com.imageworks.spcue.VirtualProc;
@@ -66,6 +66,8 @@ import com.imageworks.spcue.service.JobManager;
 import com.imageworks.spcue.service.JobManagerSupport;
 import com.imageworks.spcue.util.CueExceptionUtil;
 import com.imageworks.spcue.util.CueUtil;
+
+import static com.imageworks.spcue.dispatcher.Dispatcher.*;
 
 public class HostReportHandler {
 
@@ -211,9 +213,9 @@ public class HostReportHandler {
             killTimedOutFrames(report);
 
             /*
-             * Increase/decreased reserved memory.
+             * Prevent OOM (Out-Of-Memory) issues on the host and manage frame reserved memory
              */
-            handleMemoryReservations(host, report);
+            handleMemoryUsage(host, report);
 
             /*
              * The checks are done in order of least CPU intensive to
@@ -456,103 +458,186 @@ public class HostReportHandler {
     }
 
     /**
-     * Handle memory reservations for the given host.  This will re-balance memory
-     * reservations on the machine and kill and frames that are out of control.
-     *
+     * Prevent host from entering an OOM state where oom-killer might start killing important OS processes.
+     * The kill logic will kick in one of the following conditions is met:
+     *   - Host has less than OOM_MEMORY_LEFT_THRESHOLD_PERCENT memory available
+     *   - A frame is taking more than OOM_FRAME_OVERBOARD_PERCENT of what it had reserved
+     * For frames that are using more than they had reserved but not above the threshold, negotiate expanding
+     * the reservations with other frames on the same host
      * @param host
      * @param report
      */
-    private void handleMemoryReservations(final DispatchHost host, final HostReport report) {
+    private void handleMemoryUsage(final DispatchHost host, final HostReport report) {
+        RenderHost renderHost = report.getHost();
+        List<RunningFrameInfo> runningFrames = report.getFramesList();
 
-        // TODO: GPU: Need to keep frames from growing into space reserved for GPU frames
-        // However all this is done in the database without a chance to edit the values here
+        boolean memoryWarning = renderHost.getTotalMem() > 0 &&
+                ((double)renderHost.getFreeMem()/renderHost.getTotalMem() <
+                        (1.0 - OOM_MAX_SAFE_USED_MEMORY_THRESHOLD));
 
-        /*
-         * Check to see if we enable kill mode to free up memory.
-         */
-        boolean killMode = hostManager.isSwapping(host);
+        if (memoryWarning) {
+            VirtualProc killedProc = killWorstMemoryOffender(host);
+            long memoryAvailable = renderHost.getFreeMem();
+            long minSafeMemoryAvailable = (long)(renderHost.getTotalMem() * (1.0 - OOM_MAX_SAFE_USED_MEMORY_THRESHOLD));
+            // Some extra protection for this possibly unbound loop
+            int unboundProtectionLimit = 10;
+            while (killedProc != null && unboundProtectionLimit > 0) {
+                memoryAvailable = memoryAvailable + killedProc.memoryUsed;
 
-        for (final RunningFrameInfo f: report.getFramesList()) {
-
-            VirtualProc proc = null;
-            try {
-                proc = hostManager.getVirtualProc(f.getResourceId());
-
-                // TODO: handle memory management for local dispatches
-                // Skip local dispatches for now.
-                if (proc.isLocalDispatch) {
-                    continue;
+                // If killing this proc solved the memory issue, stop the attack
+                if (memoryAvailable >= minSafeMemoryAvailable) {
+                    break;
                 }
-
-
-                if (f.getRss() > host.memory) {
-                    try{
-                        logger.info("Killing frame " + f.getJobName() + "/" + f.getFrameName() + ", "
-                                + proc.getName() + " was OOM");
-                        try {
-                            killQueue.execute(new DispatchRqdKillFrame(proc, "The frame required " +
-                                    CueUtil.KbToMb(f.getRss()) + " but the machine only has " +
-                                    CueUtil.KbToMb(host.memory), rqdClient));
-                        } catch (TaskRejectedException e) {
-                            logger.warn("Unable to queue RQD kill, task rejected, " + e);
-                        }
-                        DispatchSupport.killedOomProcs.incrementAndGet();
-                    } catch (Exception e) {
-                        logger.info("failed to kill frame on " + proc.getName() +
-                                "," + e);
+                killedProc = killWorstMemoryOffender(host);
+                unboundProtectionLimit -= 1;
+            }
+        } else {
+            // When no mass cleaning was required, check for frames going overboard
+            // if frames didn't go overboard, manage its reservations trying to increase
+            // them accordingly
+            for (final RunningFrameInfo frame: runningFrames) {
+                if (isFrameOverboard(frame)) {
+                    if (!killFrame(frame, host.getName())) {
+                        logger.warn("Frame " + frame.getJobName() + "." + frame.getFrameName() +
+                                " is overboard but could not be killed");
                     }
+                } else {
+                    handleMemoryReservations(frame);
                 }
+            }
+        }
+    }
 
-                if (dispatchSupport.increaseReservedMemory(proc, f.getRss())) {
-                    proc.memoryReserved = f.getRss();
-                    logger.info("frame " + f.getFrameName() + " on job " + f.getJobName()
-                            + " increased its reserved memory to " +
-                            CueUtil.KbToMb(f.getRss()));
-                }
+    private boolean killFrame(RunningFrameInfo frame, String hostName) {
+        try {
+            VirtualProc proc = hostManager.getVirtualProc(frame.getResourceId());
 
-            } catch (ResourceReservationFailureException e) {
+            // Don't mess with localDispatch procs
+            if (proc.isLocalDispatch) {
+                return false;
+            }
 
-                long memNeeded = f.getRss() - proc.memoryReserved;
+            logger.info("Killing frame on " + frame.getJobName() + "." + frame.getFrameName() +
+                    ", using too much memory.");
+            DispatchSupport.killedOffenderProcs.incrementAndGet();
 
-                logger.info("frame " + f.getFrameName() + " on job " + f.getJobName()
+            if (!dispatcher.isTestMode()) {
+                jobManagerSupport.kill(proc, new Source("This frame is using way more than it had reserved."));
+            }
+            return true;
+        } catch (EmptyResultDataAccessException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Kill proc with the worst user/reserved memory ratio.
+     *
+     * @param host
+     * @return killed proc, or null if none could be found
+     */
+    private VirtualProc killWorstMemoryOffender(final DispatchHost host) {
+        VirtualProc proc;
+        try {
+            proc = hostManager.getWorstMemoryOffender(host);
+        }
+        catch (EmptyResultDataAccessException e) {
+            logger.error(host.name + " is under OOM and no proc is running on it.");
+            return null;
+        }
+
+        logger.info("Killing frame on " + proc.getName() + ", host is under stress.");
+        DispatchSupport.killedOffenderProcs.incrementAndGet();
+
+        if (!dispatcher.isTestMode()) {
+            jobManagerSupport.kill(proc, new Source("The host was dangerously low on memory and swapping."));
+        }
+
+        return proc;
+    }
+
+    /**
+     * Check frame memory usage comparing the amount used with the amount it had reserved
+     * @param frame
+     * @return
+     */
+    private boolean isFrameOverboard(final RunningFrameInfo frame) {
+        double rss = (double)frame.getRss();
+        double maxRss = (double)frame.getMaxRss();
+        final double MAX_RSS_OVERBOARD_THRESHOLD = OOM_FRAME_OVERBOARD_ALLOWED_THRESHOLD * 2;
+        final double RSS_AVAILABLE_FOR_MAX_RSS_TRIGGER = 0.1;
+
+        try {
+            VirtualProc proc = hostManager.getVirtualProc(frame.getResourceId());
+            double reserved = (double)proc.memoryReserved;
+
+            // Last memory report is higher than the threshold
+            if (isOverboard(rss, reserved, OOM_FRAME_OVERBOARD_ALLOWED_THRESHOLD)) {
+                return true;
+            }
+            // If rss is not overboard, handle the situation where the frame might be going overboard from
+            // time to time but the last report wasn't during a spike. For this case, consider a combination
+            // of rss and maxRss. maxRss > 2 * threshold and rss > 0.9
+            else {
+                return isOverboard(maxRss, reserved, MAX_RSS_OVERBOARD_THRESHOLD) &&
+                        isOverboard(rss, reserved, -RSS_AVAILABLE_FOR_MAX_RSS_TRIGGER);
+            }
+        } catch (EmptyResultDataAccessException e) {
+            logger.info("HostReportHandler(isFrameOverboard): Virtual proc for frame " +
+                    frame.getFrameName() + " on job " + frame.getJobName() + " doesn't exist on the database");
+            // Not able to mark the frame overboard is it couldn't be found on the db.
+            // Proc accounting (verifyRunningProc) should take care of it
+            return false;
+        }
+    }
+
+    private boolean isOverboard(double value, double total, double threshold) {
+        return value/total >= (1 + threshold);
+    }
+
+    /**
+     * Handle memory reservations for the given frame
+     *
+     * @param frame
+     */
+    private void handleMemoryReservations(final RunningFrameInfo frame) {
+        VirtualProc proc = null;
+        try {
+            proc = hostManager.getVirtualProc(frame.getResourceId());
+
+            if (proc.isLocalDispatch) {
+                return;
+            }
+
+            if (dispatchSupport.increaseReservedMemory(proc, frame.getRss())) {
+                proc.memoryReserved = frame.getRss();
+                logger.info("frame " + frame.getFrameName() + " on job " + frame.getJobName()
+                        + " increased its reserved memory to " +
+                        CueUtil.KbToMb(frame.getRss()));
+            }
+        } catch (ResourceReservationFailureException e) {
+            if (proc != null) {
+                long memNeeded = frame.getRss() - proc.memoryReserved;
+                logger.info("frame " + frame.getFrameName() + " on job " + frame.getJobName()
                         + "was unable to reserve an additional " + CueUtil.KbToMb(memNeeded)
                         + "on proc " + proc.getName() + ", " + e);
-
                 try {
                     if (dispatchSupport.balanceReservedMemory(proc, memNeeded)) {
-                        proc.memoryReserved = f.getRss();
+                        proc.memoryReserved = frame.getRss();
                         logger.info("was able to balance host: " + proc.getName());
-                    }
-                    else {
+                    } else {
                         logger.info("failed to balance host: " + proc.getName());
                     }
                 } catch (Exception ex) {
                     logger.warn("failed to balance host: " + proc.getName() + ", " + e);
                 }
-            } catch (EmptyResultDataAccessException e) {
-                logger.info("HostReportHandler: frame " + f.getFrameName() +
-                        " on job " + f.getJobName() +
-                        " was unable be processed" +
-                        " because the proc could not be found");
+            } else {
+                logger.info("frame " + frame.getFrameName() + " on job " + frame.getJobName()
+                        + "was unable to reserve an additional memory. Proc could not be found");
             }
-        }
-
-        if (killMode) {
-            VirtualProc proc;
-            try {
-                proc = hostManager.getWorstMemoryOffender(host);
-            }
-            catch (EmptyResultDataAccessException e) {
-                logger.info(host.name + " is swapping and no proc is running on it.");
-                return;
-            }
-
-            logger.info("Killing frame on " +
-                    proc.getName() + ", host is distressed.");
-
-            DispatchSupport.killedOffenderProcs.incrementAndGet();
-            jobManagerSupport.kill(proc, new Source(
-                    "The host was dangerously low on memory and swapping."));
+        } catch (EmptyResultDataAccessException e) {
+            logger.info("HostReportHandler: Memory reservations for frame " + frame.getFrameName() +
+                    " on job " + frame.getJobName() + " proc could not be found");
         }
     }
 

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
@@ -493,8 +493,8 @@ public class HostReportHandler {
             // When no mass cleaning was required, check for frames going overboard
             // if frames didn't go overboard, manage its reservations trying to increase
             // them accordingly
-            for (final RunningFrameInfo frame: runningFrames) {
-                if (isFrameOverboard(frame)) {
+            for (final RunningFrameInfo frame : runningFrames) {
+                if (OOM_FRAME_OVERBOARD_ALLOWED_THRESHOLD > 0 && isFrameOverboard(frame)) {
                     if (!killFrameOverusingMemory(frame, host.getName())) {
                         logger.warn("Frame " + frame.getJobName() + "." + frame.getFrameName() +
                                 " is overboard but could not be killed");

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
@@ -24,8 +24,12 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -92,6 +96,10 @@ public class HostReportHandler {
     private static final String SUBJECT_COMMENT_FULL_TEMP_DIR = "Host set to REPAIR for not having enough storage " +
             "space on the temporary directory (mcp)";
     private static final String CUEBOT_COMMENT_USER = "cuebot";
+
+    Cache<String, Long> killRequestCounterCache = CacheBuilder.newBuilder()
+            .expireAfterWrite(FRAME_KILL_CACHE_EXPIRE_AFTER_WRITE_MINUTES, TimeUnit.MINUTES)
+            .build();
 
     /**
      * Boolean to toggle if this class is accepting data or not.
@@ -466,6 +474,10 @@ public class HostReportHandler {
      * @param report
      */
     private void handleMemoryUsage(final DispatchHost host, final HostReport report) {
+        final double OOM_MAX_SAFE_USED_MEMORY_THRESHOLD =
+                env.getRequiredProperty("dispatcher.oom_max_safe_used_memory_threshold", Double.class);
+        final double OOM_FRAME_OVERBOARD_ALLOWED_THRESHOLD =
+                env.getRequiredProperty("dispatcher.oom_frame_overboard_allowed_threshold", Double.class);
         RenderHost renderHost = report.getHost();
         List<RunningFrameInfo> runningFrames = report.getFramesList();
 
@@ -474,21 +486,17 @@ public class HostReportHandler {
                         (1.0 - OOM_MAX_SAFE_USED_MEMORY_THRESHOLD));
 
         if (memoryWarning) {
-            VirtualProc killedProc = killWorstMemoryOffender(host);
             long memoryAvailable = renderHost.getFreeMem();
             long minSafeMemoryAvailable = (long)(renderHost.getTotalMem() * (1.0 - OOM_MAX_SAFE_USED_MEMORY_THRESHOLD));
-            // Some extra protection for this possibly unbound loop
-            int unboundProtectionLimit = 10;
-            while (killedProc != null && unboundProtectionLimit > 0) {
-                memoryAvailable = memoryAvailable + killedProc.memoryUsed;
-
-                // If killing this proc solved the memory issue, stop the attack
-                if (memoryAvailable >= minSafeMemoryAvailable) {
-                    break;
+            // Only allow killing up to 10 frames at a time
+            int killAttemptsRemaining = 10;
+            do {
+                VirtualProc killedProc = killWorstMemoryOffender(host);
+                killAttemptsRemaining -= 1;
+                if (killedProc != null) {
+                    memoryAvailable = memoryAvailable + killedProc.memoryUsed;
                 }
-                killedProc = killWorstMemoryOffender(host);
-                unboundProtectionLimit -= 1;
-            }
+            } while (killAttemptsRemaining > 0 && memoryAvailable < minSafeMemoryAvailable);
         } else {
             // When no mass cleaning was required, check for frames going overboard
             // if frames didn't go overboard, manage its reservations trying to increase
@@ -506,6 +514,23 @@ public class HostReportHandler {
         }
     }
 
+    public enum KillCause {
+        FrameOverboard("This frame is using way more than it had reserved."),
+        HostUnderOom("Frame killed by host under Oom pressure"),
+        FrameTimedOut("Frame timed out"),
+        FrameLluTimedOut("Frame LLU timed out"),
+        FrameVerificationFailure("Frame failed to be verified on the database");
+        private final String message;
+
+        private KillCause(String message) {
+            this.message = message;
+        }
+        @Override
+        public String toString() {
+            return message;
+        }
+    }
+
     private boolean killFrameOverusingMemory(RunningFrameInfo frame, String hostname) {
         try {
             VirtualProc proc = hostManager.getVirtualProc(frame.getResourceId());
@@ -517,32 +542,87 @@ public class HostReportHandler {
 
             logger.info("Killing frame on " + frame.getJobName() + "." + frame.getFrameName() +
                     ", using too much memory.");
-            return killProcForMemory(proc, hostname, "This frame is using way more than it had reserved.");
+            return killProcForMemory(proc, hostname, KillCause.FrameOverboard);
         } catch (EmptyResultDataAccessException e) {
             return false;
         }
     }
 
-    private boolean killProcForMemory(VirtualProc proc, String hostname, String reason) {
-        try {
-            FrameInterface frame = jobManager.getFrame(proc.frameId);
+    private boolean getKillClearance(String hostname, String frameId) {
+        String cacheKey = hostname + "-" + frameId;
+        final int FRAME_KILL_RETRY_LIMIT =
+                env.getRequiredProperty("dispatcher.frame_kill_retry_limit", Integer.class);
 
-            if (dispatcher.isTestMode()) {
-                // For testing, don't run on a different threadpool, as different threads don't share
-                // the same database state
-                (new DispatchRqdKillFrameMemory(proc.hostName, frame, reason, rqdClient,
-                        dispatchSupport, dispatcher.isTestMode())).run();
-            } else {
-                killQueue.execute(new DispatchRqdKillFrameMemory(proc.hostName, frame, reason, rqdClient,
-                        dispatchSupport, dispatcher.isTestMode()));
-                prometheusMetrics.incrementFrameOomKilledCounter(hostname);
-            }
-            DispatchSupport.killedOffenderProcs.incrementAndGet();
-            return true;
-        } catch (TaskRejectedException e) {
-            logger.warn("Unable to queue RQD kill, task rejected, " + e);
+        // Cache frame+host receiving a killRequest and count how many times the request is being retried
+        // meaning rqd is probably failing at attempting to kill the related proc
+        long cachedCount;
+        try {
+            cachedCount = 1 + killRequestCounterCache.get(cacheKey, () -> 0L);
+        } catch (ExecutionException e) {
             return false;
         }
+        killRequestCounterCache.put(cacheKey, cachedCount);
+        if (cachedCount > FRAME_KILL_RETRY_LIMIT) {
+            // If the kill retry limit has been reached, notify prometheus of the issue and give up
+            if (!dispatcher.isTestMode()) {
+                FrameInterface frame = jobManager.getFrame(frameId);
+                JobInterface job = jobManager.getJob(frame.getJobId());
+                prometheusMetrics.incrementFrameKillFailureCounter(
+                        hostname,
+                        job.getName(),
+                        frame.getName(),
+                        frameId);
+            }
+            return false;
+        }
+        return true;
+    }
+
+    private boolean killProcForMemory(VirtualProc proc, String hostname, KillCause killCause) {
+        if (!getKillClearance(hostname, proc.frameId)) {
+            return false;
+        }
+
+        FrameInterface frame = jobManager.getFrame(proc.frameId);
+        if (dispatcher.isTestMode()) {
+            // Different threads don't share the same database state on the test environment
+            (new DispatchRqdKillFrameMemory(hostname, frame, killCause.toString(), rqdClient,
+                    dispatchSupport, dispatcher.isTestMode())).run();
+        } else {
+            try {
+                killQueue.execute(new DispatchRqdKillFrameMemory(hostname, frame, killCause.toString(), rqdClient,
+                        dispatchSupport, dispatcher.isTestMode()));
+                prometheusMetrics.incrementFrameKilledCounter(hostname, killCause);
+            } catch (TaskRejectedException e) {
+                logger.warn("Unable to add a DispatchRqdKillFrame request, task rejected, " + e);
+                return false;
+            }
+        }
+        DispatchSupport.killedOffenderProcs.incrementAndGet();
+        return true;
+    }
+
+    private boolean killFrame(String frameId, String hostname, KillCause killCause) {
+        if (!getKillClearance(hostname, frameId)) {
+            return false;
+        }
+
+        if (dispatcher.isTestMode()) {
+            // Different threads don't share the same database state on the test environment
+            (new DispatchRqdKillFrame(hostname, frameId, killCause.toString(), rqdClient)).run();
+        } else {
+            try {
+                killQueue.execute(new DispatchRqdKillFrame(hostname,
+                        frameId,
+                        killCause.toString(),
+                        rqdClient));
+                prometheusMetrics.incrementFrameKilledCounter(hostname, killCause);
+            } catch (TaskRejectedException e) {
+                logger.warn("Unable to add a DispatchRqdKillFrame request, task rejected, " + e);
+            }
+        }
+        DispatchSupport.killedOffenderProcs.incrementAndGet();
+        return true;
     }
 
     /**
@@ -556,8 +636,7 @@ public class HostReportHandler {
             VirtualProc proc = hostManager.getWorstMemoryOffender(host);
             logger.info("Killing frame on " + proc.getName() + ", host is under stress.");
 
-            if (!killProcForMemory(proc, host.getName(), "The host was dangerously low on memory and swapping.")) {
-                // Returning null will prevent the caller from overflowing the kill queue with more messages
+            if (!killProcForMemory(proc, host.getName(), KillCause.HostUnderOom)) {
                 proc = null;
             }
             return proc;
@@ -576,6 +655,8 @@ public class HostReportHandler {
     private boolean isFrameOverboard(final RunningFrameInfo frame) {
         double rss = (double)frame.getRss();
         double maxRss = (double)frame.getMaxRss();
+        final double OOM_FRAME_OVERBOARD_ALLOWED_THRESHOLD =
+                env.getRequiredProperty("dispatcher.oom_frame_overboard_allowed_threshold", Double.class);
         final double MAX_RSS_OVERBOARD_THRESHOLD = OOM_FRAME_OVERBOARD_ALLOWED_THRESHOLD * 2;
         final double RSS_AVAILABLE_FOR_MAX_RSS_TRIGGER = 0.1;
 
@@ -659,7 +740,6 @@ public class HostReportHandler {
      * @param rFrames
      */
     private void killTimedOutFrames(HostReport report) {
-
         final Map<String, LayerDetail> layers = new HashMap<String, LayerDetail>(5);
 
         for (RunningFrameInfo frame: report.getFramesList()) {
@@ -667,36 +747,16 @@ public class HostReportHandler {
             LayerDetail layer = layerDao.getLayerDetail(layerId);
             long runtimeMinutes = ((System.currentTimeMillis() - frame.getStartTime()) / 1000l) / 60;
 
+            String hostname = report.getHost().getName();
+
             if (layer.timeout != 0 && runtimeMinutes > layer.timeout){
-                try {
-                    killQueue.execute(new DispatchRqdKillFrame(report.getHost().getName(),
-                            frame.getFrameId(),
-                            "This frame has reached it timeout.",
-                            rqdClient));
-                    } catch (TaskRejectedException e) {
-                        logger.warn("Unable to queue  RQD kill, task rejected, " + e);
-                }
-            }
+                killFrame(frame.getFrameId(), hostname, KillCause.FrameTimedOut);
+            } else if (layer.timeout_llu != 0 && frame.getLluTime() != 0) {
+                long r = System.currentTimeMillis() / 1000;
+                long lastUpdate = (r - frame.getLluTime()) / 60;
 
-            if (layer.timeout_llu == 0){
-                continue;
-            }
-
-            if (frame.getLluTime() == 0){
-                continue;
-            }
-
-            long r = System.currentTimeMillis() / 1000;
-            long lastUpdate = (r - frame.getLluTime()) / 60;
-
-            if (layer.timeout_llu != 0 && lastUpdate > (layer.timeout_llu -1)){
-                try {
-                    killQueue.execute(new DispatchRqdKillFrame(report.getHost().getName(),
-                            frame.getFrameId(),
-                            "This frame has reached it LLU timeout.",
-                            rqdClient));
-                    } catch (TaskRejectedException e) {
-                        logger.warn("Unable to queue  RQD kill, task rejected, " + e);
+                if (layer.timeout_llu != 0 && lastUpdate > (layer.timeout_llu - 1)){
+                    killFrame(frame.getFrameId(), hostname, KillCause.FrameLluTimedOut);
                 }
             }
         }
@@ -822,98 +882,59 @@ public class HostReportHandler {
                 continue;
             }
 
+            if (hostManager.verifyRunningProc(runningFrame.getResourceId(), runningFrame.getFrameId())) {
+                runningFrames.add(runningFrame);
+                continue;
+            }
 
-            if (!hostManager.verifyRunningProc(runningFrame.getResourceId(),
-                    runningFrame.getFrameId())) {
+            /*
+             * The frame this proc is running is no longer
+             * assigned to this proc.   Don't ever touch
+             * the frame record.  If we make it here that means
+             * the proc has been running for over 2 min.
+             */
+            String msg;
+            VirtualProc proc = null;
 
-                /*
-                 * The frame this proc is running is no longer
-                 * assigned to this proc.   Don't ever touch
-                 * the frame record.  If we make it here that means
-                 * the proc has been running for over 2 min.
-                 */
-
-                String msg;
-                VirtualProc proc = null;
-
-                try {
-                    proc = hostManager.getVirtualProc(runningFrame.getResourceId());
-                    msg = "Virutal proc " + proc.getProcId() +
+            try {
+                proc = hostManager.getVirtualProc(runningFrame.getResourceId());
+                msg = "Virtual proc " + proc.getProcId() +
                         "is assigned to " + proc.getFrameId() +
                         " not " + runningFrame.getFrameId();
-                }
-                catch (Exception e) {
-                    /*
-                     * This will happen if the host goes off line and then
-                     * comes back.  In this case, we don't touch the frame
-                     * since it might already be running somewhere else.  We
-                     * do however kill the proc.
-                     */
-                    msg = "Virtual proc did not exist.";
-                }
-
-                logger.info("warning, the proc " +
-                        runningFrame.getResourceId() + " on host " +
-                        report.getHost().getName() + " was running for " +
-                        (runtimeSeconds / 60.0f) + " minutes " +
-                        runningFrame.getJobName() + "/" + runningFrame.getFrameName() +
-                        "but the DB did not " +
-                        "reflect this " +
-                        msg);
-
-                DispatchSupport.accountingErrors.incrementAndGet();
-
-                try {
-                    /*
-                     * If the proc did exist unbook it if we can't
-                     * verify its running something.
-                     */
-                    boolean rqd_kill = false;
-                    if (proc != null) {
-
-                        /*
-                         * Check to see if the proc is an orphan.
-                         */
-                        if (hostManager.isOprhan(proc)) {
-                            dispatchSupport.clearVirtualProcAssignement(proc);
-                            dispatchSupport.unbookProc(proc);
-                            rqd_kill = true;
-                        }
-                    }
-                    else {
-                        /* Proc doesn't exist so a kill won't hurt */
-                        rqd_kill = true;
-                    }
-
-                    if (rqd_kill) {
-                        try {
-                        killQueue.execute(new DispatchRqdKillFrame(report.getHost().getName(),
-                                runningFrame.getFrameId(),
-                                "OpenCue could not verify this frame.",
-                                rqdClient));
-                        } catch (TaskRejectedException e) {
-                            logger.warn("Unable to queue  RQD kill, task rejected, " + e);
-                        }
-                    }
-
-                } catch (RqdClientException rqde) {
-                    logger.warn("failed to kill " +
-                            runningFrame.getJobName() + "/" +
-                            runningFrame.getFrameName() +
-                            " when trying to clear a failed " +
-                            " frame verification, " + rqde);
-
-                } catch (Exception e) {
-                    CueExceptionUtil.logStackTrace("failed", e);
-                    logger.warn("failed to verify " +
-                            runningFrame.getJobName() + "/" +
-                            runningFrame.getFrameName() +
-                            " was running but the frame was " +
-                            " unable to be killed, " + e);
-                }
             }
-            else {
-                runningFrames.add(runningFrame);
+            catch (Exception e) {
+                /*
+                 * This will happen if the host goes offline and then
+                 * comes back.  In this case, we don't touch the frame
+                 * since it might already be running somewhere else.  We
+                 * do however kill the proc.
+                 */
+                msg = "Virtual proc did not exist.";
+            }
+
+            DispatchSupport.accountingErrors.incrementAndGet();
+            if (proc != null && hostManager.isOprhan(proc)) {
+                dispatchSupport.clearVirtualProcAssignement(proc);
+                dispatchSupport.unbookProc(proc);
+                proc = null;
+            }
+            if (proc == null) {
+                if (killFrame(runningFrame.getFrameId(),
+                        report.getHost().getName(),
+                        KillCause.FrameVerificationFailure)) {
+                    logger.info("FrameVerificationError, the proc " +
+                            runningFrame.getResourceId() + " on host " +
+                            report.getHost().getName() + " was running for " +
+                            (runtimeSeconds / 60.0f) + " minutes " +
+                            runningFrame.getJobName() + "/" + runningFrame.getFrameName() +
+                            "but the DB did not " +
+                            "reflect this. " +
+                            msg);
+                } else {
+                    logger.warn("FrameStuckWarning: frameId=" + runningFrame.getFrameId() +
+                            " render_node=" + report.getHost().getName() + " - " +
+                            runningFrame.getJobName() + "/" + runningFrame.getFrameName());
+                }
             }
         }
     }

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/commands/DispatchRqdKillFrameMemory.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/commands/DispatchRqdKillFrameMemory.java
@@ -53,12 +53,14 @@ public class DispatchRqdKillFrameMemory extends KeyRunnable {
     public void run() {
         long startTime = System.currentTimeMillis();
         try {
-            if (!isTestMode) {
+            if (dispatchSupport.updateFrameMemoryError(frame) && !isTestMode) {
                 rqdClient.killFrame(hostname, frame.getFrameId(), message);
+            } else {
+                logger.warn("Could not update frame " + frame.getFrameId() +
+                        " status to EXIT_STATUS_MEMORY_FAILURE. Canceling kill request!");
             }
-            dispatchSupport.updateFrameMemoryError(frame);
         } catch (RqdClientException e) {
-            logger.info("Failed to contact host " + hostname + ", " + e);
+            logger.warn("Failed to contact host " + hostname + ", " + e);
         } finally {
             long elapsedTime =  System.currentTimeMillis() - startTime;
             logger.info("RQD communication with " + hostname +

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/commands/DispatchRqdKillFrameMemory.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/commands/DispatchRqdKillFrameMemory.java
@@ -27,7 +27,12 @@ import com.imageworks.spcue.rqd.RqdClientException;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
-
+/**
+ * A runnable to communicate with rqd requesting for a frame to be killed due to memory issues.
+ * <p>
+ * Before killing a frame, the database is updated to mark the frame status as EXIT_STATUS_MEMORY_FAILURE,
+ * this allows the FrameCompleteHandler to possibly retry the frame after increasing its memory requirements
+ */
 public class DispatchRqdKillFrameMemory extends KeyRunnable {
 
     private static final Logger logger = LogManager.getLogger(DispatchRqdKillFrameMemory.class);

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/commands/DispatchRqdKillFrameMemory.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/commands/DispatchRqdKillFrameMemory.java
@@ -24,11 +24,13 @@ import com.imageworks.spcue.VirtualProc;
 import com.imageworks.spcue.dispatcher.DispatchSupport;
 import com.imageworks.spcue.rqd.RqdClient;
 import com.imageworks.spcue.rqd.RqdClientException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
 
 public class DispatchRqdKillFrameMemory extends KeyRunnable {
 
-    private static final Logger logger = Logger.getLogger(DispatchRqdKillFrameMemory.class);
+    private static final Logger logger = LogManager.getLogger(DispatchRqdKillFrameMemory.class);
 
     private String message;
     private String hostname;

--- a/cuebot/src/main/java/com/imageworks/spcue/service/HostManager.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/service/HostManager.java
@@ -70,15 +70,6 @@ public interface HostManager {
      */
     void setHostFreeTempDir(HostInterface host, Long freeTempDir);
 
-    /**
-     * Return true if the host is swapping hard enough
-     * that killing frames will save the entire machine.
-     *
-     * @param host
-     * @return
-     */
-    boolean isSwapping(HostInterface host);
-
     DispatchHost createHost(HostReport report);
     DispatchHost createHost(RenderHost host);
 

--- a/cuebot/src/main/java/com/imageworks/spcue/service/HostManagerService.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/service/HostManagerService.java
@@ -98,12 +98,6 @@ public class HostManagerService implements HostManager {
         hostDao.updateHostFreeTempDir(host, freeTempDir);
     }
 
-    @Override
-    @Transactional(propagation = Propagation.REQUIRED, readOnly=true)
-    public boolean isSwapping(HostInterface host) {
-        return hostDao.isKillMode(host);
-    }
-
     public void rebootWhenIdle(HostInterface host) {
         try {
             hostDao.updateHostState(host, HardwareState.REBOOT_WHEN_IDLE);

--- a/cuebot/src/main/resources/conf/spring/applicationContext-service.xml
+++ b/cuebot/src/main/resources/conf/spring/applicationContext-service.xml
@@ -384,7 +384,6 @@
     <property name="rqdClient" ref="rqdClient" />
     <property name="jobManager" ref="jobManager" />
     <property name="bookingManager" ref="bookingManager" />
-    <property name="jobManagerSupport" ref="jobManagerSupport" />
     <property name="jobDao" ref="jobDao" />
     <property name="layerDao" ref="layerDao" />
     <property name="killQueue" ref="killQueue"/>

--- a/cuebot/src/main/resources/opencue.properties
+++ b/cuebot/src/main/resources/opencue.properties
@@ -130,7 +130,21 @@ dispatcher.booking_queue.max_pool_size=6
 # Queue capacity for booking.
 dispatcher.booking_queue.queue_capacity=1000
 
-# Whether or not to satisfy dependents (*_ON_FRAME and *_ON_LAYER) only on Frame success
+# Percentage of used memory to consider a risk for triggering oom-killer
+dispatcher.oom_max_safe_used_memory_threshold=0.95
+
+# How much can a frame exceed its reserved memory.
+#  - 0.5 means 50% above reserve
+#  - -1.0 makes the feature inactive
+# This feature is being kept inactive for now as we work on improving the
+#  frame retry logic (See commit comment for more details).
+dispatcher.oom_frame_overboard_allowed_threshold=-1.0
+
+# How many times should cuebot send a kill request for the same frame-host before reporting
+# the frame as stuck
+dispatcher.frame_kill_retry_limit=3
+
+# Whether to satisfy dependents (*_ON_FRAME and *_ON_LAYER) only on Frame success
 depend.satisfy_only_on_frame_success=true
 
 # Jobs will be archived to the history tables after being completed for this long.

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/HostDaoTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/HostDaoTests.java
@@ -334,24 +334,6 @@ public class HostDaoTests extends AbstractTransactionalJUnit4SpringContextTests 
     @Test
     @Transactional
     @Rollback(true)
-    public void testIsKillMode() {
-        hostDao.insertRenderHost(buildRenderHost(TEST_HOST),
-                hostManager.getDefaultAllocationDetail(),
-                false);
-
-        HostEntity host = hostDao.findHostDetail(TEST_HOST);
-        assertFalse(hostDao.isKillMode(host));
-
-        jdbcTemplate.update(
-                "UPDATE host_stat SET int_swap_free = ?, int_mem_free = ? WHERE pk_host = ?",
-                CueUtil.MB256, CueUtil.MB256, host.getHostId());
-
-        assertTrue(hostDao.isKillMode(host));
-    }
-
-    @Test
-    @Transactional
-    @Rollback(true)
     public void testIsHostUp() {
         hostDao.insertRenderHost(buildRenderHost(TEST_HOST),
                 hostManager.getDefaultAllocationDetail(),

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/FrameCompleteHandlerTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/FrameCompleteHandlerTests.java
@@ -310,10 +310,11 @@ public class FrameCompleteHandlerTests extends TransactionalTest {
 
         DispatchJob dispatchJob = jobManager.getDispatchJob(proc.getJobId());
         DispatchFrame dispatchFrame = jobManager.getDispatchFrame(report.getFrame().getFrameId());
+        FrameDetail frameDetail = jobManager.getFrameDetail(report.getFrame().getFrameId());
         dispatchSupport.stopFrame(dispatchFrame, frameState, report.getExitStatus(),
             report.getFrame().getMaxRss());
         frameCompleteHandler.handlePostFrameCompleteOperations(proc,
-            report, dispatchJob, dispatchFrame, frameState);
+            report, dispatchJob, dispatchFrame, frameState, frameDetail);
 
         assertTrue(jobManager.isLayerComplete(layerFirst));
         assertFalse(jobManager.isLayerComplete(layerSecond));
@@ -401,10 +402,11 @@ public class FrameCompleteHandlerTests extends TransactionalTest {
 
         DispatchJob dispatchJob = jobManager.getDispatchJob(proc.getJobId());
         DispatchFrame dispatchFrame = jobManager.getDispatchFrame(report.getFrame().getFrameId());
+        FrameDetail frameDetail = jobManager.getFrameDetail(report.getFrame().getFrameId());
         dispatchSupport.stopFrame(dispatchFrame, FrameState.DEAD, report.getExitStatus(),
                 report.getFrame().getMaxRss());
         frameCompleteHandler.handlePostFrameCompleteOperations(proc,
-                report, dispatchJob, dispatchFrame, FrameState.WAITING);
+                report, dispatchJob, dispatchFrame, FrameState.WAITING, frameDetail);
 
         assertFalse(jobManager.isLayerComplete(layer));
 

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HostReportHandlerGpuTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HostReportHandlerGpuTests.java
@@ -83,12 +83,12 @@ public class HostReportHandlerGpuTests extends TransactionalTest {
                 .setBootTime(1192369572)
                 // The minimum amount of free space in the temporary directory to book a host.
                 .setFreeMcp(CueUtil.GB)
-                .setFreeMem(53500)
-                .setFreeSwap(20760)
+                .setFreeMem(CueUtil.GB8)
+                .setFreeSwap(CueUtil.GB2)
                 .setLoad(0)
                 .setTotalMcp(CueUtil.GB4)
-                .setTotalMem(1048576L * 4096)
-                .setTotalSwap(20960)
+                .setTotalMem(CueUtil.GB8)
+                .setTotalSwap(CueUtil.GB2)
                 .setNimbyEnabled(false)
                 .setNumProcs(2)
                 .setCoresPerProc(100)
@@ -115,7 +115,7 @@ public class HostReportHandlerGpuTests extends TransactionalTest {
         hostReportHandler.handleHostReport(report, true);
         DispatchHost host = getHost();
         assertEquals(host.lockState, LockState.OPEN);
-        assertEquals(host.memory, 4294443008L);
+        assertEquals(host.memory, CueUtil.GB8 - 524288);
         assertEquals(host.gpus, 64);
         assertEquals(host.idleGpus, 64);
         assertEquals(host.gpuMemory, 1048576L * 2048);

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HostReportHandlerTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HostReportHandlerTests.java
@@ -486,7 +486,7 @@ public class HostReportHandlerTests extends TransactionalTest {
                 .build();
 
         long killCount = DispatchSupport.killedOffenderProcs.get();
-        hostReportHandler.handleHostReport(report, false, System.currentTimeMillis());
+        hostReportHandler.handleHostReport(report, false);
         assertEquals(killCount + 1, DispatchSupport.killedOffenderProcs.get());
     }
 
@@ -523,7 +523,7 @@ public class HostReportHandlerTests extends TransactionalTest {
                 .build();
 
         long killCount = DispatchSupport.killedOffenderProcs.get();
-        hostReportHandler.handleHostReport(report, false, System.currentTimeMillis());
+        hostReportHandler.handleHostReport(report, false);
         assertEquals(killCount + 1, DispatchSupport.killedOffenderProcs.get());
     }
 
@@ -586,7 +586,7 @@ public class HostReportHandlerTests extends TransactionalTest {
 
         // In this case, killing one job should be enough to ge the machine to a safe state
         long killCount = DispatchSupport.killedOffenderProcs.get();
-        hostReportHandler.handleHostReport(report, false, System.currentTimeMillis());
+        hostReportHandler.handleHostReport(report, false);
         assertEquals(killCount + 1, DispatchSupport.killedOffenderProcs.get());
 
         // Confirm the frame will be set to retry after it's completion has been processed

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HostReportHandlerTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HostReportHandlerTests.java
@@ -21,10 +21,13 @@ package com.imageworks.spcue.test.dispatcher;
 
 import java.io.File;
 import java.sql.Timestamp;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ThreadPoolExecutor;
 import javax.annotation.Resource;
 
+import com.imageworks.spcue.dispatcher.DispatchSupport;
+import com.imageworks.spcue.dispatcher.HostReportQueue;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.test.annotation.Rollback;
@@ -99,9 +102,9 @@ public class HostReportHandlerTests extends TransactionalTest {
     public void createHost() {
         hostname = UUID.randomUUID().toString().substring(0, 8);
         hostname2 = UUID.randomUUID().toString().substring(0, 8);
-        hostManager.createHost(getRenderHost(hostname, HardwareState.UP),
+        hostManager.createHost(getRenderHost(hostname),
                 adminManager.findAllocationDetail("spi","general"));
-        hostManager.createHost(getRenderHost(hostname2, HardwareState.UP),
+        hostManager.createHost(getRenderHost(hostname2),
                 adminManager.findAllocationDetail("spi","general"));
     }
 
@@ -118,52 +121,32 @@ public class HostReportHandlerTests extends TransactionalTest {
         return hostManager.findDispatchHost(hostname);
     }
 
-    private static RenderHost getRenderHost(String hostname, HardwareState state) {
+    private static RenderHost.Builder getRenderHostBuilder(String hostname) {
         return RenderHost.newBuilder()
                 .setName(hostname)
                 .setBootTime(1192369572)
                 // The minimum amount of free space in the temporary directory to book a host.
                 .setFreeMcp(CueUtil.GB)
-                .setFreeMem((int) CueUtil.GB8)
-                .setFreeSwap(20760)
+                .setFreeMem(CueUtil.GB8)
+                .setFreeSwap(CueUtil.GB2)
                 .setLoad(0)
                 .setTotalMcp(CueUtil.GB4)
                 .setTotalMem(CueUtil.GB8)
                 .setTotalSwap(CueUtil.GB2)
                 .setNimbyEnabled(false)
-                .setNumProcs(2)
+                .setNumProcs(16)
                 .setCoresPerProc(100)
                 .addTags("test")
-                .setState(state)
+                .setState(HardwareState.UP)
                 .setFacility("spi")
                 .putAttributes("SP_OS", "Linux")
-                .setFreeGpuMem((int) CueUtil.MB512)
-                .setTotalGpuMem((int) CueUtil.MB512)
-                .build();
+                .setNumGpus(0)
+                .setFreeGpuMem(0)
+                .setTotalGpuMem(0);
     }
 
-    private static RenderHost getRenderHost(String hostname, HardwareState state, Long freeTempDir) {
-        return RenderHost.newBuilder()
-                .setName(hostname)
-                .setBootTime(1192369572)
-                // The minimum amount of free space in the temporary directory to book a host.
-                .setFreeMcp(freeTempDir)
-                .setFreeMem((int) CueUtil.GB8)
-                .setFreeSwap(20760)
-                .setLoad(0)
-                .setTotalMcp(freeTempDir * 4)
-                .setTotalMem(CueUtil.GB8)
-                .setTotalSwap(CueUtil.GB2)
-                .setNimbyEnabled(false)
-                .setNumProcs(2)
-                .setCoresPerProc(100)
-                .addTags("test")
-                .setState(state)
-                .setFacility("spi")
-                .putAttributes("SP_OS", "Linux")
-                .setFreeGpuMem((int) CueUtil.MB512)
-                .setTotalGpuMem((int) CueUtil.MB512)
-                .build();
+    private static RenderHost getRenderHost(String hostname) {
+        return getRenderHostBuilder(hostname).build();
     }
 
     private static RenderHost getNewRenderHost(String tags) {
@@ -172,12 +155,12 @@ public class HostReportHandlerTests extends TransactionalTest {
                 .setBootTime(1192369572)
                 // The minimum amount of free space in the temporary directory to book a host.
                 .setFreeMcp(CueUtil.GB)
-                .setFreeMem(53500)
-                .setFreeSwap(20760)
+                .setFreeMem(CueUtil.GB8)
+                .setFreeSwap(CueUtil.GB2)
                 .setLoad(0)
-                .setTotalMcp(CueUtil.GB4)
-                .setTotalMem(8173264)
-                .setTotalSwap(20960)
+                .setTotalMcp(195430)
+                .setTotalMem(CueUtil.GB8)
+                .setTotalSwap(CueUtil.GB2)
                 .setNimbyEnabled(false)
                 .setNumProcs(2)
                 .setCoresPerProc(100)
@@ -196,15 +179,15 @@ public class HostReportHandlerTests extends TransactionalTest {
     public void testHandleHostReport() throws InterruptedException {
         CoreDetail cores = getCoreDetail(200, 200, 0, 0);
         HostReport report1 = HostReport.newBuilder()
-                .setHost(getRenderHost(hostname, HardwareState.UP))
+                .setHost(getRenderHost(hostname))
                 .setCoreInfo(cores)
                 .build();
         HostReport report2 = HostReport.newBuilder()
-                .setHost(getRenderHost(hostname2, HardwareState.UP))
+                .setHost(getRenderHost(hostname2))
                 .setCoreInfo(cores)
                 .build();
         HostReport report1_2 = HostReport.newBuilder()
-                .setHost(getRenderHost(hostname, HardwareState.UP))
+                .setHost(getRenderHost(hostname))
                 .setCoreInfo(getCoreDetail(200, 200, 100, 0))
                 .build();
 
@@ -314,7 +297,7 @@ public class HostReportHandlerTests extends TransactionalTest {
         * */
         // Create HostReport
         HostReport report1 = HostReport.newBuilder()
-                .setHost(getRenderHost(hostname, HardwareState.UP, 1024L))
+                .setHost(getRenderHostBuilder(hostname).setFreeMcp(1024L).build())
                 .setCoreInfo(cores)
                 .build();
         // Call handleHostReport() => Create the comment with subject=SUBJECT_COMMENT_FULL_TEMP_DIR and change the
@@ -356,7 +339,7 @@ public class HostReportHandlerTests extends TransactionalTest {
          * */
         // Set the host freeTempDir to the minimum size required = 1GB (1048576 KB)
         HostReport report2 = HostReport.newBuilder()
-                .setHost(getRenderHost(hostname, HardwareState.UP, 1048576L))
+                .setHost(getRenderHostBuilder(hostname).setFreeMcp(CueUtil.GB).build())
                 .setCoreInfo(cores)
                 .build();
         // Call handleHostReport() => Delete the comment with subject=SUBJECT_COMMENT_FULL_TEMP_DIR and change the
@@ -397,7 +380,7 @@ public class HostReportHandlerTests extends TransactionalTest {
          * */
         // Create HostReport
         HostReport report = HostReport.newBuilder()
-                .setHost(getRenderHost(hostname, HardwareState.UP, 1048576L))
+                .setHost(getRenderHostBuilder(hostname).setFreeMcp(CueUtil.GB).build())
                 .setCoreInfo(cores)
                 .build();
         // Get host
@@ -451,7 +434,7 @@ public class HostReportHandlerTests extends TransactionalTest {
                 .setMaxRss(420000)
                 .build();
         HostReport report = HostReport.newBuilder()
-                .setHost(getRenderHost(hostname, HardwareState.UP))
+                .setHost(getRenderHost(hostname))
                 .setCoreInfo(cores)
                 .addFrames(info)
                 .build();
@@ -461,6 +444,135 @@ public class HostReportHandlerTests extends TransactionalTest {
         FrameDetail frame = jobManager.getFrameDetail(proc.getFrameId());
         assertEquals(frame.dateLLU, new Timestamp(now / 1000 * 1000));
         assertEquals(420000, frame.maxRss);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testMemoryAggressionRss() {
+        jobLauncher.testMode = true;
+        jobLauncher.launch(new File("src/test/resources/conf/jobspec/jobspec_simple.xml"));
+
+        DispatchHost host = getHost(hostname);
+        List<VirtualProc> procs = dispatcher.dispatchHost(host);
+        assertEquals(1, procs.size());
+        VirtualProc proc = procs.get(0);
+
+        long memoryOverboard = (long) Math.ceil((double) proc.memoryReserved *
+                (1.0 + Dispatcher.OOM_FRAME_OVERBOARD_ALLOWED_THRESHOLD));
+
+        // Test rss overboard
+        RunningFrameInfo info = RunningFrameInfo.newBuilder()
+                .setJobId(proc.getJobId())
+                .setLayerId(proc.getLayerId())
+                .setFrameId(proc.getFrameId())
+                .setResourceId(proc.getProcId())
+                .setRss(memoryOverboard)
+                .setMaxRss(memoryOverboard)
+                .build();
+        HostReport report = HostReport.newBuilder()
+                .setHost(getRenderHost(hostname))
+                .setCoreInfo(getCoreDetail(200, 200, 0, 0))
+                .addFrames(info)
+                .build();
+
+        long killCount = DispatchSupport.killedOffenderProcs.get();
+        hostReportHandler.handleHostReport(report, false, System.currentTimeMillis());
+        assertEquals(killCount + 1, DispatchSupport.killedOffenderProcs.get());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testMemoryAggressionMaxRss() {
+        jobLauncher.testMode = true;
+        jobLauncher.launch(new File("src/test/resources/conf/jobspec/jobspec_simple.xml"));
+
+        DispatchHost host = getHost(hostname);
+        List<VirtualProc> procs = dispatcher.dispatchHost(host);
+        assertEquals(1, procs.size());
+        VirtualProc proc = procs.get(0);
+
+        long memoryOverboard = (long) Math.ceil((double) proc.memoryReserved *
+                (1.0 + (2 * Dispatcher.OOM_FRAME_OVERBOARD_ALLOWED_THRESHOLD)));
+
+        // Test rss>90% and maxRss overboard
+        RunningFrameInfo info = RunningFrameInfo.newBuilder()
+                .setJobId(proc.getJobId())
+                .setLayerId(proc.getLayerId())
+                .setFrameId(proc.getFrameId())
+                .setResourceId(proc.getProcId())
+                .setRss((long)Math.ceil(0.95 * proc.memoryReserved))
+                .setMaxRss(memoryOverboard)
+                .build();
+        HostReport report = HostReport.newBuilder()
+                .setHost(getRenderHost(hostname))
+                .setCoreInfo(getCoreDetail(200, 200, 0, 0))
+                .addFrames(info)
+                .build();
+
+        long killCount = DispatchSupport.killedOffenderProcs.get();
+        hostReportHandler.handleHostReport(report, false, System.currentTimeMillis());
+        assertEquals(killCount + 1, DispatchSupport.killedOffenderProcs.get());
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testMemoryAggressionMemoryWarning() {
+        jobLauncher.testMode = true;
+        dispatcher.setTestMode(true);
+        jobLauncher.launch(new File("src/test/resources/conf/jobspec/jobspec_multiple_frames.xml"));
+
+        DispatchHost host = getHost(hostname);
+        List<VirtualProc> procs = dispatcher.dispatchHost(host);
+        assertEquals(3, procs.size());
+        VirtualProc proc1 = procs.get(0);
+        VirtualProc proc2 = procs.get(1);
+        VirtualProc proc3 = procs.get(2);
+
+        // Ok
+        RunningFrameInfo info1 = RunningFrameInfo.newBuilder()
+                .setJobId(proc1.getJobId())
+                .setLayerId(proc1.getLayerId())
+                .setFrameId(proc1.getFrameId())
+                .setResourceId(proc1.getProcId())
+                .setRss(CueUtil.GB2)
+                .setMaxRss(CueUtil.GB2)
+                .build();
+
+        // Overboard Rss
+        RunningFrameInfo info2 = RunningFrameInfo.newBuilder()
+                .setJobId(proc2.getJobId())
+                .setLayerId(proc2.getLayerId())
+                .setFrameId(proc2.getFrameId())
+                .setResourceId(proc2.getProcId())
+                .setRss(CueUtil.GB4)
+                .setMaxRss(CueUtil.GB4)
+                .build();
+
+        // Overboard Rss
+        RunningFrameInfo info3 = RunningFrameInfo.newBuilder()
+                .setJobId(proc3.getJobId())
+                .setLayerId(proc3.getLayerId())
+                .setFrameId(proc3.getFrameId())
+                .setResourceId(proc3.getProcId())
+                .setRss(CueUtil.GB4)
+                .setMaxRss(CueUtil.GB4)
+                .build();
+
+        RenderHost hostAfterUpdate = getRenderHostBuilder(hostname).setFreeMem(0).build();
+
+        HostReport report = HostReport.newBuilder()
+                .setHost(hostAfterUpdate)
+                .setCoreInfo(getCoreDetail(200, 200, 0, 0))
+                .addAllFrames(Arrays.asList(info1, info2, info3))
+                .build();
+
+        // In this case, killing one job should be enough to ge the machine to a safe state
+        long killCount = DispatchSupport.killedOffenderProcs.get();
+        hostReportHandler.handleHostReport(report, false, System.currentTimeMillis());
+        assertEquals(killCount + 1, DispatchSupport.killedOffenderProcs.get());
     }
 }
 

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HostReportHandlerTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HostReportHandlerTests.java
@@ -458,6 +458,8 @@ public class HostReportHandlerTests extends TransactionalTest {
     @Rollback(true)
     public void testMemoryAggressionRss() {
         jobLauncher.testMode = true;
+        dispatcher.setTestMode(true);
+
         jobLauncher.launch(new File("src/test/resources/conf/jobspec/jobspec_simple.xml"));
 
         DispatchHost host = getHost(hostname);
@@ -465,8 +467,8 @@ public class HostReportHandlerTests extends TransactionalTest {
         assertEquals(1, procs.size());
         VirtualProc proc = procs.get(0);
 
-        long memoryOverboard = (long) Math.ceil((double) proc.memoryReserved *
-                (1.0 + Dispatcher.OOM_FRAME_OVERBOARD_ALLOWED_THRESHOLD));
+        // 1.6 = 1 + dispatcher.oom_frame_overboard_allowed_threshold
+        long memoryOverboard = (long) Math.ceil((double) proc.memoryReserved * 1.6);
 
         // Test rss overboard
         RunningFrameInfo info = RunningFrameInfo.newBuilder()
@@ -493,6 +495,7 @@ public class HostReportHandlerTests extends TransactionalTest {
     @Rollback(true)
     public void testMemoryAggressionMaxRss() {
         jobLauncher.testMode = true;
+        dispatcher.setTestMode(true);
         jobLauncher.launch(new File("src/test/resources/conf/jobspec/jobspec_simple.xml"));
 
         DispatchHost host = getHost(hostname);
@@ -500,8 +503,9 @@ public class HostReportHandlerTests extends TransactionalTest {
         assertEquals(1, procs.size());
         VirtualProc proc = procs.get(0);
 
+        // 0.6 = dispatcher.oom_frame_overboard_allowed_threshold
         long memoryOverboard = (long) Math.ceil((double) proc.memoryReserved *
-                (1.0 + (2 * Dispatcher.OOM_FRAME_OVERBOARD_ALLOWED_THRESHOLD)));
+                (1.0 + (2 * 0.6)));
 
         // Test rss>90% and maxRss overboard
         RunningFrameInfo info = RunningFrameInfo.newBuilder()

--- a/cuebot/src/test/resources/conf/jobspec/jobspec_multiple_frames.xml
+++ b/cuebot/src/test/resources/conf/jobspec/jobspec_multiple_frames.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<!--
+   Copyright Contributors to the OpenCue Project
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+
+
+
+<!DOCTYPE spec SYSTEM "../dtd/cjsl-1.12.dtd">
+<spec>
+    <facility>spi</facility>
+    <show>pipe</show>
+    <shot>default</shot>
+    <user>testuser</user>
+    <uid>9860</uid>
+
+    <job name="test">
+        <paused>False</paused>
+        <maxretries>2</maxretries>
+        <autoeat>False</autoeat>
+        <env/>
+        <layers>
+            <layer name="test_layer" type="Render">
+                <cmd>echo hello</cmd>
+                <range>1-3</range>
+                <chunk>1</chunk>
+                <memory>2gb</memory>
+                <env/>
+                <services>
+                    <service>shell</service>
+                </services>
+            </layer>
+        </layers>
+    </job>
+    <depends/>
+</spec>

--- a/cuebot/src/test/resources/opencue.properties
+++ b/cuebot/src/test/resources/opencue.properties
@@ -38,7 +38,7 @@ dispatcher.job_query_max=20
 dispatcher.job_lock_expire_seconds=2
 dispatcher.job_lock_concurrency_level=3
 dispatcher.frame_query_max=10
-dispatcher.job_frame_dispatch_max=2
+dispatcher.job_frame_dispatch_max=3
 dispatcher.host_frame_dispatch_max=12
 
 dispatcher.launch_queue.core_pool_size=1

--- a/cuebot/src/test/resources/opencue.properties
+++ b/cuebot/src/test/resources/opencue.properties
@@ -64,9 +64,8 @@ dispatcher.kill_queue.queue_capacity=1000
 dispatcher.booking_queue.core_pool_size=6
 dispatcher.booking_queue.max_pool_size=6
 dispatcher.booking_queue.queue_capacity=1000
-
-# The minimum amount of free space in the temporary directory (mcp) to book a host.
-# E.g: 1G = 1048576 kB => dispatcher.min_bookable_free_temp_dir_kb=1048576
-# Default = 1G = 1048576 kB
-# If equals to -1, it means the feature is turned off
 dispatcher.min_bookable_free_temp_dir_kb=1048576
+dispatcher.min_bookable_free_mcp_kb=1048576
+dispatcher.oom_max_safe_used_memory_threshold=0.95
+dispatcher.oom_frame_overboard_allowed_threshold=0.6
+dispatcher.frame_kill_retry_limit=3

--- a/rqd/rqd/rqdservicers.py
+++ b/rqd/rqd/rqdservicers.py
@@ -67,6 +67,8 @@ class RqdInterfaceServicer(rqd.compiled_proto.rqd_pb2_grpc.RqdInterfaceServicer)
         frame = self.rqCore.getRunningFrame(request.frame_id)
         if frame:
             frame.kill(message=request.message)
+        else:
+            log.warning("Wasn't able to find frame(%s) to kill", request.frame_id)
         return rqd.compiled_proto.rqd_pb2.RqdStaticKillRunningFrameResponse()
 
     def ShutdownRqdNow(self, request, context):

--- a/rqd/rqd/rqnetwork.py
+++ b/rqd/rqd/rqnetwork.py
@@ -162,6 +162,7 @@ class RunningFrame(object):
                     else:
                         os.killpg(self.pid, rqd.rqconstants.KILL_SIGNAL)
                 finally:
+                    log.warning("kill() successfully killed frameId=%s pid=%s", self.frameId, self.pid)
                     rqd.rqutil.permissionsLow()
             except OSError as e:
                 log.warning(


### PR DESCRIPTION
The current logic relies on hardcoded values which are not suitable for large hosts. The new logic takes into account the size of hosts and also tries to be more aggressive with misbehaving frames.

Prevent host from entering an OOM state where oom-killer might start killing important OS processes. The kill logic will kick in one of the following conditions is met:
  - Host has less than `OOM_MEMORY_LEFT_THRESHOLD_PERCENT` memory available
  - A frame is taking more than `OOM_FRAME_OVERBOARD_PERCENT` of what it had reserved For frames that are using more than they had reserved but not above the threshold, negotiate expanding the reservations with other frames on the same host.

Additional observations:
 - Setting `OOM_FRAME_OVERBOARD_PERCENT` to -1 will turn off the frame overboard protection feature. 
 - Frames killed by this logic will be marked to be retried and will trigger the existing memory bump logic, in which the memory requirements for the layer will be increased to try to allocate a larger portion of memory for subsequent executions.
 - In rare occasions a frame can leave child processes behind. As rqd keeps track of procs related to the original frame, it will continue to report the Frame as active and cuebot will continue to request that it gets killed. To avoid this condition, there is a new logic that prevents repeated kill requests to be sent more then `FRAME_KILL_RETRY_LIMIT` times in 3 minutes (configurable). 