### PR TITLE
[cuegui] Add Max Threads and Memory Optimizer to Attributes Plugin

### DIFF
--- a/cuegui/cuegui/plugins/AttributesPlugin.py
+++ b/cuegui/cuegui/plugins/AttributesPlugin.py
@@ -252,6 +252,8 @@ class LayerAttributes(AbstractAttributes):
                 "tags": layer.data.tags,
                 "threadable": str(layer.data.is_threadable),
                 "minCores": "%0.2f" % layer.data.min_cores,
+                "maxCores": "%0.2f" % layer.data.max_cores,
+                "memory optimizer enabled": str(layer.data.memory_optimizer_enabled),
                 "minMemory": "%0.2fMB" % (layer.data.min_memory / 1024.0),
                 "outputs": {},
                 "frames": {
@@ -281,8 +283,8 @@ class LayerAttributes(AbstractAttributes):
                           "maxRss": int(layer.data.layer_stats.max_rss)
                 },
                 "__childOrder":["id","layer","services","type","command","range","tags",
-                                "threadable","minCores","minMemory","outputs",
-                                "depends", "frames","resources"],
+                                "threadable","minCores","maxCores","memory optimizer enabled",
+                                "minMemory","outputs", "depends", "frames","resources"],
                 "depends": getDependsForm(preload["depends"]),
                 }
 


### PR DESCRIPTION
- Added Max Threads and Memory Optimizer attributes to the Attributes plugin
- Enhances usability by providing key layer info when the Properties popup is unavailable