### PR TITLE
[tests] Change tests to not use setup.py, but use the unittest module directly

### DIFF
--- a/ci/run_gui_test.sh
+++ b/ci/run_gui_test.sh
@@ -21,7 +21,7 @@ fi
 echo "Using Python binary ${py}"
 
 test_log="/tmp/cuegui_result.log"
-PYTHONPATH=pycue xvfb-run -d "${py}" cuegui/setup.py test | tee ${test_log}
+PYTHONPATH=pycue xvfb-run -d "${py}" -m unittest discover -s cuegui/tests -t cuegui -p "*.py"| tee ${test_log}
 
 grep -Pz 'Ran \d+ tests in [0-9\.]+s\n\nOK' ${test_log}
 if [ $? -eq 0 ]; then

--- a/ci/run_python_tests.sh
+++ b/ci/run_python_tests.sh
@@ -22,11 +22,12 @@ python -m grpc_tools.protoc -I=proto/ --python_out=rqd/rqd/compiled_proto --grpc
 2to3 -wn -f import pycue/opencue/compiled_proto/*_pb2*.py
 2to3 -wn -f import rqd/rqd/compiled_proto/*_pb2*.py
 
-python pycue/setup.py test
-PYTHONPATH=pycue python pyoutline/setup.py test
-PYTHONPATH=pycue python cueadmin/setup.py test
-PYTHONPATH=pycue:pyoutline python cuesubmit/setup.py test
-python rqd/setup.py test
+python3 -m unittest discover -s pycue/tests -t pycue -p "*.py"
+PYTHONPATH=pycue python3 -m unittest discover -s pyoutline/tests -t pyoutline -p "*.py"
+PYTHONPATH=pycue python3 -m unittest discover -s cueadmin/tests -t cueadmin -p "*.py"
+PYTHONPATH=pycue:pyoutline python3 -m unittest discover -s cuesubmit/tests -t cuesubmit -p "*.py"
+python3 -m unittest discover -s rqd/tests -t rqd -p "*.py"
+
 
 # Xvfb no longer supports Python 2.
 if [[ "$python_version" =~ "Python 3" && ${args[0]} != "--no-gui" ]]; then


### PR DESCRIPTION
**Summarize your change.**
Have changed most tests to use `-m unittest discover` instead og `setup.py test`

The old `setup.py test` doesn't work in newer versions of python since it has been deprecated

