### PR TITLE
Fix logviewer issue on invalid type

### DIFF
--- a/cuegui/cuegui/FrameMonitorTree.py
+++ b/cuegui/cuegui/FrameMonitorTree.py
@@ -387,9 +387,10 @@ class FrameMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         @type  job: job, string, None"""
         self.frameSearch = opencue.search.FrameSearch()
         self.__job = job
-        self.__jobState = job.state()
         self.removeAllItems()
-        self.__sortByColumnLoad()
+        if job:
+            self.__jobState = job.state()
+            self.__sortByColumnLoad()
         self._lastUpdate = 0
         self.job_changed.emit()
 

--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -487,8 +487,11 @@ def popupView(file, facility=None):
         app = cuegui.app()
         if editor_from_env:
             job_log_cmd = editor_from_env.split()
-        elif app.settings.contains('LogEditor'):
-            job_log_cmd = app.settings.value("LogEditor")
+        elif app.settings.contains('LogEditor') and (
+                len(app.settings.value("LogEditor").strip()) > 0):
+            job_log_cmd = app.settings.value("LogEditor").split()
+            if not isinstance(job_log_cmd, list):
+                job_log_cmd = job_log_cmd.split()
         else:
             job_log_cmd = cuegui.Constants.DEFAULT_EDITOR.split()
         job_log_cmd.append(str(file))


### PR DESCRIPTION
Current logic would fail with `str has no attribute append` when a log editor is configured using cuegui.yaml