### PR TITLE
[cuegui] Fix output viewer cmd format

### DIFF
--- a/cuegui/cuegui/MenuActions.py
+++ b/cuegui/cuegui/MenuActions.py
@@ -1215,7 +1215,7 @@ class FrameActions(AbstractActions):
     def kill(self, rpcObjects=None):
         names = [frame.data.name for frame in self._getOnlyFrameObjects(rpcObjects)]
         if names:
-            if not cuegui.Utils.isPermissible(self._getSource(), self):
+            if not cuegui.Utils.isPermissible(self._getSource()):
                 cuegui.Utils.showErrorMessageBox(
                     AbstractActions.USER_INTERACTION_PERMISSIONS.format(
                         "kill frames",
@@ -1331,7 +1331,7 @@ class FrameActions(AbstractActions):
         if frames:
             frameNames = [frame.data.name for frame in frames]
             #check permissions
-            if not cuegui.Utils.isPermissible(self._getSource(), self):
+            if not cuegui.Utils.isPermissible(self._getSource()):
                 cuegui.Utils.showErrorMessageBox(
                     AbstractActions.USER_INTERACTION_PERMISSIONS.format(
                         "eat and mark done frames",

--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -644,10 +644,9 @@ def launchViewerUsingPaths(paths, test_mode=False):
     # Launch viewer and inform user
     msg = 'Launching viewer: {0}'.format(cmd)
     if not test_mode:
-        QtGui.qApp.emit(QtCore.SIGNAL('status(PyQt_PyObject)'), msg)
         print(msg)
         try:
-            subprocess.check_call(cmd)
+            subprocess.check_call(cmd.split())
         except subprocess.CalledProcessError as e:
             showErrorMessageBox(str(e), title='Error running Viewer command')
         except Exception as e:


### PR DESCRIPTION
The output cmd call was not handling well all types of cmd formats. The cmd string needs to be passed as an array to be properly interpreted by the subprocess.
