### PR TITLE
[cuegui] Add dynamic version fetching for the CueGUI About menu

### DIFF
--- a/cuegui/cuegui/Constants.py
+++ b/cuegui/cuegui/Constants.py
@@ -91,9 +91,10 @@ def __packaged_version():
 
 def __get_version_from_cmd(command):
     try:
-        result = subprocess.run(command, shell=True, capture_output=True, text=True)
-        if result.returncode == 0:
-            return result.stdout.strip()
+        result = subprocess.run(command, shell=True, capture_output=True, text=True, check=True)
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        print(f"Command failed with return code {e.returncode}: {e}")
     except Exception as e:
         print(f"Failed to get version from command: {e}")
     return None

--- a/cuegui/cuegui/Constants.py
+++ b/cuegui/cuegui/Constants.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 
 import logging
 import os
+import subprocess
 import platform
 
 from qtpy import QtGui
@@ -88,10 +89,26 @@ def __packaged_version():
         return default_version
     return "1.3.0"
 
+def __get_version_from_cmd(command):
+    try:
+        result = subprocess.run(command, shell=True, capture_output=True, text=True)
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception as e:
+        print(f"Failed to get version from command: {e}")
+    return None
 
 __config = __loadConfigFromFile()
 
-VERSION = __config.get('version', __packaged_version())
+# Decide which CueGUI version to show
+if __config.get('cuegui.use.custom.version', False):
+    beta_version = os.getenv('OPENCUE_BETA', '0')
+    if beta_version == '1':
+        VERSION = __get_version_from_cmd(__config.get('cuegui.custom.cmd.version.beta'))
+    else:
+        VERSION = __get_version_from_cmd(__config.get('cuegui.custom.cmd.version.stable'))
+else:
+    VERSION = __config.get('version', __packaged_version())
 
 STARTUP_NOTICE_DATE = __config.get('startup_notice.date')
 STARTUP_NOTICE_MSG = __config.get('startup_notice.msg')

--- a/cuegui/cuegui/MainWindow.py
+++ b/cuegui/cuegui/MainWindow.py
@@ -120,6 +120,15 @@ class MainWindow(QtWidgets.QMainWindow):
     def displayAbout(self):
         """Displays about text."""
         msg = self.app_name + "\n\nA opencue tool\n\n"
+        msg += "CueGUI:\n%s\n\n" % cuegui.Constants.VERSION
+
+        # You can add more details like beta/stable indication here
+        beta_version = os.getenv('OPENCUE_BETA', '0')
+        if beta_version == '1':
+            msg += "(Beta Version)\n\n"
+        else:
+            msg += "(Stable Version)\n\n"
+
         msg += "Qt:\n%s\n\n" % QtCore.qVersion()
         msg += "Python:\n%s\n\n" % sys.version
         QtWidgets.QMessageBox.about(self, "About", msg)

--- a/cuegui/cuegui/MainWindow.py
+++ b/cuegui/cuegui/MainWindow.py
@@ -122,9 +122,7 @@ class MainWindow(QtWidgets.QMainWindow):
         msg = self.app_name + "\n\nA opencue tool\n\n"
         msg += "CueGUI:\n%s\n\n" % cuegui.Constants.VERSION
 
-        # You can add more details like beta/stable indication here
-        beta_version = os.getenv('OPENCUE_BETA', '0')
-        if beta_version == '1':
+        if os.getenv('OPENCUE_BETA'):
             msg += "(Beta Version)\n\n"
         else:
             msg += "(Stable Version)\n\n"

--- a/cuegui/cuegui/config/cuegui.yaml
+++ b/cuegui/cuegui/config/cuegui.yaml
@@ -1,7 +1,8 @@
 # Default CueGUI config file
 
-# If False, use the version number in the VERSION.in file
-# Otherwise, use the version cuegui.custom.cmd.version.beta (for beta) or cuegui.custom.cmd.version.stable (for stable)
+# Configure how a version number should be acquired. 
+#  - False, use the version number in VERSION.in
+#  - True, run the commands defined at cuegui.custom.cmd.version.beta (for beta) or cuegui.custom.cmd.version.stable (for stable) to acquire the version number
 cuegui.use.custom.version: False
 # Used to show the CueGUI beta version, if the environment variable OPENCUE_BETA = 1 (setenv OPENCUE_BETA 1)
 # If the CueGUI is deployed using the SPK and SPAWN (https://getspk.io/), it is also possible to run the SPAWN command

--- a/cuegui/cuegui/config/cuegui.yaml
+++ b/cuegui/cuegui/config/cuegui.yaml
@@ -5,8 +5,8 @@
 #  - True, run the commands defined at cuegui.custom.cmd.version.beta (for beta) or cuegui.custom.cmd.version.stable (for stable) to acquire the version number
 cuegui.use.custom.version: False
 # Used to show the CueGUI beta version, if the environment variable OPENCUE_BETA = 1 (setenv OPENCUE_BETA 1)
-# If the CueGUI is deployed using the SPK and SPAWN (https://getspk.io/), it is also possible to run the SPAWN command
-# to get the cuegui version or any other shell command.
+# If the CueGUI beta version is enabled, it's possible to run a shell command to get the cuegui version or any other
+# custom command specified in the environment configuration.
 cuegui.custom.cmd.version.beta: "echo 1.0.0"
 # Used to show the CueGUI stable version, if the environment variable OPENCUE_BETA = 0 (setenv OPENCUE_BETA 0)
 cuegui.custom.cmd.version.stable: "echo 1.0.1"

--- a/cuegui/cuegui/config/cuegui.yaml
+++ b/cuegui/cuegui/config/cuegui.yaml
@@ -1,5 +1,15 @@
 # Default CueGUI config file
 
+# If False, use the version number in the VERSION.in file
+# Otherwise, use the version cuegui.custom.cmd.version.beta (for beta) or cuegui.custom.cmd.version.stable (for stable)
+cuegui.use.custom.version: False
+# Used to show the CueGUI beta version, if the environment variable OPENCUE_BETA = 1 (setenv OPENCUE_BETA 1)
+# If the CueGUI is deployed using the SPK and SPAWN (https://getspk.io/), it is also possible to run the SPAWN command
+# to get the cuegui version or any other shell command.
+cuegui.custom.cmd.version.beta: "echo 1.0.0"
+# Used to show the CueGUI stable version, if the environment variable OPENCUE_BETA = 0 (setenv OPENCUE_BETA 0)
+cuegui.custom.cmd.version.stable: "echo 1.0.1"
+
 logger.format: '%(levelname)-9s %(module)-10s %(message)s'
 logger.level: 'WARNING'
 


### PR DESCRIPTION
- Implemented new configuration options in cuegui.yaml:
  - `cuegui.use.custom.version`: Toggle between using VERSION.in or custom CueGUI version.
  - `cuegui.custom.cmd.version.stable`: Command to fetch stable version (`setenv OPENCUE_BETA 0`)
  - `cuegui.custom.cmd.version.beta`: Command to fetch beta version (`setenv OPENCUE_BETA 1`)
- Modified Constants.py to fetch version dynamically based on config.
- Updated MainWindows.py to display the correct version (stable or beta) in the About menu.
- Fallback to VERSION.in if custom version is disabled.