### PR TITLE
Add sample RQD Dockerfile with CUDA base image

### DIFF
--- a/samples/rqd/cuda/Dockerfile
+++ b/samples/rqd/cuda/Dockerfile
@@ -16,23 +16,15 @@ RUN yum -y install \
 RUN python3.6 -m pip install --upgrade pip
 RUN python3.6 -m pip install --upgrade setuptools
 
-COPY --from=opencue/rqd /opt/opencue/rqd-0.22-custom-all.tar.gz /opt/opencue/rqd-0.22-custom-all.tar.gz
+COPY --from=opencue/rqd /opt/opencue/rqd-*-all.tar.gz /opt/opencue/
 COPY --from=opencue/rqd /opt/opencue/proto/ /opt/opencue/proto/
 
 RUN mkdir -p /etc/opencue
 COPY --from=opencue/rqd /etc/opencue/rqd.conf /etc/opencue/rqd.conf
 
-RUN tar -xvf /opt/opencue/rqd-0.22-custom-all.tar.gz --strip-components=1
+RUN tar -xvf /opt/opencue/rqd-*-all.tar.gz --strip-components=1
 
 RUN python3.6 -m pip install -r requirements.txt
-
-RUN python3.6 -m grpc_tools.protoc \
-  -I=./proto \
-  --python_out=./rqd/compiled_proto \
-  --grpc_python_out=./rqd/compiled_proto \
-  ./proto/*.proto
-
-RUN 2to3 -wn -f import rqd/compiled_proto/*_pb2*.py
 
 RUN python3.6 setup.py test
 RUN python3.6 setup.py install

--- a/samples/rqd/cuda/Dockerfile
+++ b/samples/rqd/cuda/Dockerfile
@@ -1,0 +1,63 @@
+FROM nvidia/cudagl:10.2-base-centos7
+
+WORKDIR /opt/opencue
+
+RUN yum -y install \
+  epel-release \
+  gcc \
+  python-devel \
+  time
+
+RUN yum -y install \
+  python36 \
+  python36-devel \
+  python36-pip
+
+RUN python3.6 -m pip install --upgrade pip
+RUN python3.6 -m pip install --upgrade setuptools
+
+COPY LICENSE ./
+COPY requirements.txt ./
+
+RUN python3.6 -m pip install -r requirements.txt
+
+COPY proto/ ./proto
+COPY rqd/deploy ./rqd/deploy
+COPY rqd/README.md ./rqd/
+COPY rqd/setup.py ./rqd/
+COPY rqd/tests/ ./rqd/tests
+COPY rqd/rqd/ ./rqd/rqd
+
+RUN python3.6 -m grpc_tools.protoc \
+  -I=./proto \
+  --python_out=./rqd/rqd/compiled_proto \
+  --grpc_python_out=./rqd/rqd/compiled_proto \
+  ./proto/*.proto
+
+# Fix imports to work in both Python 2 and 3. See
+# <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
+RUN 2to3 -wn -f import rqd/rqd/compiled_proto/*_pb2*.py
+
+COPY VERSION.in VERSIO[N] ./
+RUN test -e VERSION || echo "$(cat VERSION.in)-custom" | tee VERSION
+
+RUN cd rqd && python3.6 setup.py test
+RUN cd rqd && python3.6 setup.py install
+
+# This step isn't really needed at runtime, but is used when publishing an OpenCue release
+# from this build.
+RUN versioned_name="rqd-$(cat ./VERSION)-all" \
+  && cp LICENSE requirements.txt VERSION rqd/ \
+  && mv rqd $versioned_name \
+  && tar -cvzf $versioned_name.tar.gz $versioned_name/* \
+  && ln -s $versioned_name rqd
+
+RUN mkdir -p /etc/opencue
+RUN echo "[Override]" > /etc/opencue/rqd.conf
+RUN echo "USE_NIMBY_PYNPUT=false" >> /etc/opencue/rqd.conf
+
+# RQD gRPC server
+EXPOSE 8444
+
+# NOTE: This shell out is needed to avoid RQD getting PID 0 which leads to leaking child processes.
+ENTRYPOINT ["/bin/bash", "-c", "set -e && rqd"]

--- a/samples/rqd/cuda/Dockerfile
+++ b/samples/rqd/cuda/Dockerfile
@@ -28,16 +28,14 @@ RUN python3.6 -m pip install -r requirements.txt
 
 RUN python3.6 -m grpc_tools.protoc \
   -I=./proto \
-  --python_out=./rqd/rqd/compiled_proto \
-  --grpc_python_out=./rqd/rqd/compiled_proto \
+  --python_out=./rqd/compiled_proto \
+  --grpc_python_out=./rqd/compiled_proto \
   ./proto/*.proto
 
-RUN 2to3 -wn -f import rqd/rqd/compiled_proto/*_pb2*.py
+RUN 2to3 -wn -f import rqd/compiled_proto/*_pb2*.py
 
-RUN test -e VERSION || echo "$(cat VERSION.in)-custom" | tee VERSION
-
-RUN cd rqd && python3.6 setup.py test
-RUN cd rqd && python3.6 setup.py install
+RUN python3.6 setup.py test
+RUN python3.6 setup.py install
 
 # RQD gRPC server
 EXPOSE 8444

--- a/samples/rqd/cuda/Dockerfile
+++ b/samples/rqd/cuda/Dockerfile
@@ -16,17 +16,15 @@ RUN yum -y install \
 RUN python3.6 -m pip install --upgrade pip
 RUN python3.6 -m pip install --upgrade setuptools
 
-COPY LICENSE ./
-COPY requirements.txt ./
+COPY --from=opencue/rqd /opt/opencue/rqd-0.22-custom-all.tar.gz /opt/opencue/rqd-0.22-custom-all.tar.gz
+COPY --from=opencue/rqd /opt/opencue/proto/ /opt/opencue/proto/
+
+RUN mkdir -p /etc/opencue
+COPY --from=opencue/rqd /etc/opencue/rqd.conf /etc/opencue/rqd.conf
+
+RUN tar -xvf /opt/opencue/rqd-0.22-custom-all.tar.gz --strip-components=1
 
 RUN python3.6 -m pip install -r requirements.txt
-
-COPY proto/ ./proto
-COPY rqd/deploy ./rqd/deploy
-COPY rqd/README.md ./rqd/
-COPY rqd/setup.py ./rqd/
-COPY rqd/tests/ ./rqd/tests
-COPY rqd/rqd/ ./rqd/rqd
 
 RUN python3.6 -m grpc_tools.protoc \
   -I=./proto \
@@ -34,30 +32,16 @@ RUN python3.6 -m grpc_tools.protoc \
   --grpc_python_out=./rqd/rqd/compiled_proto \
   ./proto/*.proto
 
-# Fix imports to work in both Python 2 and 3. See
-# <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
 RUN 2to3 -wn -f import rqd/rqd/compiled_proto/*_pb2*.py
 
-COPY VERSION.in VERSIO[N] ./
 RUN test -e VERSION || echo "$(cat VERSION.in)-custom" | tee VERSION
 
 RUN cd rqd && python3.6 setup.py test
 RUN cd rqd && python3.6 setup.py install
-
-# This step isn't really needed at runtime, but is used when publishing an OpenCue release
-# from this build.
-RUN versioned_name="rqd-$(cat ./VERSION)-all" \
-  && cp LICENSE requirements.txt VERSION rqd/ \
-  && mv rqd $versioned_name \
-  && tar -cvzf $versioned_name.tar.gz $versioned_name/* \
-  && ln -s $versioned_name rqd
-
-RUN mkdir -p /etc/opencue
-RUN echo "[Override]" > /etc/opencue/rqd.conf
-RUN echo "USE_NIMBY_PYNPUT=false" >> /etc/opencue/rqd.conf
 
 # RQD gRPC server
 EXPOSE 8444
 
 # NOTE: This shell out is needed to avoid RQD getting PID 0 which leads to leaking child processes.
 ENTRYPOINT ["/bin/bash", "-c", "set -e && rqd"]
+


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Related to PR https://github.com/AcademySoftwareFoundation/OpenCue/pull/1309.
As discussed in the mail thread [Blender plugin development](https://lists.aswf.io/g/opencue-dev/message/527).

**Summarize your change.**
Adds a sample RQD Dockerfile with CUDA supported base image for GPU rendering. 
Tested with new derived RQD Blender image.

Works in combination with [Nvidia Container Toolkit](https://github.com/NVIDIA/nvidia-container-toolkit).