### PR TITLE
[cuegui] Limit user actions on alien jobs

### DIFF
--- a/cuegui/cuegui/Constants.py
+++ b/cuegui/cuegui/Constants.py
@@ -137,6 +137,8 @@ EMAIL_SUBJECT_PREFIX = __config.get('email.subject_prefix')
 EMAIL_BODY_PREFIX = __config.get('email.body_prefix')
 EMAIL_BODY_SUFFIX = __config.get('email.body_suffix')
 EMAIL_DOMAIN = __config.get('email.domain')
+USER_CONFIRM_RESTART = "You must restart for this action to take effect, close window?: "
+USER_INTERACTION_PERMISSIONS = "You do not have permissions to {0} {1} owned by {2}"
 
 GITHUB_CREATE_ISSUE_URL = __config.get('links.issue.create')
 URL_USERGUIDE = __config.get('links.user_guide')

--- a/cuegui/cuegui/Constants.py
+++ b/cuegui/cuegui/Constants.py
@@ -137,8 +137,6 @@ EMAIL_SUBJECT_PREFIX = __config.get('email.subject_prefix')
 EMAIL_BODY_PREFIX = __config.get('email.body_prefix')
 EMAIL_BODY_SUFFIX = __config.get('email.body_suffix')
 EMAIL_DOMAIN = __config.get('email.domain')
-USER_CONFIRM_RESTART = "You must restart for this action to take effect, close window?: "
-USER_INTERACTION_PERMISSIONS = "You do not have permissions to {0} {1} owned by {2}"
 
 GITHUB_CREATE_ISSUE_URL = __config.get('links.issue.create')
 URL_USERGUIDE = __config.get('links.user_guide')

--- a/cuegui/cuegui/MainWindow.py
+++ b/cuegui/cuegui/MainWindow.py
@@ -27,6 +27,7 @@ from builtins import str
 from builtins import range
 import sys
 import time
+import yaml
 
 from qtpy import QtCore
 from qtpy import QtGui
@@ -71,7 +72,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.name = window_name
         else:
             self.name = self.windows_names[0]
-        self.__isEnabled = bool(int(QtGui.qApp.settings.value("EnableJobInteraction", 0)))
+        self.__isEnabled = yaml.safe_load(self.app.settings.value("EnableJobInteraction", "False"))
 
         # Provides a location for widgets to the right of the menu
         menuLayout = QtWidgets.QHBoxLayout()
@@ -201,14 +202,16 @@ class MainWindow(QtWidgets.QMainWindow):
 
         if self.__isEnabled is False:
             # Menu Bar: File -> Enable Job Interaction
-            enableJobInteraction = QtWidgets.QAction(QtGui.QIcon('icons/exit.png'), '&Enable Job Interaction', self)
+            enableJobInteraction = QtWidgets.QAction(QtGui.QIcon('icons/exit.png'),
+                                                     '&Enable Job Interaction', self)
             enableJobInteraction.setStatusTip('Enable Job Interaction')
             enableJobInteraction.triggered.connect(self.__enableJobInteraction)
             self.fileMenu.addAction(enableJobInteraction)
         # allow user to disable the job interaction
         else:
             # Menu Bar: File -> Disable Job Interaction
-            enableJobInteraction = QtWidgets.QAction(QtGui.QIcon('icons/exit.png'), '&Disable Job Interaction', self)
+            enableJobInteraction = QtWidgets.QAction(QtGui.QIcon('icons/exit.png'),
+                                                     '&Disable Job Interaction', self)
             enableJobInteraction.setStatusTip('Disable Job Interaction')
             enableJobInteraction.triggered.connect(self.__enableJobInteraction)
             self.fileMenu.addAction(enableJobInteraction)

--- a/cuegui/cuegui/MainWindow.py
+++ b/cuegui/cuegui/MainWindow.py
@@ -68,6 +68,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.name = window_name
         else:
             self.name = self.windows_names[0]
+        self.__isEnabled = bool(int(QtGui.qApp.settings.value("EnableJobInteraction", 0)))
 
         # Provides a location for widgets to the right of the menu
         menuLayout = QtWidgets.QHBoxLayout()
@@ -194,6 +195,20 @@ class MainWindow(QtWidgets.QMainWindow):
         self.PluginMenu = self.menuBar().addMenu("&Views/Plugins")
         self.windowMenu = self.menuBar().addMenu("&Window")
         self.helpMenu = self.menuBar().addMenu("&Help")
+
+        if self.__isEnabled is False:
+            # Menu Bar: File -> Enable Job Interaction
+            enableJobInteraction = QtWidgets.QAction(QtGui.QIcon('icons/exit.png'), '&Enable Job Interaction', self)
+            enableJobInteraction.setStatusTip('Enable Job Interaction')
+            enableJobInteraction.triggered.connect(self.__enableJobInteraction)
+            self.fileMenu.addAction(enableJobInteraction)
+        # allow user to disable the job interaction
+        else:
+            # Menu Bar: File -> Disable Job Interaction
+            enableJobInteraction = QtWidgets.QAction(QtGui.QIcon('icons/exit.png'), '&Disable Job Interaction', self)
+            enableJobInteraction.setStatusTip('Disable Job Interaction')
+            enableJobInteraction.triggered.connect(self.__enableJobInteraction)
+            self.fileMenu.addAction(enableJobInteraction)
 
         # Menu Bar: File -> Close Window
         close = QtWidgets.QAction(QtGui.QIcon('icons/exit.png'), '&Close Window', self)
@@ -454,9 +469,26 @@ class MainWindow(QtWidgets.QMainWindow):
         result = QtWidgets.QMessageBox.question(
                     self,
                     "Restart required ",
-                    "You must restart for this action to take effect, close window?: ",
+                    cuegui.Constants.USER_CONFIRM_RESTART,
                     QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No)
 
         if result == QtWidgets.QMessageBox.Yes:
             self.settings.setValue("RevertLayout", True)
             self.__windowCloseApplication()
+
+    def __enableJobInteraction(self):
+        """ Enable/Disable user job interaction """
+        result = QtWidgets.QMessageBox.question(
+                    self,
+                    "Job Interaction Settings ",
+                    cuegui.Constants.USER_CONFIRM_RESTART,
+                    QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No)
+
+        if result == QtWidgets.QMessageBox.Yes:
+            # currently not enabled, user wants to enable
+            if self.__isEnabled is False:
+                self.settings.setValue("EnableJobInteraction", 1)
+                self.__windowCloseApplication()
+            else:
+                self.settings.setValue("EnableJobInteraction", 0)
+                self.__windowCloseApplication()

--- a/cuegui/cuegui/MainWindow.py
+++ b/cuegui/cuegui/MainWindow.py
@@ -46,6 +46,9 @@ logger = cuegui.Logger.getLogger(__file__)
 class MainWindow(QtWidgets.QMainWindow):
     """The main window of the application. Multiple windows may exist."""
 
+    # Message to be displayed when a change requires an application restart
+    USER_CONFIRM_RESTART = "You must restart for this action to take effect, close window?: "
+
     windows = []
     windows_names = []
     windows_titles = {}
@@ -469,7 +472,7 @@ class MainWindow(QtWidgets.QMainWindow):
         result = QtWidgets.QMessageBox.question(
                     self,
                     "Restart required ",
-                    cuegui.Constants.USER_CONFIRM_RESTART,
+                    MainWindow.USER_CONFIRM_RESTART,
                     QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No)
 
         if result == QtWidgets.QMessageBox.Yes:
@@ -481,7 +484,7 @@ class MainWindow(QtWidgets.QMainWindow):
         result = QtWidgets.QMessageBox.question(
                     self,
                     "Job Interaction Settings ",
-                    cuegui.Constants.USER_CONFIRM_RESTART,
+                    MainWindow.USER_CONFIRM_RESTART,
                     QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No)
 
         if result == QtWidgets.QMessageBox.Yes:

--- a/cuegui/cuegui/MenuActions.py
+++ b/cuegui/cuegui/MenuActions.py
@@ -214,6 +214,9 @@ class AbstractActions(object):
 class JobActions(AbstractActions):
     """Actions for jobs."""
 
+    # Template for permission alert messages
+    USER_INTERACTION_PERMISSIONS = "You do not have permissions to {0} {1} owned by {2}"
+
     def __init__(self, *args):
         AbstractActions.__init__(self, *args)
 
@@ -384,9 +387,9 @@ class JobActions(AbstractActions):
                 for job in jobs:
                     # check permissions
                     if not cuegui.Utils.isPermissible(job):
-                        msg = cuegui.Constants.USER_INTERACTION_PERMISSIONS.format("kill",
-                                                                                   "job(s)",
-                                                                                   job.username())
+                        msg = JobActions.USER_INTERACTION_PERMISSIONS.format("kill",
+                                                                             "job(s)",
+                                                                             job.username())
                         cuegui.Utils.showErrorMessageBox(msg)
                     else:
                         job.kill(reason=DEFAULT_JOB_KILL_REASON)
@@ -465,9 +468,9 @@ class JobActions(AbstractActions):
                 for job in jobs:
                     # check permissions
                     if not cuegui.Utils.isPermissible(job):
-                        msg = cuegui.Constants.USER_INTERACTION_PERMISSIONS.format("eat dead",
-                                                                                   "job",
-                                                                                   job.username())
+                        msg = JobActions.USER_INTERACTION_PERMISSIONS.format("eat dead",
+                                                                             "job",
+                                                                             job.username())
                         cuegui.Utils.showErrorMessageBox(msg)
                     else:
                         job.eatFrames(state=[opencue.compiled_proto.job_pb2.DEAD])
@@ -503,9 +506,9 @@ class JobActions(AbstractActions):
                                              [job.data.name for job in jobs]):
                 for job in jobs:
                     if not cuegui.Utils.isPermissible(job):
-                        msg = cuegui.Constants.USER_INTERACTION_PERMISSIONS.format("retry dead",
-                                                                                   "job",
-                                                                                   job.username())
+                        msg = JobActions.USER_INTERACTION_PERMISSIONS.format("retry dead",
+                                                                             "job",
+                                                                             job.username())
                         cuegui.showErrorMessageBox(msg)
                     else:
                         job.retryFrames(
@@ -804,9 +807,9 @@ class LayerActions(AbstractActions):
         if layers:
             #check permissions
             if not cuegui.Utils.isPermissible(self._getSource()):
-                msg = cuegui.Constants.USER_INTERACTION_PERMISSIONS.format("kill",
-                                                                           "layers",
-                                                                           self._getSource().username())
+                msg = JobActions.USER_INTERACTION_PERMISSIONS.format("kill",
+                                                                     "layers",
+                                                                     self._getSource().username())
                 cuegui.Utils.showErrorMessageBox(msg)
             else:
                 if cuegui.Utils.questionBoxYesNo(self._caller, "Confirm",
@@ -822,9 +825,9 @@ class LayerActions(AbstractActions):
         layers = self._getOnlyLayerObjects(rpcObjects)
         if layers:
             if not cuegui.Utils.isPermissible(self._getSource()):
-                msg = cuegui.Constants.USER_INTERACTION_PERMISSIONS.format("eat",
-                                                                           "layers",
-                                                                           self._getSource().username())
+                msg = JobActions.USER_INTERACTION_PERMISSIONS.format("eat",
+                                                                     "layers",
+                                                                     self._getSource().username())
                 cuegui.Utils.showErrorMessageBox(msg)
             else:
                 if cuegui.Utils.questionBoxYesNo(self._caller, "Confirm",
@@ -840,9 +843,9 @@ class LayerActions(AbstractActions):
         layers = self._getOnlyLayerObjects(rpcObjects)
         if layers:
             if not cuegui.Utils.isPermissible(self._getSource()):
-                msg = cuegui.Constants.USER_INTERACTION_PERMISSIONS.format("retry",
-                                                                           "layers",
-                                                                           self._getSource().username())
+                msg = JobActions.USER_INTERACTION_PERMISSIONS.format("retry",
+                                                                     "layers",
+                                                                     self._getSource().username())
                 cuegui.Utils.showErrorMessageBox(msg)
             else:
                 if cuegui.Utils.questionBoxYesNo(self._caller, "Confirm",
@@ -858,9 +861,9 @@ class LayerActions(AbstractActions):
         layers = self._getOnlyLayerObjects(rpcObjects)
         if layers:
             if not cuegui.Utils.isPermissible(self._getSource()):
-                msg = cuegui.Constants.USER_INTERACTION_PERMISSIONS.format("retry dead",
-                                                                           "layers",
-                                                                           self._getSource().username())
+                msg = JobActions.USER_INTERACTION_PERMISSIONS.format("retry dead",
+                                                                     "layers",
+                                                                     self._getSource().username())
                 cuegui.Utils.showErrorMessageBox(msg)
             else:
                 if cuegui.Utils.questionBoxYesNo(self._caller, "Confirm",
@@ -1093,9 +1096,9 @@ class FrameActions(AbstractActions):
             job = self._getSource()
             # check permissions
             if not cuegui.Utils.isPermissible(job):
-                msg = cuegui.Constants.USER_INTERACTION_PERMISSIONS.format("retry",
-                                                                           "frames",
-                                                                           job.username())
+                msg = JobActions.USER_INTERACTION_PERMISSIONS.format("retry",
+                                                                     "frames",
+                                                                     job.username())
                 cuegui.Utils.showErrorMessageBox(msg)
             else:
                 if cuegui.Utils.questionBoxYesNo(
@@ -1138,9 +1141,9 @@ class FrameActions(AbstractActions):
             #check permissions
             print(self._getSource())
             if not cuegui.Utils.isPermissible(self._getSource()):
-                msg = cuegui.Constants.USER_INTERACTION_PERMISSIONS.format("eat",
-                                                                           "frames",
-                                                                           self._getSource().username())
+                msg = JobActions.USER_INTERACTION_PERMISSIONS.format("eat",
+                                                                     "frames",
+                                                                     self._getSource().username())
                 cuegui.Utils.showErrorMessageBox(msg)
             else:
                 if cuegui.Utils.questionBoxYesNo(self._caller, "Confirm",
@@ -1155,9 +1158,9 @@ class FrameActions(AbstractActions):
         names = [frame.data.name for frame in self._getOnlyFrameObjects(rpcObjects)]
         if names:
             if not cuegui.Utils.isPermissible(self._getSource(), self):
-                msg = cuegui.Constants.USER_INTERACTION_PERMISSIONS.format("kill",
-                                                                           "frames",
-                                                                           self._getSource().username())
+                msg = JobActions.USER_INTERACTION_PERMISSIONS.format("kill",
+                                                                     "frames",
+                                                                     self._getSource().username())
                 cuegui.Utils.showErrorMessageBox(msg)
             else:
                 if cuegui.Utils.questionBoxYesNo(self._caller, "Confirm",
@@ -1271,9 +1274,9 @@ class FrameActions(AbstractActions):
             frameNames = [frame.data.name for frame in frames]
             #check permissions
             if not cuegui.Utils.isPermissible(self._getSource(), self):
-                msg = cuegui.Constants.USER_INTERACTION_PERMISSIONS.format("eat and mark done",
-                                                                           "frames",
-                                                                           self._getSource().username())
+                msg = JobActions.USER_INTERACTION_PERMISSIONS.format("eat and mark done",
+                                                                     "frames",
+                                                                     self._getSource().username())
                 cuegui.Utils.showErrorMessageBox(msg)
             else:
                 if cuegui.Utils.questionBoxYesNo(
@@ -1750,9 +1753,9 @@ class ProcActions(AbstractActions):
         if procs:
             print(self._getSource())
             if not cuegui.Utils.isPermissible(self._getSource(), self):
-                msg = cuegui.Constants.USER_INTERACTION_PERMISSIONS.format("eat and mark done",
-                                                                           "frames",
-                                                                           self._getSource().username())
+                msg = JobActions.USER_INTERACTION_PERMISSIONS.format("eat and mark done",
+                                                                     "frames",
+                                                                     self._getSource().username())
                 cuegui.Utils.showErrorMessageBox(msg)
             else:
                 if cuegui.Utils.questionBoxYesNo(

--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -35,6 +35,7 @@ import webbrowser
 from qtpy import QtCore
 from qtpy import QtGui
 from qtpy import QtWidgets
+import getpass
 import six
 
 import opencue
@@ -671,3 +672,25 @@ def byteConversion(amount, btype):
     for _ in range(n):
         _bytes *= 1024
     return _bytes
+
+
+def isPermissible(jobObject):
+    """
+    Validate if the current user has the correct permissions to perform
+    the action
+
+    :param userName: jobObject
+    :ptype userName: Opencue Job Object
+    :return:
+    """
+    hasPermissions = False
+    # Case 1. Check if current user is the job owner
+    currentUser = getpass.getuser()
+    if currentUser.lower() == jobObject.username().lower():
+        hasPermissions = True
+
+    # Case 2. Check if "Enable not owned Job Interactions" is Enabled
+    if bool(int(QtGui.qApp.settings.value("EnableJobInteraction", 0))):
+        hasPermissions = True
+
+    return hasPermissions

--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -31,11 +31,11 @@ import sys
 import time
 import traceback
 import webbrowser
+import yaml
 
 from qtpy import QtCore
 from qtpy import QtGui
 from qtpy import QtWidgets
-import getpass
 import six
 
 import opencue
@@ -683,14 +683,10 @@ def isPermissible(jobObject):
     :ptype userName: Opencue Job Object
     :return:
     """
-    hasPermissions = False
-    # Case 1. Check if current user is the job owner
+    # Read cached setting from user config file
+    hasPermissions = yaml.safe_load(cuegui.app().settings.value("EnableJobInteraction", "False"))
+    # If not set by default, check if current user is the job owner
     currentUser = getpass.getuser()
-    if currentUser.lower() == jobObject.username().lower():
+    if not hasPermissions and currentUser.lower() == jobObject.username().lower():
         hasPermissions = True
-
-    # Case 2. Check if "Enable not owned Job Interactions" is Enabled
-    if bool(int(QtGui.qApp.settings.value("EnableJobInteraction", 0))):
-        hasPermissions = True
-
     return hasPermissions

--- a/cuegui/tests/MenuActions_tests.py
+++ b/cuegui/tests/MenuActions_tests.py
@@ -230,7 +230,8 @@ class JobActionsTests(unittest.TestCase):
         job.resume.assert_called()
 
     @mock.patch('cuegui.Utils.questionBoxYesNo', return_value=True)
-    def test_kill(self, yesNoMock):
+    @mock.patch('cuegui.Utils.isPermissible', return_value=True)
+    def test_kill(self, isPermissibleMock, yesNoMock):
         job = opencue.wrappers.job.Job(opencue.compiled_proto.job_pb2.Job(name='job-name'))
         job.kill = mock.Mock()
         job.getWhatDependsOnThis = mock.Mock()
@@ -241,7 +242,8 @@ class JobActionsTests(unittest.TestCase):
         job.kill.assert_called()
 
     @mock.patch('cuegui.Utils.questionBoxYesNo', return_value=False)
-    def test_killCanceled(self, yesNoMock):
+    @mock.patch('cuegui.Utils.isPermissible', return_value=True)
+    def test_killCanceled(self, isPermissibleMock, yesNoMock):
         job = opencue.wrappers.job.Job(opencue.compiled_proto.job_pb2.Job(name='job-name'))
         job.kill = mock.Mock()
 
@@ -250,7 +252,8 @@ class JobActionsTests(unittest.TestCase):
         job.kill.assert_not_called()
 
     @mock.patch('cuegui.Utils.questionBoxYesNo', return_value=True)
-    def test_eatDead(self, yesNoMock):
+    @mock.patch('cuegui.Utils.isPermissible', return_value=True)
+    def test_eatDead(self, isPermissibleMock, yesNoMock):
         job = opencue.wrappers.job.Job(opencue.compiled_proto.job_pb2.Job(name='job-name'))
         job.eatFrames = mock.Mock()
 
@@ -259,7 +262,8 @@ class JobActionsTests(unittest.TestCase):
         job.eatFrames.assert_called_with(state=[opencue.compiled_proto.job_pb2.DEAD])
 
     @mock.patch('cuegui.Utils.questionBoxYesNo', return_value=False)
-    def test_eatDeadCanceled(self, yesNoMock):
+    @mock.patch('cuegui.Utils.isPermissible', return_value=True)
+    def test_eatDeadCanceled(self, isPermissibleMock, yesNoMock):
         job = opencue.wrappers.job.Job(opencue.compiled_proto.job_pb2.Job(name='job-name'))
         job.eatFrames = mock.Mock()
 
@@ -267,7 +271,8 @@ class JobActionsTests(unittest.TestCase):
 
         job.eatFrames.assert_not_called()
 
-    def test_autoEatOn(self):
+    @mock.patch('cuegui.Utils.isPermissible', return_value=True)
+    def test_autoEatOn(self, isPermissibleMock):
         job = opencue.wrappers.job.Job(opencue.compiled_proto.job_pb2.Job(name='job-name'))
         job.setAutoEat = mock.Mock()
         job.eatFrames = mock.Mock()
@@ -277,7 +282,8 @@ class JobActionsTests(unittest.TestCase):
         job.setAutoEat.assert_called_with(True)
         job.eatFrames.assert_called_with(state=[opencue.compiled_proto.job_pb2.DEAD])
 
-    def test_autoEatOff(self):
+    @mock.patch('cuegui.Utils.isPermissible', return_value=True)
+    def test_autoEatOff(self, isPermissibleMock):
         job = opencue.wrappers.job.Job(opencue.compiled_proto.job_pb2.Job(name='job-name'))
         job.setAutoEat = mock.Mock()
 
@@ -286,7 +292,8 @@ class JobActionsTests(unittest.TestCase):
         job.setAutoEat.assert_called_with(False)
 
     @mock.patch('cuegui.Utils.questionBoxYesNo', return_value=True)
-    def test_retryDead(self, yesNoMock):
+    @mock.patch('cuegui.Utils.isPermissible', return_value=True)
+    def test_retryDead(self, isPermissibleMock, yesNoMock):
         job = opencue.wrappers.job.Job(opencue.compiled_proto.job_pb2.Job(name='job-name'))
         job.retryFrames = mock.Mock()
 
@@ -295,7 +302,8 @@ class JobActionsTests(unittest.TestCase):
         job.retryFrames.assert_called_with(state=[opencue.compiled_proto.job_pb2.DEAD])
 
     @mock.patch('cuegui.Utils.questionBoxYesNo', return_value=False)
-    def test_retryDeadCanceled(self, yesNoMock):
+    @mock.patch('cuegui.Utils.isPermissible', return_value=True)
+    def test_retryDeadCanceled(self, isPermissibleMock, yesNoMock):
         job = opencue.wrappers.job.Job(opencue.compiled_proto.job_pb2.Job(name='job-name'))
         job.retryFrames = mock.Mock()
 
@@ -669,7 +677,8 @@ class LayerActionsTests(unittest.TestCase):
 
     @mock.patch.object(opencue.wrappers.layer.Layer, 'kill')
     @mock.patch('cuegui.Utils.questionBoxYesNo', return_value=True)
-    def test_kill(self, yesNoMock, killMock):
+    @mock.patch('cuegui.Utils.isPermissible', return_value=True)
+    def test_kill(self, isPermissibleMock, yesNoMock, killMock):
         layer = opencue.wrappers.layer.Layer(
             opencue.compiled_proto.job_pb2.Layer(name='arbitrary-name'))
 
@@ -679,7 +688,8 @@ class LayerActionsTests(unittest.TestCase):
 
     @mock.patch.object(opencue.wrappers.layer.Layer, 'kill')
     @mock.patch('cuegui.Utils.questionBoxYesNo', return_value=False)
-    def test_killCanceled(self, yesNoMock, killMock):
+    @mock.patch('cuegui.Utils.isPermissible', return_value=True)
+    def test_killCanceled(self, isPermissibleMock, yesNoMock, killMock):
         layer = opencue.wrappers.layer.Layer(
             opencue.compiled_proto.job_pb2.Layer(name='arbitrary-name'))
 
@@ -689,7 +699,8 @@ class LayerActionsTests(unittest.TestCase):
 
     @mock.patch.object(opencue.wrappers.layer.Layer, 'eat')
     @mock.patch('cuegui.Utils.questionBoxYesNo', return_value=True)
-    def test_eat(self, yesNoMock, eatMock):
+    @mock.patch('cuegui.Utils.isPermissible', return_value=True)
+    def test_eat(self, isPermissibleMock, yesNoMock, eatMock):
         layer = opencue.wrappers.layer.Layer(
             opencue.compiled_proto.job_pb2.Layer(name='arbitrary-name'))
 
@@ -699,7 +710,8 @@ class LayerActionsTests(unittest.TestCase):
 
     @mock.patch.object(opencue.wrappers.layer.Layer, 'eat')
     @mock.patch('cuegui.Utils.questionBoxYesNo', return_value=False)
-    def test_eatCanceled(self, yesNoMock, eatMock):
+    @mock.patch('cuegui.Utils.isPermissible', return_value=True)
+    def test_eatCanceled(self, isPermissibleMock, yesNoMock, eatMock):
         layer = opencue.wrappers.layer.Layer(
             opencue.compiled_proto.job_pb2.Layer(name='arbitrary-name'))
 
@@ -709,7 +721,8 @@ class LayerActionsTests(unittest.TestCase):
 
     @mock.patch.object(opencue.wrappers.layer.Layer, 'retry', autospec=True)
     @mock.patch('cuegui.Utils.questionBoxYesNo', return_value=True)
-    def test_retry(self, yesNoMock, retryMock):
+    @mock.patch('cuegui.Utils.isPermissible', return_value=True)
+    def test_retry(self, isPermissibleMock, yesNoMock, retryMock):
         layer = opencue.wrappers.layer.Layer(
             opencue.compiled_proto.job_pb2.Layer(name='arbitrary-name'))
 
@@ -719,7 +732,8 @@ class LayerActionsTests(unittest.TestCase):
 
     @mock.patch.object(opencue.wrappers.layer.Layer, 'retry')
     @mock.patch('cuegui.Utils.questionBoxYesNo', return_value=False)
-    def test_retryCanceled(self, yesNoMock, retryMock):
+    @mock.patch('cuegui.Utils.isPermissible', return_value=True)
+    def test_retryCanceled(self, isPermissibleMock, yesNoMock, retryMock):
         layer = opencue.wrappers.layer.Layer(
             opencue.compiled_proto.job_pb2.Layer(name='arbitrary-name'))
 
@@ -728,7 +742,8 @@ class LayerActionsTests(unittest.TestCase):
         retryMock.assert_not_called()
 
     @mock.patch('cuegui.Utils.questionBoxYesNo', return_value=True)
-    def test_retryDead(self, yesNoMock):
+    @mock.patch('cuegui.Utils.isPermissible', return_value=True)
+    def test_retryDead(self, isPermissibleMock, yesNoMock):
         layer_name = 'arbitrary-name'
         layer = opencue.wrappers.layer.Layer(
             opencue.compiled_proto.job_pb2.Layer(name=layer_name))
@@ -914,7 +929,8 @@ class FrameActionsTests(unittest.TestCase):
         self.frame_actions.getWhatDependsOnThis(rpcObjects=[frame])
 
     @mock.patch('cuegui.Utils.questionBoxYesNo', return_value=True)
-    def test_retry(self, yesNoMock):
+    @mock.patch('cuegui.Utils.isPermissible', return_value=True)
+    def test_retry(self, isPermissibleMock, yesNoMock):
         frame_name = 'arbitrary-frame-name'
         frame = opencue.wrappers.frame.Frame(opencue.compiled_proto.job_pb2.Frame(name=frame_name))
 
@@ -943,7 +959,8 @@ class FrameActionsTests(unittest.TestCase):
         previewProcessorDialogMock.return_value.exec_.assert_called()
 
     @mock.patch('cuegui.Utils.questionBoxYesNo', return_value=True)
-    def test_eat(self, yesNoMock):
+    @mock.patch('cuegui.Utils.isPermissible', return_value=True)
+    def test_eat(self, isPermissibleMock, yesNoMock):
         frame_name = 'arbitrary-frame-name'
         frame = opencue.wrappers.frame.Frame(opencue.compiled_proto.job_pb2.Frame(name=frame_name))
 
@@ -952,7 +969,8 @@ class FrameActionsTests(unittest.TestCase):
         self.job.eatFrames.assert_called_with(name=[frame_name])
 
     @mock.patch('cuegui.Utils.questionBoxYesNo', return_value=True)
-    def test_kill(self, yesNoMock):
+    @mock.patch('cuegui.Utils.isPermissible', return_value=True)
+    def test_kill(self, isPermissibleMock, yesNoMock):
         frame_name = 'arbitrary-frame-name'
         frame = opencue.wrappers.frame.Frame(opencue.compiled_proto.job_pb2.Frame(name=frame_name))
 
@@ -1019,7 +1037,8 @@ class FrameActionsTests(unittest.TestCase):
 
     @mock.patch.object(opencue.wrappers.layer.Layer, 'markdone', autospec=True)
     @mock.patch('cuegui.Utils.questionBoxYesNo', return_value=True)
-    def test_eatandmarkdone(self, yesNoMock, markdoneMock):
+    @mock.patch('cuegui.Utils.isPermissible', return_value=True)
+    def test_eatandmarkdone(self, isPermissibleMock, yesNoMock, markdoneMock):
         layer_name = 'layer-name'
         frames = [
             opencue.wrappers.frame.Frame(
@@ -1339,7 +1358,7 @@ class ProcActionsTests(unittest.TestCase):
         self.app = test_utils.createApplication()
         self.widgetMock = mock.Mock()
         self.proc_actions = cuegui.MenuActions.ProcActions(
-            self.widgetMock, mock.Mock(), None, None)
+            self.widgetMock, mock.Mock(), mock.Mock(), mock.Mock())
 
     @mock.patch('opencue.api.findJob')
     def test_view(self, findJobMock):
@@ -1353,8 +1372,9 @@ class ProcActionsTests(unittest.TestCase):
 
         self.app.view_object.emit.assert_called_once_with(job)
 
-    @mock.patch('cuegui.Utils.questionBoxYesNo', new=mock.Mock(return_value=True))
-    def test_kill(self):
+    @mock.patch('cuegui.Utils.questionBoxYesNo', return_value=True)
+    @mock.patch('cuegui.Utils.isPermissible', return_value=True)
+    def test_kill(self, isPermissibleMock, yesNoMock):
         proc = opencue.wrappers.proc.Proc(opencue.compiled_proto.host_pb2.Proc())
         proc.kill = mock.MagicMock()
 


### PR DESCRIPTION
**Rationale**
Users shouldn't be allowed by default to execute destructive actions on jobs they don't own. For "superusers" there should be a simple way to toggle this behavior off. This preference should be saved on the user profile. 

**Implementation details**
This feature checks user permissions before allowing a user to "eat, kill, retry" jobs that they do not own. 
The behavior can be overwritten at: "File -> Enable Job Interaction". This gets saved to the config file and is disabled by
default.