### PR TITLE
[cuebot] Fix integration pipeline

### DIFF
--- a/cuebot/build.gradle
+++ b/cuebot/build.gradle
@@ -56,7 +56,8 @@ dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.8.0'
-    testImplementation group: 'io.zonky.test', name: 'embedded-postgres', version: '1.3.1'
+    testImplementation group: 'io.zonky.test', name: 'embedded-postgres', version: '2.0.1'
+    testImplementation group: 'io.zonky.test.postgres', name: 'embedded-postgres-binaries-linux-arm64v8', version: '15.2.0'
     testImplementation group: 'org.flywaydb', name: 'flyway-core', version: '5.2.0'
 
     // Use newer version of Postgres for tests: https://github.com/zonkyio/embedded-postgres/issues/78
@@ -106,12 +107,9 @@ sourceSets {
     }
 }
 
-jar {
-    enabled = true
-}
-
 bootJar {
     baseName = 'cuebot'
+    mainClassName = 'com.imageworks.spcue.CuebotApplication'
 }
 
 jacoco {


### PR DESCRIPTION
* Upgrade `io.zonky.test.embedded-postgres` and add required package for building on MacOS environments
* Add `mainClassName` to solve issues on the newer version of gradle where the main class was not being found on the generated jar