### PR TITLE
[cuegui] Reduce page size for FrameSearch and reuse config on FrameMonitor widget

### DIFF
--- a/cuegui/cuegui/FrameMonitor.py
+++ b/cuegui/cuegui/FrameMonitor.py
@@ -49,6 +49,7 @@ class FrameMonitor(QtWidgets.QWidget):
 
         self.frameMonitorTree = cuegui.FrameMonitorTree.FrameMonitorTree(self)
         self.page = self.frameMonitorTree.frameSearch.page
+        self.frameSearchLimit = self.frameMonitorTree.frameSearch.limit
         # Setup main vertical layout
         layout = QtWidgets.QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
@@ -66,7 +67,7 @@ class FrameMonitor(QtWidgets.QWidget):
         self._filterLayersSetup(hlayout)  # Menu to filter layers
         self._filterStatusSetup(hlayout)  # Menu to filter frames by status
         hlayout.addStretch()
-        hlayout.addWidget(QtWidgets.QLabel("(Limited to 1000 frames)"))
+        hlayout.addWidget(QtWidgets.QLabel("(Limited to {0} frames)".format(self.frameSearchLimit)))
         hlayout.addStretch()
         self._displayJobNameSetup(hlayout)
 
@@ -127,7 +128,7 @@ class FrameMonitor(QtWidgets.QWidget):
 
     def _frameRangeSelectionFilterUpdate(self):
         if not self.frameMonitorTree.getJob():
-            self.frameRangeSelection.setFrameRange(["1", "10000"])
+            self.frameRangeSelection.setFrameRange(["1", str(self.frameSearchLimit)])
         else:
             layers = self.frameMonitorTree.getJob().getLayers()
 
@@ -151,7 +152,7 @@ class FrameMonitor(QtWidgets.QWidget):
             if _min == _max:
                 _max += 1
 
-            self.frameRangeSelection.default_select_size = 1000 // len(layers)
+            self.frameRangeSelection.default_select_size = self.frameSearchLimit // len(layers)
 
             self.frameRangeSelection.setFrameRange([str(_min), str(_max)])
 
@@ -256,7 +257,7 @@ class FrameMonitor(QtWidgets.QWidget):
             return
 
         total_frames = job.totalFrames()
-        if total_frames <= 1000:
+        if total_frames <= self.frameSearchLimit:
             self.page_label.setText('<font color="gray">{0}</font>'
                                     .format('Page 1 of 1'))
             return
@@ -269,7 +270,7 @@ class FrameMonitor(QtWidgets.QWidget):
                     if item.isChecked():
                         has_filters = True
                         break
-        total_pages = int(math.ceil(total_frames / 1000.0))
+        total_pages = int(math.ceil(total_frames / float(self.frameSearchLimit)))
         page_label_text = 'Page {0}'.format(self.page)
         if has_filters:
             temp_search = deepcopy(self.frameMonitorTree.frameSearch)

--- a/cuegui/cuegui/FrameMonitor.py
+++ b/cuegui/cuegui/FrameMonitor.py
@@ -67,7 +67,8 @@ class FrameMonitor(QtWidgets.QWidget):
         self._filterLayersSetup(hlayout)  # Menu to filter layers
         self._filterStatusSetup(hlayout)  # Menu to filter frames by status
         hlayout.addStretch()
-        hlayout.addWidget(QtWidgets.QLabel("(Limited to {0} frames)".format(self.frameSearchLimit)))
+        hlayout.addWidget(QtWidgets.QLabel("(Limited to {0} frames)"
+                                           .format(self.frameSearchLimit)))
         hlayout.addStretch()
         self._displayJobNameSetup(hlayout)
 

--- a/pycue/opencue/search.py
+++ b/pycue/opencue/search.py
@@ -114,7 +114,7 @@ class FrameSearch(BaseSearch):
     """Class for searching for frames."""
 
     page = 1
-    limit = 1000
+    limit = 500
     change_date = 0
 
     @classmethod

--- a/pycue/tests/api_test.py
+++ b/pycue/tests/api_test.py
@@ -359,11 +359,12 @@ class FrameTests(unittest.TestCase):
         getStubMock.return_value = stubMock
 
         frames = opencue.api.getFrames(TEST_JOB_NAME, range="1-5")
+        framePageLimit = opencue.api.search.FrameSearch.limit
 
         stubMock.GetFrames.assert_called_with(
             job_pb2.FrameGetFramesRequest(
                 job=TEST_JOB_NAME, r=job_pb2.FrameSearchCriteria(
-                    frame_range="1-5", page=1, limit=1000)),
+                    frame_range="1-5", page=1, limit=framePageLimit)),
             timeout=mock.ANY)
         self.assertEqual(5, len(frames))
         self.assertTrue(all((frame.layer() == TEST_LAYER_NAME for frame in frames)))


### PR DESCRIPTION
Reduce the limit of frames queried by FrameSearch by half. It was identified that the GUI becomes unusable with 1000 frames being displayed at the same time. 

FrameMonitor was also updated to stop using a hardcoded value for the limit and start reusing the same value from the API.