### PR TITLE
[docker] Fix building docker images without 2to3

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 ci
+!ci/fix_compiled_proto.py
 cuebot/src/compiled_protobuf
 images
 samples

--- a/cueadmin/Dockerfile
+++ b/cueadmin/Dockerfile
@@ -24,6 +24,7 @@ RUN python3 -m grpc_tools.protoc \
 
 # Fix imports to work in both Python 2 and 3. See
 # <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
+COPY ci/fix_compiled_proto.py ./ci/
 RUN python3 ci/fix_compiled_proto.py pycue/opencue/compiled_proto
 
 COPY cueadmin/README.md ./cueadmin/

--- a/pycue/Dockerfile
+++ b/pycue/Dockerfile
@@ -25,7 +25,8 @@ RUN python3 -m grpc_tools.protoc \
 
 # Fix imports to work in both Python 2 and 3. See
 # <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
-RUN python ci/fix_compiled_proto.py pycue/opencue/compiled_proto
+COPY ci/fix_compiled_proto.py ./ci/
+RUN python3 ci/fix_compiled_proto.py pycue/opencue/compiled_proto
 
 COPY VERSION.in VERSIO[N] ./
 RUN test -e VERSION || echo "$(cat VERSION.in)" | tee VERSION

--- a/pyoutline/Dockerfile
+++ b/pyoutline/Dockerfile
@@ -24,7 +24,8 @@ RUN python3 -m grpc_tools.protoc \
 
 # Fix imports to work in both Python 2 and 3. See
 # <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
-RUN python ci/fix_compiled_proto.py pycue/opencue/compiled_proto
+COPY ci/fix_compiled_proto.py ./ci/
+RUN python3 ci/fix_compiled_proto.py pycue/opencue/compiled_proto
 
 COPY pyoutline/README.md ./pyoutline/
 COPY pyoutline/setup.py ./pyoutline/

--- a/rqd/Dockerfile
+++ b/rqd/Dockerfile
@@ -35,7 +35,8 @@ RUN python3.9 -m grpc_tools.protoc \
 
 # Fix imports to work in both Python 2 and 3. See
 # <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
-RUN python ci/fix_compiled_proto.py rqd/rqd/compiled_proto
+COPY ci/fix_compiled_proto.py ./ci/
+RUN python3.9 ci/fix_compiled_proto.py rqd/rqd/compiled_proto
 
 COPY VERSION.in VERSIO[N] ./
 RUN test -e VERSION || echo "$(cat VERSION.in)" | tee VERSION


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Fixes #1582 

**Summarize your change.**
This copies in the `ci/fix_compiled_proto.py` script into the images which is needed to build them