### PR TITLE
Add a flag to search job with appended results

### DIFF
--- a/cuegui/cuegui/Constants.py
+++ b/cuegui/cuegui/Constants.py
@@ -195,6 +195,8 @@ DISABLED_ACTION_TYPES = [action_type.strip()
                          for action_type
                          in __config.get('filter_dialog.disabled_action_types', "").split(",")]
 
+SEARCH_JOBS_APPEND_RESULTS = __config.get('search_jobs.append_results', True)
+
 TYPE_JOB = QtWidgets.QTreeWidgetItem.UserType + 1
 TYPE_LAYER = QtWidgets.QTreeWidgetItem.UserType + 2
 TYPE_FRAME = QtWidgets.QTreeWidgetItem.UserType + 3

--- a/cuegui/cuegui/config/cuegui.yaml
+++ b/cuegui/cuegui/config/cuegui.yaml
@@ -152,3 +152,8 @@ finished_jobs_readonly.layer: True
 # MOVE_JOB_TO_GROUP, SET_ALL_RENDER_LAYER_MAX_CORES)
 # An empty string means all actions are active.
 filter_dialog.disabled_action_types: ''
+
+# A flag for search job with appended results
+# true to appended to the current list of monitored jobs,
+# false to clear the current job list and show only the new search results
+search_jobs.append_results: True

--- a/cuegui/cuegui/config/cuegui.yaml
+++ b/cuegui/cuegui/config/cuegui.yaml
@@ -153,7 +153,7 @@ finished_jobs_readonly.layer: True
 # An empty string means all actions are active.
 filter_dialog.disabled_action_types: ''
 
-# A flag for search job with appended results
-# true to appended to the current list of monitored jobs,
-# false to clear the current job list and show only the new search results
+# Define whether or not new jobs should be appended to the current list of jobs on the JobMonitor widget
+#  - True: search result will append jobs to the current list of monitored jobs
+#  - False: repopulate the jobs table with the search result
 search_jobs.append_results: True

--- a/cuegui/cuegui/plugins/MonitorJobsPlugin.py
+++ b/cuegui/cuegui/plugins/MonitorJobsPlugin.py
@@ -193,12 +193,14 @@ class MonitorJobsDockWidget(cuegui.AbstractDockWidget.AbstractDockWidget):
         self.__loadFinishedJobsCheckBox.stateChanged.connect(self._regexLoadJobsHandle)  # pylint: disable=no-member
 
     def _regexLoadJobsHandle(self):
-        """This will select all jobs that have a name that contain the substring
-        in self.__regexLoadJobsEditBox.text() and scroll to the first match"""
+        """This will select all jobs that have a name that contains the substring
+        in self.__regexLoadJobsEditBox.text() and scroll to the first match."""
         substring = str(self.__regexLoadJobsEditBox.text()).strip()
         load_finished_jobs = self.__loadFinishedJobsCheckBox.isChecked()
 
-        self.jobMonitor.removeAllItems()
+        # Only clear the existing jobs if SEARCH_JOBS_APPEND_RESULTS is False
+        if not cuegui.Constants.SEARCH_JOBS_APPEND_RESULTS:
+            self.jobMonitor.removeAllItems()
 
         if substring:
             # Load job if a uuid is provided


### PR DESCRIPTION
- Add a new configuration option `search_jobs.append_results` in cuegui.yaml to control job search behaviour.
- If `search_jobs.append_results` is set to true, search results will be appended to the current list of monitored jobs.
- If `search_jobs.append_results` is set to false, the existing jobs will be cleared before displaying the search results.
- Updated Constants.py to include the new configuration parameter.
- Modified MonitorJobsPlugin.py to conditionally clear the job monitor based on the config setting.