### PR TITLE
[cuegui] Fix FrameContextMenu and test_rightClickItem to handle NoneType job attribute

### DIFF
--- a/cuegui/cuegui/FrameMonitorTree.py
+++ b/cuegui/cuegui/FrameMonitorTree.py
@@ -915,24 +915,25 @@ class FrameContextMenu(QtWidgets.QMenu):
 
         if cuegui.Constants.OUTPUT_VIEWERS:
             job = widget.getJob()
-            outputPaths = []
-            selectedFrames = widget.selectedObjects()
+            if job is not None:
+                outputPaths = []
+                selectedFrames = widget.selectedObjects()
 
-            layers_dict = {layer.name(): layer for layer in job.getLayers()}
+                layers_dict = {layer.name(): layer for layer in job.getLayers()}
 
-            for frame in selectedFrames:
-                layer_name = frame.layer()
-                layer = layers_dict.get(layer_name)
-                if layer:
-                    outputPaths.extend(cuegui.Utils.getOutputFromFrame(layer, frame))
+                for frame in selectedFrames:
+                    layer_name = frame.layer()
+                    layer = layers_dict.get(layer_name)
+                    if layer:
+                        outputPaths.extend(cuegui.Utils.getOutputFromFrame(layer, frame))
 
-            if outputPaths:
-                for viewer in cuegui.Constants.OUTPUT_VIEWERS:
-                    self.addAction(viewer['action_text'],
-                                   functools.partial(cuegui.Utils.viewFramesOutput,
-                                                     job,
-                                                     selectedFrames,
-                                                     viewer['action_text']))
+                if outputPaths:
+                    for viewer in cuegui.Constants.OUTPUT_VIEWERS:
+                        self.addAction(viewer['action_text'],
+                                       functools.partial(cuegui.Utils.viewFramesOutput,
+                                                         job,
+                                                         selectedFrames,
+                                                         viewer['action_text']))
 
         if self.app.applicationName() == "CueCommander":
             self.__menuActions.frames().addAction(self, "viewHost")

--- a/cuegui/tests/FrameMonitorTree_tests.py
+++ b/cuegui/tests/FrameMonitorTree_tests.py
@@ -131,9 +131,11 @@ class FrameMonitorTreeTests(unittest.TestCase):
         # Ensure the job attribute is set
         self.frameMonitorTree.setJob(self.job)
 
-        self.frameMonitorTree.contextMenuEvent(
-            qtpy.QtGui.QContextMenuEvent(
-                qtpy.QtGui.QContextMenuEvent.Reason.Mouse, mouse_position, mouse_position))
+        # Mock the getLayers method to return an empty list or a list of mock layers
+        with mock.patch.object(self.job, 'getLayers', return_value=[]):
+            self.frameMonitorTree.contextMenuEvent(
+                qtpy.QtGui.QContextMenuEvent(
+                    qtpy.QtGui.QContextMenuEvent.Reason.Mouse, mouse_position, mouse_position))
 
         execMock.assert_called_with(mouse_position)
 


### PR DESCRIPTION
- Ensure the job attribute is set before triggering the context menu event.
- Mock the getLayers method to return an empty list to avoid NoneType errors.