### PR TITLE
[rqd] Remove hardcoded MAIL and HOME rqd environment variables

### DIFF
--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -98,10 +98,7 @@ class FrameAttendantThread(threading.Thread):
         self.frameEnv["CUE_GPU_MEMORY"] = str(self.rqCore.machine.getGpuMemoryFree())
         self.frameEnv["SP_NOMYCSHRC"] = "1"
 
-        if platform.system() in ("Linux", "Darwin"):
-            self.frameEnv["MAIL"] = "/usr/mail/%s" % self.runFrame.user_name
-            self.frameEnv["HOME"] = "/net/homedirs/%s" % self.runFrame.user_name
-        elif platform.system() == "Windows":
+        if platform.system() == "Windows":
             for variable in ["SYSTEMROOT", "APPDATA", "TMP", "COMMONPROGRAMFILES", "SYSTEMDRIVE"]:
                 if variable in os.environ:
                     self.frameEnv[variable] = os.environ[variable]


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Fixes #420 

**Summarize your change.**
Removes hardcoded environment variables specific for SPI
If the variables are still needed, they can be exposed for the job again by adding them to the `[UseHostEnvVar]` section of `rqd.conf`