### PR TITLE
[cicd] Limit dependency for pip package NodeGraphQtPy

### DIFF
--- a/requirements_gui.txt
+++ b/requirements_gui.txt
@@ -3,4 +3,4 @@ PySide6==6.5.3;python_version=="3.11"
 PySide2==5.15.2.1;python_version<="3.10"
 QtPy==1.11.3;python_version<"3.7"
 QtPy==2.4.1;python_version>="3.7"
-NodeGraphQtPy==0.6.38.6
+NodeGraphQtPy==0.6.38.6;python_version>="3.7"


### PR DESCRIPTION
For now, cuesubmit's release pipeline is still based on centos7 and python36. I'm limiting the NodeGraphQtPy dependency to python3.7 to avoid crashing the pipeline. Cuesubmit doesn't really depend on this package.