### PR TITLE
Fix CI/CD checks that uses old docker images

### DIFF
--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -11,6 +11,8 @@ jobs:
     name: Run Python Unit Tests (CY2022)
     runs-on: ubuntu-latest
     container: aswf/ci-opencue:2022
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - uses: actions/checkout@v3
       - name: Run Python Tests
@@ -21,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: aswf/ci-opencue:2022
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - uses: actions/checkout@v3
       - name: Build with Gradle
@@ -53,6 +57,8 @@ jobs:
     name: Run Python Unit Tests using Python2
     runs-on: ubuntu-latest
     container: aswf/ci-opencue:2019
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - uses: actions/checkout@v3
       - name: Run Python Tests
@@ -71,6 +77,8 @@ jobs:
     name: Lint Python Code
     runs-on: ubuntu-latest
     container: aswf/ci-opencue:2022
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - uses: actions/checkout@v3
       - name: Lint Python Code


### PR DESCRIPTION
**Summarize your change.**
This is to fix CI/CD checks when running in old images (based on centos 7)

Apparently node was recently forced to be version 20 (from version 16) which does not run on Centos 7.

This PR add an environment variable `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true` to those checks.