### PR TITLE
[rqd] Fix issue on rqd when killing a frame that no longer exists

### DIFF
--- a/rqd/rqd/rqdservicers.py
+++ b/rqd/rqd/rqdservicers.py
@@ -68,6 +68,10 @@ class RqdInterfaceServicer(rqd.compiled_proto.rqd_pb2_grpc.RqdInterfaceServicer)
         if frame:
             frame.kill(message=request.message)
         else:
+            context.set_details(
+                "The requested frame to kill was not found. frameId: {}".format(
+                    request.frameId))
+            context.set_code(grpc.StatusCode.NOT_FOUND)
             log.warning("Wasn't able to find frame(%s) to kill", request.frame_id)
         return rqd.compiled_proto.rqd_pb2.RqdStaticKillRunningFrameResponse()
 

--- a/rqd/rqd/rqdservicers.py
+++ b/rqd/rqd/rqdservicers.py
@@ -70,7 +70,7 @@ class RqdInterfaceServicer(rqd.compiled_proto.rqd_pb2_grpc.RqdInterfaceServicer)
         else:
             context.set_details(
                 "The requested frame to kill was not found. frameId: {}".format(
-                    request.frameId))
+                    request.frame_id))
             context.set_code(grpc.StatusCode.NOT_FOUND)
             log.warning("Wasn't able to find frame(%s) to kill", request.frame_id)
         return rqd.compiled_proto.rqd_pb2.RqdStaticKillRunningFrameResponse()


### PR DESCRIPTION
When killing a frame on a rqd node that has restarted and lost track of its running frames, the request should return a status to be handled accordingly and trigger the lostProc logic. The current behavior leaves the frame stuck at RUNNING until the job itself is killed or eaten.
