### PR TITLE
[pycue] Add interactive functions to reboot hosts using the api

### DIFF
--- a/pycue/opencue/wrappers/host.py
+++ b/pycue/opencue/wrappers/host.py
@@ -326,7 +326,7 @@ class Host(object):
                     # pylint: enable=no-member
 
         # Wait for remaining hosts to finish (20% not awaited for)
-        if len(host_still_rebooting) > 0:
+        if host_still_rebooting:
             print("Waiting on remaining hosts to reboot")
             while True:
                 try:


### PR DESCRIPTION
New api functions can be used to interactively reboot hosts on the farm and monitor their state. New functions:
 * `rebootFarmSafely`: uses the hostSearch module to find hosts and requests a reboot for each of them in groups defined by the arg `group_size`. If `start_time` is provided the function will only target hosts that have `boot_time` > `start_time`
 * `monitorRebootFarm` Similar to rebootFarmSafely, but instead of requesting a reboot, it continuosly monitors reboot groups and only finishes when all the hosts on the query have been rebooted.
