### PR TITLE
[rqd] Default to locked on override_nimby

### DIFF
--- a/rqd/rqd/rqnimby.py
+++ b/rqd/rqd/rqnimby.py
@@ -378,6 +378,8 @@ class NimbyNop(Nimby):
         self.warning_msg()
 
     def unlockedIdle(self):
+        if rqd.rqconstants.OVERRIDE_NIMBY:
+            self.lockNimby()
         self.warning_msg()
 
     def lockedIdle(self):


### PR DESCRIPTION
When a server is marked with `OVERRIDE_NIMBY` but  doesn't have the libraries required to monitor user activity (select or pynput), it should be marked as locked by default. It is safer to assume that a host that was set with `OVERRIDE_NIMBY` is meant to be locked from the start than available to launch jobs.