### PR TITLE
[cicd] Remove dockerhub comments

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -75,13 +75,15 @@ jobs:
           context: .
           push: true
 
-      - name: Docker Hub Description
-        uses: peter-evans/dockerhub-description@v4
-        with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASS }}
-          repository: AcademySoftwareFoundation/OpenCue
-          readme-filepath: ./${{ matrix.component }}/README.md
+      # This step has been failing with permission issues.
+      # Commenting this out temporarily to unblock the release of v1.4
+      # - name: Docker Hub Description
+      #   uses: peter-evans/dockerhub-description@v4
+      #   with:
+      #     username: ${{ secrets.DOCKER_USER }}
+      #     password: ${{ secrets.DOCKER_PASS }}
+      #     repository: opencue/${{ matrix.component }}
+      #     readme-filepath: ./${{ matrix.component }}/README.md
 
   create_release:
     needs: preflight

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -4,7 +4,7 @@ name: OpenCue Release Pipeline
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   preflight:
@@ -80,7 +80,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
-          repository: opencue/${{ matrix.component }}
+          repository: AcademySoftwareFoundation/OpenCue
           readme-filepath: ./${{ matrix.component }}/README.md
 
   create_release:


### PR DESCRIPTION
This step has been failing with permission issues.
Commenting this out temporarily to unblock the release of v1.4