### PR TITLE
[rqd] Add sentry support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ six==1.16.0
 
 # Optional requirements
 # Sentry support for rqd
-sentry-sdk=2.11.0
+sentry-sdk==2.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,7 @@ pylint==2.15.10
 pynput==1.7.6
 PyYAML==5.1
 six==1.16.0
+
+# Optional requirements
+# Sentry support for rqd
+sentry-sdk=2.11.0

--- a/rqd/rqd.example.conf
+++ b/rqd/rqd.example.conf
@@ -12,6 +12,8 @@ OVERRIDE_NIMBY=True
 CHECK_INTERVAL_LOCKED = 60
 # Seconds of idle time required before nimby unlocks.
 MINIMUM_IDLE = 900
+# Url to the rqd project on sentry
+# SENTRY_DSN_PATH=http://sentry.yourdomain.com/40
 
 # This section tells RQD which env var it should copy from the worker machine to the job's environment.
 # For instance you could need to copy PIXAR_LICENSE_FILE if you launch a renderman job.

--- a/rqd/rqd/__main__.py
+++ b/rqd/rqd/__main__.py
@@ -102,7 +102,6 @@ def setup_sentry():
     except ImportError:
         logging.warning('Sentry support disabled. SENTRY_DSN_PATH is set but '
                         'the lib is not available')
-        pass
 
 
 def usage():
@@ -149,9 +148,6 @@ def main():
     rqd.rqutil.permissionsLow()
 
     logging.warning('RQD Starting Up')
-
-    if rqd.rqconstants.FACILITY == 'abq':
-        os.environ['TZ'] = 'PST8PDT'
 
     setup_sentry()
 

--- a/rqd/rqd/__main__.py
+++ b/rqd/rqd/__main__.py
@@ -87,6 +87,24 @@ def setupLogging():
     logging.getLogger('').setLevel(logging.DEBUG)
 
 
+def setup_sentry():
+    """Set up sentry if a SENTRY_DSN_PATH is configured"""
+    sentry_dsn_path = rqd.rqconstants.SENTRY_DSN_PATH
+    if sentry_dsn_path is not None:
+        return
+
+    # Not importing sentry at the toplevel to avoid an unecessary dependency
+    try:
+        # pylint: disable=import-outside-toplevel
+        import sentry_sdk
+        # pylint: enable=import-outside-toplevel
+        sentry_sdk.init(sentry_dsn_path)
+    except ImportError:
+        logging.warning('Sentry support disabled. SENTRY_DSN_PATH is set but '
+                        'the lib is not available')
+        pass
+
+
 def usage():
     """Prints command line syntax"""
     usage_msg = f"""SYNOPSIS
@@ -131,6 +149,11 @@ def main():
     rqd.rqutil.permissionsLow()
 
     logging.warning('RQD Starting Up')
+
+    if rqd.rqconstants.FACILITY == 'abq':
+        os.environ['TZ'] = 'PST8PDT'
+
+    setup_sentry()
 
     rqCore = rqd.rqcore.RqCore(optNimbyOff)
     rqCore.start()

--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -74,6 +74,7 @@ RQD_HOST_ENV_VARS = []
 
 RQD_BECOME_JOB_USER = True
 RQD_CREATE_USER_IF_NOT_EXISTS = True
+SENTRY_DSN_PATH = None
 RQD_TAGS = ''
 RQD_PREPEND_TIMESTAMP = False
 
@@ -220,6 +221,8 @@ try:
             CHECK_INTERVAL_LOCKED = config.getint(__override_section, "CHECK_INTERVAL_LOCKED")
         if config.has_option(__override_section, "MINIMUM_IDLE"):
             MINIMUM_IDLE = config.getint(__override_section, "MINIMUM_IDLE")
+        if config.has_option(__override_section, "SENTRY_DSN_PATH"):
+            SENTRY_DSN_PATH = config.getint(__override_section, "SENTRY_DSN_PATH")
 
         if config.has_section(__host_env_var_section):
             RQD_HOST_ENV_VARS = config.options(__host_env_var_section)


### PR DESCRIPTION
Add sentry as an optional integration to collect events from the rqd module.

If SENTRY_DSN_PATH is configured on rqd.conf, a sentry collector will be initialized.
