### PR TITLE
[cuegui] Fix LayerDialog layout scroll

### DIFF
--- a/cuegui/cuegui/LayerDialog.py
+++ b/cuegui/cuegui/LayerDialog.py
@@ -76,6 +76,7 @@ class LayerPropertiesItem(QtWidgets.QWidget):
         self.__widget = widget
 
         layout = QtWidgets.QHBoxLayout(self)
+        layout.setContentsMargins(1, 1, 1, 1)
         if label:
             layout.addWidget(QtWidgets.QLabel(label, self))
         if stretch:
@@ -228,14 +229,7 @@ class LayerPropertiesDialog(QtWidgets.QDialog):
         self.__timeout.setValue(self.getTimeout())
         self.__timeout_llu.setValue(self.getTimeoutLLU())
 
-        topLayout = QtWidgets.QVBoxLayout()
-        topWidget = QtWidgets.QWidget()
-        topWidget.setLayout(topLayout)
-        scrollArea = QtWidgets.QScrollArea(widgetResizable=True)
-        scrollArea.setWidget(topWidget)
-
         QtWidgets.QVBoxLayout(self)
-        self.layout().addWidget(scrollArea)
 
         layout = QtWidgets.QVBoxLayout()
         layout.addWidget(EnableableItem(LayerPropertiesItem("Minimum Memory:",
@@ -281,10 +275,10 @@ class LayerPropertiesDialog(QtWidgets.QDialog):
         layout.addStretch()
         self.__group.setLayout(layout)
 
-        topLayout.addWidget(EnableableItem(self.__tags, multiSelect))
-        topLayout.addWidget(EnableableItem(self.__limits, multiSelect))
-        topLayout.addWidget(self.__group)
-        topLayout.addWidget(self.__buttons)
+        self.layout().addWidget(EnableableItem(self.__tags, multiSelect))
+        self.layout().addWidget(EnableableItem(self.__limits, multiSelect))
+        self.layout().addWidget(self.__group)
+        self.layout().addWidget(self.__buttons)
 
     def _cfg(self):
         """


### PR DESCRIPTION
Revert layout changes from #1055 that caused issues with the scroll functionality of the Layout 'dialog'.