### PR TITLE
Feature: RQD command expand env vars

### DIFF
--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -124,11 +124,18 @@ class FrameAttendantThread(threading.Thread):
 
     def _createCommandFile(self, command):
         """Creates a file that subprocess. Popen then executes.
+
+        Environment variables are expanded before writing the file.
+
         @type  command: string
         @param command: The command specified in the runFrame request
         @rtype:  string
         @return: Command file location"""
         # TODO: this should use tempfile to create the files and clean them up afterwards
+        
+        # Expand environment variables
+        command = os.path.expandvars(command)
+
         try:
             if platform.system() == "Windows":
                 rqd_tmp_dir = os.path.join(tempfile.gettempdir(), 'rqd')


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Started discussion in [discussion mail list](https://lists.aswf.io/g/opencue-user/topic/render_command_path_resolving/101381758?p=,,,20,0,0,0::recentpostdate/sticky,,,20,2,0,101381758,previd%3D1697464276523306623,nextid%3D1689790757197015748&previd=1697464276523306623&nextid=1689790757197015748).

**Summarize your change.**
Run `os.path.expandvars` before the command is executed on RQD host. This allows to use Environment Variables, for path resolving it might be a great help.

I haven't found any place in documentation where to accurately put this information. Please tell me.