### PR TITLE
Ignore Free Temp logic on Windows hosts

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
@@ -365,7 +365,7 @@ public class HostReportHandler {
         Long minBookableFreeTempDir = env.getRequiredProperty("dispatcher.min_bookable_free_temp_dir_kb", Long.class);
 
         // Prevent cue frames from booking on hosts with full temporary directories
-        if (minBookableFreeTempDir != -1) {
+        if (minBookableFreeTempDir != -1 && !host.os.equalsIgnoreCase("Windows")) {
             if (host.hardwareState == HardwareState.UP && freeTempDir < minBookableFreeTempDir) {
 
                 // Insert a comment indicating that the Host status = Repair with reason = Full temporary directory


### PR DESCRIPTION
The free temp logic is not working as intended on Windows, for now it is being disabled.

There is an action item being worked on to document the stage of feature parity between Linux and Windows hosts.