### PR TITLE
Add prometheus metrics collecting

### DIFF
--- a/cuebot/build.gradle
+++ b/cuebot/build.gradle
@@ -61,6 +61,8 @@ dependencies {
     compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.16.0'
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.16.0'
     compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.16.0'
+    compile group: 'io.prometheus', name: 'simpleclient', version: '0.16.0'
+    compile group: 'io.prometheus', name: 'simpleclient_servlet', version: '0.16.0'
 
     protobuf fileTree("../proto/")
 

--- a/cuebot/src/main/java/com/imageworks/spcue/PrometheusMetricsCollector.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/PrometheusMetricsCollector.java
@@ -1,0 +1,300 @@
+package com.imageworks.spcue;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import com.imageworks.spcue.dispatcher.BookingQueue;
+import com.imageworks.spcue.dispatcher.DispatchQueue;
+import com.imageworks.spcue.dispatcher.HostReportHandler;
+import com.imageworks.spcue.dispatcher.HostReportQueue;
+
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.Histogram;
+
+@Component
+public class PrometheusMetricsCollector {
+    private BookingQueue bookingQueue;
+
+    private DispatchQueue manageQueue;
+
+    private DispatchQueue dispatchQueue;
+
+    private HostReportQueue reportQueue;
+
+    private boolean enabled;
+
+    public void setBookingQueue(BookingQueue bookingQueue) {
+        this.bookingQueue = bookingQueue;
+    }
+
+    public void setManageQueue(DispatchQueue manageQueue) {
+        this.manageQueue = manageQueue;
+    }
+
+    public void setDispatchQueue(DispatchQueue dispatchQueue) {
+        this.dispatchQueue = dispatchQueue;
+    }
+
+    public void setReportQueue(HostReportQueue reportQueue) {
+        this.reportQueue = reportQueue;
+    }
+
+    // BookingQueue bookingQueue
+    private static final Gauge bookingWaitingTotal = Gauge.build()
+            .name("cue_booking_waiting_total")
+            .help("Booking Queue number of waiting tasks")
+            .labelNames("env", "cuebot_hosts")
+            .register();
+    private static final Gauge bookingRemainingCapacityTotal = Gauge.build()
+            .name("cue_booking_remaining_capacity_total")
+            .help("Booking Queue remaining capacity")
+            .labelNames("env", "cuebot_hosts")
+            .register();
+    private static final Gauge bookingThreadsTotal = Gauge.build()
+            .name("cue_booking_threads_total")
+            .help("Booking Queue number of active threads")
+            .labelNames("env", "cuebot_hosts")
+            .register();
+    private static final Gauge bookingExecutedTotal = Gauge.build()
+            .name("cue_booking_executed_total")
+            .help("Booking Queue number of executed tasks")
+            .labelNames("env", "cuebot_hosts")
+            .register();
+    private static final Gauge bookingRejectedTotal = Gauge.build()
+            .name("cue_booking_rejected_total")
+            .help("Booking Queue number of rejected tasks")
+            .labelNames("env", "cuebot_hosts")
+            .register();
+
+    // DispatchQueue manageQueue
+    private static final Gauge manageWaitingTotal = Gauge.build()
+            .name("cue_manage_waiting_total")
+            .help("Manage Queue number of waiting tasks")
+            .labelNames("env", "cuebot_hosts")
+            .register();
+    private static final Gauge manageRemainingCapacityTotal = Gauge.build()
+            .name("cue_manage_remaining_capacity_total")
+            .help("Manage Queue remaining capacity")
+            .labelNames("env", "cuebot_hosts")
+            .register();
+    private static final Gauge manageThreadsTotal = Gauge.build()
+            .name("cue_manage_threads_total")
+            .help("Manage Queue number of active threads")
+            .labelNames("env", "cuebot_hosts")
+            .register();
+    private static final Gauge manageExecutedTotal = Gauge.build()
+            .name("cue_manage_executed_total")
+            .help("Manage Queue number of executed tasks")
+            .labelNames("env", "cuebot_hosts")
+            .register();
+    private static final Gauge manageRejectedTotal = Gauge.build()
+            .name("cue_manage_rejected_total")
+            .help("Manage Queue number of rejected tasks")
+            .labelNames("env", "cuebot_hosts")
+            .register();
+
+    // DispatchQueue dispatchQueue
+    private static final Gauge dispatchWaitingTotal = Gauge.build()
+            .name("cue_dispatch_waiting_total")
+            .help("Dispatch Queue number of waiting tasks")
+            .labelNames("env", "cuebot_hosts")
+            .register();
+    private static final Gauge dispatchRemainingCapacityTotal = Gauge.build()
+            .name("cue_dispatch_remaining_capacity_total")
+            .help("Dispatch Queue remaining capacity")
+            .labelNames("env", "cuebot_hosts")
+            .register();
+    private static final Gauge dispatchThreadsTotal = Gauge.build()
+            .name("cue_dispatch_threads_total")
+            .help("Dispatch Queue number of active threads")
+            .labelNames("env", "cuebot_hosts")
+            .register();
+    private static final Gauge dispatchExecutedTotal = Gauge.build()
+            .name("cue_dispatch_executed_total")
+            .help("Dispatch Queue number of executed tasks")
+            .labelNames("env", "cuebot_hosts")
+            .register();
+    private static final Gauge dispatchRejectedTotal = Gauge.build()
+            .name("cue_dispatch_rejected_total")
+            .help("Dispatch Queue number of rejected tasks")
+            .labelNames("env", "cuebot_hosts")
+            .register();
+
+    // HostReportQueue reportQueue
+    private static final Gauge reportQueueWaitingTotal = Gauge.build()
+            .name("cue_report_waiting_total")
+            .help("Report Queue number of waiting tasks")
+            .labelNames("env", "cuebot_hosts")
+            .register();
+    private static final Gauge reportQueueRemainingCapacityTotal = Gauge.build()
+            .name("cue_report_remaining_capacity_total")
+            .help("Report Queue remaining capacity")
+            .labelNames("env", "cuebot_hosts")
+            .register();
+    private static final Gauge reportQueueThreadsTotal = Gauge.build()
+            .name("cue_report_threads_total")
+            .help("Report Queue number of active threads")
+            .labelNames("env", "cuebot_hosts")
+            .register();
+    private static final Gauge reportQueueExecutedTotal = Gauge.build()
+            .name("cue_report_executed_total")
+            .help("Report Queue number of executed tasks")
+            .labelNames("env", "cuebot_hosts")
+            .register();
+    private static final Gauge reportQueueRejectedTotal = Gauge.build()
+            .name("cue_report_rejected_total")
+            .help("Report Queue number of rejected tasks")
+            .labelNames("env", "cuebot_hosts")
+            .register();
+
+    private static final Counter findJobsByShowQueryCountMetric = Counter.build()
+            .name("cue_find_jobs_by_show_count")
+            .help("Count the occurrences of the query FIND_JOBS_BY_SHOW.")
+            .labelNames("env", "cuebot_hosts")
+            .register();
+    private static final Gauge bookingDurationMillisMetric = Gauge.build()
+            .name("cue_booking_durations_in_millis")
+            .help("Register duration of booking steps in milliseconds.")
+            .labelNames("env", "cuebot_host", "stage_desc")
+            .register();
+    private static final Histogram bookingDurationMillisHistogramMetric = Histogram.build()
+            .name("cue_booking_durations_histogram_in_millis")
+            .help("Register a summary of duration of booking steps in milliseconds.")
+            .labelNames("env", "cuebot_host", "stage_desc")
+            .register();
+
+    private static final Counter frameKilledCounter = Counter.build()
+            .name("cue_frame_killed_counter")
+            .help("Number of frames kill requests processed")
+            .labelNames("env", "cuebot_host", "render_node", "cause")
+            .register();
+
+    private static final Counter frameKillFailureCounter = Counter.build()
+            .name("cue_frame_kill_failure_counter")
+            .help("Number of frames that failed to be killed after FRAME_KILL_RETRY_LIMIT tries")
+            .labelNames("env", "cuebot_host", "render_node", "job_name", "frame_name", "frame_id")
+            .register();
+
+    private String deployment_environment;
+    private String cuebot_host;
+
+    @Autowired
+    public PrometheusMetricsCollector(Environment env) {
+        if (env == null) {
+            throw new SpcueRuntimeException("Env not defined");
+        }
+        this.enabled = env.getProperty("metrics.prometheus.collector", Boolean.class, false);
+        String envKey = env.getProperty("metrics.prometheus.environment_id.environment_variable", String.class,
+                "DEPLOYMENT_ENVIRONMENT");
+
+        this.cuebot_host = getHostNameFromEnv();
+        // Get environment id from environment variable
+        this.deployment_environment = System.getenv(envKey);
+        if (this.deployment_environment == null) {
+            this.deployment_environment = "undefined";
+        }
+    }
+
+    /**
+     * Get hostname from environment variable
+     * 
+     * Uses the following fallback order:
+     * 
+     * - NODE_HOSTNAME -> HOSTNAME -> HOST -> "undefined"
+     * 
+     * @return
+     */
+    private String getHostNameFromEnv() {
+        String hostname = System.getenv("NODE_HOSTNAME");
+        if (hostname != null) {
+            return hostname;
+        }
+
+        hostname = System.getenv("HOSTNAME");
+        if (hostname != null) {
+            return hostname;
+        }
+
+        hostname = System.getenv("HOST");
+        if (hostname != null) {
+            return hostname;
+        }
+
+        return "undefined";
+    }
+
+    /**
+     * Collect metrics from queues
+     */
+    public void collectPrometheusMetrics() {
+        if (this.enabled) {
+            // BookingQueue bookingQueue
+            bookingWaitingTotal.labels(this.deployment_environment, this.cuebot_host).set(bookingQueue.getSize());
+            bookingRemainingCapacityTotal.labels(this.deployment_environment, this.cuebot_host)
+                    .set(bookingQueue.getRemainingCapacity());
+            bookingThreadsTotal.labels(this.deployment_environment, this.cuebot_host)
+                    .set(bookingQueue.getActiveCount());
+            bookingExecutedTotal.labels(this.deployment_environment, this.cuebot_host)
+                    .set(bookingQueue.getCompletedTaskCount());
+            bookingRejectedTotal.labels(this.deployment_environment, this.cuebot_host)
+                    .set(bookingQueue.getRejectedTaskCount());
+
+            // DispatchQueue manageQueue
+            manageWaitingTotal.labels(this.deployment_environment, this.cuebot_host).set(manageQueue.getSize());
+            manageRemainingCapacityTotal.labels(this.deployment_environment, this.cuebot_host)
+                    .set(manageQueue.getRemainingCapacity());
+            manageThreadsTotal.labels(this.deployment_environment, this.cuebot_host).set(manageQueue.getActiveCount());
+            manageExecutedTotal.labels(this.deployment_environment, this.cuebot_host)
+                    .set(manageQueue.getCompletedTaskCount());
+            manageRejectedTotal.labels(this.deployment_environment, this.cuebot_host)
+                    .set(manageQueue.getRejectedTaskCount());
+
+            // DispatchQueue dispatchQueue
+            dispatchWaitingTotal.labels(this.deployment_environment, this.cuebot_host).set(dispatchQueue.getSize());
+            dispatchRemainingCapacityTotal.labels(this.deployment_environment, this.cuebot_host)
+                    .set(dispatchQueue.getRemainingCapacity());
+            dispatchThreadsTotal.labels(this.deployment_environment, this.cuebot_host)
+                    .set(dispatchQueue.getActiveCount());
+            dispatchExecutedTotal.labels(this.deployment_environment, this.cuebot_host)
+                    .set(dispatchQueue.getCompletedTaskCount());
+            dispatchRejectedTotal.labels(this.deployment_environment, this.cuebot_host)
+                    .set(dispatchQueue.getRejectedTaskCount());
+
+            // HostReportQueue reportQueue
+            reportQueueWaitingTotal.labels(this.deployment_environment, this.cuebot_host)
+                    .set(reportQueue.getQueue().size());
+            reportQueueRemainingCapacityTotal.labels(this.deployment_environment, this.cuebot_host)
+                    .set(reportQueue.getQueue().remainingCapacity());
+            reportQueueThreadsTotal.labels(this.deployment_environment, this.cuebot_host)
+                    .set(reportQueue.getActiveCount());
+            reportQueueExecutedTotal.labels(this.deployment_environment, this.cuebot_host)
+                    .set(reportQueue.getTaskCount());
+            reportQueueRejectedTotal.labels(this.deployment_environment, this.cuebot_host)
+                    .set(reportQueue.getRejectedTaskCount());
+        }
+    }
+
+    public void setBookingDurationMetric(String stage_desc, double value) {
+        bookingDurationMillisMetric.labels(this.deployment_environment, this.cuebot_host, stage_desc).set(value);
+        bookingDurationMillisHistogramMetric.labels(this.deployment_environment, this.cuebot_host, stage_desc).observe(value);
+    }
+
+    public void incrementFindJobsByShowQueryCountMetric() {
+        findJobsByShowQueryCountMetric.labels(this.deployment_environment, this.cuebot_host).inc();
+    }
+
+    public void incrementFrameKilledCounter(String renderNode, HostReportHandler.KillCause killCause) {
+        frameKilledCounter.labels(this.deployment_environment, this.cuebot_host, renderNode, killCause.name()).inc();
+    }
+
+    public void incrementFrameKillFailureCounter(String hostname, String jobName, String frameName, String frameId) {
+        frameKillFailureCounter.labels(this.deployment_environment,
+                this.cuebot_host,
+                hostname,
+                jobName,
+                frameName,
+                frameId).inc();
+    }
+}

--- a/cuebot/src/main/java/com/imageworks/spcue/PrometheusMetricsCollector.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/PrometheusMetricsCollector.java
@@ -13,6 +13,9 @@ import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import io.prometheus.client.Histogram;
 
+/**
+ * Collects and exposes metrics to Prometheus
+ */
 @Component
 public class PrometheusMetricsCollector {
     private BookingQueue bookingQueue;
@@ -24,22 +27,6 @@ public class PrometheusMetricsCollector {
     private HostReportQueue reportQueue;
 
     private boolean enabled;
-
-    public void setBookingQueue(BookingQueue bookingQueue) {
-        this.bookingQueue = bookingQueue;
-    }
-
-    public void setManageQueue(DispatchQueue manageQueue) {
-        this.manageQueue = manageQueue;
-    }
-
-    public void setDispatchQueue(DispatchQueue dispatchQueue) {
-        this.dispatchQueue = dispatchQueue;
-    }
-
-    public void setReportQueue(HostReportQueue reportQueue) {
-        this.reportQueue = reportQueue;
-    }
 
     // BookingQueue bookingQueue
     private static final Gauge bookingWaitingTotal = Gauge.build()
@@ -276,19 +263,42 @@ public class PrometheusMetricsCollector {
         }
     }
 
+    /**
+     * Set a new value to the cue_booking_durations_in_millis metric
+     * 
+     * @param stage_desc booking stage description to be used as a tag
+     * @param value value to set
+     */
     public void setBookingDurationMetric(String stage_desc, double value) {
         bookingDurationMillisMetric.labels(this.deployment_environment, this.cuebot_host, stage_desc).set(value);
         bookingDurationMillisHistogramMetric.labels(this.deployment_environment, this.cuebot_host, stage_desc).observe(value);
     }
 
+    /**
+     * Increment cue_find_jobs_by_show_count metric
+     */
     public void incrementFindJobsByShowQueryCountMetric() {
         findJobsByShowQueryCountMetric.labels(this.deployment_environment, this.cuebot_host).inc();
     }
 
+    /**
+     * Increment cue_frame_killed_counter metric
+     * 
+     * @param renderNode hostname of the render node receiving the kill request
+     * @param killCause cause assigned to the request
+     */
     public void incrementFrameKilledCounter(String renderNode, HostReportHandler.KillCause killCause) {
         frameKilledCounter.labels(this.deployment_environment, this.cuebot_host, renderNode, killCause.name()).inc();
     }
 
+    /**
+     * Increment cue_frame_kill_failure_counter metric
+     * 
+     * @param hostname
+     * @param jobName
+     * @param frameName
+     * @param frameId
+     */
     public void incrementFrameKillFailureCounter(String hostname, String jobName, String frameName, String frameId) {
         frameKillFailureCounter.labels(this.deployment_environment,
                 this.cuebot_host,
@@ -296,5 +306,22 @@ public class PrometheusMetricsCollector {
                 jobName,
                 frameName,
                 frameId).inc();
+    }
+
+    // Setters used for dependency injection
+    public void setBookingQueue(BookingQueue bookingQueue) {
+        this.bookingQueue = bookingQueue;
+    }
+
+    public void setManageQueue(DispatchQueue manageQueue) {
+        this.manageQueue = manageQueue;
+    }
+
+    public void setDispatchQueue(DispatchQueue dispatchQueue) {
+        this.dispatchQueue = dispatchQueue;
+    }
+
+    public void setReportQueue(HostReportQueue reportQueue) {
+        this.reportQueue = reportQueue;
     }
 }

--- a/cuebot/src/main/java/com/imageworks/spcue/config/AppConfig.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/config/AppConfig.java
@@ -77,6 +77,11 @@ public class AppConfig {
         return b;
     }
 
+    /**
+     * Registers the Prometheus MetricsServlet to expose metrics at /metrics endpoint
+     * 
+     * @return A ServletRegistrationBean for MetricsServlet
+     */
     @Bean
     public ServletRegistrationBean<MetricsServlet> prometheusServer() {
         ServletRegistrationBean<MetricsServlet> b = new ServletRegistrationBean<>();

--- a/cuebot/src/main/java/com/imageworks/spcue/config/AppConfig.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/config/AppConfig.java
@@ -23,6 +23,8 @@ import com.imageworks.spcue.servlet.JobLaunchServlet;
 import com.imageworks.spcue.servlet.HealthCheckServlet;
 
 import javax.sql.DataSource;
+
+import io.prometheus.client.exporter.MetricsServlet;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -31,7 +33,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.PropertySource;
 
@@ -73,6 +74,14 @@ public class AppConfig {
         b.addUrlMappings("/health");
         b.addInitParameter("contextConfigLocation", "classpath:conf/spring/healthCheckServlet-servlet.xml");
         b.setServlet(new HealthCheckServlet());
+        return b;
+    }
+
+    @Bean
+    public ServletRegistrationBean<MetricsServlet> prometheusServer() {
+        ServletRegistrationBean<MetricsServlet> b = new ServletRegistrationBean<>();
+        b.addUrlMappings("/metrics");
+        b.setServlet(new MetricsServlet());
         return b;
     }
 }

--- a/cuebot/src/main/resources/conf/spring/applicationContext-dao-postgres.xml
+++ b/cuebot/src/main/resources/conf/spring/applicationContext-dao-postgres.xml
@@ -77,6 +77,7 @@
 
     <bean id="dispatcherDao" class="com.imageworks.spcue.dao.postgres.DispatcherDaoJdbc">
         <property name="dataSource" ref="cueDataSource" />
+        <property name="prometheusMetrics" ref="prometheusMetricsCollector" />
     </bean>
 
     <bean id="maintenanceDao" class="com.imageworks.spcue.dao.postgres.MaintenanceDaoJdbc">

--- a/cuebot/src/main/resources/conf/spring/applicationContext-service.xml
+++ b/cuebot/src/main/resources/conf/spring/applicationContext-service.xml
@@ -287,6 +287,13 @@
     <property name="groupManager" ref="groupManager"/>
   </bean>
 
+  <bean id="prometheusMetricsCollector" class="com.imageworks.spcue.PrometheusMetricsCollector">
+    <property name="bookingQueue" ref="bookingQueue" />
+    <property name="manageQueue" ref="manageQueue" />
+    <property name="dispatchQueue" ref="dispatchQueue" />
+    <property name="reportQueue" ref="reportQueue" />
+  </bean>
+
   <bean id="historicalManager" class="com.imageworks.spcue.service.HistoricalManagerService">
     <property name="historicalDao" ref="historicalDao" />
   </bean>
@@ -558,6 +565,19 @@
     <property name="repeatInterval" value="604800000" />
   </bean>
 
+  <bean id="collectPrometheusMetrics" class="org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean">
+    <property name="targetObject" ref="prometheusMetricsCollector" />
+    <property name="targetMethod" value="collectPrometheusMetrics" />
+  </bean>
+
+  <bean id="collectPrometheusMetricsTrigger" class="org.springframework.scheduling.quartz.SimpleTriggerFactoryBean">
+    <property name="jobDetail" ref="collectPrometheusMetrics" />
+    <!-- delay 60 seconds (1 minute) -->
+    <property name="startDelay" value="60000" />
+    <!-- repeat every 60 seconds (1 minute) -->
+    <property name="repeatInterval" value="60000" />
+  </bean>
+
   <bean class="org.springframework.scheduling.quartz.SchedulerFactoryBean" destroy-method="destroy">
    <property name="waitForJobsToCompleteOnShutdown"><value>false</value></property>
     <property name="triggers">
@@ -572,7 +592,8 @@
         <ref bean="dispatchQueueSchedule" />
         <ref bean="manageQueueSchedule" />
         <ref bean="killQueueSchedule" />
-        <ref bean="updateShowsStatusTrigger"/>
+        <ref bean="updateShowsStatusTrigger" />
+        <ref bean="collectPrometheusMetricsTrigger" />
       </list>
     </property>
   </bean>

--- a/cuebot/src/main/resources/conf/webapp/web.xml
+++ b/cuebot/src/main/resources/conf/webapp/web.xml
@@ -81,5 +81,14 @@
  		<url-pattern>/health</url-pattern>
  	</servlet-mapping>
 
+	<servlet>
+		<servlet-name>PrometheusServer</servlet-name>
+		<servlet-class>io.prometheus.client.exporter.MetricsServlet</servlet-class>
+	</servlet>
+	<servlet-mapping>
+		<servlet-name>PrometheusServer</servlet-name>
+		<url-pattern>/metrics</url-pattern>
+	</servlet-mapping>
+
 </web-app>
 

--- a/cuebot/src/main/resources/opencue.properties
+++ b/cuebot/src/main/resources/opencue.properties
@@ -167,3 +167,8 @@ max_show_stale_days=-1
 # If flags are set as true, layers/frames cannot be retried, eaten, edited dependency on, etc.
 layer.finished_jobs_readonly=false
 frame.finished_jobs_readonly=false
+
+# Enable prometheus metrics collecting module
+metrics.prometheus.collector=false
+# What environment variable to use to acquire the deployment environment id (et. dev, prod, staging)
+metrics.prometheus.environment_id.environment_variable=DEPLOYMENT_ENVIRONMENT

--- a/cuebot/src/main/resources/opencue.properties
+++ b/cuebot/src/main/resources/opencue.properties
@@ -168,7 +168,7 @@ max_show_stale_days=-1
 layer.finished_jobs_readonly=false
 frame.finished_jobs_readonly=false
 
-# Enable prometheus metrics collecting module
+# Enable Prometheus metrics collecting module
 metrics.prometheus.collector=false
 # What environment variable to use to acquire the deployment environment id (et. dev, prod, staging)
 metrics.prometheus.environment_id.environment_variable=DEPLOYMENT_ENVIRONMENT


### PR DESCRIPTION
Adds a new optional module that runs every 60 seconds to collect metrics about the state of thread pools. Also, it collects basic time measurements and counts from dispatchDaoJdbc, which helps assess performance degradation on the system.

Metrics are exposed under /metrics for being collected by a Prometheus instance (the Prometheus server setup is not part of this PR).

A future PR is coming that will include Grafana charts to consume the exposed metrics.

Exposed metrics:

BookingQueue
 - cue_booking_waiting_total: Booking Queue number of waiting tasks
 - cue_booking_remaining_capacity_total: Booking Queue remaining capacity
 - cue_booking_threads_total: Booking Queue number of active threads
 - cue_booking_executed_total: Booking Queue number of executed tasks
 - cue_booking_rejected_total: Booking Queue number of rejected tasks 
 
Manage Queue
 - cue_manage_waiting_total: Manage Queue number of waiting tasks
 - cue_manage_remaining_capacity_total: Manage Queue remaining capacity
 - cue_manage_threads_total: Manage Queue number of active threads
 - cue_manage_executed_total: Manage Queue number of executed tasks
 - cue_manage_rejected_total: Manage Queue number of rejected tasks 

DispatchQueue
 - cue_dispatch_waiting_total: Dispatch Queue number of waiting tasks
 - cue_dispatch_remaining_capacity_total: Dispatch Queue remaining capacity
 - cue_dispatch_threads_total: Dispatch Queue number of active threads
 - cue_dispatch_executed_total: Dispatch Queue number of executed tasks
 - cue_dispatch_rejected_total: Dispatch Queue number of rejected tasks 

HostReportQueue
 - cue_report_waiting_total: Report Queue number of waiting tasks
 - cue_report_remaining_capacity_total: Report Queue remaining capacity
 - cue_report_threads_total: Report Queue number of active threads
 - cue_report_executed_total: Report Queue number of executed tasks
 - cue_report_rejected_total: Report Queue number of rejected tasks 

General Performance Metrics:
 - cue_find_jobs_by_show_count: Count the occurrences of the query FIND_JOBS_BY_SHOW.
 - cue_booking_durations_in_millis: Register the duration of booking steps in milliseconds.
 - cue_booking_durations_histogram_in_millis: Register a summary of the duration of booking steps in milliseconds.
 - cue_frame_killed_counter: Number of frames kill requests processed
 - cue_frame_kill_failure_counter: Number of frames that failed to be killed after FRAME_KILL_RETRY_LIMIT tries
