### PR TITLE
Another attempt on fixing the packaging pipeline

### DIFF
--- a/cueadmin/Dockerfile
+++ b/cueadmin/Dockerfile
@@ -35,7 +35,7 @@ COPY VERSION.in VERSIO[N] ./
 RUN test -e VERSION || echo "$(cat VERSION.in)" | tee VERSION
 
 RUN cd pycue && python3 -m pip install .
-RUN cd pycue && python3 -m unittest tests/*.py
+RUN cd cueadmin && python3 tests/test_suite.py
 
 RUN cp LICENSE requirements.txt VERSION cueadmin/
 

--- a/cueadmin/tests/test_suite.py
+++ b/cueadmin/tests/test_suite.py
@@ -1,6 +1,21 @@
+#  Copyright Contributors to the OpenCue Project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 import unittest
 
 def create_test_suite():
+    """Create test suite for this module"""
     loader = unittest.TestLoader()
     start_dir = '.'  # Specify the directory where your test files reside
     suite = loader.discover(start_dir, pattern='*_tests.py')

--- a/cueadmin/tests/test_suite.py
+++ b/cueadmin/tests/test_suite.py
@@ -1,0 +1,12 @@
+import unittest
+
+def create_test_suite():
+    loader = unittest.TestLoader()
+    start_dir = '.'  # Specify the directory where your test files reside
+    suite = loader.discover(start_dir, pattern='*_tests.py')
+    return suite
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner()
+    test_suite = create_test_suite()
+    runner.run(test_suite)

--- a/cueadmin/tests/test_suite.py
+++ b/cueadmin/tests/test_suite.py
@@ -11,11 +11,11 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+# pylint: disable=missing-function-docstring,missing-module-docstring
 
 import unittest
 
 def create_test_suite():
-    """Create test suite for this module"""
     loader = unittest.TestLoader()
     start_dir = '.'  # Specify the directory where your test files reside
     suite = loader.discover(start_dir, pattern='*_tests.py')

--- a/pycue/Dockerfile
+++ b/pycue/Dockerfile
@@ -31,7 +31,7 @@ COPY VERSION.in VERSIO[N] ./
 RUN test -e VERSION || echo "$(cat VERSION.in)" | tee VERSION
 
 RUN cd pycue && python3 -m pip install .
-RUN cd pycue && python3 -m unittest tests/*.py
+RUN cd pycue && python3 tests/test_suite.py
 
 RUN cp LICENSE requirements.txt VERSION pycue/
 

--- a/pycue/tests/test_suite.py
+++ b/pycue/tests/test_suite.py
@@ -1,6 +1,21 @@
+#  Copyright Contributors to the OpenCue Project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 import unittest
 
 def create_test_suite():
+    """Create test suite for this module"""
     loader = unittest.TestLoader()
     start_dir = '.'  # Specify the directory where your test files reside
     suite = loader.discover(start_dir, pattern='*_test.py')

--- a/pycue/tests/test_suite.py
+++ b/pycue/tests/test_suite.py
@@ -1,0 +1,12 @@
+import unittest
+
+def create_test_suite():
+    loader = unittest.TestLoader()
+    start_dir = '.'  # Specify the directory where your test files reside
+    suite = loader.discover(start_dir, pattern='*_test.py')
+    return suite
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner()
+    test_suite = create_test_suite()
+    runner.run(test_suite)

--- a/pycue/tests/test_suite.py
+++ b/pycue/tests/test_suite.py
@@ -11,11 +11,11 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+# pylint: disable=missing-function-docstring,missing-module-docstring
 
 import unittest
 
 def create_test_suite():
-    """Create test suite for this module"""
     loader = unittest.TestLoader()
     start_dir = '.'  # Specify the directory where your test files reside
     suite = loader.discover(start_dir, pattern='*_test.py')

--- a/pyoutline/Dockerfile
+++ b/pyoutline/Dockerfile
@@ -36,8 +36,9 @@ COPY pyoutline/outline ./pyoutline/outline
 COPY VERSION.in VERSIO[N] ./
 RUN test -e VERSION || echo "$(cat VERSION.in)" | tee VERSION
 
+# Install pycue as pyoutline depends on it to run tests
 RUN cd pycue && python3 -m pip install .
-RUN cd pycue && python3 -m unittest tests/*.py
+RUN cd pyoutline && python3 tests/test_suite.py
 
 RUN cp LICENSE requirements.txt VERSION pyoutline/
 

--- a/pyoutline/tests/test_suite.py
+++ b/pyoutline/tests/test_suite.py
@@ -1,6 +1,21 @@
+#  Copyright Contributors to the OpenCue Project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 import unittest
 
 def create_test_suite():
+    """Create test suite for this module"""
     loader = unittest.TestLoader()
     start_dir = '.'  # Specify the directory where your test files reside
     suite = loader.discover(start_dir, pattern='*_test.py')

--- a/pyoutline/tests/test_suite.py
+++ b/pyoutline/tests/test_suite.py
@@ -1,0 +1,12 @@
+import unittest
+
+def create_test_suite():
+    loader = unittest.TestLoader()
+    start_dir = '.'  # Specify the directory where your test files reside
+    suite = loader.discover(start_dir, pattern='*_test.py')
+    return suite
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner()
+    test_suite = create_test_suite()
+    runner.run(test_suite)

--- a/pyoutline/tests/test_suite.py
+++ b/pyoutline/tests/test_suite.py
@@ -11,11 +11,11 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+# pylint: disable=missing-function-docstring,missing-module-docstring
 
 import unittest
 
 def create_test_suite():
-    """Create test suite for this module"""
     loader = unittest.TestLoader()
     start_dir = '.'  # Specify the directory where your test files reside
     suite = loader.discover(start_dir, pattern='*_test.py')


### PR DESCRIPTION
Some packages require pycue to run their unit tests and this requirement wasn't being installed on the dockerfile.

A `test_suite.py` file was added with the rules for test discover to make sure all unit tests are executed on projects that are built with python3.9.