### PR TITLE
[rqd] Fix swap memory on Linux

### DIFF
--- a/rqd/rqd/rqmachine.py
+++ b/rqd/rqd/rqmachine.py
@@ -29,6 +29,7 @@ from builtins import str
 from builtins import range
 from builtins import object
 
+import codecs
 import ctypes
 import errno
 import logging
@@ -620,7 +621,7 @@ class Machine(object):
                         currCore[lineList[0]] = ""
 
                 # Reads information from /proc/meminfo
-                with open(rqd.rqconstants.PATH_MEMINFO, "r", encoding="utf-8") as fp:
+                with codecs.open(rqd.rqconstants.PATH_MEMINFO, "r", encoding="utf-8") as fp:
                     for line in fp:
                         if line.startswith("MemTotal"):
                             self.__renderHost.total_mem = int(line.split()[1])

--- a/rqd/rqd/rqmachine.py
+++ b/rqd/rqd/rqmachine.py
@@ -618,6 +618,14 @@ class Machine(object):
                     # An entry without data
                     elif len(lineList) == 1:
                         currCore[lineList[0]] = ""
+
+                # Reads information from /proc/meminfo
+                with open(rqd.rqconstants.PATH_MEMINFO, "r", encoding="utf-8") as fp:
+                    for line in fp:
+                        if line.startswith("MemTotal"):
+                            self.__renderHost.total_mem = int(line.split()[1])
+                        elif line.startswith("SwapTotal"):
+                            self.__renderHost.total_swap = int(line.split()[1])
         else:
             hyperthreadingMultiplier = 1
 


### PR DESCRIPTION
- Add the render host's total_mem, total_swap in the initMachineStats function.
- Specify file encoding when opening `/proc/meminfo`.

This logic was removed on 18/Dec/2018 at 11:04 in the pull request: Add build and packaging for RQD. (#48), cfd6e6b5