### PR TITLE
[cueweb] Prevent page reload on data updates in jobs, layers, and frames tables

### DIFF
--- a/cueweb/app/jobs/data-table.tsx
+++ b/cueweb/app/jobs/data-table.tsx
@@ -628,6 +628,7 @@ export function DataTable({ columns, data, session }: DataTableProps) {
     onColumnVisibilityChange: setColumnVisibility(dispatch, state.columnVisibility),
     onRowSelectionChange: setRowSelection(dispatch, state.rowSelection),
     getRowId: (job: Job) => job.id,
+    autoResetPageIndex: false,
 
     state: {
       sorting: state.sorting,

--- a/cueweb/components/ui/simple-data-table.tsx
+++ b/cueweb/components/ui/simple-data-table.tsx
@@ -61,6 +61,7 @@ export function SimpleDataTable<TData, TValue>({
     getSortedRowModel: getSortedRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     state: { sorting },
+    autoResetPageIndex: false,
   });
 
   const leftAlignedColumns = React.useMemo(() => ["dispatchOrder", "name", "services", "lastResource"], []);


### PR DESCRIPTION
- Fixed an issue where data updates caused the page index to reset in the jobs, layers, and frames tables.
- Added type check in Jobs worker to verify received data format.

Co-authored-by: Zachary Fong <zfong@imageworks.com>
Co-authored-by: Ramon Figueiredo <rfigueiredo@imageworks.com>