### PR TITLE
[rqd] Set uid and gid when creating user for a job

### DIFF
--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -223,6 +223,8 @@ try:
             MINIMUM_IDLE = config.getint(__override_section, "MINIMUM_IDLE")
         if config.has_option(__override_section, "SENTRY_DSN_PATH"):
             SENTRY_DSN_PATH = config.getint(__override_section, "SENTRY_DSN_PATH")
+        if config.has_option(__override_section, "SP_OS"):
+            SP_OS = config.get(__override_section, "SP_OS")
 
         if config.has_section(__host_env_var_section):
             RQD_HOST_ENV_VARS = config.options(__host_env_var_section)

--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -297,7 +297,7 @@ class FrameAttendantThread(threading.Thread):
         self.__writeHeader()
         if rqd.rqconstants.RQD_CREATE_USER_IF_NOT_EXISTS:
             rqd.rqutil.permissionsHigh()
-            rqd.rqutil.checkAndCreateUser(runFrame.user_name)
+            rqd.rqutil.checkAndCreateUser(runFrame.user_name, runFrame.uid, runFrame.gid)
             rqd.rqutil.permissionsLow()
 
         tempStatFile = "%srqd-stat-%s-%s" % (self.rqCore.machine.getTempPath(),

--- a/rqd/rqd/rqutil.py
+++ b/rqd/rqd/rqutil.py
@@ -132,7 +132,7 @@ def __becomeRoot():
             pass
 
 
-def checkAndCreateUser(username):
+def checkAndCreateUser(username, uid=None, gid=None):
     """Check to see if the provided user exists, if not attempt to create it."""
     # TODO(gregdenton): Add Windows and Mac support here. (Issue #61)
     if not rqd.rqconstants.RQD_BECOME_JOB_USER:
@@ -141,11 +141,17 @@ def checkAndCreateUser(username):
         pwd.getpwnam(username)
         return
     except KeyError:
-        subprocess.check_call([
+        cmd = [
             'useradd',
             '-p', str(uuid.uuid4()),  # generate a random password
-            username
-        ])
+        ]
+        if uid:
+            cmd += ['-u', str(uid)]
+        if gid:
+            cmd += ['-g', str(gid)]
+        cmd.append(username)
+        log.info("Frame's username not found on host. Adding user with: %s" % cmd)
+        subprocess.check_call(cmd)
 
 
 def getHostIp():

--- a/rqd/rqd/rqutil.py
+++ b/rqd/rqd/rqutil.py
@@ -150,7 +150,7 @@ def checkAndCreateUser(username, uid=None, gid=None):
         if gid:
             cmd += ['-g', str(gid)]
         cmd.append(username)
-        log.info("Frame's username not found on host. Adding user with: %s" % cmd)
+        log.info("Frame's username not found on host. Adding user with: %s", cmd)
         subprocess.check_call(cmd)
 
 


### PR DESCRIPTION
When a user has to be created with `useradd`, the user should have the same `uid` and `gid` of the user who created the job. This ensures directories and files created during the job execution have the same permissions.

Not explicitly setting uid and gid causes problems for dockerized rqds trying to write to shared storage volumes mounted in bind mode.

 - This PR also contains a minor change to allow overriding the value of `SP_OS` (Constant used to identify a host distro) using the config file.