### PR TITLE
[cuegui] Prevent UI freeze during file preview by implementing subprocess.Popen for non-forking viewer applications

### DIFF
--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -666,7 +666,7 @@ def launchViewerUsingPaths(paths, actionText, test_mode=False):
     if not test_mode:
         print(msg)
         try:
-            subprocess.check_call(cmd.split())
+            subprocess.Popen(cmd.split())
         except subprocess.CalledProcessError as e:
             showErrorMessageBox(str(e), title='Error running Viewer command')
         except Exception as e:

--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -666,6 +666,7 @@ def launchViewerUsingPaths(paths, actionText, test_mode=False):
     if not test_mode:
         print(msg)
         try:
+            # pylint: disable=consider-using-with
             subprocess.Popen(cmd.split())
         except subprocess.CalledProcessError as e:
             showErrorMessageBox(str(e), title='Error running Viewer command')


### PR DESCRIPTION
This is a small fix to not lock the UI when using preview in cuegui when using software that does not detach itself from the console.
It changes it from using `subprocess.check_call` to `subprocess.Popen`

Fixes #1568 