### PR TITLE
[rqd] Add SYSTEMDRIVE to env var list for Windows machines

### DIFF
--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -101,7 +101,7 @@ class FrameAttendantThread(threading.Thread):
             self.frameEnv["MAIL"] = "/usr/mail/%s" % self.runFrame.user_name
             self.frameEnv["HOME"] = "/net/homedirs/%s" % self.runFrame.user_name
         elif platform.system() == "Windows":
-            for variable in ["SYSTEMROOT", "APPDATA", "TMP", "COMMONPROGRAMFILES"]:
+            for variable in ["SYSTEMROOT", "APPDATA", "TMP", "COMMONPROGRAMFILES", "SYSTEMDRIVE"]:
                 if variable in os.environ:
                     self.frameEnv[variable] = os.environ[variable]
 


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Fixes https://github.com/AcademySoftwareFoundation/OpenCue/issues/1310

**Summarize your change.**
When running a `mayabatch.exe` command in RQD on Windows, the application errors out, saying it's unable to start correctly. It turns out `mayabatch.exe` requires the `SYSTEMDRIVE` environment variable to be set on Windows machines. After adding this env var manually, `mayabatch.exe` runs as expected.

This change will add `SYSTEMDRIVE` to the default list of environment variables that will be copied over to the subprocess on Windows RQD machines. This will also solve the problem of Maya Render jobs failing out of the box on Windows machines when launching from CueSubmit.

<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->
