### PR TITLE
Update RQD Dockerfile to mitigate Centos 7 deprecation

### DIFF
--- a/rqd/Dockerfile
+++ b/rqd/Dockerfile
@@ -1,25 +1,24 @@
-FROM --platform=linux/x86_64 centos:7
+FROM rockylinux:8.9
 
 WORKDIR /opt/opencue
 
 RUN yum -y install \
   epel-release \
   gcc \
-  python-devel \
   time
 
-RUN yum -y install \
-  python36 \
-  python36-devel \
-  python36-pip
+RUN dnf install -y \
+  python39 \
+  python39-devel \
+  python39-pip
 
-RUN python3.6 -m pip install --upgrade pip
-RUN python3.6 -m pip install --upgrade setuptools
+RUN python3.9 -m pip install --upgrade pip
+RUN python3.9 -m pip install --upgrade setuptools
 
 COPY LICENSE ./
 COPY requirements.txt ./
 
-RUN python3.6 -m pip install -r requirements.txt
+RUN python3.9 -m pip install -r requirements.txt
 
 COPY proto/ ./proto
 COPY rqd/deploy ./rqd/deploy
@@ -28,7 +27,7 @@ COPY rqd/setup.py ./rqd/
 COPY rqd/tests/ ./rqd/tests
 COPY rqd/rqd/ ./rqd/rqd
 
-RUN python3.6 -m grpc_tools.protoc \
+RUN python3.9 -m grpc_tools.protoc \
   -I=./proto \
   --python_out=./rqd/rqd/compiled_proto \
   --grpc_python_out=./rqd/rqd/compiled_proto \
@@ -41,8 +40,8 @@ RUN 2to3 -wn -f import rqd/rqd/compiled_proto/*_pb2*.py
 COPY VERSION.in VERSIO[N] ./
 RUN test -e VERSION || echo "$(cat VERSION.in)-custom" | tee VERSION
 
-RUN cd rqd && python3.6 setup.py test
-RUN cd rqd && python3.6 setup.py install
+RUN cd rqd && python3.9 setup.py test
+RUN cd rqd && python3.9 setup.py install
 
 # This step isn't really needed at runtime, but is used when publishing an OpenCue release
 # from this build.

--- a/rqd/Dockerfile
+++ b/rqd/Dockerfile
@@ -38,10 +38,10 @@ RUN python3.9 -m grpc_tools.protoc \
 RUN 2to3 -wn -f import rqd/rqd/compiled_proto/*_pb2*.py
 
 COPY VERSION.in VERSIO[N] ./
-RUN test -e VERSION || echo "$(cat VERSION.in)-custom" | tee VERSION
+RUN test -e VERSION || echo "$(cat VERSION.in)" | tee VERSION
 
-RUN cd rqd && python3.9 setup.py test
-RUN cd rqd && python3.9 setup.py install
+RUN cd rqd && python3.9 -m unittest discover
+RUN cd rqd && python3.9 -m pip install .
 
 # This step isn't really needed at runtime, but is used when publishing an OpenCue release
 # from this build.


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Issue https://github.com/AcademySoftwareFoundation/OpenCue/issues/1438

**Summarize your change.**
Update the Dockerfile base image and perform related changes due to Centos 7 reaching [EOL](https://www.redhat.com/en/topics/linux/centos-linux-eol) on June 30th.

Encountered while updating packaging pipeline with integrations related to PR https://github.com/AcademySoftwareFoundation/OpenCue/pull/1309

