### PR TITLE
Update flyway dockerfile base image

### DIFF
--- a/sandbox/flyway.Dockerfile
+++ b/sandbox/flyway.Dockerfile
@@ -1,4 +1,4 @@
-FROM almalinux:8.7
+FROM almalinux:9
 
 ARG FLYWAY_VERSION=9.11.0
 


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
https://github.com/AcademySoftwareFoundation/OpenCue/issues/1340
GPG key issue while installing packages also results in `docker compose up` failing, leading to issues while developing integration tests https://github.com/AcademySoftwareFoundation/OpenCue/pull/1309#issuecomment-2145509478.

**Summarize your change.**
Updates base image to almalinux v9. 
