### PR TITLE
[cicd] Fix cuegui and cuesubmit dockerfiles

### DIFF
--- a/cuegui/Dockerfile
+++ b/cuegui/Dockerfile
@@ -8,26 +8,26 @@ RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/CentOS-*.repo
 RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/CentOS-*.repo
 
 RUN yum -y install \
-  epel-release \
-  fontconfig \
-  freetype \
-  gcc \
-  libXi \
-  libXrender \
-  libxkbcommon-x11.x86_64 \
-  mesa-libGL \
-  python-devel \
-  which \
-  Xvfb \
-  xcb-util-image.x86_64 \
-  xcb-util-keysyms.x86_64 \
-  xcb-util-renderutil.x86_64 \
-  xcb-util-wm.x86_64
+    epel-release \
+    fontconfig \
+    freetype \
+    gcc \
+    libXi \
+    libXrender \
+    libxkbcommon-x11.x86_64 \
+    mesa-libGL \
+    python-devel \
+    which \
+    Xvfb \
+    xcb-util-image.x86_64 \
+    xcb-util-keysyms.x86_64 \
+    xcb-util-renderutil.x86_64 \
+    xcb-util-wm.x86_64
 
 RUN yum -y install \
-  python36 \
-  python36-devel \
-  python36-pip
+    python36 \
+    python36-devel \
+    python36-pip
 
 RUN python3.6 -m pip install --upgrade pip
 RUN python3.6 -m pip install --upgrade setuptools
@@ -45,16 +45,17 @@ COPY pycue/README.md ./pycue/
 COPY pycue/setup.py ./pycue/
 COPY pycue/FileSequence ./pycue/FileSequence
 COPY pycue/opencue ./pycue/opencue
+COPY ci/fix_compiled_proto.py .
 
 RUN python3.6 -m grpc_tools.protoc \
-  -I=./proto \
-  --python_out=./pycue/opencue/compiled_proto \
-  --grpc_python_out=./pycue/opencue/compiled_proto \
-  ./proto/*.proto
+    -I=./proto \
+    --python_out=./pycue/opencue/compiled_proto \
+    --grpc_python_out=./pycue/opencue/compiled_proto \
+    ./proto/*.proto
 
 # Fix imports to work in both Python 2 and 3. See
 # <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
-RUN python3 ci/fix_compiled_proto.py pycue/opencue/compiled_proto
+RUN python3 ./fix_compiled_proto.py pycue/opencue/compiled_proto
 
 COPY cuegui/README.md ./cuegui/
 COPY cuegui/setup.py ./cuegui/
@@ -71,7 +72,7 @@ RUN cd cuegui && xvfb-run -d python3.6 setup.py test
 RUN cp LICENSE requirements.txt requirements_gui.txt VERSION cuegui/
 
 RUN versioned_name="cuegui-$(cat ./VERSION)-all" \
-  && mv cuegui "${versioned_name}" \
-  && tar -cvzf "${versioned_name}.tar.gz" ${versioned_name}/* \
-  && mkdir -p /opt/opencue \
-  && cp "${versioned_name}.tar.gz" /opt/opencue/
+    && mv cuegui "${versioned_name}" \
+    && tar -cvzf "${versioned_name}.tar.gz" ${versioned_name}/* \
+    && mkdir -p /opt/opencue \
+    && cp "${versioned_name}.tar.gz" /opt/opencue/

--- a/cuesubmit/Dockerfile
+++ b/cuesubmit/Dockerfile
@@ -8,15 +8,15 @@ RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/CentOS-*.repo
 RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/CentOS-*.repo
 
 RUN yum -y install \
-  epel-release \
-  gcc \
-  mesa-libGL \
-  python-devel
+    epel-release \
+    gcc \
+    mesa-libGL \
+    python-devel
 
 RUN yum -y install \
-  python36 \
-  python36-devel \
-  python36-pip
+    python36 \
+    python36-devel \
+    python36-pip
 
 RUN python3.6 -m pip install --upgrade pip
 RUN python3.6 -m pip install --upgrade setuptools
@@ -32,16 +32,17 @@ COPY pycue/README.md ./pycue/
 COPY pycue/setup.py ./pycue/
 COPY pycue/opencue ./pycue/opencue
 COPY pycue/FileSequence ./pycue/FileSequence
+COPY ci/fix_compiled_proto.py .
 
 RUN python3.6 -m grpc_tools.protoc \
-  -I=./proto \
-  --python_out=./pycue/opencue/compiled_proto \
-  --grpc_python_out=./pycue/opencue/compiled_proto \
-  ./proto/*.proto
+    -I=./proto \
+    --python_out=./pycue/opencue/compiled_proto \
+    --grpc_python_out=./pycue/opencue/compiled_proto \
+    ./proto/*.proto
 
 # Fix imports to work in both Python 2 and 3. See
 # <https://github.com/protocolbuffers/protobuf/issues/1491> for more info.
-RUN python3 ci/fix_compiled_proto.py pycue/opencue/compiled_proto
+RUN python3 ./fix_compiled_proto.py pycue/opencue/compiled_proto
 
 COPY pyoutline/README.md ./pyoutline/
 COPY pyoutline/setup.py ./pyoutline/
@@ -65,7 +66,7 @@ RUN cd cuesubmit && python3.6 setup.py test
 RUN cp LICENSE requirements.txt requirements_gui.txt VERSION cuesubmit/
 
 RUN versioned_name="cuesubmit-$(cat ./VERSION)-all" \
-  && mv cuesubmit "${versioned_name}" \
-  && tar -cvzf "${versioned_name}.tar.gz" ${versioned_name}/* \
-  && mkdir -p /opt/opencue \
-  && cp "${versioned_name}.tar.gz" /opt/opencue/
+    && mv cuesubmit "${versioned_name}" \
+    && tar -cvzf "${versioned_name}.tar.gz" ${versioned_name}/* \
+    && mkdir -p /opt/opencue \
+    && cp "${versioned_name}.tar.gz" /opt/opencue/

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,10 +14,12 @@ pylint==2.15.10;python_version>="3.7"
 pynput==1.7.6
 PyYAML==5.1
 six==1.16.0
-pytest==8.3.3
+pytest==7.0.1;python_version<"3.7"
+pytest==8.3.3;python_version>="3.7"
 
 # Optional requirements
 # Sentry support for rqd
 sentry-sdk==2.11.0
-
-docker==7.1.0
+# Docker support for rqd
+docker==5.0.3;python_version<"3.7"
+docker==7.1.0;python_version>="3.7"


### PR DESCRIPTION
Changes on requirements.txt were not compatible with the centos7 image being used on cuegui and cuesubmit release pipelines. The long term goal is to upgrade those images and drop centos7 compatibility.