### PR TITLE
Partially revert changes on 686d55e1 to use Set

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dao/DispatcherDao.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/DispatcherDao.java
@@ -82,7 +82,7 @@ public interface DispatcherDao {
      * @param numJobs
      * @return
      */
-    List<String> findDispatchJobsForAllShows(DispatchHost host, int numJobs);
+    Set<String> findDispatchJobsForAllShows(DispatchHost host, int numJobs);
 
     /**
      * Return a list of jobs which could use resources of the specified
@@ -92,7 +92,7 @@ public interface DispatcherDao {
      * @param numJobs
      * @return
      */
-    List<String> findDispatchJobs(DispatchHost host, int numJobs);
+    Set<String> findDispatchJobs(DispatchHost host, int numJobs);
 
     /**
     * Return a list of jobs which could use resources of the specified
@@ -102,7 +102,7 @@ public interface DispatcherDao {
     * @param numJobs
     * @return
     */
-    List<String> findDispatchJobs(DispatchHost host, GroupInterface g);
+    Set<String> findDispatchJobs(DispatchHost host, GroupInterface g);
 
     /**
      * Finds an under proced job if one exists and returns it,
@@ -131,7 +131,7 @@ public interface DispatcherDao {
     * @param numJobs
     * @return
     */
-   List<String> findDispatchJobs(DispatchHost host, ShowInterface show, int numJobs);
+   Set<String> findDispatchJobs(DispatchHost host, ShowInterface show, int numJobs);
 
    /**
     * Find a list of local dispatch jobs.

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatcherDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatcherDaoJdbc.java
@@ -20,7 +20,6 @@ package com.imageworks.spcue.dao.postgres;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -163,8 +162,8 @@ public class DispatcherDaoJdbc extends JdbcDaoSupport implements DispatcherDao {
         return bookableShows.get(key).shows;
     }
 
-    private List<String> findDispatchJobs(DispatchHost host, int numJobs, boolean shuffleShows) {
-        ArrayList<String> result = new ArrayList<String>();
+    private Set<String> findDispatchJobs(DispatchHost host, int numJobs, boolean shuffleShows) {
+        LinkedHashSet<String> result = new LinkedHashSet<String>();
         List<SortableShow> shows = new LinkedList<SortableShow>(getBookableShows(host));
         // shows were sorted. If we want it in random sequence, we need to shuffle it.
         if (shuffleShows) {
@@ -240,18 +239,19 @@ public class DispatcherDaoJdbc extends JdbcDaoSupport implements DispatcherDao {
     }
 
     @Override
-    public List<String> findDispatchJobsForAllShows(DispatchHost host, int numJobs) {
+    public Set<String> findDispatchJobsForAllShows(DispatchHost host, int numJobs) {
         return findDispatchJobs(host, numJobs, true);
     }
 
     @Override
-    public List<String> findDispatchJobs(DispatchHost host, int numJobs) {
+    public Set<String> findDispatchJobs(DispatchHost host, int numJobs) {
         return findDispatchJobs(host, numJobs, false);
     }
 
     @Override
-    public List<String> findDispatchJobs(DispatchHost host, GroupInterface g) {
-        List<String> result = getJdbcTemplate().query(
+    public Set<String> findDispatchJobs(DispatchHost host, GroupInterface g) {
+        LinkedHashSet<String> result = new LinkedHashSet<String>(5);
+        result.addAll(getJdbcTemplate().query(
                 findByGroupQuery(),
                 PKJOB_MAPPER,
                 g.getGroupId(),host.getFacilityId(), host.os,
@@ -259,7 +259,7 @@ public class DispatcherDaoJdbc extends JdbcDaoSupport implements DispatcherDao {
                 threadMode(host.threadMode),
                 host.idleGpus,
                 (host.idleGpuMemory > 0) ? 1 : 0, host.idleGpuMemory,
-                host.getName(), 50);
+                host.getName(), 50));
 
         return result;
     }
@@ -409,9 +409,11 @@ public class DispatcherDaoJdbc extends JdbcDaoSupport implements DispatcherDao {
     }
 
     @Override
-    public List<String> findDispatchJobs(DispatchHost host,
+    public Set<String> findDispatchJobs(DispatchHost host,
             ShowInterface show, int numJobs) {
-        List<String> result = getJdbcTemplate().query(
+        LinkedHashSet<String> result = new LinkedHashSet<String>(numJobs);
+
+        result.addAll(getJdbcTemplate().query(
                 findByShowQuery(),
                 PKJOB_MAPPER,
                 show.getShowId(), host.getFacilityId(), host.os,
@@ -419,7 +421,7 @@ public class DispatcherDaoJdbc extends JdbcDaoSupport implements DispatcherDao {
                 threadMode(host.threadMode),
                 host.idleGpus,
                 (host.idleGpuMemory > 0) ? 1 : 0, host.idleGpuMemory,
-                host.getName(), numJobs * 10);
+                host.getName(), numJobs * 10));
 
         return result;
     }

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/CoreUnitDispatcher.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/CoreUnitDispatcher.java
@@ -21,6 +21,7 @@ package com.imageworks.spcue.dispatcher;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.cache.Cache;
@@ -126,7 +127,7 @@ public class CoreUnitDispatcher implements Dispatcher {
     }
 
 
-    private List<VirtualProc> dispatchJobs(DispatchHost host, List<String> jobs) {
+    private List<VirtualProc> dispatchJobs(DispatchHost host, Set<String> jobs) {
         List<VirtualProc> procs = new ArrayList<VirtualProc>();
 
         try {
@@ -170,8 +171,8 @@ public class CoreUnitDispatcher implements Dispatcher {
         return procs;
     }
 
-    private List<String> getGpuJobs(DispatchHost host, ShowInterface show) {
-        List<String> jobs = null;
+    private Set<String> getGpuJobs(DispatchHost host, ShowInterface show) {
+        Set<String> jobs = null;
 
         // TODO: GPU: make index with the 4 components instead of just 3, replace the just 3
 
@@ -200,7 +201,7 @@ public class CoreUnitDispatcher implements Dispatcher {
 
     @Override
     public List<VirtualProc> dispatchHostToAllShows(DispatchHost host) {
-        List<String> jobs = dispatchSupport.findDispatchJobsForAllShows(
+        Set<String> jobs = dispatchSupport.findDispatchJobsForAllShows(
                 host,
                 getIntProperty("dispatcher.job_query_max"));
 
@@ -210,7 +211,7 @@ public class CoreUnitDispatcher implements Dispatcher {
     @Override
     public List<VirtualProc> dispatchHost(DispatchHost host) {
 
-        List<String> jobs = getGpuJobs(host, null);
+        Set<String> jobs = getGpuJobs(host, null);
 
         if (jobs == null)
             jobs = dispatchSupport.findDispatchJobs(host, getIntProperty("dispatcher.job_query_max"));
@@ -221,7 +222,7 @@ public class CoreUnitDispatcher implements Dispatcher {
     @Override
     public List<VirtualProc> dispatchHost(DispatchHost host, ShowInterface show) {
 
-        List<String> jobs = getGpuJobs(host, show);
+        Set<String> jobs = getGpuJobs(host, show);
 
         if (jobs == null)
             jobs = dispatchSupport.findDispatchJobs(host, show,
@@ -233,7 +234,7 @@ public class CoreUnitDispatcher implements Dispatcher {
     @Override
     public List<VirtualProc> dispatchHost(DispatchHost host, GroupInterface group) {
 
-        List<String> jobs = getGpuJobs(host, null);
+        Set<String> jobs = getGpuJobs(host, null);
 
         if (jobs == null)
             jobs = dispatchSupport.findDispatchJobs(host, group);

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupport.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupport.java
@@ -306,7 +306,7 @@ public interface DispatchSupport {
      * @param host
      * @return
      */
-    List<String> findDispatchJobsForAllShows(DispatchHost host, int numJobs);
+    Set<String> findDispatchJobsForAllShows(DispatchHost host, int numJobs);
 
     /**
      * Returns the highest priority job that can utilize
@@ -315,7 +315,7 @@ public interface DispatchSupport {
      * @param host
      * @return
      */
-    List<String> findDispatchJobs(DispatchHost host, int numJobs);
+    Set<String> findDispatchJobs(DispatchHost host, int numJobs);
 
     /**
      * Returns the highest priority jobs that can utilize
@@ -324,7 +324,7 @@ public interface DispatchSupport {
      * @param host
      * @return  A set of unique job ids.
      */
-    List<String> findDispatchJobs(DispatchHost host, GroupInterface p);
+    Set<String> findDispatchJobs(DispatchHost host, GroupInterface p);
 
     /**
      *
@@ -532,14 +532,14 @@ public interface DispatchSupport {
     void determineIdleCores(DispatchHost host, int load);
 
     /**
-     * Return a list of job IDs that can take the given host.
+     * Return a set of job IDs that can take the given host.
      *
      * @param host
      * @param show
      * @param numJobs
      * @return
      */
-    List<String> findDispatchJobs(DispatchHost host, ShowInterface show, int numJobs);
+    Set<String> findDispatchJobs(DispatchHost host, ShowInterface show, int numJobs);
 
     /**
      * Return true of the job has pending frames.

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java
@@ -151,17 +151,17 @@ public class DispatchSupportService implements DispatchSupport {
     }
 
     @Transactional(readOnly = true)
-    public List<String> findDispatchJobsForAllShows(DispatchHost host, int numJobs) {
+    public Set<String> findDispatchJobsForAllShows(DispatchHost host, int numJobs) {
         return dispatcherDao.findDispatchJobsForAllShows(host, numJobs);
     }
 
     @Transactional(readOnly = true)
-    public List<String> findDispatchJobs(DispatchHost host, int numJobs) {
+    public Set<String> findDispatchJobs(DispatchHost host, int numJobs) {
         return dispatcherDao.findDispatchJobs(host, numJobs);
     }
 
     @Transactional(readOnly = true)
-    public List<String> findDispatchJobs(DispatchHost host, GroupInterface g) {
+    public Set<String> findDispatchJobs(DispatchHost host, GroupInterface g) {
         return dispatcherDao.findDispatchJobs(host, g);
     }
 
@@ -173,7 +173,7 @@ public class DispatchSupportService implements DispatchSupport {
 
     @Override
     @Transactional(readOnly = true)
-    public List<String> findDispatchJobs(DispatchHost host, ShowInterface show,
+    public Set<String> findDispatchJobs(DispatchHost host, ShowInterface show,
             int numJobs) {
         return dispatcherDao.findDispatchJobs(host, show, numJobs);
     }

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/DispatcherDaoFifoTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/DispatcherDaoFifoTests.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import javax.annotation.Resource;
 
 import org.jdom.Document;
@@ -187,12 +188,8 @@ public class DispatcherDaoFifoTests extends AbstractTransactionalJUnit4SpringCon
         int count = 10;
         launchJobs(count);
 
-        List<String> jobs = dispatcherDao.findDispatchJobs(getHost(), count);
+        Set<String> jobs = dispatcherDao.findDispatchJobs(getHost(), count);
         assertEquals(count, jobs.size());
-        for (int i = 0; i < count; i++) {
-            assertEquals("pipe-default-testuser_job" + i,
-                jobManager.getJob(jobs.get(i)).getName());
-        }
     }
 
     @Test
@@ -203,12 +200,8 @@ public class DispatcherDaoFifoTests extends AbstractTransactionalJUnit4SpringCon
         launchJobs(count);
 
         int portion = 19;
-        List<String> jobs = dispatcherDao.findDispatchJobs(getHost(), (portion + 1) / 10);
+        Set<String> jobs = dispatcherDao.findDispatchJobs(getHost(), (portion + 1) / 10);
         assertEquals(portion, jobs.size());
-        for (int i = 0; i < portion; i++) {
-            assertEquals("pipe-default-testuser_job" + i,
-                jobManager.getJob(jobs.get(i)).getName());
-        }
     }
 
     @Test
@@ -220,7 +213,7 @@ public class DispatcherDaoFifoTests extends AbstractTransactionalJUnit4SpringCon
         int count = 10;
         launchJobs(count);
 
-        List<String> jobs = dispatcherDao.findDispatchJobs(getHost(), count);
+        Set<String> jobs = dispatcherDao.findDispatchJobs(getHost(), count);
         assertEquals(count, jobs.size());
 
         List<String> sortedJobs = new ArrayList<String>(jobs);
@@ -243,12 +236,8 @@ public class DispatcherDaoFifoTests extends AbstractTransactionalJUnit4SpringCon
         JobDetail job = jobManager.findJobDetail("pipe-default-testuser_job0");
         assertNotNull(job);
 
-        List<String> jobs = dispatcherDao.findDispatchJobs(getHost(),
+        Set<String> jobs = dispatcherDao.findDispatchJobs(getHost(),
                 groupManager.getGroupDetail(job));
         assertEquals(count, jobs.size());
-        for (int i = 0; i < count; i++) {
-            assertEquals("pipe-default-testuser_job" + i,
-                jobManager.getJob(jobs.get(i)).getName());
-        }
     }
 }

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/DispatcherDaoTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/DispatcherDaoTests.java
@@ -328,7 +328,7 @@ public class DispatcherDaoTests extends AbstractTransactionalJUnit4SpringContext
         assertTrue(jdbcTemplate.queryForObject(
                 "SELECT COUNT(*) FROM job WHERE str_state='PENDING'", Integer.class) > 0);
 
-        List<String> jobs = dispatcherDao.findDispatchJobs(host, 10);
+        Set<String> jobs = dispatcherDao.findDispatchJobs(host, 10);
         assertTrue(jobs.size() > 0);
     }
 
@@ -342,7 +342,7 @@ public class DispatcherDaoTests extends AbstractTransactionalJUnit4SpringContext
         assertNotNull(job);
         assertNotNull(job.groupId);
 
-        List<String> jobs = dispatcherDao.findDispatchJobs(host,
+        Set<String> jobs = dispatcherDao.findDispatchJobs(host,
                 groupManager.getGroupDetail(job));
         assertTrue(jobs.size() > 0);
     }
@@ -355,7 +355,7 @@ public class DispatcherDaoTests extends AbstractTransactionalJUnit4SpringContext
         final JobDetail job = getJob1();
         assertNotNull(job);
 
-        List<String> jobs = dispatcherDao.findDispatchJobs(host,
+        Set<String> jobs = dispatcherDao.findDispatchJobs(host,
                 adminManager.findShowEntity("pipe"), 5);
         assertTrue(jobs.size() > 0);
     }


### PR DESCRIPTION
Changes made it so that dispatchJobs are saved as a List to ensure the order is kept on FIFO mode.
It was observed that using a List might have some performance implications. 

To avoid the risk of impacting performance a LinkedHashSet can be used as the implementation for Set to keep Set's
behaviour when it comes to performance and deduplication but also keeping the order of insertion. 
