### PR TITLE
[rqd] Allow customizing HOME and MAIL environments

### DIFF
--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -72,6 +72,9 @@ RQD_USE_PATH_ENV_VAR = False
 # Copy specific environment variable from the RQD host to the frame env.
 RQD_HOST_ENV_VARS = []
 
+RQD_CUSTOM_HOME_PREFIX = None
+RQD_CUSTOM_MAIL_PREFIX = None
+
 RQD_BECOME_JOB_USER = True
 RQD_CREATE_USER_IF_NOT_EXISTS = True
 SENTRY_DSN_PATH = None
@@ -226,6 +229,10 @@ try:
             SENTRY_DSN_PATH = config.getint(__override_section, "SENTRY_DSN_PATH")
         if config.has_option(__override_section, "SP_OS"):
             SP_OS = config.get(__override_section, "SP_OS")
+        if config.has_option(__override_section, "RQD_CUSTOM_HOME_PREFIX"):
+            RQD_CUSTOM_HOME_PREFIX = config.get(__override_section, "RQD_CUSTOM_HOME_PREFIX")
+        if config.has_option(__override_section, "RQD_CUSTOM_MAIL_PREFIX"):
+            RQD_CUSTOM_MAIL_PREFIX = config.get(__override_section, "RQD_CUSTOM_MAIL_PREFIX")
 
         if config.has_section(__host_env_var_section):
             RQD_HOST_ENV_VARS = config.options(__host_env_var_section)

--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -98,6 +98,16 @@ class FrameAttendantThread(threading.Thread):
         self.frameEnv["CUE_GPU_MEMORY"] = str(self.rqCore.machine.getGpuMemoryFree())
         self.frameEnv["SP_NOMYCSHRC"] = "1"
 
+        if rqd.rqconstants.RQD_CUSTOM_HOME_PREFIX:
+            self.frameEnv["HOME"] = "%s/%s" % (
+                rqd.rqconstants.RQD_CUSTOM_HOME_PREFIX,
+                self.runFrame.user_name)
+
+        if rqd.rqconstants.RQD_CUSTOM_MAIL_PREFIX:
+            self.frameEnv["MAIL"] = "%s/%s" % (
+                rqd.rqconstants.RQD_CUSTOM_MAIL_PREFIX,
+                self.runFrame.user_name)
+
         if platform.system() == "Windows":
             for variable in ["SYSTEMROOT", "APPDATA", "TMP", "COMMONPROGRAMFILES", "SYSTEMDRIVE"]:
                 if variable in os.environ:


### PR DESCRIPTION
SPI's environment requires customized home and email directories that need to be set on the frame environment variable. This change allows it to be set on rqd.conf as `RQD_CUSTOM_HOME_PREFIX` and `RQD_CUSTOM_MAIL_PREFIX`
