### PR TITLE
[cuegui] Enable some separator characters on service name

### DIFF
--- a/cuegui/cuegui/ServiceDialog.py
+++ b/cuegui/cuegui/ServiceDialog.py
@@ -170,7 +170,7 @@ class ServiceForm(QtWidgets.QWidget):
         # inconsistently
         if (not service_name.isalnum()) and \
             [char for char in service_name
-             if not char.isalnum and char not in "|/-_"]:
+             if not char.isalnum() and char not in "|/-_"]:
             QtWidgets.QMessageBox.critical(self, "Error", "The service name must alphanumeric.")
             return
 

--- a/cuegui/cuegui/ServiceDialog.py
+++ b/cuegui/cuegui/ServiceDialog.py
@@ -159,12 +159,18 @@ class ServiceForm(QtWidgets.QWidget):
         Create and emit a ServiceData object based
         on the contents of the form.
         """
-        if len(str(self.name.text())) < 3:
+        service_name = str(self.name.text())
+        if len(service_name) < 3:
             QtWidgets.QMessageBox.critical(self, "Error",
                                            "The service name must be at least 3 characters.")
             return
 
-        if not str(self.name.text()).isalnum():
+        # Allow alphanumeric chars and | / - _
+        # chars like , and . can be used as separators in other parts of the API and behave
+        # inconsistently
+        if (not service_name.isalnum()) and \
+            [char for char in service_name
+             if not char.isalnum and char not in "|/-_"]:
             QtWidgets.QMessageBox.critical(self, "Error", "The service name must alphanumeric.")
             return
 
@@ -176,7 +182,7 @@ class ServiceForm(QtWidgets.QWidget):
         service = opencue.wrappers.service.Service()
         if self.__service:
             service.data.id = self.__service.data.id
-        service.setName(str(self.name.text()))
+        service.setName(service_name)
         service.setThreadable(self.threadable.isChecked())
         service.setMinCores(self.min_cores.value())
         service.setMaxCores(self.max_cores.value())


### PR DESCRIPTION
The following separators can now be used to name services:
 | / - _