### PR TITLE
[rqd] Add an option to daemonize the process

### DIFF
--- a/rqd/rqd/__main__.py
+++ b/rqd/rqd/__main__.py
@@ -110,7 +110,7 @@ def daemonize(log_path=None, chdir_to_root=True):
     # pylint: disable=protected-access
     if os.fork() != 0:
         # Intentionally not using sys.exit here to avoid raising SystemExit,
-        # cleaning handlers and flushing stdio buffers        
+        # cleaning handlers and flushing stdio buffers
         os._exit(0)
 
     os.setsid()

--- a/rqd/rqd/__main__.py
+++ b/rqd/rqd/__main__.py
@@ -59,9 +59,97 @@ import rqd.rqcore
 import rqd.rqutil
 
 
+def reopen_stdout_stderr(log_path):
+    """
+    Flush sys.stdout and sys.stderr and then reopen the underlying
+    file descriptor for both stdout and stderr to the file at
+    LOG_PATH.  LOG_PATH is opened before stdout and stderr are closed,
+    so if LOG_PATH fails to open, stdout and stderr will remain
+    unchanged.
+    """
+    log_fd = os.open(log_path, os.O_CREAT|os.O_WRONLY|os.O_TRUNC, 0o644)
+
+    for f in [sys.stdout, sys.stderr]:
+        fileno = f.fileno()
+        f.flush()
+        os.close(fileno)
+        os.dup2(log_fd, fileno)
+
+    os.close(log_fd)
+
+
+def daemonize(log_path=None, chdir_to_root=True):
+    """
+    Daemonizes the current process. The process will be in a new session
+    with stdin reading from /dev/null and stdout and stderr writing to
+    /dev/null with all other file descriptors closed.
+
+    :type log_path: String
+    :param log_path: If LOG_PATH is provided, then stdout and stderr
+                     write to LOG_PATH. LOG_PATH may be a relative
+                     path to the process' current working directory
+                     before calling daemonize().
+    :type chdir_to_root: bool
+    :param chdir_to_root: If CHDIR_TO_ROOT is True, then the process'
+                          current working directory will be changed
+                          to / after opening the log files; if
+                          CHDIR_TO_ROOT is false, then the current
+                          working directory is not changed.
+    """
+    # pylint: disable=import-outside-toplevel
+    import resource
+
+    if hasattr(os, "devnull"):
+        dev_null = os.devnull
+    else:
+        dev_null = "/dev/null"
+
+    if not log_path:
+        log_path = dev_null
+
+    # pylint: disable=protected-access
+    if os.fork() != 0:
+        # Intentionally not using sys.exit here to avoid raising SystemExit,
+        # cleaning handlers and flushing stdio buffers        
+        os._exit(0)
+
+    os.setsid()
+
+    if os.fork() != 0:
+        # Intentionally not using sys.exit here to avoid raising SystemExit,
+        # cleaning handlers and flushing stdio buffers
+        os._exit(0)
+    # pylint: enable=protected-access
+
+    os.close(sys.stdin.fileno())
+    os.open(dev_null, os.O_RDONLY)
+
+    # The log file is opened before chdir'ing so a relative path may
+    # be used and is opened before stdout and stderr are closed so any
+    # errors in opening it will appear on stderr.
+    reopen_stdout_stderr(log_path)
+
+    if chdir_to_root:
+        os.chdir('/')
+
+    max_fd = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
+    if max_fd == resource.RLIM_INFINITY:
+        max_fd = 1024
+    for fd in range(3, max_fd+1):
+        try:
+            # Ice.loadSlice() function sometimes open /dev/urandom to
+            # get random numbers. If daemonize() function is called after
+            # Ice.loadSlice(), we should not close /dev/urandom. Or else
+            # the child process will get exceptions when trying to access
+            # /dev/urandom.
+            fn = os.readlink("/proc/%s/%s" % (os.getpid(), fd))
+            if fn != "/dev/urandom":
+                os.close(fd)
+        except OSError:
+            pass
+
 def setupLogging():
-    """Sets up the logging for RQD.
-       Logs to /var/log/messages"""
+    """Sets up the logging for RQD. Logs to /var/log/messages"""
 
     consolehandler = logging.StreamHandler()
     consolehandler.setLevel(rqd.rqconstants.CONSOLE_LOG_LEVEL)
@@ -122,9 +210,8 @@ def main():
         if option in ["-h", "--help"]:
             usage()
             sys.exit(0)
-        if option in ["-d", "--daemon"]:
-            # TODO(bcipriano) Background the process. (Issue #153)
-            pass
+        if option in ["-d", "--daemon"] and platform.system() != "Windows":
+            daemonize()
         if option in ["--nimbyoff"]:
             optNimbyOff = True
 


### PR DESCRIPTION
This option was already present on rqd, but was a noop. With this option , the process will run in a new session with stdin reading from /dev/null and stdout and stderr writing to /dev/null with all other file descriptors closed. 

Resolves #153 
