### PR TITLE
Add missing determineOutputs in JobSpec.java

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/service/JobSpec.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/service/JobSpec.java
@@ -446,6 +446,7 @@ public class JobSpec {
             determineMinimumMemory(buildableJob, layerTag, layer,
                     buildableLayer);
             determineMinimumGpuMemory(buildableJob, layerTag, layer);
+            determineOutputs(layerTag, buildableJob, layer);
 
             // set a timeout value on the layer
             if (layerTag.getChildTextTrim("timeout") != null) {


### PR DESCRIPTION
When importing the changes for "add-outputs" I was missing the function to parse the output data from the jobspec.

Follow up to #1361