### PR TITLE
Improve max reserved memory handling

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/Dispatcher.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/Dispatcher.java
@@ -57,7 +57,7 @@ public interface Dispatcher {
     public static final long MEM_RESERVED_DEFAULT = 3355443;
 
     // The maximum amount of memory that can be requested for a given frame.
-    public static final long MEM_RESERVED_MAX = CueUtil.GB * 30;
+    public static final long MEM_RESERVED_MAX = CueUtil.GB * 50;
 
     // The minimum amount of memory that can be assigned to a frame.
     public static final long MEM_RESERVED_MIN = 262144;

--- a/cuebot/src/main/java/com/imageworks/spcue/service/JobSpec.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/service/JobSpec.java
@@ -512,31 +512,25 @@ public class JobSpec {
         long minMemory;
         String memory = layerTag.getChildTextTrim("memory").toLowerCase();
 
-        try {
-            minMemory = convertMemoryInput(memory);
+        minMemory = convertMemoryInput(memory);
 
-            // Some quick sanity checks to make sure memory hasn't gone
-            // over or under reasonable defaults.
-            if (minMemory> Dispatcher.MEM_RESERVED_MAX) {
-                throw new SpecBuilderException("Memory requirements exceed " +
-                        "maximum. Are you specifying the correct units?");
-            }
-            else if (minMemory < Dispatcher.MEM_RESERVED_MIN) {
-                logger.warn(buildableJob.detail.name + "/" + layer.name +
-                        "Specified too little memory, defaulting to: " +
-                        Dispatcher.MEM_RESERVED_MIN);
-                minMemory = Dispatcher.MEM_RESERVED_MIN;
-            }
-
-            buildableLayer.isMemoryOverride = true;
-            layer.minimumMemory = minMemory;
-
-        } catch (Exception e) {
-            logger.info("Setting setting memory for " +
-                    buildableJob.detail.name + "/" + layer.name +
-                    " failed, reason: " + e + ". Using default.");
-            layer.minimumMemory = Dispatcher.MEM_RESERVED_DEFAULT;
+        // Some quick sanity checks to make sure memory hasn't gone
+        // over or under reasonable defaults.
+        if (minMemory > Dispatcher.MEM_RESERVED_MAX) {
+            logger.warn("Setting memory for " + buildableJob.detail.name +
+                    "/" + layer.name + " to: "+ Dispatcher.MEM_RESERVED_MAX);
+            layer.minimumMemory = Dispatcher.MEM_RESERVED_MAX;
         }
+        else if (minMemory < Dispatcher.MEM_RESERVED_MIN) {
+            logger.warn(buildableJob.detail.name + "/" + layer.name +
+                    "Specified too little memory, defaulting to: " +
+                    Dispatcher.MEM_RESERVED_MIN);
+            minMemory = Dispatcher.MEM_RESERVED_MIN;
+        }
+
+        buildableLayer.isMemoryOverride = true;
+        layer.minimumMemory = minMemory;
+
     }
 
     /**
@@ -620,6 +614,9 @@ public class JobSpec {
 
         if (corePoints < Dispatcher.CORE_POINTS_RESERVED_MIN) {
             corePoints = Dispatcher.CORE_POINTS_RESERVED_DEFAULT;
+        }
+        else if (corePoints > Dispatcher.CORE_POINTS_RESERVED_MAX) {
+            corePoints = Dispatcher.CORE_POINTS_RESERVED_MAX;
         }
 
         layer.minimumCores = corePoints;


### PR DESCRIPTION
If a job requests more memory than MEM_RESERVED_MAX it should be given the maximum amount of memory possible (`MEM_RESERVED_MAX`) and not `MEM_RESERVED_DEFAULT`.  This will give jobs the maximum possible memory if they request more than we can provide. 