### PR TITLE
Fix bug with running frames not being updated

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
@@ -42,6 +42,7 @@ import org.springframework.dao.EmptyResultDataAccessException;
 import com.imageworks.spcue.CommentDetail;
 import com.imageworks.spcue.DispatchHost;
 import com.imageworks.spcue.FrameInterface;
+import com.imageworks.spcue.FrameDetail;
 import com.imageworks.spcue.JobEntity;
 import com.imageworks.spcue.LayerEntity;
 import com.imageworks.spcue.LayerDetail;


### PR DESCRIPTION
**Issue**
Render host resources reported on opencue were not accurate with reality. 

**Summarize your change.**
Comparing with the cue3 version of HostReportHandler, the verifyRunningFrameInfo was supposed to update the list of frames to only keep what has been verified for the following steps. As grpc objects are immutable, the logic simple kept the full list of frames that may have been canceled, completed or migrated impacting the following calls.
