### PR TITLE
Add framespec parameter format check to CueSubmit

### DIFF
--- a/cuesubmit/cuesubmit/Submission.py
+++ b/cuesubmit/cuesubmit/Submission.py
@@ -21,6 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 
 from builtins import str
+import re
 
 import outline
 import outline.cuerun
@@ -73,7 +74,7 @@ def buildBlenderCmd(layerData):
         renderCommand += ' -o {}'.format(outputPath)
     if outputFormat:
         renderCommand += ' -F {}'.format(outputFormat)
-    if frameRange:
+    if re.match(r"^\d+-\d+$", frameRange):
         # Render frames from start to end (inclusive) via '-a' command argument
         renderCommand += (' -s {startFrame} -e {endFrame} -a'
                           .format(startFrame=Constants.FRAME_START_TOKEN,


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Update to developments made in PR https://github.com/AcademySoftwareFoundation/OpenCue/pull/1337 as discussed here:  https://github.com/AcademySoftwareFoundation/OpenCue/pull/1309#issuecomment-2132367342

**Summarize your change.**
Checks the format of the framespec parameter input to determine the Blender render command format.
