### PR TITLE
Draft: [rqd/pyoutline/pycue] Fix Dockerfile build failures

### DIFF
--- a/rqd/Dockerfile
+++ b/rqd/Dockerfile
@@ -35,7 +35,7 @@ RUN python3.9 -m grpc_tools.protoc \
 
 # Fix imports to work in both Python 2 and 3. See
 # <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
-RUN python ci/fix_compiled_proto.py rqd/rqd/compiled_proto
+RUN python3.9 ci/fix_compiled_proto.py rqd/rqd/compiled_proto
 
 COPY VERSION.in VERSIO[N] ./
 RUN test -e VERSION || echo "$(cat VERSION.in)" | tee VERSION

--- a/rqd/Dockerfile
+++ b/rqd/Dockerfile
@@ -26,6 +26,7 @@ COPY rqd/README.md ./rqd/
 COPY rqd/setup.py ./rqd/
 COPY rqd/tests/ ./rqd/tests
 COPY rqd/rqd/ ./rqd/rqd
+COPY ci/fix_compiled_proto.py ./ci/
 
 RUN python3.9 -m grpc_tools.protoc \
   -I=./proto \


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
https://github.com/AcademySoftwareFoundation/OpenCue/issues/1582

**Summarize your change.**
Fix missing file error by running a `COPY` command to import file into the images during build.

