### PR TITLE
Add frame range to Blender command in CueSubmit

### DIFF
--- a/cuesubmit/cuesubmit/Constants.py
+++ b/cuesubmit/cuesubmit/Constants.py
@@ -37,8 +37,8 @@ MAYA_RENDER_CMD = config.get('MAYA_RENDER_CMD', 'Render')
 NUKE_RENDER_CMD = config.get('NUKE_RENDER_CMD', 'nuke')
 BLENDER_RENDER_CMD = config.get('BLENDER_RENDER_CMD', 'blender')
 FRAME_TOKEN = config.get('FRAME_TOKEN', '#IFRAME#')
-FRAME_START = config.get('FRAME_START', '#FRAME_START#')
-FRAME_END = config.get('FRAME_END', '#FRAME_END#')
+FRAME_START_TOKEN = config.get('FRAME_START', '#FRAME_START#')
+FRAME_END_TOKEN = config.get('FRAME_END', '#FRAME_END#')
 
 # Tokens are replaced by cuebot during dispatch with their computed value.
 # see: cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java

--- a/cuesubmit/cuesubmit/Constants.py
+++ b/cuesubmit/cuesubmit/Constants.py
@@ -17,7 +17,6 @@
 
 Some values can be overridden by custom config, see Config.py."""
 
-
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
@@ -38,6 +37,8 @@ MAYA_RENDER_CMD = config.get('MAYA_RENDER_CMD', 'Render')
 NUKE_RENDER_CMD = config.get('NUKE_RENDER_CMD', 'nuke')
 BLENDER_RENDER_CMD = config.get('BLENDER_RENDER_CMD', 'blender')
 FRAME_TOKEN = config.get('FRAME_TOKEN', '#IFRAME#')
+FRAME_START = config.get('FRAME_START', '#FRAME_START#')
+FRAME_END = config.get('FRAME_END', '#FRAME_END#')
 
 # Tokens are replaced by cuebot during dispatch with their computed value.
 # see: cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java
@@ -55,7 +56,7 @@ COMMAND_TOKENS = {'#ZFRAME#': 'Current frame with a padding of 4',
 BLENDER_FORMATS = ['', 'AVIJPEG', 'AVIRAW', 'BMP', 'CINEON', 'DPX', 'EXR', 'HDR', 'IRIS', 'IRIZ',
                    'JP2', 'JPEG', 'MPEG', 'MULTILAYER', 'PNG', 'RAWTGA', 'TGA', 'TIFF']
 BLENDER_OUTPUT_OPTIONS_URL = \
-  'https://docs.blender.org/manual/en/latest/advanced/command_line/arguments.html#render-options'
+    'https://docs.blender.org/manual/en/latest/advanced/command_line/arguments.html#render-options'
 
 DIR_PATH = os.path.dirname(__file__)
 

--- a/cuesubmit/cuesubmit/Submission.py
+++ b/cuesubmit/cuesubmit/Submission.py
@@ -75,15 +75,10 @@ def buildBlenderCmd(layerData):
     if outputFormat:
         renderCommand += ' -F {}'.format(outputFormat)
     if frameRange:
-        # Checks if frame range is in the correct format
-        if re.match(r'^\d+$', frameRange):
-            renderCommand += ' -f {}'.format(frameRange)
-        elif re.match(r'^\d+-\d+$', frameRange):
-            startFrame, endFrame = map(int, frameRange.split("-"))
-            renderCommand += (' -s {startFrame} -e {endFrame} -a'
-                              .format(startFrame=startFrame, endFrame=endFrame))
-        else:
-            raise ValueError('Invalid frameRange format: {}'.format(frameRange))
+        # Renders animation within frame range
+        renderCommand += (' -s {startFrame} -e {endFrame} -a'
+                          .format(startFrame=Constants.FRAME_START,
+                                  endFrame=Constants.FRAME_END))
     else:
         # The render frame must come after the scene and output
         renderCommand += ' -f {frameToken}'.format(frameToken=Constants.FRAME_TOKEN)

--- a/cuesubmit/cuesubmit/Submission.py
+++ b/cuesubmit/cuesubmit/Submission.py
@@ -74,7 +74,7 @@ def buildBlenderCmd(layerData):
     if outputFormat:
         renderCommand += ' -F {}'.format(outputFormat)
     if frameRange:
-        # Renders animation within frame range
+        # Render frames from start to end (inclusive) via '-a' command argument
         renderCommand += (' -s {startFrame} -e {endFrame} -a'
                           .format(startFrame=Constants.FRAME_START_TOKEN,
                                   endFrame=Constants.FRAME_END_TOKEN))

--- a/cuesubmit/cuesubmit/Submission.py
+++ b/cuesubmit/cuesubmit/Submission.py
@@ -21,7 +21,6 @@ from __future__ import division
 from __future__ import absolute_import
 
 from builtins import str
-import re
 
 import outline
 import outline.cuerun

--- a/cuesubmit/cuesubmit/Submission.py
+++ b/cuesubmit/cuesubmit/Submission.py
@@ -80,7 +80,8 @@ def buildBlenderCmd(layerData):
             renderCommand += ' -f {}'.format(frameRange)
         elif re.match(r'^\d+-\d+$', frameRange):
             startFrame, endFrame = map(int, frameRange.split("-"))
-            renderCommand += ' -s {startFrame} -e {endFrame} -a'.format(startFrame=startFrame, endFrame=endFrame)
+            renderCommand += (' -s {startFrame} -e {endFrame} -a'
+                              .format(startFrame=startFrame, endFrame=endFrame))
         else:
             raise ValueError('Invalid frameRange format: {}'.format(frameRange))
     else:

--- a/cuesubmit/cuesubmit/Submission.py
+++ b/cuesubmit/cuesubmit/Submission.py
@@ -21,6 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 
 from builtins import str
+import re
 
 import outline
 import outline.cuerun
@@ -63,6 +64,7 @@ def buildBlenderCmd(layerData):
     blenderFile = layerData.cmd.get('blenderFile')
     outputPath = layerData.cmd.get('outputPath')
     outputFormat = layerData.cmd.get('outputFormat')
+    frameRange = layerData.layerRange
     if not blenderFile:
         raise ValueError('No Blender file provided. Cannot submit job.')
 
@@ -72,8 +74,18 @@ def buildBlenderCmd(layerData):
         renderCommand += ' -o {}'.format(outputPath)
     if outputFormat:
         renderCommand += ' -F {}'.format(outputFormat)
-    # The render frame must come after the scene and output
-    renderCommand += ' -f {frameToken}'.format(frameToken=Constants.FRAME_TOKEN)
+    if frameRange:
+        # Checks if frame range is in the correct format
+        if re.match(r'^\d+$', frameRange):
+            renderCommand += ' -f {}'.format(frameRange)
+        elif re.match(r'^\d+-\d+$', frameRange):
+            startFrame, endFrame = map(int, frameRange.split("-"))
+            renderCommand += ' -s {startFrame} -e {endFrame} -a'.format(startFrame=startFrame, endFrame=endFrame)
+        else:
+            raise ValueError('Invalid frameRange format: {}'.format(frameRange))
+    else:
+        # The render frame must come after the scene and output
+        renderCommand += ' -f {frameToken}'.format(frameToken=Constants.FRAME_TOKEN)
     return renderCommand
 
 

--- a/cuesubmit/cuesubmit/Submission.py
+++ b/cuesubmit/cuesubmit/Submission.py
@@ -76,8 +76,8 @@ def buildBlenderCmd(layerData):
     if frameRange:
         # Renders animation within frame range
         renderCommand += (' -s {startFrame} -e {endFrame} -a'
-                          .format(startFrame=Constants.FRAME_START,
-                                  endFrame=Constants.FRAME_END))
+                          .format(startFrame=Constants.FRAME_START_TOKEN,
+                                  endFrame=Constants.FRAME_END_TOKEN))
     else:
         # The render frame must come after the scene and output
         renderCommand += ' -f {frameToken}'.format(frameToken=Constants.FRAME_TOKEN)

--- a/cuesubmit/tests/Submission_tests.py
+++ b/cuesubmit/tests/Submission_tests.py
@@ -56,7 +56,8 @@ BLENDER_MULTI_LAYER_DATA = {
             'blenderFile': '/path/to/scene.blend',
             'outputFormat': 'PNG'},
     'layerRange': '3-9',
-    'cores': '2'
+    'cores': '2',
+    'services': ['blender']
 }
 
 BLENDER_SINGLE_LAYER_DATA = {
@@ -65,7 +66,8 @@ BLENDER_SINGLE_LAYER_DATA = {
     'cmd': {'outputPath': '/path/to/output',
             'blenderFile': '/path/to/scene.blend',
             'outputFormat': 'PNG'},
-    'cores': '2'
+    'cores': '2',
+    'services': ['blender']
 }
 
 SHELL_LAYER_DATA = {


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
https://github.com/AcademySoftwareFoundation/OpenCue/issues/1334
https://github.com/AcademySoftwareFoundation/OpenCue/issues/1264

**Summarize your change.**
Adds frame range to the Blender render command in CueSubmit.
Required for when rendering animations.
Related Blender command linked [here](https://docs.blender.org/manual/en/latest/advanced/command_line/render.html#animation).

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
