### PR TITLE
[cuegui] Update AllocationsPlugin columns

### DIFF
--- a/cuegui/cuegui/plugins/AllocationsPlugin.py
+++ b/cuegui/cuegui/plugins/AllocationsPlugin.py
@@ -129,13 +129,6 @@ class MonitorAllocations(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                                                     for host in allocation.getHosts()
                                                     if host.state() == 4]))
 
-
-
-
-        # It would be nice to display this again:
-        #self.addColumn("Nimby", 40, id=6,
-        #               data=lambda alloc:(alloc.totalNimbyLockedHosts()))
-
         cuegui.AbstractTreeWidget.AbstractTreeWidget.__init__(self, parent)
 
         # Used to build right click context menus

--- a/cuegui/cuegui/plugins/AllocationsPlugin.py
+++ b/cuegui/cuegui/plugins/AllocationsPlugin.py
@@ -77,17 +77,57 @@ class MonitorAllocations(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         self.addColumn("Tag", 100, id=2,
                        data=lambda alloc: alloc.data.tag)
 
-        self.addColumn("Cores", 45, id=3,
-                       data=lambda allocation: allocation.data.stats.cores,
+        self.addColumn("Cores", 50, id=3,
+                       data=lambda allocation: int(allocation.data.stats.cores),
                        sort=lambda allocation: allocation.data.stats.cores)
 
-        self.addColumn("Idle",45, id=4,
-                       data=lambda allocation: (int(allocation.data.stats.available_cores)),
-                       sort=lambda allocation: allocation.data.stats.available_cores)
+        self.addColumn("Idle", 50, id=4,
+                       data=lambda allocation: (int(allocation.totalAvailableCores())),
+                       sort=lambda allocation: allocation.totalAvailableCores())
 
-        self.addColumn("Hosts", 45, id=5,
+        self.addColumn("Locked", 65, id=5,
+                       data=lambda allocation: int(allocation.totalLockedCores()),
+                       sort=lambda allocation: allocation.totalLockedCores())
+
+        self.addColumn("Down", 55, id=6,
+                       data=lambda allocation: sum(int(host.cores())
+                                                   for host in allocation.getHosts()
+                                                   if host.state() == 1),
+                       sort=lambda allocation: (host.cores() for host in allocation.getHosts()
+                                                if host.state() == 1))
+
+        self.addColumn("Repair", 65, id=7,
+                       data=lambda allocation: sum(int(host.cores())
+                                                   for host in allocation.getHosts()
+                                                   if host.state() == 4),
+                       sort=lambda allocation: (host.cores() for host in allocation.getHosts()
+                                                if host.state() == 4))
+
+        self.addColumn("Hosts", 55, id=8,
                        data=lambda alloc: alloc.data.stats.hosts,
                        sort=lambda alloc: alloc.data.stats.hosts)
+
+        self.addColumn("Locked", 65, id=9,
+                       data=lambda alloc: alloc.totalLockedHosts()
+                                          + len(list(host for host in alloc.getHosts()
+                                                     if host.lockState() == 2)),
+                       sort=lambda alloc: alloc.totalLockedHosts()
+                                          + len(list(host for host in alloc.getHosts()
+                                                     if host.lockState() == 2)))
+
+        self.addColumn("Down", 55, id=10,
+                       data=lambda alloc: alloc.totalDownHosts(),
+                       sort=lambda alloc: alloc.totalDownHosts())
+
+        self.addColumn("Repair", 50, id=11,
+                       data=lambda allocation: len(list((host)
+                                                        for host in allocation.getHosts()
+                                                        if host.state() == 4)),
+                       sort=lambda allocation: (host for host in allocation.getHosts()
+                                                if host.state() == 4))
+
+
+
 
         # It would be nice to display this again:
         #self.addColumn("Nimby", 40, id=6,

--- a/cuegui/cuegui/plugins/AllocationsPlugin.py
+++ b/cuegui/cuegui/plugins/AllocationsPlugin.py
@@ -93,15 +93,17 @@ class MonitorAllocations(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                        data=lambda allocation: sum(int(host.cores())
                                                    for host in allocation.getHosts()
                                                    if host.state() == 1),
-                       sort=lambda allocation: (host.cores() for host in allocation.getHosts()
-                                                if host.state() == 1))
+                       sort=lambda allocation: sum(int(host.cores())
+                                                   for host in allocation.getHosts()
+                                                   if host.state() == 1))
 
         self.addColumn("Repair", 65, id=7,
                        data=lambda allocation: sum(int(host.cores())
                                                    for host in allocation.getHosts()
                                                    if host.state() == 4),
-                       sort=lambda allocation: (host.cores() for host in allocation.getHosts()
-                                                if host.state() == 4))
+                       sort=lambda allocation: sum(int(host.cores())
+                                                   for host in allocation.getHosts()
+                                                   if host.state() == 4))
 
         self.addColumn("Hosts", 55, id=8,
                        data=lambda alloc: alloc.data.stats.hosts,
@@ -109,22 +111,23 @@ class MonitorAllocations(cuegui.AbstractTreeWidget.AbstractTreeWidget):
 
         self.addColumn("Locked", 65, id=9,
                        data=lambda alloc: alloc.totalLockedHosts()
-                                          + len(list(host for host in alloc.getHosts()
-                                                     if host.lockState() == 2)),
+                                          + len([host for host in alloc.getHosts()
+                                                     if host.lockState() == 2]),
                        sort=lambda alloc: alloc.totalLockedHosts()
-                                          + len(list(host for host in alloc.getHosts()
-                                                     if host.lockState() == 2)))
+                                          + len([host for host in alloc.getHosts()
+                                                     if host.lockState() == 2]))
 
         self.addColumn("Down", 55, id=10,
                        data=lambda alloc: alloc.totalDownHosts(),
                        sort=lambda alloc: alloc.totalDownHosts())
 
         self.addColumn("Repair", 50, id=11,
-                       data=lambda allocation: len(list((host)
-                                                        for host in allocation.getHosts()
-                                                        if host.state() == 4)),
-                       sort=lambda allocation: (host for host in allocation.getHosts()
-                                                if host.state() == 4))
+                       data=lambda allocation: len([host
+                                                    for host in allocation.getHosts()
+                                                    if host.state() == 4]),
+                       sort=lambda allocation: len([host
+                                                    for host in allocation.getHosts()
+                                                    if host.state() == 4]))
 
 
 


### PR DESCRIPTION
Currently, the Allocations plugin "Idle" cores column includes cores in hosts that are locked, down, or set to repair.
It would be preferable for those cores to be broken into their columns so that the number of cores available to be booked would be more accurate.