### PR TITLE
[cuebot] fix dispatched frame chunk end frame number

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java
@@ -376,12 +376,9 @@ public class DispatchSupportService implements DispatchSupport {
         FrameSet fs = new FrameSet(frame.range);
         int startFrameIndex = fs.index(frameNumber);
         String frameSpec = fs.getChunk(startFrameIndex, frame.chunkSize);
-        int lastFrameIndex = fs.size() - 1;
-        int endChunkIndex = startFrameIndex + frame.chunkSize - 1;
-        if (endChunkIndex > lastFrameIndex) {
-            endChunkIndex = lastFrameIndex;
-        }
 
+        FrameSet chunkFrameSet = new FrameSet(frameSpec);
+        int chunkEndFrame = chunkFrameSet.get(-1);
 
         RunFrame.Builder builder = RunFrame.newBuilder()
                 .setShot(frame.shot)
@@ -424,7 +421,7 @@ public class DispatchSupportService implements DispatchSupport {
                                 .replaceAll("#ZFRAME#", zFrameNumber)
                                 .replaceAll("#IFRAME#",  String.valueOf(frameNumber))
                                 .replaceAll("#FRAME_START#",  String.valueOf(frameNumber))
-                                .replaceAll("#FRAME_END#",  String.valueOf(endChunkIndex))
+                                .replaceAll("#FRAME_END#",  String.valueOf(chunkEndFrame))
                                 .replaceAll("#FRAME_CHUNK#",  String.valueOf(frame.chunkSize))
                                 .replaceAll("#LAYER#", frame.layerName)
                                 .replaceAll("#JOB#",  frame.jobName)

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java
@@ -378,7 +378,7 @@ public class DispatchSupportService implements DispatchSupport {
         String frameSpec = fs.getChunk(startFrameIndex, frame.chunkSize);
 
         FrameSet chunkFrameSet = new FrameSet(frameSpec);
-        int chunkEndFrame = chunkFrameSet.get(-1);
+        int chunkEndFrame = chunkFrameSet.get(chunkFrameSet.size()-1);
 
         RunFrame.Builder builder = RunFrame.newBuilder()
                 .setShot(frame.shot)

--- a/cuebot/src/test/java/com/imageworks/spcue/test/util/FrameSetTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/util/FrameSetTests.java
@@ -89,15 +89,15 @@ public class FrameSetTests {
     public void shouldReturnLastFrame() {
         FrameSet result1 = new FrameSet("1-10x2");
 
-        FrameSet chunk1 = new FrameSet(result1.getChunk(1, 3));
+        FrameSet chunk1 = new FrameSet(result1.getChunk(0, 3));
         FrameSet chunk2 = new FrameSet(result1.getChunk(3, 3));
 
-        assertEquals(5, chunk1.get(-1));
-        assertEquals(9, chunk2.get(-1));
+        assertEquals(5, chunk1.get(chunk1.size()-1));
+        assertEquals(9, chunk2.get(chunk2.size()-1));
 
         FrameSet result2 = new FrameSet("1");
-        FrameSet chunk3 = new FrameSet(result2.getChunk(1, 3));
+        FrameSet chunk3 = new FrameSet(result2.getChunk(0, 3));
 
-        assertEquals(1, chunk3.get(-1));
+        assertEquals(1, chunk3.get(chunk3.size()-1));
     }
 }

--- a/cuebot/src/test/java/com/imageworks/spcue/test/util/FrameSetTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/util/FrameSetTests.java
@@ -84,4 +84,20 @@ public class FrameSetTests {
 
         assertEquals("55-60", result.getChunk(0, 10));
     }
+
+    @Test
+    public void shouldReturnLastFrame() {
+        FrameSet result1 = new FrameSet("1-10x2");
+
+        FrameSet chunk1 = new FrameSet(result1.getChunk(1, 3));
+        FrameSet chunk2 = new FrameSet(result1.getChunk(3, 3));
+
+        assertEquals(5, chunk1.get(-1));
+        assertEquals(9, chunk2.get(-1));
+
+        FrameSet result2 = new FrameSet("1");
+        FrameSet chunk3 = new FrameSet(result2.getChunk(1, 3));
+
+        assertEquals(1, chunk3.get(-1));
+    }
 }


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
#1129 

**Summarize your change.**
Fix the frame end resolution of a frame chunk used to fill the place holder `#FRAME_END#`.
The current behavior incorrectly returns the index of the last frame in the frame list instead of its value.

Leverage `FrameSet.get_chunk` method that is already doing all the legwork to get the last frame.


**Related topics**
- https://github.com/AcademySoftwareFoundation/OpenCue/pull/1320
- https://github.com/AcademySoftwareFoundation/OpenCue/pull/367