### PR TITLE
[pycue] Fix typeError on criterion search

### DIFF
--- a/pycue/opencue/search.py
+++ b/pycue/opencue/search.py
@@ -282,7 +282,7 @@ def _createCriterion(search, searchType, convert=None):
     if search.startswith("lt"):
         criterion = getattr(criterion_pb2,
                             "LessThan%sSearchCriterion" % searchTypeStr)
-        return criterion(value=_convert(search[2:]))
+        return criterion(value=_convert(int(search[2:])))
 
     if search.find("-") > -1:
         criterion = getattr(criterion_pb2,

--- a/pycue/opencue/search.py
+++ b/pycue/opencue/search.py
@@ -277,12 +277,12 @@ def _createCriterion(search, searchType, convert=None):
     if search.startswith("gt"):
         criterion = getattr(criterion_pb2,
                             "GreaterThan%sSearchCriterion" % searchTypeStr)
-        return criterion(_convert(search[2:]))
+        return criterion(value=_convert(search[2:]))
 
     if search.startswith("lt"):
         criterion = getattr(criterion_pb2,
                             "LessThan%sSearchCriterion" % searchTypeStr)
-        return criterion(_convert(search[2:]))
+        return criterion(value=_convert(search[2:]))
 
     if search.find("-") > -1:
         criterion = getattr(criterion_pb2,


### PR DESCRIPTION
Searching with criterion `gt` or `lt` returned `TypeError: No positional arguments allowed`. Grpc objects don't accept position arguments.
