### PR TITLE
[cuegot] Upgrade gradle version on dockerfile

### DIFF
--- a/cuebot/Dockerfile
+++ b/cuebot/Dockerfile
@@ -1,7 +1,7 @@
 # -----------------
 # BUILD
 # -----------------
-FROM gradle:6.0.1-jdk13 AS build
+FROM gradle:7.6.4-jdk17 AS build
 
 USER gradle
 


### PR DESCRIPTION
The version of gradle was updated on https://github.com/AcademySoftwareFoundation/OpenCue/pull/1393 but the change didn't make it to the Dockerfile.
