### PR TITLE
Revert booking balanced query for no-gpu

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatchQuery.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatchQuery.java
@@ -20,6 +20,76 @@
 package com.imageworks.spcue.dao.postgres;
 
 public class DispatchQuery {
+    public static final String FIND_JOBS_BY_SHOW =
+        "/* FIND_JOBS_BY_SHOW */ " +
+            "SELECT pk_job, int_priority, rank FROM ( " +
+            "SELECT " +
+                "ROW_NUMBER() OVER (ORDER BY int_priority DESC) AS rank, " +
+                "pk_job, " +
+                "int_priority " +
+            "FROM ( " +
+            "SELECT DISTINCT " +
+                "job.pk_job as pk_job, " +
+                "/* sort = priority + (100 * (1 - (job.cores/job.int_min_cores))) + (age in days) */ " +
+                "CAST( " +
+                        "job_resource.int_priority + ( " +
+                            "100 * (CASE WHEN job_resource.int_min_cores <= 0 THEN 0 " +
+                        "ELSE " +
+                            "CASE WHEN job_resource.int_cores > job_resource.int_min_cores THEN 0 " +
+                            "ELSE 1 - job_resource.int_cores/job_resource.int_min_cores " +
+                            "END " +
+                        "END) " +
+				") + ( " +
+                "(DATE_PART('days', NOW()) - DATE_PART('days', job.ts_updated)) " +
+            ") as INT) as int_priority " +
+            "FROM " +
+                "job            , " +
+                "job_resource   , " +
+                "folder         , " +
+                "folder_resource, " +
+                "point          , " +
+                "layer          , " +
+                "layer_stat     , " +
+                "host             " +
+            "WHERE " +
+                "job.pk_job                 = job_resource.pk_job " +
+                "AND job.pk_folder          = folder.pk_folder " +
+                "AND folder.pk_folder       = folder_resource.pk_folder " +
+                "AND folder.pk_dept         = point.pk_dept " +
+                "AND folder.pk_show         = point.pk_show " +
+                "AND job.pk_job             = layer.pk_job " +
+                "AND job_resource.pk_job    = job.pk_job " +
+                "AND (CASE WHEN layer_stat.int_waiting_count > 0 THEN layer_stat.pk_layer ELSE NULL END) = layer.pk_layer " +
+                "AND " +
+                    "(" +
+                        "folder_resource.int_max_cores = -1 " +
+                    "OR " +
+                        "folder_resource.int_cores + layer.int_cores_min < folder_resource.int_max_cores " +
+                    ") " +
+                "AND job.str_state                  = 'PENDING' " +
+                "AND job.b_paused                   = false " +
+                "AND job.pk_show                    = ? " +
+                "AND job.pk_facility                = ? " +
+                "AND " +
+                    "(" +
+                        "job.str_os IS NULL OR job.str_os = '' " +
+                    "OR " +
+                        "job.str_os = ? " +
+                    ") " +
+                "AND (CASE WHEN layer_stat.int_waiting_count > 0 THEN 1 ELSE NULL END) = 1 " +
+                "AND layer.int_cores_min            <= ? " +
+                "AND layer.int_mem_min              <= ? " +
+                "AND (CASE WHEN layer.b_threadable = true THEN 1 ELSE 0 END) >= ? " +
+                "AND layer.int_gpus_min              BETWEEN 1 AND ? " +
+                "AND layer.int_gpu_mem_min          BETWEEN ? AND ? " +
+                "AND job_resource.int_cores + layer.int_cores_min <= job_resource.int_max_cores " +
+                "AND host.str_tags ~* ('(?x)' || layer.str_tags) " +
+                "AND host.str_name = ? " +
+        ") AS t1 ) AS t2 WHERE rank < ?";
+
+    public static final String FIND_JOBS_BY_SHOW_NO_GPU =
+        FIND_JOBS_BY_SHOW.replace("AND layer.int_gpus_min              BETWEEN 1 AND ? ", "")
+                .replace("AND layer.int_gpu_mem_min          BETWEEN ? AND ? ", "");
 
     public static final String FIND_JOBS_BY_SHOW_PRIORITY_MODE =
         "/* FIND_JOBS_BY_SHOW_PRIORITY_MODE */ " +
@@ -100,72 +170,6 @@ public class DispatchQuery {
                 ") " +
         ") AS t1 WHERE rank < ?";
 
-    // sort = priority + (100 * (1 - (job.cores/job.int_min_cores))) + (age in days) */
-    public static final String FIND_JOBS_BY_SHOW_BALANCED_MODE =
-            "/* FIND_JOBS_BY_SHOW_BALANCED_MODE */ " +
-            "SELECT pk_job, int_priority, rank FROM ( " +
-            "SELECT " +
-                "ROW_NUMBER() OVER (ORDER BY int_priority DESC) AS rank, " +
-                "pk_job, " +
-                "int_priority " +
-            "FROM ( " +
-            "SELECT DISTINCT " +
-                "job.pk_job as pk_job, " +
-                "CAST( " +
-                        "job_resource.int_priority + ( " +
-                            "100 * (CASE WHEN job_resource.int_min_cores <= 0 THEN 0 " +
-                        "ELSE " +
-                            "CASE WHEN job_resource.int_cores > job_resource.int_min_cores THEN 0 " +
-                            "ELSE 1 - job_resource.int_cores/job_resource.int_min_cores " +
-                            "END " +
-                        "END) " +
-				") + ( " +
-                "(DATE_PART('days', NOW()) - DATE_PART('days', job.ts_updated)) " +
-            ") as INT) as int_priority " +
-            "FROM " +
-                "job            , " +
-                "job_resource   , " +
-                "folder         , " +
-                "folder_resource, " +
-                "point          , " +
-                "layer          , " +
-                "layer_stat     , " +
-                "host             " +
-            "WHERE " +
-                "job.pk_job                 = job_resource.pk_job " +
-                "AND job.pk_folder          = folder.pk_folder " +
-                "AND folder.pk_folder       = folder_resource.pk_folder " +
-                "AND folder.pk_dept         = point.pk_dept " +
-                "AND folder.pk_show         = point.pk_show " +
-                "AND job.pk_job             = layer.pk_job " +
-                "AND (CASE WHEN layer_stat.int_waiting_count > 0 THEN layer_stat.pk_layer ELSE NULL END) = layer.pk_layer " +
-                "AND " +
-                    "(" +
-                        "folder_resource.int_max_cores = -1 " +
-                    "OR " +
-                        "folder_resource.int_cores + layer.int_cores_min < folder_resource.int_max_cores " +
-                    ") " +
-                "AND job.str_state                  = 'PENDING' " +
-                "AND job.b_paused                   = false " +
-                "AND job.pk_show                    = ? " +
-                "AND job.pk_facility                = ? " +
-                "AND " +
-                    "(" +
-                        "job.str_os IS NULL OR job.str_os = '' " +
-                    "OR " +
-                        "job.str_os = ? " +
-                    ") " +
-                "AND (CASE WHEN layer_stat.int_waiting_count > 0 THEN 1 ELSE NULL END) = 1 " +
-                "AND layer.int_cores_min            <= ? " +
-                "AND layer.int_mem_min              <= ? " +
-                "AND (CASE WHEN layer.b_threadable = true THEN 1 ELSE 0 END) >= ? " +
-                "AND layer.int_gpus_min             <= ? " +
-                "AND layer.int_gpu_mem_min          BETWEEN ? AND ? " +
-                "AND job_resource.int_cores + layer.int_cores_min <= job_resource.int_max_cores " +
-                "AND host.str_tags ~* ('(?x)' || layer.str_tags || '\\y') " +
-                "AND host.str_name = ? " +
-        ") AS t1 ) AS t2 WHERE rank < ?";
-
 
     public static final String FIND_JOBS_BY_GROUP_PRIORITY_MODE =
         FIND_JOBS_BY_SHOW_PRIORITY_MODE
@@ -177,13 +181,31 @@ public class DispatchQuery {
                 "AND job.pk_folder                  = ? ");
 
     public static final String FIND_JOBS_BY_GROUP_BALANCED_MODE =
-        FIND_JOBS_BY_SHOW_BALANCED_MODE
+        FIND_JOBS_BY_SHOW
             .replace(
                 "FIND_JOBS_BY_SHOW",
                 "FIND_JOBS_BY_GROUP")
             .replace(
                 "AND job.pk_show                    = ? ",
                 "AND job.pk_folder                  = ? ");
+
+    public static final String FIND_JOBS_BY_GROUP =
+            FIND_JOBS_BY_SHOW
+                    .replace(
+                            "FIND_JOBS_BY_SHOW",
+                            "FIND_JOBS_BY_GROUP")
+                    .replace(
+                            "AND job.pk_show                    = ? ",
+                            "AND job.pk_folder                  = ? ");
+
+    public static final String FIND_JOBS_BY_GROUP_NO_GPU =
+            FIND_JOBS_BY_SHOW_NO_GPU
+                    .replace(
+                            "FIND_JOBS_BY_SHOW",
+                            "FIND_JOBS_BY_GROUP")
+                    .replace(
+                            "AND job.pk_show                    = ? ",
+                            "AND job.pk_folder                  = ? ");
 
     private static final String replaceQueryForFifo(String query) {
         return query

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatcherDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatcherDaoJdbc.java
@@ -197,15 +197,26 @@ public class DispatcherDaoJdbc extends JdbcDaoSupport implements DispatcherDao {
                 continue;
             }
 
-            result.addAll(getJdbcTemplate().query(
-                    findByShowQuery(),
-                    PKJOB_MAPPER,
-                    s.getShowId(), host.getFacilityId(), host.os,
-                    host.idleCores, host.idleMemory,
-                    threadMode(host.threadMode),
-                    host.idleGpus,
-                    (host.idleGpuMemory > 0) ? 1 : 0, host.idleGpuMemory,
-                    host.getName(), numJobs * 10));
+            if (host.idleGpus == 0 && (schedulingMode == SchedulingMode.BALANCED)) {
+                result.addAll(getJdbcTemplate().query(
+                        FIND_JOBS_BY_SHOW_NO_GPU,
+                        PKJOB_MAPPER,
+                        s.getShowId(), host.getFacilityId(), host.os,
+                        host.idleCores, host.idleMemory,
+                        threadMode(host.threadMode),
+                        host.getName(), numJobs * 10));
+            }
+            else {
+                result.addAll(getJdbcTemplate().query(
+                        findByShowQuery(),
+                        PKJOB_MAPPER,
+                        s.getShowId(), host.getFacilityId(), host.os,
+                        host.idleCores, host.idleMemory,
+                        threadMode(host.threadMode),
+                        host.idleGpus,
+                        (host.idleGpuMemory > 0) ? 1 : 0, host.idleGpuMemory,
+                        host.getName(), numJobs * 10));
+            }
 
             if (result.size() < 1) {
                 if (host.gpuMemory == 0) {
@@ -224,7 +235,7 @@ public class DispatcherDaoJdbc extends JdbcDaoSupport implements DispatcherDao {
         switch (schedulingMode) {
             case PRIORITY_ONLY: return FIND_JOBS_BY_SHOW_PRIORITY_MODE;
             case FIFO: return FIND_JOBS_BY_SHOW_FIFO_MODE;
-            case BALANCED: return FIND_JOBS_BY_SHOW_BALANCED_MODE;
+            case BALANCED: return FIND_JOBS_BY_SHOW;
             default: return FIND_JOBS_BY_SHOW_PRIORITY_MODE;
         }
     }
@@ -251,15 +262,28 @@ public class DispatcherDaoJdbc extends JdbcDaoSupport implements DispatcherDao {
     @Override
     public Set<String> findDispatchJobs(DispatchHost host, GroupInterface g) {
         LinkedHashSet<String> result = new LinkedHashSet<String>(5);
-        result.addAll(getJdbcTemplate().query(
-                findByGroupQuery(),
-                PKJOB_MAPPER,
-                g.getGroupId(),host.getFacilityId(), host.os,
-                host.idleCores, host.idleMemory,
-                threadMode(host.threadMode),
-                host.idleGpus,
-                (host.idleGpuMemory > 0) ? 1 : 0, host.idleGpuMemory,
-                host.getName(), 50));
+        long lastTime = System.currentTimeMillis();
+
+        if (host.idleGpus == 0 && (schedulingMode == SchedulingMode.BALANCED)) {
+            result.addAll(getJdbcTemplate().query(
+                    FIND_JOBS_BY_GROUP_NO_GPU,
+                    PKJOB_MAPPER,
+                    g.getGroupId(), host.getFacilityId(), host.os,
+                    host.idleCores, host.idleMemory,
+                    threadMode(host.threadMode),
+                    host.getName(), 50));
+        }
+        else {
+            result.addAll(getJdbcTemplate().query(
+                    findByGroupQuery(),
+                    PKJOB_MAPPER,
+                    g.getGroupId(),host.getFacilityId(), host.os,
+                    host.idleCores, host.idleMemory,
+                    threadMode(host.threadMode),
+                    host.idleGpus,
+                    (host.idleGpuMemory > 0) ? 1 : 0, host.idleGpuMemory,
+                    host.getName(), 50));
+        }
 
         return result;
     }
@@ -412,16 +436,26 @@ public class DispatcherDaoJdbc extends JdbcDaoSupport implements DispatcherDao {
     public Set<String> findDispatchJobs(DispatchHost host,
             ShowInterface show, int numJobs) {
         LinkedHashSet<String> result = new LinkedHashSet<String>(numJobs);
-
-        result.addAll(getJdbcTemplate().query(
-                findByShowQuery(),
-                PKJOB_MAPPER,
-                show.getShowId(), host.getFacilityId(), host.os,
-                host.idleCores, host.idleMemory,
-                threadMode(host.threadMode),
-                host.idleGpus,
-                (host.idleGpuMemory > 0) ? 1 : 0, host.idleGpuMemory,
-                host.getName(), numJobs * 10));
+        if (host.idleGpus == 0 && (schedulingMode == SchedulingMode.BALANCED)) {
+            result.addAll(getJdbcTemplate().query(
+                    FIND_JOBS_BY_SHOW_NO_GPU,
+                    PKJOB_MAPPER,
+                    show.getShowId(), host.getFacilityId(), host.os,
+                    host.idleCores, host.idleMemory,
+                    threadMode(host.threadMode),
+                    host.getName(), numJobs * 10));
+        }
+        else {
+            result.addAll(getJdbcTemplate().query(
+                    findByShowQuery(),
+                    PKJOB_MAPPER,
+                    show.getShowId(), host.getFacilityId(), host.os,
+                    host.idleCores, host.idleMemory,
+                    threadMode(host.threadMode),
+                    host.idleGpus,
+                    (host.idleGpuMemory > 0) ? 1 : 0, host.idleGpuMemory,
+                    host.getName(), numJobs * 10));
+        }
 
         return result;
     }


### PR DESCRIPTION
Using `between 0 and 0` seems to impact which query plan the database is choosing, causing up to 4x speed decrease in the worst case. The current setup chooses which query/arguments to use based on the number of idleGpus so there's some room for improvements in the future here.

This change only impacts the BALANCED scheduling mode as it is the most db intensive mode and seems to be the only one affected.
