### PR TITLE
[cuebot] Fix queries find_jobs_by_show

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatchQuery.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatchQuery.java
@@ -44,7 +44,6 @@ public class DispatchQuery {
                 "AND folder.pk_dept         = point.pk_dept " +
                 "AND folder.pk_show         = point.pk_show " +
                 "AND job.pk_job             = layer.pk_job " +
-                "AND job_resource.pk_job    = job.pk_job " +
                 "AND (CASE WHEN layer_stat.int_waiting_count > 0 THEN layer_stat.pk_layer ELSE NULL END) = layer.pk_layer " +
                 "AND " +
                     "(" +
@@ -139,7 +138,6 @@ public class DispatchQuery {
                 "AND folder.pk_dept         = point.pk_dept " +
                 "AND folder.pk_show         = point.pk_show " +
                 "AND job.pk_job             = layer.pk_job " +
-                "AND job_resource.pk_job    = job.pk_job " +
                 "AND (CASE WHEN layer_stat.int_waiting_count > 0 THEN layer_stat.pk_layer ELSE NULL END) = layer.pk_layer " +
                 "AND " +
                     "(" +


### PR DESCRIPTION
- Fix the where clause in the find_jobs_by_show queries (FIND_JOBS_BY_SHOW_PRIORITY_MODE and FIND_JOBS_BY_SHOW_BALANCED_MODE)
- Remove duplicate PK check "job_resource.pk_job = job.pk_job" that is the same as "job.pk_job = job_resource.pk_job"