### PR TITLE
Log integration tests to stdout

### DIFF
--- a/ci/run_integration_test.sh
+++ b/ci/run_integration_test.sh
@@ -243,9 +243,8 @@ main() {
     log INFO "Creating Python virtual environment..."
     create_and_activate_venv
     log INFO "Installing OpenCue Python libraries..."
-    install_log="${TEST_LOGS}/install-client-sources.log"
-    sandbox/install-client-sources.sh &>"${install_log}"
-    log INFO "Testing pycue library..."
+    sandbox/install-client-sources.sh
+    log INFO "Testing pycue library..."£
     test_pycue
     log INFO "Testing cueadmin..."
     test_cueadmin


### PR DESCRIPTION
Logs are being piped into a file that cannot be accessed from the cicd pipeline, which makes it impossible to find issues that are specific to the cicd environment.
