### PR TITLE
[cuegui] Extend jobId regex to accept format saved on user profile

### DIFF
--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -179,7 +179,7 @@ def isTask(obj):
     return obj.__class__.__name__ == "Task"
 
 
-__REGEX_ID = re.compile(r"[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}")
+__REGEX_ID = re.compile(r"(?:Job.)?[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}")
 
 
 def isStringId(value):
@@ -257,8 +257,10 @@ def findJob(job):
     if not isinstance(job, six.string_types):
         return None
     if isStringId(job):
+        if re.search("^Job.", job):
+            job = re.sub("Job.", "", job)
         return opencue.api.getJob(job)
-    if not re.search(r"^([a-z0-9\_]+)\-([a-z0-9\.\_]+)\-", job, re.IGNORECASE):
+    if not re.search(r"^(?:Job.)?([a-z0-9\_]+)\-([a-z0-9\.\_]+)\-", job, re.IGNORECASE):
         return None
     try:
         return opencue.api.findJob(job)

--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -179,6 +179,9 @@ def isTask(obj):
     return obj.__class__.__name__ == "Task"
 
 
+# Regex matches:
+#  - 12345678-1234-1234-1234-123456789ABC
+#  - Job.12345678-1234-1234-1234-123456789ABC
 __REGEX_ID = re.compile(r"(?:Job.)?[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}")
 
 

--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -263,7 +263,7 @@ def findJob(job):
         if re.search("^Job.", job):
             job = re.sub("Job.", "", job)
         return opencue.api.getJob(job)
-    if not re.search(r"^(?:Job.)?([a-z0-9\_]+)\-([a-z0-9\.\_]+)\-", job, re.IGNORECASE):
+    if not re.search(r"^(?:Job.)?([a-z0-9_]+)-([a-z0-9._]+)-", job, re.IGNORECASE):
         return None
     try:
         return opencue.api.findJob(job)


### PR DESCRIPTION
The `findJob` function on Utils.py has to account for the format of jobIds saved on the .ini file which prepends "Job."  to the id.