### PR TITLE
Remove enum34 dependency from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-enum34==1.1.6
 future==1.0.0
 grpcio==1.48.2;python_version<"3.7"
 grpcio-tools==1.48.2;python_version<"3.7"


### PR DESCRIPTION
- The `enum34` (https://pypi.org/project/enum34/) package backports the enum module for Python versions 2.4–3.3. Since our project uses Python 3.7+, where `enum` is part of the standard library, this dependency is no longer required.
- This change cleans up the `requirements.txt` file by removing `enum34==1.1.6`