### PR TITLE
[cuegui] Output viewer feature

### DIFF
--- a/cuegui/cuegui/Constants.py
+++ b/cuegui/cuegui/Constants.py
@@ -186,6 +186,7 @@ RESOURCE_LIMITS = __config.get('resources')
 OUTPUT_VIEWER_ACTION_TEXT = __config.get('output_viewer.action_text')
 OUTPUT_VIEWER_EXTRACT_ARGS_REGEX = __config.get('output_viewer.extract_args_regex')
 OUTPUT_VIEWER_CMD_PATTERN = __config.get('output_viewer.cmd_pattern')
+OUTPUT_VIEWER_STEREO_MODIFIERS = __config.get('output_viewer.stereo_modifiers')
 
 TYPE_JOB = QtWidgets.QTreeWidgetItem.UserType + 1
 TYPE_LAYER = QtWidgets.QTreeWidgetItem.UserType + 2

--- a/cuegui/cuegui/Constants.py
+++ b/cuegui/cuegui/Constants.py
@@ -183,6 +183,10 @@ LOG_HIGHLIGHT_INFO = __config.get('render_logs.highlight.info')
 
 RESOURCE_LIMITS = __config.get('resources')
 
+OUTPUT_VIEWER_ACTION_TEXT = __config.get('output_viewer.action_text')
+OUTPUT_VIEWER_EXTRACT_ARGS_REGEX = __config.get('output_viewer.extract_args_regex')
+OUTPUT_VIEWER_CMD_PATTERN = __config.get('output_viewer.cmd_pattern')
+
 TYPE_JOB = QtWidgets.QTreeWidgetItem.UserType + 1
 TYPE_LAYER = QtWidgets.QTreeWidgetItem.UserType + 2
 TYPE_FRAME = QtWidgets.QTreeWidgetItem.UserType + 3

--- a/cuegui/cuegui/FrameMonitorTree.py
+++ b/cuegui/cuegui/FrameMonitorTree.py
@@ -909,6 +909,8 @@ class FrameContextMenu(QtWidgets.QMenu):
         if bool(int(self.app.settings.value("AllowDeeding", 0))):
             self.__menuActions.frames().addAction(self, "useLocalCores")
 
+        self.__menuActions.frames().addAction(self, "viewOutputInItview")
+
         if self.app.applicationName() == "CueCommander":
             self.__menuActions.frames().addAction(self, "viewHost")
 

--- a/cuegui/cuegui/FrameMonitorTree.py
+++ b/cuegui/cuegui/FrameMonitorTree.py
@@ -909,7 +909,7 @@ class FrameContextMenu(QtWidgets.QMenu):
         if bool(int(self.app.settings.value("AllowDeeding", 0))):
             self.__menuActions.frames().addAction(self, "useLocalCores")
 
-        self.__menuActions.frames().addAction(self, "viewOutputInItview")
+        self.__menuActions.frames().addAction(self, "viewOutput")
 
         if self.app.applicationName() == "CueCommander":
             self.__menuActions.frames().addAction(self, "viewHost")

--- a/cuegui/cuegui/JobMonitorTree.py
+++ b/cuegui/cuegui/JobMonitorTree.py
@@ -392,7 +392,7 @@ class JobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         if bool(int(self.app.settings.value("AllowDeeding", 0))):
             self.__menuActions.jobs().addAction(menu, "useLocalCores")
 
-        it_view_action = self.__menuActions.jobs().addAction(menu, "viewOutputInItview")
+        it_view_action = self.__menuActions.jobs().addAction(menu, "viewOutput")
         it_view_action.setDisabled(__count == 0)
         it_view_action.setToolTip("Open ItView for the selected items")
 

--- a/cuegui/cuegui/JobMonitorTree.py
+++ b/cuegui/cuegui/JobMonitorTree.py
@@ -394,7 +394,7 @@ class JobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
 
         it_view_action = self.__menuActions.jobs().addAction(menu, "viewOutput")
         it_view_action.setDisabled(__count == 0)
-        it_view_action.setToolTip("Open ItView for the selected items")
+        it_view_action.setToolTip("Open Viewer for the selected items")
 
         depend_menu = QtWidgets.QMenu("&Dependencies",self)
         self.__menuActions.jobs().addAction(depend_menu, "viewDepends")

--- a/cuegui/cuegui/JobMonitorTree.py
+++ b/cuegui/cuegui/JobMonitorTree.py
@@ -392,6 +392,10 @@ class JobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         if bool(int(self.app.settings.value("AllowDeeding", 0))):
             self.__menuActions.jobs().addAction(menu, "useLocalCores")
 
+        it_view_action = self.__menuActions.jobs().addAction(menu, "viewOutputInItview")
+        it_view_action.setDisabled(__count == 0)
+        it_view_action.setToolTip("Open ItView for the selected items")
+
         depend_menu = QtWidgets.QMenu("&Dependencies",self)
         self.__menuActions.jobs().addAction(depend_menu, "viewDepends")
         self.__menuActions.jobs().addAction(depend_menu, "dependWizard")

--- a/cuegui/cuegui/LayerMonitorTree.py
+++ b/cuegui/cuegui/LayerMonitorTree.py
@@ -222,7 +222,7 @@ class LayerMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         menu = QtWidgets.QMenu()
 
         self.__menuActions.layers().addAction(menu, "view")
-        self.__menuActions.layers().addAction(menu, "viewOutputInItview")
+        self.__menuActions.layers().addAction(menu, "viewOutput")
         depend_menu = QtWidgets.QMenu("&Dependencies", self)
         self.__menuActions.layers().addAction(depend_menu, "viewDepends")
         self.__menuActions.layers().addAction(depend_menu, "dependWizard")

--- a/cuegui/cuegui/LayerMonitorTree.py
+++ b/cuegui/cuegui/LayerMonitorTree.py
@@ -222,6 +222,7 @@ class LayerMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         menu = QtWidgets.QMenu()
 
         self.__menuActions.layers().addAction(menu, "view")
+        self.__menuActions.layers().addAction(menu, "viewOutputInItview")
         depend_menu = QtWidgets.QMenu("&Dependencies", self)
         self.__menuActions.layers().addAction(depend_menu, "viewDepends")
         self.__menuActions.layers().addAction(depend_menu, "dependWizard")

--- a/cuegui/cuegui/MenuActions.py
+++ b/cuegui/cuegui/MenuActions.py
@@ -232,7 +232,7 @@ class JobActions(AbstractActions):
     def viewOutputInItview(self, rpcObjects=None):
         jobs = self._getOnlyJobObjects(rpcObjects)
         if jobs:
-            cuegui.Utils.viewOutputInItview(jobs[0], None, self._caller)
+            cuegui.Utils.viewOutputInItview(jobs)
 
     viewDepends_info = ["&View Dependencies...", None, "log"]
 
@@ -850,7 +850,7 @@ class LayerActions(AbstractActions):
     def viewOutputInItview(self, rpcObjects=None):
         layers = self._getOnlyLayerObjects(rpcObjects)
         if layers:
-            cuegui.Utils.viewOutputInItview(self._getSource(), layers, self._caller)
+            cuegui.Utils.viewOutputInItview(layers)
 
     reorder_info = ["Reorder Frames...", None, "configure"]
 
@@ -1046,7 +1046,7 @@ class FrameActions(AbstractActions):
     def viewOutputInItview(self, rpcObjects=None):
         frames = self._getOnlyFrameObjects(rpcObjects)
         if frames:
-            cuegui.Utils.viewOutputInItview(self._getSource(), frames, self._caller)
+            cuegui.Utils.viewFramesOutputInItview(self._getSource(), frames)
 
     getWhatDependsOnThis_info = ["print getWhatDependsOnThis", None, "log"]
 

--- a/cuegui/cuegui/MenuActions.py
+++ b/cuegui/cuegui/MenuActions.py
@@ -171,6 +171,7 @@ class AbstractActions(object):
             self.__actionCache[key] = action
 
         menu.addAction(self.__actionCache[key])
+        return self.__actionCache[key]
 
     def cuebotCall(self, functionToCall, errorMessageTitle, *args):
         """Makes the given call to the Cuebot, displaying exception info if needed.
@@ -226,6 +227,12 @@ class JobActions(AbstractActions):
     def view(self, rpcObjects=None):
         for job in self._getOnlyJobObjects(rpcObjects):
             self.app.view_object.emit(job)
+
+    viewOutputInItview_info = ["View Output in Itview", None, "view"]
+    def viewOutputInItview(self, rpcObjects=None):
+        jobs = self._getOnlyJobObjects(rpcObjects)
+        if jobs:
+            cuegui.Utils.viewOutputInItview(jobs[0], None, self._caller)
 
     viewDepends_info = ["&View Dependencies...", None, "log"]
 
@@ -839,6 +846,12 @@ class LayerActions(AbstractActions):
         if layers:
             cuegui.DependWizard.DependWizard(self._caller, [self._getSource()], layers=layers)
 
+    viewOutputInItview_info = ["View Output in Itview", None, "view"]
+    def viewOutputInItview(self, rpcObjects=None):
+        layers = self._getOnlyLayerObjects(rpcObjects)
+        if layers:
+            cuegui.Utils.viewOutputInItview(self._getSource(), layers, self._caller)
+
     reorder_info = ["Reorder Frames...", None, "configure"]
 
     def reorder(self, rpcObjects=None):
@@ -1028,6 +1041,12 @@ class FrameActions(AbstractActions):
     def viewDepends(self, rpcObjects=None):
         frames = self._getOnlyFrameObjects(rpcObjects)
         cuegui.DependDialog.DependDialog(frames[0], self._caller).show()
+
+    viewOutputInItview_info = ["View Output in Itview", None, "view"]
+    def viewOutputInItview(self, rpcObjects=None):
+        frames = self._getOnlyFrameObjects(rpcObjects)
+        if frames:
+            cuegui.Utils.viewOutputInItview(self._getSource(), frames, self._caller)
 
     getWhatDependsOnThis_info = ["print getWhatDependsOnThis", None, "log"]
 

--- a/cuegui/cuegui/MenuActions.py
+++ b/cuegui/cuegui/MenuActions.py
@@ -228,11 +228,11 @@ class JobActions(AbstractActions):
         for job in self._getOnlyJobObjects(rpcObjects):
             self.app.view_object.emit(job)
 
-    viewOutputInItview_info = ["View Output in Itview", None, "view"]
-    def viewOutputInItview(self, rpcObjects=None):
+    viewOutput_info = [cuegui.Constants.OUTPUT_VIEWER_ACTION_TEXT, None, "view"]
+    def viewOutput(self, rpcObjects=None):
         jobs = self._getOnlyJobObjects(rpcObjects)
-        if jobs:
-            cuegui.Utils.viewOutputInItview(jobs)
+        if jobs and cuegui.Constants.OUTPUT_VIEWER_ACTION_TEXT:
+            cuegui.Utils.viewOutput(jobs)
 
     viewDepends_info = ["&View Dependencies...", None, "log"]
 
@@ -846,11 +846,11 @@ class LayerActions(AbstractActions):
         if layers:
             cuegui.DependWizard.DependWizard(self._caller, [self._getSource()], layers=layers)
 
-    viewOutputInItview_info = ["View Output in Itview", None, "view"]
-    def viewOutputInItview(self, rpcObjects=None):
+    viewOutput_info = [cuegui.Constants.OUTPUT_VIEWER_ACTION_TEXT, None, "view"]
+    def viewOutput(self, rpcObjects=None):
         layers = self._getOnlyLayerObjects(rpcObjects)
-        if layers:
-            cuegui.Utils.viewOutputInItview(layers)
+        if layers and cuegui.Constants.OUTPUT_VIEWER_ACTION_TEXT:
+            cuegui.Utils.viewOutput(layers)
 
     reorder_info = ["Reorder Frames...", None, "configure"]
 
@@ -1042,11 +1042,11 @@ class FrameActions(AbstractActions):
         frames = self._getOnlyFrameObjects(rpcObjects)
         cuegui.DependDialog.DependDialog(frames[0], self._caller).show()
 
-    viewOutputInItview_info = ["View Output in Itview", None, "view"]
-    def viewOutputInItview(self, rpcObjects=None):
+    viewOutput_info = [cuegui.Constants.OUTPUT_VIEWER_ACTION_TEXT, None, "view"]
+    def viewOutput(self, rpcObjects=None):
         frames = self._getOnlyFrameObjects(rpcObjects)
-        if frames:
-            cuegui.Utils.viewFramesOutputInItview(self._getSource(), frames)
+        if frames and cuegui.Constants.OUTPUT_VIEWER_ACTION_TEXT:
+            cuegui.Utils.viewFramesOutput(self._getSource(), frames)
 
     getWhatDependsOnThis_info = ["print getWhatDependsOnThis", None, "log"]
 

--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -617,9 +617,12 @@ def launchViewerUsingPaths(paths, test_mode=False):
     if regexp:
         try:
             match = re.search(regexp, sample_path)
-            if match:
-                args = match.groupdict().update({"paths": joined_paths})
-                cmd = cmd_pattern.format(**args)
+            if match is None:
+                raise KeyError
+            args = match.groupdict()
+            args.update({"paths": joined_paths})
+            # Raises KeyError if args don't match pattern
+            cmd = cmd_pattern.format(**args)
         except KeyError:
             print("groups extracted by regex output_viewer.extract_args_regex "
                     "(%s) on sample path (%s) don't match output_viewer.cmd_pattern (%s) " %

--- a/cuegui/cuegui/config/cuegui.yaml
+++ b/cuegui/cuegui/config/cuegui.yaml
@@ -121,7 +121,7 @@ memory_warning_level: 5242880
 #   # extract_args_regex: Regex to extract arguments from the output path produced by a job/layer/frame
 #   # cmd_pattern: Command pattern to be matched with the regex defined at extract_args_regex
 #   # if extract_args_regex is not provided, cmd_pattern is called directly with paths as arguments
-#   extract_args_regex: '/shots/(?P<show>\w+)/(?P<name>shot\w+)/.*'
+#   extract_args_regex: '/shots/(?P<show>\w+)/(?P<shot>shot\w+)/.*'
 #   cmd_pattern: "env SHOW={show} SHOT={shot} COLOR_IO=/{show}/home/colorspaces.xml OCIO=/{show}/home/config.ocio openrv {paths}"
 
 #   # if provided, paths containing any of the two values are considered the same output and only one

--- a/cuegui/cuegui/config/cuegui.yaml
+++ b/cuegui/cuegui/config/cuegui.yaml
@@ -111,7 +111,7 @@ startup_notice.msg: ''
 # Memory usage above this level will be displayed in a different color.
 memory_warning_level: 5242880
 
-# Output Viewer config. 
+# Output Viewer config.
 # Frame, Layer and Job objects have right click menu option for opening an output viewer
 # (eg. OpenRV)
 # output_viewer:

--- a/cuegui/cuegui/config/cuegui.yaml
+++ b/cuegui/cuegui/config/cuegui.yaml
@@ -110,3 +110,20 @@ startup_notice.msg: ''
 
 # Memory usage above this level will be displayed in a different color.
 memory_warning_level: 5242880
+
+# Output Viewer config. 
+# Frame, Layer and Job objects have right click menu option for opening an output viewer
+# (eg. OpenRV)
+# output_viewer:
+#   # Text to be displayed at the menu action button
+#   action_text: "View Output in Itview"
+
+#   # extract_args_regex: Regex to extract arguments from the output path produced by a job/layer/frame
+#   # cmd_pattern: Command pattern to be matched with the regex defined at extract_args_regex
+#   # if extract_args_regex is not provided, cmd_pattern is called directly with paths as arguments
+#   extract_args_regex: '/shots/(?P<show>\w+)/(?P<name>shot\w+)/.*'
+#   cmd_pattern: "env SHOW={show} SHOT={shot} COLOR_IO=/{show}/home/colorspaces.xml OCIO=/{show}/home/config.ocio openrv {paths}"
+
+#   # if provided, paths containing any of the two values are considered the same output and only one
+#   # of them will be passed to the viewer
+#   stereo_modifiers: "_rt_,_lf_"

--- a/cuegui/tests/Utils_tests.py
+++ b/cuegui/tests/Utils_tests.py
@@ -82,44 +82,58 @@ class UtilsTests(unittest.TestCase):
             'redirect_wasted_cores_threshold': 100,
         }, result)
 
-    def test_shouldLaunchViewerUsingPaths(self):
+    def test_shouldLaunchViewerUsingEmptyPaths(self):
         # Test launching without empty paths
-        self.assertIsNone(cuegui.Utils.launchViewerUsingPaths([]))
+        self.assertIsNone(cuegui.Utils.launchViewerUsingPaths([], test_mode=True))
 
+    def test_shouldLaunchViewerUsingSimplePath(self):
         # Test launching without regexp
         cuegui.Constants.OUTPUT_VIEWER_EXTRACT_ARGS_REGEX = None
         cuegui.Constants.OUTPUT_VIEWER_CMD_PATTERN = 'echo'
 
-        out = cuegui.Utils.launchViewerUsingPaths(["/shots/test_show/test_shot/something/else"])
+        out = cuegui.Utils.launchViewerUsingPaths(["/shots/test_show/test_shot/something/else"],
+                                                  test_mode=True)
         self.assertEqual('echo /shots/test_show/test_shot/something/else', out)
 
+    def test_shouldNotLaunchViewerUsingInvalidCombination(self):
         # Test launching with invalig regex and pattern combination
-        cuegui.Constants.OUTPUT_VIEWER_EXTRACT_ARGS_REGEX = '/shots/(?P<show>\w+)/(?P<name>shot\w+)/.*'
-        cuegui.Constants.OUTPUT_VIEWER_CMD_PATTERN = 'echo show={not_a_show}, shot={shot}'
+        cuegui.Constants.OUTPUT_VIEWER_EXTRACT_ARGS_REGEX = \
+            r'/shots/(?P<show>\w+)/(?P<name>shot\w+)/.*'
+        cuegui.Constants.OUTPUT_VIEWER_CMD_PATTERN = \
+            'echo show={not_a_show}, shot={shot}'
 
-        out = cuegui.Utils.launchViewerUsingPaths(["/shots/test_show/test_shot/something/else"])
+        out = cuegui.Utils.launchViewerUsingPaths(["/shots/test_show/test_shot/something/else"],
+                                                  test_mode=True)
         self.assertIsNone(out)
 
+    def test_shouldLaunchViewerUsingRegextAndPattern(self):
         # Test launching with valid regex and pattern
-        cuegui.Constants.OUTPUT_VIEWER_EXTRACT_ARGS_REGEX = '/shots/(?P<show>\w+)/(?P<name>shot\w+)/.*'
+        cuegui.Constants.OUTPUT_VIEWER_EXTRACT_ARGS_REGEX = \
+            r'/shots/(?P<show>\w+)/(?P<name>shot\w+)/.*'
         cuegui.Constants.OUTPUT_VIEWER_CMD_PATTERN = 'echo show={show}, shot={shot}'
 
-        out = cuegui.Utils.launchViewerUsingPaths(["/shots/test_show/test_shot/something/else"])
+        out = cuegui.Utils.launchViewerUsingPaths(["/shots/test_show/test_shot/something/else"],
+                                                  test_mode=True)
         self.assertEqual('echo show=test_show, shot=test_shot', out)
 
+    def test_shouldLaunchViewerUsingStereoPaths(self):
         # Test launching with stereo output
         cuegui.Constants.OUTPUT_VIEWER_EXTRACT_ARGS_REGEX = None
         cuegui.Constants.OUTPUT_VIEWER_CMD_PATTERN = 'echo'
+        cuegui.Constants.OUTPUT_VIEWER_STEREO_MODIFIERS = '_lf_,_rt_'
 
-        out = cuegui.Utils.launchViewerUsingPaths(["/test/something_lf_something", "/test/something_rt_something"])
+        out = cuegui.Utils.launchViewerUsingPaths(["/test/something_lf_something",
+                                                   "/test/something_rt_something"],
+                                                   test_mode=True)
         self.assertEqual('echo /test/something_rt_something', out)
 
-
+    def test_shouldLaunchViewerUsingMultiplePaths(self):
         # Test launching multiple outputs
         cuegui.Constants.OUTPUT_VIEWER_EXTRACT_ARGS_REGEX = None
         cuegui.Constants.OUTPUT_VIEWER_CMD_PATTERN = 'echo'
 
-        out = cuegui.Utils.launchViewerUsingPaths(["/test/something_1", "/test/something_2"])
+        out = cuegui.Utils.launchViewerUsingPaths(["/test/something_1", "/test/something_2"],
+                                                  test_mode=True)
         self.assertEqual('echo /test/something_1 /test/something_2', out)
 
 

--- a/cuegui/tests/Utils_tests.py
+++ b/cuegui/tests/Utils_tests.py
@@ -82,6 +82,7 @@ class UtilsTests(unittest.TestCase):
             'redirect_wasted_cores_threshold': 100,
         }, result)
 
+class UtilsViewerTests(unittest.TestCase):
     def test_shouldLaunchViewerUsingEmptyPaths(self):
         # Test launching without empty paths
         self.assertIsNone(cuegui.Utils.launchViewerUsingPaths([], test_mode=True))
@@ -109,7 +110,7 @@ class UtilsTests(unittest.TestCase):
     def test_shouldLaunchViewerUsingRegextAndPattern(self):
         # Test launching with valid regex and pattern
         cuegui.Constants.OUTPUT_VIEWER_EXTRACT_ARGS_REGEX = \
-            r'/shots/(?P<show>\w+)/(?P<name>shot\w+)/.*'
+            r'/shots/(?P<show>\w+)/(?P<shot>\w+)/.*'
         cuegui.Constants.OUTPUT_VIEWER_CMD_PATTERN = 'echo show={show}, shot={shot}'
 
         out = cuegui.Utils.launchViewerUsingPaths(["/shots/test_show/test_shot/something/else"],
@@ -125,7 +126,7 @@ class UtilsTests(unittest.TestCase):
         out = cuegui.Utils.launchViewerUsingPaths(["/test/something_lf_something",
                                                    "/test/something_rt_something"],
                                                    test_mode=True)
-        self.assertEqual('echo /test/something_rt_something', out)
+        self.assertEqual('echo /test/something_lf_something', out)
 
     def test_shouldLaunchViewerUsingMultiplePaths(self):
         # Test launching multiple outputs


### PR DESCRIPTION
Add a right click menu option on Layers, Frames and Jobs to open outputs on a Viewer.

The feature requires setting the viewer command pattern and a regex to extract arguments from outputs. The config file has an example of how to use it for itView. 

```yaml
output_viewer:
  # Text to be displayed at the menu action button
  action_text: "View Output in Itview"

  # extract_args_regex: Regex to extract arguments from the output path produced by a job/layer/frame
  # cmd_pattern: Command pattern to be matched with the regex defined at extract_args_regex
  # if extract_args_regex is not provided, cmd_pattern is called directly with paths as arguments
  extract_args_regex: '/shots/(?P<show>\w+)/(?P<shot>\w+)/.*'
  cmd_pattern: "env SHOW={show} SHOT={shot} COLOR_IO=/{show}/home/colorspaces.xml OCIO=/{show}/home/config.ocio openrv {paths}"

  # if provided, paths containing any of the two values are considered the same output and only one
  # of them will be passed to the viewer
  stereo_modifiers: "_rt_,_lf_"
```