### PR TITLE
Fix failure in updating filter action values through the API.

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/ActionEntity.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/ActionEntity.java
@@ -85,6 +85,10 @@ public class ActionEntity extends Entity implements ActionInterface {
     }
 
     public String getFilterId() {
+        if (filterId == null){
+            throw new SpcueRuntimeException(
+                    "Trying to get a filterId from a ActityEntity created without a filter");
+        }
         return filterId;
     }
 


### PR DESCRIPTION
Although ActionEntity inherits from FilterEntity, ActionEntity doesn't always fill the fields required by FilterEntity, causing problems when trying to use getFilterId on ActionEntity for example.

Cherrypicked from spi: 485886f