### PR TITLE
[rqd] Remove repeated call to onNimbyLock

### DIFF
--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -622,7 +622,6 @@ class RqCore(object):
                     log.warning('OVERRIDE_NIMBY is False, Nimby startup has been disabled')
             else:
                 self.nimbyOn()
-                self.onNimbyLock()
         elif rqd.rqconstants.OVERRIDE_NIMBY:
             log.warning('Nimby startup has been triggered by OVERRIDE_NIMBY')
             self.nimbyOn()


### PR DESCRIPTION
The repeated call would cause the host to lock and unlock when rqd starts at desktop mode. 

`onNimbyLock` is already called as part of the `lockNimby` logic so it doesn't need to be called when the application starts.
