### PR TITLE
Reduce warning logs

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/HostDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/HostDaoJdbc.java
@@ -345,7 +345,7 @@ public class HostDaoJdbc extends JdbcDaoSupport implements HostDao {
                 fqdn = host.getName();
             }
         } catch (UnknownHostException e) {
-            logger.warn(e);
+            logger.info(e);
             fqdn = host.getName();
             name = getHostNameFromFQDN(name, useLongNames);
         }

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/ProcDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/ProcDaoJdbc.java
@@ -692,7 +692,7 @@ public class ProcDaoJdbc extends JdbcDaoSupport implements ProcDao {
                  + targetProc.getName() + ", obtained " + memBorrowedTotal);
 
           if (memBorrowedTotal < targetMem) {
-              logger.warn("mem borrowed " + memBorrowedTotal +
+              logger.info("mem borrowed " + memBorrowedTotal +
                       " was less than the target memory of " + targetMem);
               return false;
           }

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/ProcDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/ProcDaoJdbc.java
@@ -90,7 +90,7 @@ public class ProcDaoJdbc extends JdbcDaoSupport implements ProcDao {
 
     public boolean deleteVirtualProc(VirtualProc proc) {
         if(getJdbcTemplate().update(DELETE_VIRTUAL_PROC, proc.getProcId()) == 0) {
-            logger.warn("failed to delete " + proc + " , proc does not exist.");
+            logger.info("failed to delete " + proc + " , proc does not exist.");
             return false;
         }
         // update all of the resource counts.

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/AbstractDispatcher.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/AbstractDispatcher.java
@@ -60,7 +60,7 @@ public abstract class AbstractDispatcher {
                     "frame reservation error, "
                             + "dispatchProcToJob failed to book next frame, "
                             + fre;
-            logger.warn(msg);
+            logger.info(msg);
         } catch (ResourceDuplicationFailureException rrfe) {
             /*
              * There is a resource already assigned to the frame we reserved!
@@ -75,7 +75,7 @@ public abstract class AbstractDispatcher {
                             + "to assign proc to job " + frame + ", " + proc
                             + " already assigned to another frame." + rrfe;
 
-            logger.warn(msg);
+            logger.info(msg);
         } catch (ResourceReservationFailureException rrfe) {
             /*
              * This should technically never happen since the proc is already
@@ -86,7 +86,7 @@ public abstract class AbstractDispatcher {
                     "proc update error, "
                             + "dispatchProcToJob failed to assign proc to job "
                             + frame + ", " + rrfe;
-            logger.warn(msg);
+            logger.info(msg);
             dispatchSupport.unbookProc(proc);
             dispatchSupport.clearFrame(frame);
 
@@ -104,7 +104,7 @@ public abstract class AbstractDispatcher {
             String msg =
                     "dispatchProcToJob failed booking proc " + proc
                             + " on job " + frame;
-            logger.warn(msg);
+            logger.info(msg);
             dispatchSupport.unbookProc(proc);
             dispatchSupport.clearFrame(frame);
 
@@ -138,7 +138,7 @@ public abstract class AbstractDispatcher {
              * just retry on the next frame.
              */
             DispatchSupport.bookingRetries.incrementAndGet();
-            logger.warn("frame reservation error, "
+            logger.info("frame reservation error, "
                     + "dispatchHostToJob failed to book new frame: " + fre);
         } catch (ResourceDuplicationFailureException rrfe) {
             /*
@@ -154,7 +154,7 @@ public abstract class AbstractDispatcher {
                             + "to assign proc to job " + frame + ", " + proc
                             + " already assigned to another frame." + rrfe;
 
-            logger.warn(msg);
+            logger.info(msg);
         } catch (ResourceReservationFailureException rrfe) {
             /*
              * This generally means that the resources we're booked by another

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/CoreUnitDispatcher.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/CoreUnitDispatcher.java
@@ -162,7 +162,7 @@ public class CoreUnitDispatcher implements Dispatcher {
             }
 
         } catch (DispatcherException e) {
-            logger.warn("dispatcher exception," + e);
+            logger.info(host.name + " dispatcher exception," + e);
         }
 
         host.restoreGpu();

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/CoreUnitDispatcher.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/CoreUnitDispatcher.java
@@ -475,7 +475,7 @@ public class CoreUnitDispatcher implements Dispatcher {
                 DispatchSupport.bookingRetries.incrementAndGet();
                 String msg = "frame reservation error, " +
                     "dispatchProcToJob failed to book next frame, " + fre;
-                logger.warn(msg);
+                logger.info(msg);
                 return false;
             }
             catch (ResourceDuplicationFailureException rrfe) {
@@ -492,7 +492,7 @@ public class CoreUnitDispatcher implements Dispatcher {
                     "to assign proc to job " + job + ", " + proc +
                     " already assigned to another frame." + rrfe;
 
-                logger.warn(msg);
+                logger.info(msg);
                 return false;
             }
             catch (ResourceReservationFailureException rrfe) {
@@ -505,7 +505,7 @@ public class CoreUnitDispatcher implements Dispatcher {
                 String msg = "proc update error, " +
                     "dispatchProcToJob failed to assign proc to job " +
                     job + ", " + rrfe;
-                logger.warn(msg);
+                logger.info(msg);
                 if (procIndb) {
                     dispatchSupport.unbookProc(proc);
                 }
@@ -524,7 +524,7 @@ public class CoreUnitDispatcher implements Dispatcher {
                 DispatchSupport.bookingErrors.incrementAndGet();
                 String msg = "dispatchProcToJob failed booking proc " +
                     proc + " on job " + job;
-                logger.warn(msg, e);
+                logger.info(msg, e);
                 dispatchSupport.unbookProc(proc);
                 dispatchSupport.clearFrame(frame);
 

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
@@ -196,7 +196,7 @@ public class HostReportHandler {
                 dispatchSupport.determineIdleCores(host, report.getHost().getLoad());
 
             } catch (DataAccessException dae) {
-                logger.warn("Unable to find host " + rhost.getName() + ","
+                logger.info("Unable to find host " + rhost.getName() + ","
                         + dae + " , creating host.");
                 // TODO: Skip adding it if the host name is over 30 characters
 


### PR DESCRIPTION
Reduce log level from `warn` to `info` to reduce the number of messages captured automatically by Sentry (PR coming soon) as Sentry automatically captures warnings. 

The log statements impacted by these changes are not warnings, but common behavior for alternative flows.