### PR TITLE
Subscribe to a job using email

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dao/JobDao.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/JobDao.java
@@ -495,5 +495,8 @@ public interface JobDao {
     boolean isLaunching(JobInterface j);
 
     void updateEmail(JobInterface job, String email);
+
+    String getEmail(JobInterface job);
+
 }
 

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/JobDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/JobDaoJdbc.java
@@ -1066,5 +1066,10 @@ public class JobDaoJdbc extends JdbcDaoSupport implements JobDao {
                 "UPDATE job SET str_email=? WHERE pk_job=?",
                 email, job.getJobId());
     }
+
+    public String getEmail(JobInterface job) {
+        String jobId = job.getJobId();
+        return getJdbcTemplate().queryForObject("SELECT str_email FROM job WHERE pk_job = ?", String.class, jobId);
+    }
 }
 

--- a/cuebot/src/main/java/com/imageworks/spcue/servant/ManageJob.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/servant/ManageJob.java
@@ -21,7 +21,9 @@ package com.imageworks.spcue.servant;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
+import com.google.common.collect.Sets;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import org.apache.logging.log4j.Logger;
@@ -61,6 +63,8 @@ import com.imageworks.spcue.grpc.job.JobAddCommentRequest;
 import com.imageworks.spcue.grpc.job.JobAddCommentResponse;
 import com.imageworks.spcue.grpc.job.JobAddRenderPartRequest;
 import com.imageworks.spcue.grpc.job.JobAddRenderPartResponse;
+import com.imageworks.spcue.grpc.job.JobAddSubscriberRequest;
+import com.imageworks.spcue.grpc.job.JobAddSubscriberResponse;
 import com.imageworks.spcue.grpc.job.JobCreateDependencyOnFrameRequest;
 import com.imageworks.spcue.grpc.job.JobCreateDependencyOnFrameResponse;
 import com.imageworks.spcue.grpc.job.JobCreateDependencyOnJobRequest;
@@ -909,6 +913,22 @@ public class ManageJob extends JobInterfaceGrpc.JobInterfaceImplBase {
         }
         catch (EmptyResultDataAccessException e) {
             responseObserver.onError(Status.INTERNAL
+                    .withDescription("Failed to find job data")
+                    .asRuntimeException());
+        }
+    }
+
+    public void addSubscriber(JobAddSubscriberRequest request, StreamObserver<JobAddSubscriberResponse> responseStreamObserver) {
+        try {
+            setupJobData(request.getJob());
+            Set<String> subscribers = Sets.newHashSet(jobManager.getEmail(job).split(","));
+            subscribers.add(request.getSubscriber());
+            jobManager.updateEmail(job, String.join(",", subscribers));
+            responseStreamObserver.onNext(JobAddSubscriberResponse.newBuilder().build());
+            responseStreamObserver.onCompleted();
+        }
+        catch (EmptyResultDataAccessException e) {
+            responseStreamObserver.onError(Status.INTERNAL
                     .withDescription("Failed to find job data")
                     .asRuntimeException());
         }

--- a/cuebot/src/main/java/com/imageworks/spcue/service/JobManager.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/service/JobManager.java
@@ -491,5 +491,20 @@ public interface JobManager {
      * @param layer
      */
     List<LimitEntity> getLayerLimits(LayerInterface layer);
+
+    /**
+     * Update email(s) of subscribers for job
+     *
+     * @param job
+     * @param email
+     */
+    void updateEmail(JobInterface job, String email);
+
+    /**
+     * Return a list of limits for the given layer.
+     *
+     * @param job
+     */
+    String getEmail(JobInterface job);
 }
 

--- a/cuebot/src/main/java/com/imageworks/spcue/service/JobManagerService.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/service/JobManagerService.java
@@ -569,6 +569,16 @@ public class JobManagerService implements JobManager {
         return frameDao.getStaleCheckpoints(cutoffTimeSec);
     }
 
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void updateEmail(JobInterface job, String email) {
+        jobDao.updateEmail(job, email);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED, readOnly=true)
+    public String getEmail(JobInterface job) {
+        return jobDao.getEmail(job);
+    }
+
     public DependManager getDependManager() {
         return dependManager;
     }

--- a/cuegui/cuegui/CueJobMonitorTree.py
+++ b/cuegui/cuegui/CueJobMonitorTree.py
@@ -535,6 +535,7 @@ class CueJobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
 
             self.__menuActions.jobs().addAction(menu, "view")
             self.__menuActions.jobs().addAction(menu, "emailArtist")
+            self.__menuActions.jobs().addAction(menu, "subscribeToJob")
             self.__menuActions.jobs().addAction(menu, "viewComments")
             self.__menuActions.jobs().addAction(menu, "sendToGroup")
 

--- a/cuegui/cuegui/JobMonitorTree.py
+++ b/cuegui/cuegui/JobMonitorTree.py
@@ -384,6 +384,7 @@ class JobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         self.__menuActions.jobs().addAction(menu, "unmonitor")
         self.__menuActions.jobs().addAction(menu, "view")
         self.__menuActions.jobs().addAction(menu, "emailArtist")
+        self.__menuActions.jobs().addAction(menu, "subscribeToJob")
         self.__menuActions.jobs().addAction(menu, "viewComments")
 
         if bool(int(self.app.settings.value("AllowDeeding", 0))):

--- a/cuegui/cuegui/MenuActions.py
+++ b/cuegui/cuegui/MenuActions.py
@@ -55,6 +55,7 @@ import cuegui.PreviewWidget
 import cuegui.ProcChildren
 import cuegui.ServiceDialog
 import cuegui.ShowDialog
+import cuegui.SubscribeToJobDialog
 import cuegui.TasksDialog
 import cuegui.UnbookDialog
 import cuegui.Utils
@@ -236,6 +237,14 @@ class JobActions(AbstractActions):
         jobs = self._getOnlyJobObjects(rpcObjects)
         if jobs:
             cuegui.EmailDialog.EmailDialog(jobs, self._caller).show()
+
+    subscribeToJob_info = ["Subscribe to job", None, "mail"]
+
+    def subscribeToJob(self, rpcObjects=None):
+        jobs = self._getOnlyJobObjects(rpcObjects)
+        if jobs:
+            # Dialog to ask for email. Use show PST email as default
+            cuegui.SubscribeToJobDialog.SubscribeToJobDialog(jobs, self._caller).show()
 
     setMinCores_info = ["Set Minimum Cores...", "Set Job(s) Minimum Cores", "configure"]
 

--- a/cuegui/cuegui/SubscribeToJobDialog.py
+++ b/cuegui/cuegui/SubscribeToJobDialog.py
@@ -1,0 +1,149 @@
+#  Copyright Contributors to the OpenCue Project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+"""Dialog for subscribing to job updates"""
+
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+
+import getpass
+
+from builtins import map
+
+from PySide2 import QtCore
+from PySide2 import QtWidgets
+import cuegui.Constants
+import cuegui.Logger
+import cuegui.Utils
+
+
+logger = cuegui.Logger.getLogger(__file__)
+
+
+class SubscribeToJobDialog(QtWidgets.QDialog):
+    """Dialog for email subscription to jobs"""
+
+    def __init__(self, jobs, parent=None):
+        QtWidgets.QDialog.__init__(self, parent)
+
+        self.__jobs = jobs
+
+        job_names = ', '.join(map(lambda job: job.data.name, jobs))
+
+        self.setWindowTitle("Subscribe to jobs %s" % job_names)
+        self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+        self.setSizeGripEnabled(True)
+        self.setFixedSize(600, 400)
+
+        self.__treeSubjects = QtWidgets.QTreeWidget(self)
+        self.__treeSubjects.setHeaderLabels(["Job name"])
+
+        self.__email = EmailInfoWidget(jobs, self)
+
+        vlayout = QtWidgets.QVBoxLayout(self)
+        vlayout.addWidget(self.__treeSubjects)
+        vlayout.addWidget(self.__email)
+
+        self.__email.save.connect(self.accept)
+        self.__email.cancel.connect(self.reject)
+
+        self.refreshJobList()
+
+    def refreshJobList(self):
+        jobs = self.__jobs
+        self.__treeSubjects.clear()
+        for job in jobs:
+            item = Job(job)
+            self.__treeSubjects.addTopLevelItem(item)
+
+class EmailInfoWidget(QtWidgets.QWidget):
+    """Widget for displaying an email form."""
+
+    save = QtCore.Signal()
+    cancel = QtCore.Signal()
+
+    def __init__(self, jobs, parent=None):
+        QtWidgets.QWidget.__init__(self, parent=parent)
+
+        self.__jobs = jobs
+
+        __default_to = "%s@%s" % (getpass.getuser(), cuegui.Constants.EMAIL_DOMAIN)
+
+        __default_from = "opencue-noreply@imageworks.com"
+
+        self.__btnSave = QtWidgets.QPushButton("Save", self)
+        self.__btnCancel = QtWidgets.QPushButton("Cancel", self)
+
+        # Body Widgets
+        spacerItem = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding,
+                                           QtWidgets.QSizePolicy.Minimum)
+
+        self.__email_from = QtWidgets.QLabel(__default_from, self)
+        self.__email_to = QtWidgets.QLineEdit(__default_to, self)
+
+        # Main Vertical Layout
+        vlayout = QtWidgets.QVBoxLayout(self)
+
+        # Top Grid Layout
+        glayout = QtWidgets.QGridLayout()
+        glayout.setContentsMargins(0, 0, 0, 0)
+
+        glayout.addWidget(QtWidgets.QLabel("From:", self), 0, 0)
+        glayout.addWidget(self.__email_from, 0, 1)
+
+        glayout.addWidget(QtWidgets.QLabel("To:", self), 1, 0)
+        glayout.addWidget(self.__email_to, 1, 1)
+
+        vlayout.addLayout(glayout)
+
+        # Bottom Horizontal Layout
+        hlayout = QtWidgets.QHBoxLayout()
+        hlayout.addItem(spacerItem)
+        hlayout.addWidget(self.__btnSave)
+        hlayout.addWidget(self.__btnCancel)
+        vlayout.addLayout(hlayout)
+
+        self.__btnSave.clicked.connect(self.addSubscriber)
+        self.__btnCancel.clicked.connect(self.cancel.emit)
+
+    def email_to(self):
+        """Gets the email recipient."""
+        return "%s" % self.__email_to.text()
+
+    def addSubscriber(self):
+        """Adds subscriber to jobs."""
+        users_csv = []
+        try:
+            users_csv = cuegui.Utils.getUsers()
+        except IOError as e:
+            pass
+        user_name = self.email_to().split('@')[0]
+        # If users_csv is not found, proceed without validation
+        if users_csv and cuegui.Utils.isValidateUser(user_name, users_csv) != self.email_to():
+            cuegui.Utils.showErrorMessageBox("Email does not exist. Please check it before proceeding")
+            return
+        for job in self.__jobs:
+            job.addSubscriber(self.email_to())
+        self.save.emit()
+
+class Job(QtWidgets.QTreeWidgetItem):
+    """A widget to represent a job in the job list"""
+    def __init__(self, job):
+        QtWidgets.QTreeWidgetItem.__init__(
+            self,
+            [job.name(),
+             ])

--- a/cuegui/cuegui/SubscribeToJobDialog.py
+++ b/cuegui/cuegui/SubscribeToJobDialog.py
@@ -64,6 +64,7 @@ class SubscribeToJobDialog(QtWidgets.QDialog):
         self.refreshJobList()
 
     def refreshJobList(self):
+        """Refresh the list of jobs"""
         jobs = self.__jobs
         self.__treeSubjects.clear()
         for job in jobs:
@@ -117,8 +118,10 @@ class EmailInfoWidget(QtWidgets.QWidget):
         hlayout.addWidget(self.__btnCancel)
         vlayout.addLayout(hlayout)
 
+        # pylint: disable=no-member
         self.__btnSave.clicked.connect(self.addSubscriber)
         self.__btnCancel.clicked.connect(self.cancel.emit)
+        # pylint: enable=no-member
 
     def email_to(self):
         """Gets the email recipient."""
@@ -126,16 +129,6 @@ class EmailInfoWidget(QtWidgets.QWidget):
 
     def addSubscriber(self):
         """Adds subscriber to jobs."""
-        users_csv = []
-        try:
-            users_csv = cuegui.Utils.getUsers()
-        except IOError as e:
-            pass
-        user_name = self.email_to().split('@')[0]
-        # If users_csv is not found, proceed without validation
-        if users_csv and cuegui.Utils.isValidateUser(user_name, users_csv) != self.email_to():
-            cuegui.Utils.showErrorMessageBox("Email does not exist. Please check it before proceeding")
-            return
         for job in self.__jobs:
             job.addSubscriber(self.email_to())
         self.save.emit()

--- a/cuegui/cuegui/plugins/StuckFramePlugin.py
+++ b/cuegui/cuegui/plugins/StuckFramePlugin.py
@@ -1185,7 +1185,8 @@ class StuckFrameMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
             self.__menuActions.jobs().addAction(menu, "viewComments")
             self.__menuActions.jobs().addAction(menu, "emailArtist")
             self.__menuActions.jobs().addAction(menu, "subscribeToJob")
-            menu.addAction(cuegui.Action.create(self, "Email and Comment", "Email and Comment", self.emailComment, "mail"))
+            menu.addAction(cuegui.Action.create(self, "Email and Comment", "Email and Comment",
+                                                self.emailComment, "mail"))
             menu.addSeparator()
             menu.addAction(cuegui.Action.create(self, "Job Not Stuck", "Job Not Stuck",
                                                 self.RemoveJob, "warning"))

--- a/cuegui/cuegui/plugins/StuckFramePlugin.py
+++ b/cuegui/cuegui/plugins/StuckFramePlugin.py
@@ -1184,9 +1184,8 @@ class StuckFrameMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         if isJob and not isFrame and sameJob:
             self.__menuActions.jobs().addAction(menu, "viewComments")
             self.__menuActions.jobs().addAction(menu, "emailArtist")
-            menu.addAction(
-                cuegui.Action.create(self, "Email and Comment", "Email and Comment",
-                                     self.emailComment, "mail"))
+            self.__menuActions.jobs().addAction(menu, "subscribeToJob")
+            menu.addAction(cuegui.Action.create(self, "Email and Comment", "Email and Comment", self.emailComment, "mail"))
             menu.addSeparator()
             menu.addAction(cuegui.Action.create(self, "Job Not Stuck", "Job Not Stuck",
                                                 self.RemoveJob, "warning"))

--- a/proto/job.proto
+++ b/proto/job.proto
@@ -139,6 +139,10 @@ service JobInterface {
     // run frames on the specified job.
     rpc AddRenderPartition(JobAddRenderPartRequest) returns (JobAddRenderPartResponse);
 
+    // Adds a subscriber to a job. When the job is finished, subscriber
+    // receives email with notification
+    rpc AddSubscriber(JobAddSubscriberRequest) returns (JobAddSubscriberResponse);
+
     // Setup and retunrn a JobOnFrame dependency
     rpc CreateDependencyOnFrame(JobCreateDependencyOnFrameRequest) returns (JobCreateDependencyOnFrameResponse);
 
@@ -1110,6 +1114,14 @@ message JobAddRenderPartRequest {
 message JobAddRenderPartResponse {
     renderPartition.RenderPartition render_partition = 1;
 }
+
+// AddSubscriber
+message JobAddSubscriberRequest {
+    Job job = 1;
+    string subscriber = 2;
+}
+
+message JobAddSubscriberResponse {}
 
 // CreateDependencyOnFrame
 message JobCreateDependencyOnFrameRequest {

--- a/pycue/opencue/wrappers/job.py
+++ b/pycue/opencue/wrappers/job.py
@@ -412,7 +412,8 @@ class Job(object):
         :type subscriber: string
         :param subscriber: email address to send update when the job finishes
         """
-        self.stub.AddSubscriber(job_pb2.JobAddSubscriberRequest(job=self.data, subscriber=subscriber))
+        self.stub.AddSubscriber(job_pb2.JobAddSubscriberRequest(job=self.data,
+                                                                subscriber=subscriber))
 
     def facility(self):
         """Returns the facility that the job must run in.

--- a/pycue/opencue/wrappers/job.py
+++ b/pycue/opencue/wrappers/job.py
@@ -406,6 +406,14 @@ class Job(object):
             job_pb2.JobStaggerFramesRequest(job=self.data, range=frame_range, stagger=stagger),
             timeout=Cuebot.Timeout)
 
+    def addSubscriber(self, subscriber):
+        """Adds email subscriber to status change for the job
+
+        :type subscriber: string
+        :param subscriber: email address to send update when the job finishes
+        """
+        self.stub.AddSubscriber(job_pb2.JobAddSubscriberRequest(job=self.data, subscriber=subscriber))
+
     def facility(self):
         """Returns the facility that the job must run in.
 


### PR DESCRIPTION
**Summarize your change.**
This change give users the ability to subscribe to a job through the API or using the GUI. 
An user subscribed to a job will receive the same emails as the owner of the job. 
