### PR TITLE
[cuesubmit] Replace PySide2 with qtpy in CueSubmit files

### DIFF
--- a/cuesubmit/README.md
+++ b/cuesubmit/README.md
@@ -4,5 +4,5 @@ The OpenCue job submission GUI.
 
 This is a Python-based QT app through which you can submit jobs to an OpenCue
 deployment. It can run as a standalone application, or as a plugin in
-applications that support PySide2 integration, such as Autodesk's Maya or
+applications that support PySide/qtpy integration, such as Autodesk's Maya or
 the Foundry's Nuke.

--- a/cuesubmit/plugins/maya/CueMayaSubmit.py
+++ b/cuesubmit/plugins/maya/CueMayaSubmit.py
@@ -19,7 +19,7 @@ import sys
 
 import maya.cmds as cmds
 import maya.utils
-from PySide2 import QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets
 
 # Path where all of the Cue Python libraries and their dependencies are installed.
 # The recommended workflow is for this to be a virtual environment, like:

--- a/cuesubmit/plugins/nuke/CueNukeSubmit.py
+++ b/cuesubmit/plugins/nuke/CueNukeSubmit.py
@@ -15,7 +15,7 @@
 import argparse
 import logging
 
-from PySide2 import QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets
 
 from cuesubmit import Constants
 from cuesubmit import JobTypes

--- a/cuesubmit/setup.py
+++ b/cuesubmit/setup.py
@@ -61,7 +61,7 @@ setup(
         'future',
         'grpcio',
         'grpcio-tools',
-        'PySide2',
+        'qtpy',
         'PyYAML',
     ]
 )


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
https://github.com/AcademySoftwareFoundation/OpenCue/issues/1633

**Summarize your change.**
- Import statements updated to use `qtpy` instead of `PySide2`
- Documentation in `README.md` updated to reflect the change
- `setup.py` modified to include `qtpy` in the `install_requires` list instead of `PySide2`

This change aims to provide a more flexible abstraction layer for different Qt bindings, improving compatibility and maintainability.
