### PR TITLE
Update grpcio and grpcio-tools dependencies to version 1.69.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 future==1.0.0
 grpcio==1.48.2;python_version<"3.7"
 grpcio-tools==1.48.2;python_version<"3.7"
-grpcio==1.53.2;python_version>="3.7"
-grpcio-tools==1.53.0;python_version>="3.7"
+grpcio==1.69.0;python_version>="3.7"
+grpcio-tools==1.69.0;python_version>="3.7"
 mock==2.0.0
 packaging==20.9;python_version<"3.7"
 packaging==24.1;python_version>="3.7"


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
https://github.com/AcademySoftwareFoundation/OpenCue/issues/1635

**Summarize your change.**
- Updated `grpcio` from 1.53.2 to 1.69.0 for Python versions >= 3.7
- Updated `grpcio-tools` from 1.53.0 to 1.69.0 for Python versions >= 3.7
- Fixes the error encountered when running: `pip install -r requirements.txt -r requirements_gui.txt`
- This update reflects the tests conducted on a MacBook Pro with Apple M2 Max