### PR TITLE
Make packaging pip package version specific

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,8 @@ grpcio-tools==1.48.2;python_version<"3.7"
 grpcio==1.53.2;python_version>="3.7"
 grpcio-tools==1.53.0;python_version>="3.7"
 mock==2.0.0
-packaging==24.1
+packaging==20.9;python_version<"3.7"
+packaging==24.1;python_version>="3.7"
 psutil==5.9.8
 pyfakefs==3.6;python_version<"3.7"
 pyfakefs==5.2.3;python_version>="3.7"


### PR DESCRIPTION
Python3.6 doesn't support packaging 24