### PR TITLE
[cuegui] Fix filter actions overlapping display

### DIFF
--- a/cuegui/cuegui/config/darkpalette.qss
+++ b/cuegui/cuegui/config/darkpalette.qss
@@ -25,7 +25,6 @@ QDoubleSpinBox {
     color: rgb(200, 200, 200);
     border: 1px solid rgb(22, 22, 22);
     margin-left: 5px;
-    min-height: 2em;
     padding-right: 15px;
 }
 


### PR DESCRIPTION
Minor UI tweak on `QDoubleSpinBox` elements to avoid lines overlapping each other. 