### PR TITLE
[cuegui] Make frames and layers readonly when a job is finished

### DIFF
--- a/cuegui/cuegui/Constants.py
+++ b/cuegui/cuegui/Constants.py
@@ -183,6 +183,9 @@ LOG_HIGHLIGHT_INFO = __config.get('render_logs.highlight.info')
 
 RESOURCE_LIMITS = __config.get('resources')
 
+FINISHED_JOBS_READONLY_FRAME = __config.get('finished_jobs_readonly.frame', False)
+FINISHED_JOBS_READONLY_LAYER = __config.get('finished_jobs_readonly.layer', False)
+
 TYPE_JOB = QtWidgets.QTreeWidgetItem.UserType + 1
 TYPE_LAYER = QtWidgets.QTreeWidgetItem.UserType + 2
 TYPE_FRAME = QtWidgets.QTreeWidgetItem.UserType + 3

--- a/cuegui/cuegui/FrameMonitorTree.py
+++ b/cuegui/cuegui/FrameMonitorTree.py
@@ -593,9 +593,8 @@ class FrameMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
 
     def contextMenuEvent(self, e):
         """When right clicking on an item, this raises a context menu"""
-        cfg_allow_edit = self._cfg().get("frame.finished_jobs_readonly", False)
         menu = FrameContextMenu(self, self._actionFilterSelectedLayers,
-                                readonly=(cfg_allow_edit and
+                                readonly=(cuegui.Constants.FINISHED_JOBS_READONLY_FRAME and
                                           self.__jobState == opencue.api.job_pb2.FINISHED))
         menu.exec_(e.globalPos())
 
@@ -605,17 +604,6 @@ class FrameMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         for frame in self.selectedObjects():
             results[frame.layer()] = True
         self.handle_filter_layers_byLayer[str].emit(list(results.keys()))
-
-    def _cfg(self):
-        """
-        Loads (if necessary) and returns the config values.
-        Warns and returns an empty dict if there's a problem reading the config
-        @return: The keys & values stored in the config file
-        @rtype: dict<str:str>
-        """
-        if not hasattr(self, '__config'):
-            self.__config = cuegui.Utils.getResourceConfig()
-        return self.__config
 
 
 class FrameWidgetItem(cuegui.AbstractWidgetItem.AbstractWidgetItem):

--- a/cuegui/cuegui/LayerMonitorTree.py
+++ b/cuegui/cuegui/LayerMonitorTree.py
@@ -239,7 +239,8 @@ class LayerMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         if len(__selectedObjects) == 1:
             menu.addSeparator()
             if bool(int(self.app.settings.value("AllowDeeding", 0))):
-                self.__menuActions.layers().addAction(menu, "useLocalCores").setEnabled(not readonly)
+                self.__menuActions.layers().addAction(menu, "useLocalCores") \
+                    .setEnabled(not readonly)
             if len({layer.data.range for layer in __selectedObjects}) == 1:
                 self.__menuActions.layers().addAction(menu, "reorder").setEnabled(not readonly)
             self.__menuActions.layers().addAction(menu, "stagger").setEnabled(not readonly)

--- a/cuegui/cuegui/LayerMonitorTree.py
+++ b/cuegui/cuegui/LayerMonitorTree.py
@@ -221,7 +221,7 @@ class LayerMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
 
     def contextMenuEvent(self, e):
         """When right clicking on an item, this raises a context menu"""
-        readonly = (self._cfg().get("layer.finished_jobs_readonly", False) and
+        readonly = (cuegui.Constants.FINISHED_JOBS_READONLY_LAYER and
                     self.__job and self.__job.state() == job_pb2.FINISHED)
 
         __selectedObjects = self.selectedObjects()
@@ -259,17 +259,6 @@ class LayerMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
     def __itemDoubleClickedFilterLayer(self, item, col):
         del col
         self.handle_filter_layers_byLayer.emit([item.rpcObject.data.name])
-
-    def _cfg(self):
-        """
-        Loads (if necessary) and returns the config values.
-        Warns and returns an empty dict if there's a problem reading the config
-        @return: The keys & values stored in the config file
-        @rtype: dict<str:str>
-        """
-        if not hasattr(self, '__config'):
-            self.__config = cuegui.Utils.getResourceConfig()
-        return self.__config
 
 
 class LayerWidgetItem(cuegui.AbstractWidgetItem.AbstractWidgetItem):

--- a/cuegui/cuegui/MenuActions.py
+++ b/cuegui/cuegui/MenuActions.py
@@ -171,6 +171,7 @@ class AbstractActions(object):
             self.__actionCache[key] = action
 
         menu.addAction(self.__actionCache[key])
+        return self.__actionCache[key]
 
     def cuebotCall(self, functionToCall, errorMessageTitle, *args):
         """Makes the given call to the Cuebot, displaying exception info if needed.

--- a/cuegui/cuegui/config/cuegui.yaml
+++ b/cuegui/cuegui/config/cuegui.yaml
@@ -110,3 +110,9 @@ startup_notice.msg: ''
 
 # Memory usage above this level will be displayed in a different color.
 memory_warning_level: 5242880
+
+# These flags determine whether or not layers/frames will be readonly when job is finished.
+# If flags are set as true, layers/frames cannot be retried, eaten, edited dependency on, etc.
+# In order to toggle the same functionality on cuebot side, set flags in opencue.properties
+frame.finished_jobs_readonly: True
+layer.finished_jobs_readonly: True

--- a/cuegui/cuegui/config/cuegui.yaml
+++ b/cuegui/cuegui/config/cuegui.yaml
@@ -113,6 +113,6 @@ memory_warning_level: 5242880
 
 # These flags determine whether or not layers/frames will be readonly when job is finished.
 # If flags are set as true, layers/frames cannot be retried, eaten, edited dependency on, etc.
-# In order to toggle the same functionality on cuebot side, set flags in opencue.properties
-frame.finished_jobs_readonly: True
-layer.finished_jobs_readonly: True
+# In order to toggle the same protection on cuebot's side, set flags in opencue.properties
+finished_jobs_readonly.frame: True
+finished_jobs_readonly.layer: True


### PR DESCRIPTION
The GUI currently allows editing frames and layers when the job state has completed. This change uses two configuration flags (`finished_jobs_readonly.frame`, `finished_jobs_readonly.layer`) to enable the behavior of making layers and frames readonly upon completion or cancelation. 

When the flags are set to `True` completed jobs can no longer have layers and frames retried, eaten and edited dependencies.