### PR TITLE
Kill job reason

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/Source.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/Source.java
@@ -49,7 +49,11 @@ public class Source {
     }
 
     public String toString() {
-        return this.source + this.username + this.pid + this.host_kill + this.reason;
+        return "User: " + this.username +
+                ", Pid: " + this.pid +
+                ", Hostname: " + this.host_kill +
+                ", Reason: " + this.reason +
+                "\n" + this.source;
     }
 }
 

--- a/cuebot/src/main/java/com/imageworks/spcue/Source.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/Source.java
@@ -25,6 +25,10 @@ package com.imageworks.spcue;
 public class Source {
 
     public String source = "unknown";
+    public String username = "";
+    public String pid = "";
+    public String host_kill = "";
+    public String reason = "";
 
     public Source() {}
 
@@ -32,8 +36,20 @@ public class Source {
         this.source = source;
     }
 
+    public Source(String source, String username, String pid, String host_kill, String reason) {
+        this.source = source;
+        this.username = username;
+        this.pid = pid;
+        this.host_kill = host_kill;
+        this.reason = reason;
+    }
+
+    public String getReason() {
+        return this.reason;
+    }
+
     public String toString() {
-        return this.source;
+        return this.source + this.username + this.pid + this.host_kill + this.reason;
     }
 }
 

--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageJob.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageJob.java
@@ -275,7 +275,9 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
         try {
             setupJobData(request.getJob());
             manageQueue.execute(new DispatchJobComplete(job,
-                    new Source(request.toString()), true, jobManagerSupport));
+                    new Source(request.toString(), request.getUsername(), request.getPid(),
+                               request.getHostKill(), request.getReason()),
+                    true, jobManagerSupport));
             responseObserver.onNext(JobKillResponse.newBuilder().build());
             responseObserver.onCompleted();
         }

--- a/cuebot/src/main/java/com/imageworks/spcue/service/JobManagerSupport.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/service/JobManagerSupport.java
@@ -75,7 +75,12 @@ public class JobManagerSupport {
 
     public boolean shutdownJob(JobInterface job, Source source, boolean isManualKill) {
 
-        if (jobManager.shutdownJob(job)) {
+        if (isManualKill && source.getReason().isEmpty()) {
+            logger.info(job.getName() + "/" + job.getId() +
+                    " **Invalid Job Kill Request** for " + source.toString());
+        }
+        else {
+            if (jobManager.shutdownJob(job)) {
 
             /*
              * Satisfy any dependencies on just the

--- a/cuegui/cuegui/MenuActions.py
+++ b/cuegui/cuegui/MenuActions.py
@@ -24,6 +24,7 @@ from __future__ import print_function
 from builtins import filter
 from builtins import str
 from builtins import object
+import getpass
 import glob
 import subprocess
 import time
@@ -65,7 +66,7 @@ logger = cuegui.Logger.getLogger(__file__)
 TITLE = 0
 TOOLTIP = 1
 ICON = 2
-
+DEFAULT_JOB_KILL_REASON = "Manual Job Kill Request in Cuegui by " + getpass.getuser()
 
 # pylint: disable=missing-function-docstring,no-self-use,unused-argument
 
@@ -368,7 +369,7 @@ class JobActions(AbstractActions):
             if cuegui.Utils.questionBoxYesNo(self._caller, "Kill jobs?", msg,
                                              [job.data.name for job in jobs]):
                 for job in jobs:
-                    job.kill()
+                    job.kill(reason=DEFAULT_JOB_KILL_REASON)
                 self.killDependents(jobs)
                 self._update()
 
@@ -384,10 +385,9 @@ class JobActions(AbstractActions):
                                   sorted([dep.name() for dep in dependents])):
             for depJob in dependents:
                 try:
-                    depJob.kill()
-                except opencue.exception.CueException as e:
-                    errMsg = "Failed to kill depending job: %s - %s" % (depJob.name(), e)
-                    logger.warning(errMsg)
+                    depJob.kill(reason=DEFAULT_JOB_KILL_REASON)
+                except Exception as e:
+                    logger.warning("Failed to kill depending job: %s - %s" % (depJob.name(), e))
         else:
             # Drop only direct dependents.
             for job in dependents:

--- a/proto/job.proto
+++ b/proto/job.proto
@@ -1283,6 +1283,10 @@ message JobIsJobPendingResponse {
 // Kill
 message JobKillRequest {
     Job job = 1;
+    string username = 2;
+    string pid = 3;
+    string host_kill = 4;
+    string reason = 5;
 }
 
 message JobKillResponse {} // Empty

--- a/pycue/opencue/wrappers/job.py
+++ b/pycue/opencue/wrappers/job.py
@@ -44,9 +44,17 @@ class Job(object):
         self.stub = Cuebot.getStub('job')
         self.__frameStateTotals = {}
 
-    def kill(self):
+    def kill(self, username=None, pid=None, host_kill=None, reason=None):
         """Kills the job."""
-        self.stub.Kill(job_pb2.JobKillRequest(job=self.data), timeout=Cuebot.Timeout)
+        username = username if username else getpass.getuser()
+        pid = pid if pid else os.getpid()
+        host_kill = host_kill if host_kill else os.uname()[1]
+        self.stub.Kill(job_pb2.JobKillRequest(job=self.data,
+                                              username=username,
+                                              pid=str(pid),
+                                              host_kill=host_kill,
+                                              reason=reason),
+                       timeout=Cuebot.Timeout)
 
     def pause(self):
         """Pauses the job."""

--- a/pycue/tests/wrappers/job_test.py
+++ b/pycue/tests/wrappers/job_test.py
@@ -46,10 +46,18 @@ class JobTests(unittest.TestCase):
 
         job = opencue.wrappers.job.Job(
             job_pb2.Job(name=TEST_JOB_NAME))
-        job.kill()
+        username = getpass.getuser()
+        pid = os.getpid()
+        host_kill = os.uname()[1]
+        reason = "Job Kill Request"
+        job.kill(username=username, pid=pid, host_kill=host_kill, reason=reason)
 
         stubMock.Kill.assert_called_with(
-            job_pb2.JobKillRequest(job=job.data), timeout=mock.ANY)
+            job_pb2.JobKillRequest(job=job.data,
+                                   username=username,
+                                   pid=str(pid),
+                                   host_kill=host_kill,
+                                   reason=reason), timeout=mock.ANY)
 
     def testPause(self, getStubMock):
         stubMock = mock.Mock()


### PR DESCRIPTION
Adding requester information to JobKillRequest

This feature requires more information from job kill
actions requested through the API.

**Link the Issue(s) this Pull Request is related to.**
This feature is motivated by a situation where a script was misusing the API and calling kill on all the jobs for a show on a regular basis. Without this feature, finding where the requests were coming from was a big endeavor. 

**Summarize your change.**
This change requires that a kill request also provide username, pid, host_kill and reason.
