### PR TITLE
[rqd] Fix file logging to handle non-ASCII characters without timestamp

### DIFF
--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -340,7 +340,7 @@ class FrameAttendantThread(threading.Thread):
         if rqd.rqconstants.RQD_PREPEND_TIMESTAMP:
             pipe_to_file(frameInfo.forkedCommand.stdout, frameInfo.forkedCommand.stderr, self.rqlog)
         else:
-            with open(self.rqlog, 'a') as f:
+            with open(self.rqlog.name, 'a') as f:
                 # Convert to ASCII while discarding characters that can not be encoded
                 for line in frameInfo.forkedCommand.stdout:
                     line = line.encode('ascii', 'ignore')


### PR DESCRIPTION
- Updated the logging logic to use the file name for appending logs.
- Corrected file logging to ensure non-ASCII characters are properly handled when RQD_PREPEND_TIMESTAMP is False.
- This change prevents crashes due to `TypeError` and fixes the broken file logging. `self.rqlog` is a file object and not a string.