### PR TITLE
[cuegui] Kill a Job from Windows.

### DIFF
--- a/pycue/opencue/wrappers/frame.py
+++ b/pycue/opencue/wrappers/frame.py
@@ -18,6 +18,7 @@ import enum
 import getpass
 import time
 import os
+import platform
 
 from opencue import Cuebot
 from opencue.compiled_proto import job_pb2
@@ -75,7 +76,7 @@ class Frame(object):
         """Kills the frame."""
         username = username if username else getpass.getuser()
         pid = pid if pid else os.getpid()
-        host_kill = host_kill if host_kill else os.uname()[1]
+        host_kill = host_kill if host_kill else platform.uname()[1]
         if self.data.state == job_pb2.FrameState.Value('RUNNING'):
             self.stub.Kill(job_pb2.FrameKillRequest(frame=self.data,
                                                     username=username,

--- a/pycue/opencue/wrappers/job.py
+++ b/pycue/opencue/wrappers/job.py
@@ -17,6 +17,7 @@
 import enum
 import getpass
 import os
+import platform
 import time
 
 from opencue import Cuebot
@@ -49,7 +50,7 @@ class Job(object):
         """Kills the job."""
         username = username if username else getpass.getuser()
         pid = pid if pid else os.getpid()
-        host_kill = host_kill if host_kill else os.uname()[1]
+        host_kill = host_kill if host_kill else platform.uname()[1]
         self.stub.Kill(job_pb2.JobKillRequest(job=self.data,
                                               username=username,
                                               pid=str(pid),
@@ -73,7 +74,7 @@ class Job(object):
         """
         username = username if username else getpass.getuser()
         pid = pid if pid else os.getpid()
-        host_kill = host_kill if host_kill else os.uname()[1]
+        host_kill = host_kill if host_kill else platform.uname()[1]
         criteria = opencue.search.FrameSearch.criteriaFromOptions(**request)
         self.stub.KillFrames(job_pb2.JobKillFramesRequest(job=self.data,
                                                           req=criteria,

--- a/pycue/opencue/wrappers/layer.py
+++ b/pycue/opencue/wrappers/layer.py
@@ -17,6 +17,7 @@
 import enum
 import getpass
 import os
+import platform
 
 import opencue.api
 from opencue.compiled_proto import job_pb2
@@ -51,7 +52,7 @@ class Layer(object):
         """Kills the entire layer."""
         username = username if username else getpass.getuser()
         pid = pid if pid else os.getpid()
-        host_kill = host_kill if host_kill else os.uname()[1]
+        host_kill = host_kill if host_kill else platform.uname()[1]
         return self.stub.KillFrames(job_pb2.LayerKillFramesRequest(layer=self.data,
                                                                    username=username,
                                                                    pid=str(pid),

--- a/pycue/tests/wrappers/frame_test.py
+++ b/pycue/tests/wrappers/frame_test.py
@@ -21,6 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 import getpass
 import os
+import platform
 import time
 import unittest
 
@@ -60,7 +61,7 @@ class FrameTests(unittest.TestCase):
             job_pb2.Frame(name=TEST_FRAME_NAME, state=job_pb2.RUNNING))
         username = getpass.getuser()
         pid = os.getpid()
-        host_kill = os.uname()[1]
+        host_kill = platform.uname()[1]
         reason = "Frames Kill Request"
         frame.kill(username=username, pid=pid, host_kill=host_kill, reason=reason)
 

--- a/pycue/tests/wrappers/job_test.py
+++ b/pycue/tests/wrappers/job_test.py
@@ -21,6 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 import getpass
 import os
+import platform
 import unittest
 
 import mock
@@ -49,7 +50,7 @@ class JobTests(unittest.TestCase):
             job_pb2.Job(name=TEST_JOB_NAME))
         username = getpass.getuser()
         pid = os.getpid()
-        host_kill = os.uname()[1]
+        host_kill = platform.uname()[1]
         reason = "Job Kill Request"
         job.kill(username=username, pid=pid, host_kill=host_kill, reason=reason)
 
@@ -95,7 +96,7 @@ class JobTests(unittest.TestCase):
             job_pb2.Job(name=TEST_JOB_NAME))
         username = getpass.getuser()
         pid = os.getpid()
-        host_kill = os.uname()[1]
+        host_kill = platform.uname()[1]
         reason = "Job Kill Request"
         job.killFrames(range=frameRange,
                        username=username,

--- a/pycue/tests/wrappers/layer_test.py
+++ b/pycue/tests/wrappers/layer_test.py
@@ -21,6 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 import getpass
 import os
+import platform
 import unittest
 
 import mock
@@ -49,7 +50,7 @@ class LayerTests(unittest.TestCase):
             job_pb2.Layer(name=TEST_LAYER_NAME))
         username = getpass.getuser()
         pid = os.getpid()
-        host_kill = os.uname()[1]
+        host_kill = platform.uname()[1]
         reason = "Frames Kill Request"
         layer.kill(username=username, pid=pid, host_kill=host_kill, reason=reason)
 

--- a/rqd/rqd/rqmachine.py
+++ b/rqd/rqd/rqmachine.py
@@ -571,11 +571,11 @@ class Machine(object):
             self.__renderHost.tags.append("windows")
             return
 
-        if os.uname()[-1] in ("i386", "i686"):
+        if platform.uname()[-1] in ("i386", "i686"):
             self.__renderHost.tags.append("32bit")
-        elif os.uname()[-1] == "x86_64":
+        elif platform.uname()[-1] == "x86_64":
             self.__renderHost.tags.append("64bit")
-        self.__renderHost.tags.append(os.uname()[2].replace(".EL.spi", "").replace("smp", ""))
+        self.__renderHost.tags.append(platform.uname()[2].replace(".EL.spi", "").replace("smp", ""))
 
     def testInitMachineStats(self, pathCpuInfo):
         """Initializes machine stats outside of normal startup process. Used for testing."""


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Fixes: https://github.com/AcademySoftwareFoundation/OpenCue/issues/1519

**Summarize your change.**
Use `platform.uname()` instead of `os.uname()`. They have the same result on Linux, but `os.uname()` is not available on Windows, making us unable to kill a job from this OS.

**Additional information.**
Linux (ubuntu 22.04.6): 
``` python
>>> os.uname()
posix.uname_result(sysname='Linux', nodename='titan', release='6.8.0-45-generic', version='#45~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Sep 11 15:25:05 UTC 2', machine='x86_64')
>>>platform.uname()
uname_result(system='Linux', node='titan', release='6.8.0-45-generic', version='#45~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Sep 11 15:25:05 UTC 2', machine='x86_64')
```
Windows (11): 
``` python
>>> platform.uname()
uname_result(system='Windows', node='StarChaser', release='10', version='10.0.22631', machine='AMD64')
```