### PR TITLE
[cuegui] Add optional sentry support

### DIFF
--- a/cuegui/cuegui/Constants.py
+++ b/cuegui/cuegui/Constants.py
@@ -155,6 +155,8 @@ LOG_ROOT_OS = __config.get('render_logs.root')
 
 ALLOWED_TAGS = tuple(__config.get('allowed_tags'))
 
+SENTRY_DSN = __config.get('sentry.dsn')
+
 DARK_STYLE_SHEET = os.path.join(CONFIG_PATH, __config.get('style.style_sheet'))
 COLOR_THEME = __config.get('style.color_theme')
 __bg_colors = __config.get('style.colors.background')

--- a/cuegui/cuegui/Main.py
+++ b/cuegui/cuegui/Main.py
@@ -102,6 +102,7 @@ def __setup_sentry():
         return
 
     try:
+        # pylint: disable=import-outside-toplevel
         # Avoid importing sentry on the top level to make this dependency optional
         import sentry_sdk
         sentry_sdk.init(cuegui.Constants.SENTRY_DSN)

--- a/cuegui/cuegui/Main.py
+++ b/cuegui/cuegui/Main.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
 
+import getpass
 import signal
 
 from qtpy import QtGui
@@ -72,6 +73,8 @@ def startup(app_name, app_version, argv):
     settings = cuegui.Layout.startup(app_name)
     app.settings = settings
 
+    __setup_sentry()
+
     cuegui.Style.init()
 
     mainWindow = cuegui.MainWindow.MainWindow(app_name, app_version,  None)
@@ -91,6 +94,22 @@ def startup(app_name, app_version, argv):
     gc = cuegui.GarbageCollector.GarbageCollector(parent=app, debug=False)  # pylint: disable=unused-variable
     app.aboutToQuit.connect(closingTime)  # pylint: disable=no-member
     app.exec_()
+
+
+def __setup_sentry():
+    """Setup sentry if cuegui.Constants.SENTRY_DSN is defined, nop otherwise"""
+    if not cuegui.Constants.SENTRY_DSN:
+        return
+
+    try:
+        # Avoid importing sentry on the top level to make this dependency optional
+        import sentry_sdk
+        sentry_sdk.init(cuegui.Constants.SENTRY_DSN)
+        sentry_sdk.set_user({
+            'username': getpass.getuser()
+        })
+    except ImportError:
+        logger.warning('Failed to import Sentry')
 
 def closingTime():
     """Window close callback."""

--- a/cuegui/cuegui/config/cuegui.yaml
+++ b/cuegui/cuegui/config/cuegui.yaml
@@ -64,6 +64,10 @@ editor.windows: 'notepad'
 editor.mac: 'open -t'
 editor.linux: 'gview -R -m -M -U {config_path}/gvimrc +'
 
+# Url to the sentry application dsn
+# comment out to disable sentry
+# sentry.dsn: 'https://someid@your-sentry.com/10'
+
 resources:
   # The max cores and max memory based on the available hardware.
   # These values are used by:


### PR DESCRIPTION
If `sentry.dsn` is set on cuegui.yaml,  sentry_sdk becomes active and will capture exceptions.