### PR TITLE
Fix "Monitor Cue" with incorrect column indexing

### DIFF
--- a/cuegui/cuegui/CueJobMonitorTree.py
+++ b/cuegui/cuegui/CueJobMonitorTree.py
@@ -190,17 +190,17 @@ class CueJobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                            data=lambda group: group.data.stats.waiting_frames)
             self.addColumn("", 0, id=8)
             self.addColumn("", 0, id=9)
-            self.addColumn("", 0, id=10,
-                           data=lambda group: (group.data.min_cores or ""))
+            self.addColumn("", 0, id=10)
             self.addColumn("", 0, id=11,
+                           data=lambda group: (group.data.min_cores or ""))
+            self.addColumn("", 0, id=12,
                            data=lambda group: (
                                    group.data.max_cores > 0 and group.data.max_cores or ""))
-            self.addColumn("", 0, id=12,
-                           data=lambda group: (group.data.min_gpus or ""))
             self.addColumn("", 0, id=13,
+                           data=lambda group: (group.data.min_gpus or ""))
+            self.addColumn("", 0, id=14,
                            data=lambda group: (
                                    group.data.max_gpus > 0 and group.data.max_gpus or ""))
-            self.addColumn("", 0, id=14)
             self.addColumn("", 0, id=15)
             self.addColumn("", 0, id=16)
             self.addColumn("", 0, id=17)


### PR DESCRIPTION
Fix "Monitor Cue" with incorrect column indexing for "Min" and "Max" columns
- Fix the column indexing on the "addColumn" of class CueJobMonitorTree.
- This bug was introduced after the merge from the pull request "Add multiple GPU support #760 (#924)" on 4/18/22 at 11:45 AM where the following new columns were introduced on the CueJobMonitorTree: "Gpus", "Min Gpus", "Max Gpus", "MaxGpuMem" and the indexing of the columns were wrongly defined.