### PR TITLE
Remove incorrect parameter on frame_on_frame dependency

### DIFF
--- a/cuegui/cuegui/Cuedepend.py
+++ b/cuegui/cuegui/Cuedepend.py
@@ -139,7 +139,7 @@ def createHardDepend(job, onjob):
     for depend_er_layer in opencue.api.findJob(job).getLayers():
         for depend_on_layer in onLayers:
             if depend_er_layer.data.type == depend_on_layer.data.type:
-                depends.append(depend_er_layer.createFrameByFrameDependency(depend_on_layer, False))
+                depends.append(depend_er_layer.createFrameByFrameDependency(depend_on_layer))
     return depends
 
 

--- a/cuegui/cuegui/Cuedepend.py
+++ b/cuegui/cuegui/Cuedepend.py
@@ -378,7 +378,7 @@ def createFrameByFrameDepend(job, layer, onjob, onlayer):
 
     depend_er_layer = opencue.api.findLayer(job, layer)
     depend_on_layer = opencue.api.findLayer(onjob, onlayer)
-    return depend_er_layer.createFrameByFrameDependency(depend_on_layer, False)
+    return depend_er_layer.createFrameByFrameDependency(depend_on_layer)
 
 
 def createLayerOnSimFrameDepend(job, layer, onjob, onlayer, onframe):


### PR DESCRIPTION
Creating a frame_on_frame dependency from a layer wrapper object only takes one argument (See wrappers/layer.py)
