### PR TITLE
[pycue] Minor API improvements

### DIFF
--- a/pycue/opencue/api.py
+++ b/pycue/opencue/api.py
@@ -614,7 +614,7 @@ def findAllocation(name):
     """Returns the Allocation object that matches the name.
 
     :type  name: str
-    :param name: the name of the allocation
+    :param name: fully qualified name of the allocation (facility.allocation)
     :rtype:  Allocation
     :return: an Allocation object"""
     return Allocation(Cuebot.getStub('allocation').Find(
@@ -678,6 +678,7 @@ def allocSetBillable(alloc, is_billable):
     :rtype:  facility_pb2.AllocSetBillableResponse
     :return: empty response
     """
+    alloc.name = alloc.name.split(".")[-1]
     return Cuebot.getStub('allocation').SetBillable(
         facility_pb2.AllocSetBillableRequest(allocation=alloc, value=is_billable),
         timeout=Cuebot.Timeout)

--- a/pycue/opencue/search.py
+++ b/pycue/opencue/search.py
@@ -387,6 +387,8 @@ def _setOptions(criteria, options):
                     _createCriterion(v, int, lambda duration: (60 * 60 * duration)))
         elif k == "limit":
             criteria.max_results = int(v)
+        elif k == "page" and isinstance(criteria, job_pb2.FrameSearchCriteria):
+            criteria.page = int(v)
         elif k == "offset":
             criteria.first_result = int(v)
         elif k == "include_finished":

--- a/pycue/opencue/wrappers/frame.py
+++ b/pycue/opencue/wrappers/frame.py
@@ -171,7 +171,7 @@ class Frame(object):
         """
         frame_dep = frame.data if isinstance(frame, type(self)) else frame
         response = self.stub.CreateDependencyOnFrame(
-            job_pb2.FrameCreateDependencyOnFrameRequest(frame=self.data, 
+            job_pb2.FrameCreateDependencyOnFrameRequest(frame=self.data,
                                                         depend_on_frame=frame_dep),
                                                         timeout=Cuebot.Timeout)
         return opencue.wrappers.depend.Depend(response.depend)

--- a/pycue/opencue/wrappers/frame.py
+++ b/pycue/opencue/wrappers/frame.py
@@ -169,10 +169,11 @@ class Frame(object):
         :rtype:  opencue.wrappers.depend.Depend
         :return: the new dependency
         """
+        frame_dep = frame.data if isinstance(frame, type(self)) else frame
         response = self.stub.CreateDependencyOnFrame(
-            job_pb2.FrameCreateDependencyOnFrameRequest(frame=self.data,
-                                                        depend_on_frame=frame.data),
-            timeout=Cuebot.Timeout)
+            job_pb2.FrameCreateDependencyOnFrameRequest(frame=self.data, 
+                                                        depend_on_frame=frame_dep),
+                                                        timeout=Cuebot.Timeout)
         return opencue.wrappers.depend.Depend(response.depend)
 
     def dropDepends(self, target):

--- a/pycue/opencue/wrappers/frame.py
+++ b/pycue/opencue/wrappers/frame.py
@@ -202,7 +202,10 @@ class Frame(object):
 
     def setFrameStateDisplayOverride(self, status, override_text, override_rgb):
         """
-        Override the displayed text of a frame status
+        Override the displayed text of a frame status.
+        If an override already exists for the frame-state combo, the existing
+        override will be updated to the new text and color values.
+        If the override is identical to an existing override, no-op.
 
         :param status: the job_pb2.FrameState to override
         :param override_text: the text to display


### PR DESCRIPTION
Quality of life changes on the pycue API. 

 * [Add paginated search option to api](https://github.com/AcademySoftwareFoundation/OpenCue/commit/73506c9d9d07b17525e08ff651a1c694ce8d5732)
 * [Accept wrapper frames on createDependencyOnFrame](https://github.com/AcademySoftwareFoundation/OpenCue/commit/d766af32b649f356a74b9ed87419812353ac0844) This makes it so that both the grpc frame object and the python wrapped object are accepted by the createDependencyOnFrame method.
 * [Improve frameStateDisplayOverride function doc](https://github.com/AcademySoftwareFoundation/OpenCue/commit/86e0c68091756a9a11ab32eb85ae3d6076c05a6a)
 * [Fix AllocSetBillable call and findAllocation](https://github.com/AcademySoftwareFoundation/OpenCue/commit/1f25f80cae1b58d5722065160d954d783d041e30) The allocation name object on the api has the format facility.allocation
while on the server it should be queried with allocation only.
(See ManageAllocation.java/setBillable)