### PR TITLE
[cuegui] Fix TypeError in Comment viewer: Handle job object as iterable

### DIFF
--- a/cuegui/cuegui/MenuActions.py
+++ b/cuegui/cuegui/MenuActions.py
@@ -581,6 +581,8 @@ class JobActions(AbstractActions):
     def viewComments(self, rpcObjects=None):
         jobs = self._getOnlyJobObjects(rpcObjects)
         if jobs:
+            if not isinstance(jobs, list):
+                jobs = [jobs]
             cuegui.Comments.CommentListDialog(jobs, self._caller).show()
 
     dependWizard_info = ["Dependency &Wizard...", None, "configure"]


### PR DESCRIPTION
- Updated `viewComments` method in `MenuActions.py` to wrap single Job objects in a list.
- This prevents `TypeError` when attempting to iterate over a non-iterable Job object.