### PR TITLE
Keep grpcio-tools in line with grpcio and better support for python above 3.11

### DIFF
--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -11,6 +11,8 @@ jobs:
     name: Run Python Unit Tests (CY2022)
     runs-on: ubuntu-latest
     container: aswf/ci-opencue:2022
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - uses: actions/checkout@v3
       - name: Run Python Tests
@@ -21,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: aswf/ci-opencue:2022
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - uses: actions/checkout@v3
       - name: Build with Gradle
@@ -53,6 +57,8 @@ jobs:
     name: Run Python Unit Tests using Python2
     runs-on: ubuntu-latest
     container: aswf/ci-opencue:2019
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - uses: actions/checkout@v3
       - name: Run Python Tests
@@ -71,6 +77,8 @@ jobs:
     name: Lint Python Code
     runs-on: ubuntu-latest
     container: aswf/ci-opencue:2022
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - uses: actions/checkout@v3
       - name: Lint Python Code

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,10 @@ future==1.0.0
 futures==3.2.0;python_version<"3.0"
 grpcio==1.26.0;python_version<"3.0"
 grpcio-tools==1.26.0;python_version<"3.0"
-grpcio==1.53.2;python_version>="3.0"
-grpcio-tools==1.47.0;python_version>="3.0"
+grpcio==1.53.2;python_version>="3.0" and python_version<"3.12"
+grpcio-tools==1.53.2;python_version>="3.0" and python_version<"3.12"
+grpcio==1.64.1;python_version>="3.12"
+grpcio-tools==1.64.1;python_version>="3.12"
 mock==2.0.0
 packaging==20.9
 pathlib==1.0.1;python_version<"3.4"


### PR DESCRIPTION
**Summarize your change.**
This keeps grpcio and grpcio-tools on the same version and use a newer version for python 3.12+
