### PR TITLE
Avoid creating the cuebot connection twice

### DIFF
--- a/cueadmin/cueadmin/common.py
+++ b/cueadmin/cueadmin/common.py
@@ -562,7 +562,7 @@ def handleArgs(args):
 
     if args.facility:
         logger.debug("setting facility to %s", args.facility)
-        opencue.Cuebot.setFacility(args.facility)
+        opencue.Cuebot.setHostWithFacility(args.facility)
 
     #
     # Query

--- a/cueadmin/tests/common_tests.py
+++ b/cueadmin/tests/common_tests.py
@@ -72,7 +72,7 @@ class CommonArgTests(unittest.TestCase):
 
         setHostsMock.assert_called_with([serverName])
 
-    @mock.patch('opencue.Cuebot.setFacility')
+    @mock.patch('opencue.Cuebot.setHostWithFacility')
     def testSetFacility(self, setFacilityMock):
         args = self.parser.parse_args(['-facility', TEST_FACILITY])
 

--- a/cuegui/cuegui/MainWindow.py
+++ b/cuegui/cuegui/MainWindow.py
@@ -178,7 +178,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         for facility in list(self.__actions_facility.values()):
             if facility.isChecked():
-                opencue.Cuebot.setFacility(str(facility.text()))
+                opencue.Cuebot.setHostWithFacility(str(facility.text()))
                 self.app.facility_changed.emit()
                 return
 

--- a/pycue/opencue/cuebot.py
+++ b/pycue/opencue/cuebot.py
@@ -150,18 +150,19 @@ class Cuebot(object):
         :type config: dict
         :param config: config dictionary, this will override the config read from disk
         """
+        hosts_env = os.getenv("CUEBOT_HOSTS")
+
         if config:
             Cuebot.Config = config
             Cuebot.Timeout = config.get('cuebot.timeout', Cuebot.Timeout)
-        if os.getenv("CUEBOT_HOSTS"):
-            Cuebot.setHosts(os.getenv("CUEBOT_HOSTS").split(","))
+        if hosts_env:
+            Cuebot.setHosts(hosts_env.split(","))
         else:
-            facility_default = Cuebot.Config.get("cuebot.facility_default")
-            Cuebot.setFacility(facility_default)
+            facility = os.getenv("CUEBOT_FACILITY", Cuebot.Config.get("cuebot.facility_default"))
+            Cuebot.setHostWithFacility(facility)
         if Cuebot.Hosts is None:
             raise CueException('Cuebot host not set. Please ensure CUEBOT_HOSTS is set ' +
                                'or a facility_default host is set in the yaml pycue config.')
-        Cuebot.setChannel()
 
     @staticmethod
     def setChannel():
@@ -182,6 +183,7 @@ class Cuebot(object):
             ),
         )
 
+        connectStr = "Not Defined"
         for host in hosts:
             if ':' in host:
                 connectStr = host
@@ -208,7 +210,7 @@ class Cuebot(object):
             atexit.register(Cuebot.closeChannel)
             return None
         raise ConnectionException('No grpc connection could be established. ' +
-                                  'Please check configured cuebot hosts.')
+                                  'Please check configured cuebot hosts: ' + connectStr)
 
     @staticmethod
     def closeChannel():
@@ -225,9 +227,10 @@ class Cuebot(object):
         Cuebot.setChannel()
 
     @staticmethod
-    def setFacility(facility):
-        """Sets the facility to connect to. If an unknown facility is provided,
-        it will fall back to the one listed in cuebot.facility_default
+    def setHostWithFacility(facility):
+        """Sets hosts to connect to based on the provided facility.
+        If an unknown facility is provided, it will fall back to the one listed
+        in cuebot.facility_default
 
         :type  facility: str
         :param facility: a facility named in the config file"""

--- a/pycue/tests/cuebot_test.py
+++ b/pycue/tests/cuebot_test.py
@@ -16,8 +16,8 @@
 
 """Tests for `opencue.cuebot`."""
 
+import os
 import unittest
-
 import mock
 
 import opencue
@@ -48,6 +48,9 @@ class CuebotTests(unittest.TestCase):
         healthcheck_mock = mock.Mock()
         self.cuebot.SERVICE_MAP['cue'] = healthcheck_mock
 
+        # Clear any existing overrides
+        if 'CUEBOT_HOSTS' in os.environ:
+            del os.environ['CUEBOT_HOSTS']
         self.cuebot.init(config=TESTING_CONFIG)
 
         self.assertEqual(["fake-cuebot-01"], self.cuebot.Hosts)
@@ -57,14 +60,14 @@ class CuebotTests(unittest.TestCase):
     def test__should_set_known_facility(self):
         self.cuebot.init(config=TESTING_CONFIG)
 
-        self.cuebot.setFacility('fake-facility-02')
+        self.cuebot.setHostWithFacility('fake-facility-02')
 
         self.assertEqual(['fake-cuebot-02', 'fake-cuebot-03'], self.cuebot.Hosts)
 
     def test__should_ignore_unknown_facility(self):
         self.cuebot.init(config=TESTING_CONFIG)
 
-        self.cuebot.setFacility('unknown-facility')
+        self.cuebot.setHostWithFacility('unknown-facility')
 
         self.assertEqual(['fake-cuebot-01'], self.cuebot.Hosts)
 


### PR DESCRIPTION
Improve the logic that connects to cuebot to only create the channel once. Previous logic would call setChannel at init and at setFacility.