### PR TITLE
Small fix for pagenation with jobs more than 1000 frames

### DIFF
--- a/cuegui/cuegui/FrameMonitor.py
+++ b/cuegui/cuegui/FrameMonitor.py
@@ -274,7 +274,7 @@ class FrameMonitor(QtWidgets.QWidget):
         if has_filters:
             temp_search = deepcopy(self.frameMonitorTree.frameSearch)
             temp_search.page = self.page + 1
-            temp_frames = job.getFrames(temp_search)
+            temp_frames = job.getFrames(**temp_search.options)
             self.next_page_btn.setEnabled(len(temp_frames) > 0)
         else:
             page_label_text += ' of {0}'.format(total_pages)


### PR DESCRIPTION
When jobs have more then 1000 frames it fails to pagenate and throws this :
```python
Traceback (most recent call last):
  File "/home/jimmy/repos/OpenCue/cuegui/cuegui/plugins/MonitorJobDetailsPlugin.py", line 96, in handleLayerFilter
    self.__monitorFrames.filterLayersFromDoubleClick(names)
  File "/home/jimmy/repos/OpenCue/cuegui/cuegui/FrameMonitor.py", line 116, in filterLayersFromDoubleClick
    self._filterLayersHandleByLayer(layerNames)
  File "/home/jimmy/repos/OpenCue/cuegui/cuegui/FrameMonitor.py", line 413, in _filterLayersHandleByLayer
    self._updatePageButtonState()
  File "/home/jimmy/repos/OpenCue/cuegui/cuegui/FrameMonitor.py", line 277, in _updatePageButtonState
    temp_frames = job.getFrames(temp_search)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Job.getFrames() takes 1 positional argument but 2 were given
```

**Summarize your change.**
Passed the `**FrameSearch.option` object instead of the `FrameSearch` object

