### PR TITLE
[cuegui] Fix issue on opening job comments

### DIFF
--- a/cuegui/cuegui/MenuActions.py
+++ b/cuegui/cuegui/MenuActions.py
@@ -581,7 +581,7 @@ class JobActions(AbstractActions):
     def viewComments(self, rpcObjects=None):
         jobs = self._getOnlyJobObjects(rpcObjects)
         if jobs:
-            cuegui.Comments.CommentListDialog(jobs[0], self._caller).show()
+            cuegui.Comments.CommentListDialog(jobs, self._caller).show()
 
     dependWizard_info = ["Dependency &Wizard...", None, "configure"]
 

--- a/cuegui/tests/MenuActions_tests.py
+++ b/cuegui/tests/MenuActions_tests.py
@@ -354,7 +354,7 @@ class JobActionsTests(unittest.TestCase):
 
         self.job_actions.viewComments(rpcObjects=[job])
 
-        commentListMock.assert_called_with(job, self.widgetMock)
+        commentListMock.assert_called_with([job], self.widgetMock)
         commentListMock.return_value.show.assert_called()
 
     @mock.patch('cuegui.DependWizard.DependWizard')


### PR DESCRIPTION
CommentListDialog expects a list of jobs and at some point the input got changed to the first job on the list.

Opening the comments dialog on the current version returns:
```
TypeError: 'Job' object is not iterable 
```
