### PR TITLE
Update version file paths to use VERSION.in

### DIFF
--- a/cueadmin/setup.py
+++ b/cueadmin/setup.py
@@ -20,8 +20,8 @@ cueadmin_dir = os.path.abspath(os.path.dirname(__file__))
 
 version = 'unknown'
 possible_version_paths = [
-    os.path.join(cueadmin_dir, 'VERSION'),
-    os.path.join(os.path.dirname(cueadmin_dir), 'VERSION'),
+    os.path.join(cueadmin_dir, 'VERSION.in'),
+    os.path.join(os.path.dirname(cueadmin_dir), 'VERSION.in'),
 ]
 for possible_version_path in possible_version_paths:
     if os.path.exists(possible_version_path):

--- a/cuegui/setup.py
+++ b/cuegui/setup.py
@@ -20,8 +20,8 @@ cuegui_dir = os.path.abspath(os.path.dirname(__file__))
 
 version = 'unknown'
 possible_version_paths = [
-    os.path.join(cuegui_dir, 'VERSION'),
-    os.path.join(os.path.dirname(cuegui_dir), 'VERSION'),
+    os.path.join(cuegui_dir, 'VERSION.in'),
+    os.path.join(os.path.dirname(cuegui_dir), 'VERSION.in'),
 ]
 for possible_version_path in possible_version_paths:
     if os.path.exists(possible_version_path):

--- a/cuesubmit/setup.py
+++ b/cuesubmit/setup.py
@@ -20,8 +20,8 @@ cuesubmit_dir = os.path.abspath(os.path.dirname(__file__))
 
 version = 'unknown'
 possible_version_paths = [
-    os.path.join(cuesubmit_dir, 'VERSION'),
-    os.path.join(os.path.dirname(cuesubmit_dir), 'VERSION'),
+    os.path.join(cuesubmit_dir, 'VERSION.in'),
+    os.path.join(os.path.dirname(cuesubmit_dir), 'VERSION.in'),
 ]
 for possible_version_path in possible_version_paths:
     if os.path.exists(possible_version_path):

--- a/pycue/setup.py
+++ b/pycue/setup.py
@@ -20,8 +20,8 @@ pycue_dir = os.path.abspath(os.path.dirname(__file__))
 
 version = 'unknown'
 possible_version_paths = [
-    os.path.join(pycue_dir, 'VERSION'),
-    os.path.join(os.path.dirname(pycue_dir), 'VERSION'),
+    os.path.join(pycue_dir, 'VERSION.in'),
+    os.path.join(os.path.dirname(pycue_dir), 'VERSION.in'),
 ]
 for possible_version_path in possible_version_paths:
     if os.path.exists(possible_version_path):

--- a/pyoutline/setup.py
+++ b/pyoutline/setup.py
@@ -20,8 +20,8 @@ pyoutline_dir = os.path.abspath(os.path.dirname(__file__))
 
 version = 'unknown'
 possible_version_paths = [
-    os.path.join(pyoutline_dir, 'VERSION'),
-    os.path.join(os.path.dirname(pyoutline_dir), 'VERSION'),
+    os.path.join(pyoutline_dir, 'VERSION.in'),
+    os.path.join(os.path.dirname(pyoutline_dir), 'VERSION.in'),
 ]
 for possible_version_path in possible_version_paths:
     if os.path.exists(possible_version_path):

--- a/rqd/setup.py
+++ b/rqd/setup.py
@@ -20,8 +20,8 @@ rqd_dir = os.path.abspath(os.path.dirname(__file__))
 
 version = 'unknown'
 possible_version_paths = [
-    os.path.join(rqd_dir, 'VERSION'),
-    os.path.join(os.path.dirname(rqd_dir), 'VERSION'),
+    os.path.join(rqd_dir, 'VERSION.in'),
+    os.path.join(os.path.dirname(rqd_dir), 'VERSION.in'),
 ]
 for possible_version_path in possible_version_paths:
     if os.path.exists(possible_version_path):


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
https://github.com/AcademySoftwareFoundation/OpenCue/issues/1637

**Summarize your change.**
- Updated version file paths in setup scripts to use VERSION.in (correct file name in the Opencue project) instead of VERSION
- Fixes the error when running `sandbox/install-client-sources.sh`
- `sandbox/install-client-sources.sh` calls `pip install pycue/ pyoutline/ cueadmin/ cuesubmit/ cuegui/` and the `setup.py` in these directories should use `VERSION.in` not `VERSION`