### PR TITLE
[cuegui] Decode logs on LogViewPlugin

### DIFF
--- a/cuegui/cuegui/plugins/LogViewPlugin.py
+++ b/cuegui/cuegui/plugins/LogViewPlugin.py
@@ -927,6 +927,14 @@ class LogViewWidget(QtWidgets.QWidget):
             self._content_box.setPlainText(content)
         else:
             current_text = (self._content_box.toPlainText() or '')
+
+            # ignore decoding higher order bytes outside ordinal range(128)
+            # ex: umlats, latin-1 etc.
+            try:
+                content = content.decode("utf-8", errors="ignore")
+                current_text = current_text.decode("utf-8", errors="ignore")
+            except AttributeError:
+                pass
             new_text = content.lstrip(str(current_text))
             if new_text:
                 self._content_box.appendPlainText(new_text)


### PR DESCRIPTION
Logs should be decoded using utf-8 ignoring chars that are not valid. If the decoding process fails, the original content will be displayed
