### PR TITLE
[rqd] Refactor runOnDocker and add gpu_mode 

### DIFF
--- a/ci/run_python_tests.sh
+++ b/ci/run_python_tests.sh
@@ -13,6 +13,9 @@ echo "Will run tests using ${python_version}"
 
 pip install --user -r requirements.txt -r requirements_gui.txt
 
+# Some rqd unit tests require docker api
+pip install docker==7.1.0
+
 # Protos need to have their Python code generated in order for tests to pass.
 python -m grpc_tools.protoc -I=proto/ --python_out=pycue/opencue/compiled_proto --grpc_python_out=pycue/opencue/compiled_proto proto/*.proto
 python -m grpc_tools.protoc -I=proto/ --python_out=rqd/rqd/compiled_proto --grpc_python_out=rqd/rqd/compiled_proto proto/*.proto

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pytest==8.3.3;python_version>="3.7"
 
 # Optional requirements
 # Sentry support for rqd
-sentry-sdk==2.11.0
+# sentry-sdk==2.11.0
 # Docker support for rqd
-docker==5.0.3;python_version<"3.7"
-docker==7.1.0;python_version>="3.7"
+# docker==5.0.3;python_version<"3.7"
+# docker==7.1.0;python_version>="3.7"

--- a/rqd/rqd.example.conf
+++ b/rqd/rqd.example.conf
@@ -32,6 +32,7 @@ PIXAR_LICENSE_FILE
 # Setting this to True requires all the additional "docker.[]" sections to be filled
 RUN_ON_DOCKER=False
 DOCKER_SHELL_PATH=/usr/bin/sh
+DOCKER_GPU_MODE=False
 
 # This section is only required if RUN_ON_DOCKER=True
 # List of volume mounts following docker run's format, but replacing = with :

--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -260,7 +260,7 @@ try:
                 from rqd.rqdocker import RqDocker
 
                 # Set config attribute for docker_gpu_mode. Configuration is made available
-                # from both the config file or an environment variable, the later takes precedency
+                # from both the config file and an environment variable, the latter takes precedence
                 if __docker_gpu_mode in os.environ:
                     config[__docker_config][__docker_gpu_mode] = os.environ[__docker_gpu_mode]
 

--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -157,10 +157,8 @@ else:
 SP_OS = platform.system()
 
 # Docker mode config
-RUN_ON_DOCKER = False
-DOCKER_IMAGES = {}
-DOCKER_MOUNTS = []
-DOCKER_SHELL_PATH = "/bin/sh"
+DOCKER_AGENT = None
+DOCKER_GPU_MODE = False
 
 # Backup running frames cache. Backup cache is turned off if this path is set to
 # None or ""
@@ -254,82 +252,23 @@ try:
             BACKUP_CACHE_TIME_TO_LIVE_SECONDS = config.getint(
                 __override_section, "BACKUP_CACHE_TIME_TO_LIVE_SECONDS")
 
-        __docker_mounts = "docker.mounts"
         __docker_config = "docker.config"
-        __docker_images = "docker.images"
+        __docker_gpu_mode = "DOCKER_GPU_MODE"
 
         if config.has_section(__docker_config):
-            RUN_ON_DOCKER = config.getboolean(__docker_config, "RUN_ON_DOCKER")
-            if RUN_ON_DOCKER:
-                import docker
-                import docker.models
-                import docker.types
+            if config.getboolean(__docker_config, "RUN_ON_DOCKER"):
+                from rqdocker import RqDocker
 
+                # Set config attribute for docker_gpu_mode. Configuration is made available
+                # from both the config file or an environment variable, the later takes precedency
+                if __docker_gpu_mode in os.environ:
+                    config[__docker_config][__docker_gpu_mode] = os.environ[__docker_gpu_mode]
+
+                DOCKER_AGENT = RqDocker.fromConfig(config)
                 # rqd needs to run as root to be able to run docker
                 RQD_UID = 0
                 RQD_GID = 0
 
-                # Path to the shell to be used in the frame environment
-                if config.has_option(__docker_config, "DOCKER_SHELL_PATH"):
-                    DOCKER_SHELL_PATH = config.get(
-                        __docker_config,
-                        "DOCKER_SHELL_PATH")
-
-                # Every key:value on the config file under docker.images
-                # is parsed as key=SP_OS and value=image_tag.
-                # SP_OS is set to a list of all available keys
-                # For example:
-                #
-                #   rqd.conf
-                #     [docker.images]
-                #     centos7=centos7.3:latest
-                #     rocky9=rocky9.3:latest
-                #
-                #   becomes:
-                #     SP_OS=centos7,rocky9
-                #     DOCKER_IMAGES={
-                #       "centos7": "centos7.3:latest",
-                #       "rocky9": "rocky9.3:latest"
-                #     }
-                keys = config.options(__docker_images)
-                DOCKER_IMAGES = {}
-                for key in keys:
-                    DOCKER_IMAGES[key] = config.get(__docker_images, key)
-                SP_OS = ",".join(keys)
-                if not DOCKER_IMAGES:
-                    raise RuntimeError("Misconfigured rqd. RUN_ON_DOCKER=True requires at "
-                                       "least one image on DOCKER_IMAGES ([docker.images] "
-                                       "section of rqd.conf)")
-                def parse_mount(mount_string):
-                    """
-                    Parse mount definitions similar to a docker run command into a docker
-                    mount obj
-
-                    Format: type=bind,source=/tmp,target=/tmp,bind-propagation=slave
-                    """
-                    parsed_mounts = {}
-                    # bind-propagation defaults to None as only type=bind accepts it
-                    parsed_mounts["bind-propagation"] = None
-                    for item in mount_string.split(","):
-                        name, mount_path = item.split(":")
-                        parsed_mounts[name.strip()] = mount_path.strip()
-                    return parsed_mounts
-
-                # Parse values under the category docker.mounts into Mount objects
-                mounts = config.options(__docker_mounts)
-                for mount_name in mounts:
-                    mount_str = ""
-                    try:
-                        mount_str = config.get(__docker_mounts, mount_name)
-                        mount_dict = parse_mount(mount_str)
-                        mount = docker.types.Mount(mount_dict["target"],
-                                                  mount_dict["source"],
-                                                  type=mount_dict["type"],
-                                                  propagation=mount_dict["bind-propagation"])
-                        DOCKER_MOUNTS.append(mount)
-                    except KeyError as e:
-                        logging.exception("Failed to create Mount for key=%s, value=%s",
-                                          mount_name, mount_str)
 
 # pylint: disable=broad-except
 except Exception as e:

--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -257,7 +257,7 @@ try:
 
         if config.has_section(__docker_config):
             if config.getboolean(__docker_config, "RUN_ON_DOCKER"):
-                from rqdocker import RqDocker
+                from rqd.rqdocker import RqDocker
 
                 # Set config attribute for docker_gpu_mode. Configuration is made available
                 # from both the config file or an environment variable, the later takes precedency

--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -37,12 +37,11 @@ import traceback
 import select
 import uuid
 
-from docker.errors import APIError, ImageNotFound
-
 import rqd.compiled_proto.host_pb2
 import rqd.compiled_proto.report_pb2
 import rqd.compiled_proto.rqd_pb2
 import rqd.rqconstants
+from rqd.rqconstants import DOCKER_AGENT
 import rqd.rqexceptions
 import rqd.rqmachine
 import rqd.rqnetwork
@@ -92,17 +91,11 @@ class RqCore(object):
         self.__session = None
         self.__stmt = None
 
-        self.docker = None
-        self.docker_mounts = []
-        self.docker_images = {}
-        self.docker_lock = threading.Lock()
-        if rqd.rqconstants.RUN_ON_DOCKER:
-            # pylint: disable=import-outside-toplevel
-            import docker
-            self.docker = docker
-            self.docker_images = rqd.rqconstants.DOCKER_IMAGES
-            self.docker_mounts = rqd.rqconstants.DOCKER_MOUNTS
-            self.handleFrameImages()
+        self.docker_agent = None
+
+        if DOCKER_AGENT:
+            self.docker_agent = DOCKER_AGENT
+            self.docker_agent.refreshFrameImages()
 
         self.backup_cache_path = None
         if rqd.rqconstants.BACKUP_CACHE_PATH:
@@ -699,22 +692,6 @@ class RqCore(object):
                                   runningFrame.runFrame.job_name,
                                   runningFrame.runFrame.frame_name)
 
-    def handleFrameImages(self):
-        """
-        Download docker images to be used by frames running on this host
-        """
-        if self.docker:
-            docker_client = self.docker.from_env()
-            for image in self.docker_images.values():
-                log.info("Downloading frame image: %s", image)
-                try:
-                    name, tag = image.split(":")
-                    docker_client.images.pull(name, tag)
-                except (ImageNotFound, APIError) as e:
-                    raise RuntimeError("Failed to download frame docker image for %s:%s - %s" %
-                                       (name, tag, e))
-            log.info("Finished downloading frame images")
-
 
 class FrameAttendantThread(threading.Thread):
     """Once a frame has been received and checked by RQD, this class handles
@@ -733,6 +710,7 @@ class FrameAttendantThread(threading.Thread):
         """
         threading.Thread.__init__(self)
         self.rqCore = rqCore
+        self.docker_agent = rqCore.docker_agent
         self.frameId = runFrame.frame_id
         self.runFrame = runFrame
         self.startTime = 0
@@ -1041,21 +1019,18 @@ class FrameAttendantThread(threading.Thread):
 
     def runDocker(self):
         """The steps required to handle a frame under a docker container"""
+        # pylint: disable=import-outside-toplevel
+        from docker.errors import APIError
+        from rqd.rqd.rqdocker import InvalidFrameOsError
+
         frameInfo = self.frameInfo
         runFrame = self.runFrame
 
         # Ensure Nullable attributes have been initialized
         if not self.rqlog:
             raise RuntimeError("Invalid state. rqlog has not been initialized")
-        if not self.rqCore.docker:
-            raise RuntimeError("Invalid state: docker_client must have been initialized.")
-
-        try:
-            image = self.__getFrameImage(runFrame.os)
-        except RuntimeError as e:
-            self.__writeHeader()
-            self.rqlog.write(str(e), prependTimestamp=rqd.rqconstants.RQD_PREPEND_TIMESTAMP)
-            raise e
+        if not self.docker_agent:
+            raise RuntimeError("Invalid state: docker_agent must have been initialized.")
 
         self.__createEnvVariables()
         self.__writeHeader()
@@ -1108,6 +1083,9 @@ exec su -s %s %s -c "echo \$$; /bin/nice /usr/bin/time -p -o %s %s %s"
             command.replace(tempPassword, "[password]").replace(";", "\n"),
             prependTimestamp=rqd.rqconstants.RQD_PREPEND_TIMESTAMP)
 
+        if self.docker_agent.gpu_mode:
+            self.rqlog.write("GPU_MODE activated")
+
         # Handle memory limits. Cuebot users KB docker uses Bytes.
         # Docker min requirement is 6MB, if request is bellow limit, give the frame a reasonable
         # amount of memory.
@@ -1124,26 +1102,20 @@ exec su -s %s %s -c "echo \$$; /bin/nice /usr/bin/time -p -o %s %s %s"
 
         # Write command to a file on the job tmpdir to simplify replaying a frame
         command = self._createCommandFile(command)
-        docker_client = self.rqCore.docker.from_env()
         container = None
+        docker_client = None
         container_id = "00000000"
         frameInfo.pid = -1
         try:
             log_stream = None
-            with self.rqCore.docker_lock:
-                container = docker_client.containers.run(image=image,
-                    detach=True,
-                    environment=self.frameEnv,
-                    working_dir=self.rqCore.machine.getTempPath(),
-                    mounts=self.rqCore.docker_mounts,
-                    privileged=True,
-                    pid_mode="host",
-                    network="host",
-                    stderr=True,
-                    hostname=self.frameEnv["jobhost"],
-                    mem_reservation=soft_memory_limit,
-                    mem_limit=hard_memory_limit,
-                    entrypoint=command)
+            docker_client, container = self.docker_agent.runContainer(
+                image_key=runFrame.os,
+                environment=self.frameEnv,
+                working_dir=self.rqCore.machine.getTempPath(),
+                hostname=self.frameEnv["jobhost"],
+                mem_reservation=soft_memory_limit,
+                mem_limit=hard_memory_limit,
+                entrypoint=command)
 
             log_stream = container.logs(stream=True)
 
@@ -1206,6 +1178,11 @@ exec su -s %s %s -c "echo \$$; /bin/nice /usr/bin/time -p -o %s %s %s"
                     frameInfo.frameId)
                 logging.error(msg)
                 self.rqlog.write(msg, prependTimestamp=rqd.rqconstants.RQD_PREPEND_TIMESTAMP)
+        except InvalidFrameOsError as e:
+            # Frame container didn't get created
+            returncode = -1
+            self.__writeHeader()
+            self.rqlog.write(str(e), prependTimestamp=rqd.rqconstants.RQD_PREPEND_TIMESTAMP)
         # pylint: disable=broad-except
         except Exception as e:
             returncode = -1
@@ -1218,7 +1195,8 @@ exec su -s %s %s -c "echo \$$; /bin/nice /usr/bin/time -p -o %s %s %s"
             if container:
                 container_id = container.short_id
                 container.remove()
-            docker_client.close()
+            if docker_client:
+                docker_client.close()
 
         # Find exitStatus and exitSignal
         if returncode < 0:
@@ -1251,28 +1229,6 @@ exec su -s %s %s -c "echo \$$; /bin/nice /usr/bin/time -p -o %s %s %s"
 
         self.__writeFooter()
         self.__cleanup()
-
-    def __getFrameImage(self, frame_os=None):
-        """
-        Get the pre-configured image for the given frame_os.
-
-        Raises:
-            RuntimeError - if a suitable image cannot be found
-        """
-        if frame_os:
-            image = self.rqCore.docker_images.get(frame_os)
-            if image is None:
-                raise RuntimeError("This rqd is not configured to run an image "
-                    "for this frame OS: %s. Check the [docker.images] "
-                    "section of rqd.conf for more information." % frame_os)
-            return image
-        if self.rqCore.docker_images:
-            # If a frame doesn't require an specic OS, default to the first configured OS on
-            # [docker.images]
-            return list(self.rqCore.docker_images.values())[0]
-
-        raise RuntimeError("Misconfigured rqd. RUN_ON_DOCKER=True requires at "
-                "least one image on DOCKER_IMAGES ([docker.images] section of rqd.conf)")
 
     def runWindows(self):
         """The steps required to handle a frame under windows"""

--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -1451,7 +1451,7 @@ exec su -s %s %s -c "echo \$$; /bin/nice /usr/bin/time -p -o %s %s %s"
         container_id = runFrame.attributes.get("container_id")
 
         docker_client = self.rqCore.docker_agent.new_client()
-        # Recovered frame will stream back logs into a new file, therefore write a new header
+        # The recovered frame will stream back the logs into a new file, therefore, write a new header
         self.__createEnvVariables()
         self.__writeHeader()
 

--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -99,7 +99,7 @@ class RqCore(object):
 
         self.backup_cache_path = None
         if rqd.rqconstants.BACKUP_CACHE_PATH:
-            if not rqd.rqconstants.RUN_ON_DOCKER:
+            if not rqd.rqconstants.DOCKER_AGENT:
                 log.warning("Cache backup is currently only available "
                     "when RUN_ON_DOCKER mode")
             else:
@@ -1021,7 +1021,7 @@ class FrameAttendantThread(threading.Thread):
         """The steps required to handle a frame under a docker container"""
         # pylint: disable=import-outside-toplevel
         from docker.errors import APIError
-        from rqd.rqd.rqdocker import InvalidFrameOsError
+        from rqd.rqdocker import InvalidFrameOsError
 
         frameInfo = self.frameInfo
         runFrame = self.runFrame
@@ -1070,7 +1070,7 @@ exec su -s %s %s -c "echo \$$; /bin/nice /usr/bin/time -p -o %s %s %s"
             gid,
             tempPassword,
             runFrame.user_name,
-            rqd.rqconstants.DOCKER_SHELL_PATH,
+            self.docker_agent.docker_shell_path,
             runFrame.user_name,
             tempStatFile,
             tasksetCmd,

--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -1020,6 +1020,7 @@ class FrameAttendantThread(threading.Thread):
     def runDocker(self):
         """The steps required to handle a frame under a docker container"""
         # pylint: disable=import-outside-toplevel
+        # pylint: disable=import-error
         from docker.errors import APIError
         from rqd.rqdocker import InvalidFrameOsError
 

--- a/rqd/rqd/rqdocker.py
+++ b/rqd/rqd/rqdocker.py
@@ -266,5 +266,9 @@ class RqDocker:
             docker_client.close()
             raise e
 
+    def new_client(self) -> DockerClient:
+        """A wrapper around the creation of a new client instance"""
+        return docker.from_env()
+
 class InvalidFrameOsError(RuntimeError):
     """Invalid setup for frame container"""

--- a/rqd/rqd/rqdocker.py
+++ b/rqd/rqd/rqdocker.py
@@ -90,7 +90,7 @@ class RqDocker:
         if cls.OVERRIDE_DOCKER_IMAGES in os.environ:
             # The OVERRIDE_DOCKER_IMAGES environment variable can be used to
             # override the dic of images to be used by the rqd container. Passing
-            # and env is handy for docker swarm and kubernetes setups.
+            # and env are handy for Docker Swarm and Kubernetes setups.
             # Format: A key=value comma-separated list
             #   centos7=centos7.3:latest,rocky9=rocky9.3:latest
             images = os.environ[cls.OVERRIDE_DOCKER_IMAGES].strip().split(",")
@@ -205,7 +205,7 @@ class RqDocker:
                     "section of rqd.conf for more information." % frame_os)
             return image
         if self.docker_images:
-            # If a frame doesn't require an specic OS, default to the first configured OS on
+            # If a frame doesn't require an specific OS, default to the first configured OS on
             # [docker.images]
             return list(self.docker_images.values())[0]
 
@@ -218,7 +218,7 @@ class RqDocker:
         """Creates and runs a new Docker container with the given parameters.
 
         Args:
-            image_key: OS key to lookup Docker image (e.g. 'centos7')
+            image_key: OS key to look up Docker image (e.g. 'centos7')
             environment: Dictionary of environment variables to set in container
             working_dir: Working directory path inside container
             hostname: Hostname to set for container
@@ -241,8 +241,8 @@ class RqDocker:
             # Similar to gpu=all on the cli counterpart
             device_requests.append(docker.types.DeviceRequest(count=-1, capabilities=[["gpu"]]))
         try:
-            # Use a lock to prevent multiple thread from trying to create containers at the same
-            # time. Experiments without a lock resulted on a fail state
+            # Use a lock to prevent multiple threads from trying to create containers at the same
+            # time. Experiments without a lock resulted in a fail state
             with self.docker_lock:
                 container = docker_client.containers.run(image=image,
                     detach=True,
@@ -262,7 +262,7 @@ class RqDocker:
         # pylint: disable=broad-except
         except Exception as e:
             # Purposedly not closing the connection on a finally here
-            # as the caller might need to interect with the daemon to collect
+            # as the caller might need to interact with the daemon to collect
             # logs and status. This portion only handles closing the connection in
             # case docker.run crashes
             docker_client.close()

--- a/rqd/rqd/rqdocker.py
+++ b/rqd/rqd/rqdocker.py
@@ -20,12 +20,14 @@ from configparser import RawConfigParser
 import logging
 import threading
 
+# pylint: disable=import-error
 import docker
 import docker.models
 import docker.types
 from docker import DockerClient
 from docker.models.containers import Container
 from docker.errors import APIError, ImageNotFound
+# pylint: enable=import-error
 
 log = logging.getLogger(__name__)
 

--- a/rqd/rqd/rqdocker.py
+++ b/rqd/rqd/rqdocker.py
@@ -1,0 +1,232 @@
+
+from typing import Tuple
+import docker
+import docker.models
+from docker import DockerClient
+from docker.models.containers import Container
+from configparser import RawConfigParser
+import logging
+import docker.types
+import threading
+from docker.errors import APIError, ImageNotFound
+
+log = logging.getLogger(__name__)
+
+
+class RqDocker:
+    DOCKER_MOUNTS = "docker.mounts"
+    DOCKER_CONFIG = "docker.config"
+    DOCKER_IMAGES = "docker.images"
+    DOCKER_GPU_MODE = "DOCKER_GPU_MODE"
+    DOCKER_SHELL_PATH = "DOCKER_SHELL_PATH"
+
+    @classmethod
+    def fromConfig(cls, config: RawConfigParser):
+        """Creates a RqDocker instance from a configuration parser.
+        Args:
+            config (RawConfigParser): Configuration parser containing Docker settings
+
+        Returns:
+            RqDocker: An initialized RqDocker instance
+
+        Raises:
+            RuntimeError: If Docker images are not properly configured
+
+        The config should contain:
+        - [docker.config] section with optional DOCKER_SHELL_PATH and DOCKER_GPU_MODE
+        - [docker.images] section mapping OS names to Docker image tags
+        - [docker.mounts] section defining container mount points
+
+        Example config:
+            [docker.config]
+            DOCKER_SHELL_PATH=/bin/bash
+            DOCKER_GPU_MODE=true
+
+            [docker.images]
+            centos7=centos7.3:latest
+            rocky9=rocky9.3:latest
+
+            [docker.mounts]
+            tmp=type=bind,source=/tmp,target=/tmp
+        """
+        docker_shell_path = "/bin/sh"
+
+        # Path to the shell to be used in the frame environment
+        if config.has_option(cls.DOCKER_CONFIG, cls.DOCKER_SHELL_PATH):
+            docker_shell_path = config.get(
+                cls.DOCKER_CONFIG, cls.DOCKER_SHELL_PATH)
+
+        # Check for gpu mode env
+        gpu_mode = False
+        if config.has_option(cls.DOCKER_CONFIG, cls.DOCKER_GPU_MODE):
+            gpu_mode = any(value in config.get(cls.DOCKER_CONFIG, cls.DOCKER_GPU_MODE)
+                for value in ["true", "True", "yes", "Yes", "1"])
+
+        # Every key:value on the config file under docker.images
+        # is parsed as key=SP_OS and value=image_tag.
+        # SP_OS is set to a list of all available keys
+        # For example:
+        #
+        #   rqd.conf
+        #     [docker.images]
+        #     centos7=centos7.3:latest
+        #     rocky9=rocky9.3:latest
+        #
+        #   becomes:
+        #     SP_OS=centos7,rocky9
+        #     DOCKER_IMAGES={
+        #       "centos7": "centos7.3:latest",
+        #       "rocky9": "rocky9.3:latest"
+        #     }
+        keys = config.options(cls.DOCKER_IMAGES)
+        docker_images = {}
+        for key in keys:
+            docker_images[key] = config.get(cls.DOCKER_IMAGES, key)
+        sp_os = ",".join(keys)
+
+        if not docker_images:
+            raise RuntimeError("Misconfigured rqd. RUN_ON_DOCKER=True requires at "
+                                "least one image on DOCKER_IMAGES ([docker.images] "
+                                "section of rqd.conf)")
+        def parse_mount(mount_string):
+            """
+            Parse mount definitions similar to a docker run command into a docker
+            mount obj
+
+            Format: type:bind,source:/tmp,target:/tmp,bind-propagation:slave
+            """
+            parsed_mounts = {}
+            # bind-propagation defaults to None as only type=bind accepts it
+            parsed_mounts["bind-propagation"] = None
+            for item in mount_string.split(","):
+                name, mount_path = item.split(":")
+                parsed_mounts[name.strip()] = mount_path.strip()
+            return parsed_mounts
+
+        # Parse values under the category docker.mounts into Mount objects
+        mounts = config.options(cls.DOCKER_MOUNTS)
+        docker_mounts = []
+        for mount_name in mounts:
+            mount_str = ""
+            try:
+                mount_str = config.get(cls.DOCKER_MOUNTS, mount_name)
+                mount_dict = parse_mount(mount_str)
+                mount = docker.types.Mount(mount_dict["target"],
+                                            mount_dict["source"],
+                                            type=mount_dict["type"],
+                                            propagation=mount_dict["bind-propagation"])
+                docker_mounts.append(mount)
+            except KeyError:
+                logging.exception("Failed to create Mount for key=%s, value=%s",
+                                    mount_name, mount_str)
+
+        return cls(sp_os, docker_images, docker_mounts, docker_shell_path, gpu_mode)
+
+    def __init__(self, sp_os:str, docker_images: dict[str, str],
+        docker_mounts: list[docker.types.Mount], docker_shell_path: str,
+        gpu_mode: bool):
+        self.sp_os = sp_os
+        self.docker_images = docker_images
+        self.docker_mounts = docker_mounts
+        self.docker_shell_path = docker_shell_path
+        self.docker_lock = threading.Lock()
+        self.gpu_mode=gpu_mode
+
+    def refreshFrameImages(self):
+        """
+        Download docker images to be used by frames running on this host
+        """
+        docker_client = docker.from_env()
+        try:
+            for image in self.docker_images.values():
+                log.info("Downloading frame image: %s", image)
+                name, tag = image.split(":")
+                try:
+                    docker_client.images.pull(name, tag)
+                except (ImageNotFound, APIError) as e:
+                    raise RuntimeError("Failed to download frame docker image for %s:%s - %s" %
+                                        (name, tag, e))
+        finally:
+            docker_client.close()
+        log.info("Finished downloading frame images")
+
+    def getFrameImage(self, frame_os=None) -> str:
+        """
+        Get the pre-configured image for the given frame_os.
+
+        Raises:
+            InvalidFrameOsError - if a suitable image cannot be found
+        """
+        if frame_os:
+            image = self.docker_images.get(frame_os)
+            if image is None:
+                raise InvalidFrameOsError("This rqd is not configured to run an image "
+                    "for this frame OS: %s. Check the [docker.images] "
+                    "section of rqd.conf for more information." % frame_os)
+            return image
+        if self.docker_images:
+            # If a frame doesn't require an specic OS, default to the first configured OS on
+            # [docker.images]
+            return list(self.docker_images.values())[0]
+
+        raise InvalidFrameOsError("Misconfigured rqd. RUN_ON_DOCKER=True requires at "
+                "least one image on DOCKER_IMAGES ([docker.images] section of rqd.conf)")
+
+    def runContainer(self, image_key: str, environment: dict[str, str], working_dir: str,
+        hostname: str, mem_reservation: str, mem_limit: str,
+        entrypoint: str) -> Tuple[DockerClient, Container]:
+        """Creates and runs a new Docker container with the given parameters.
+
+        Args:
+            image_key: OS key to lookup Docker image (e.g. 'centos7')
+            environment: Dictionary of environment variables to set in container
+            working_dir: Working directory path inside container
+            hostname: Hostname to set for container
+            mem_reservation: Soft memory limit for container (e.g. '1g')
+            mem_limit: Hard memory limit for container (e.g. '2g')
+            entrypoint: Container entrypoint command
+
+        Returns:
+            Tuple[DockerClient, Container]: Docker client and running container objects
+
+        Raises:
+            InvalidFrameOsError: If image_key doesn't match a configured image
+            docker.errors.APIError: If container creation/start fails
+            RuntimeError: For other Docker-related failures
+        """
+        docker_client = docker.from_env()
+        image = self.getFrameImage(image_key)
+        device_requests = []
+        if self.gpu_mode:
+            # Similar to gpu=all on the cli counterpart
+            device_requests.append(docker.types.DeviceRequest(count=-1, capabilities=["gpu"]))
+        try:
+            # Use a lock to prevent multiple thread from trying to create containers at the same time.
+            # Experimenting without a lock put the docker daemon in a fail state
+            with self.docker_lock:
+                container = docker_client.containers.run(image=image,
+                    detach=True,
+                    environment=environment,
+                    working_dir=working_dir,
+                    mounts=self.docker_mounts,
+                    privileged=True,
+                    pid_mode="host",
+                    network="host",
+                    stderr=True,
+                    hostname=hostname,
+                    mem_reservation=mem_reservation,
+                    mem_limit=mem_limit,
+                    entrypoint=entrypoint,
+                    device_requests=device_requests)
+            return (docker_client, container)
+        # pylint: disable=broad-except
+        except Exception as e:
+            # Purposedly not closing the connection on a finally here
+            # as the caller might need to interect with the daemon to collect
+            # logs and status. This portion only handles closing the connection in
+            # case docker.run crashes
+            docker_client.close()
+            raise e
+
+class InvalidFrameOsError(RuntimeError):
+    """Invalid setup for frame container"""

--- a/rqd/rqd/rqdocker.py
+++ b/rqd/rqd/rqdocker.py
@@ -237,7 +237,7 @@ class RqDocker:
         device_requests = []
         if self.gpu_mode:
             # Similar to gpu=all on the cli counterpart
-            device_requests.append(docker.types.DeviceRequest(count=-1, capabilities=["gpu"]))
+            device_requests.append(docker.types.DeviceRequest(count=-1, capabilities=[["gpu"]]))
         try:
             # Use a lock to prevent multiple thread from trying to create containers at the same
             # time. Experiments without a lock resulted on a fail state

--- a/rqd/rqd/rqdocker.py
+++ b/rqd/rqd/rqdocker.py
@@ -1,19 +1,39 @@
+#  Copyright Contributors to the OpenCue Project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Docker container integration for Rqd"""
 
 from typing import Tuple
-import docker
-import docker.models
-from docker import DockerClient
-from docker.models.containers import Container
 from configparser import RawConfigParser
 import logging
-import docker.types
 import threading
+
+import docker
+import docker.models
+import docker.types
+from docker import DockerClient
+from docker.models.containers import Container
 from docker.errors import APIError, ImageNotFound
 
 log = logging.getLogger(__name__)
 
 
 class RqDocker:
+    """Docker container integration for Rqd.
+    Handles launching Docker containers for running frame commands. Provides configuration
+    management for container images, mounts, resource limits, and GPU support.
+    """
     DOCKER_MOUNTS = "docker.mounts"
     DOCKER_CONFIG = "docker.config"
     DOCKER_IMAGES = "docker.images"
@@ -201,8 +221,8 @@ class RqDocker:
             # Similar to gpu=all on the cli counterpart
             device_requests.append(docker.types.DeviceRequest(count=-1, capabilities=["gpu"]))
         try:
-            # Use a lock to prevent multiple thread from trying to create containers at the same time.
-            # Experimenting without a lock put the docker daemon in a fail state
+            # Use a lock to prevent multiple thread from trying to create containers at the same
+            # time. Experiments without a lock resulted on a fail state
             with self.docker_lock:
                 container = docker_client.containers.run(image=image,
                     detach=True,

--- a/rqd/tests/rqcore_test.py
+++ b/rqd/tests/rqcore_test.py
@@ -735,7 +735,7 @@ class FrameAttendantThreadTests(pyfakefs.fake_filesystem_unittest.TestCase):
         rqCore.machine.isDesktop.return_value = True
         rqCore.machine.getHostInfo.return_value = renderHost
         rqCore.nimby.locked = False
-        rqCore.docker = None
+        rqCore.docker_agent = None
         children = rqd.compiled_proto.report_pb2.ChildrenProcStats()
 
         runFrame = rqd.compiled_proto.rqd_pb2.RunFrame(
@@ -816,18 +816,6 @@ class FrameAttendantThreadTests(pyfakefs.fake_filesystem_unittest.TestCase):
         rqCore.machine.isDesktop.return_value = True
         rqCore.machine.getHostInfo.return_value = renderHost
         rqCore.nimby.locked = False
-
-        # Setup mock docker client
-        rqCore.docker.from_env.return_value.\
-            containers.run.return_value.wait.return_value = {"StatusCode": returnCode}
-        rqCore.docker_images = {
-            "centos7": "centos7_image",
-            "rocky9": "rocky9_image",
-        }
-        rqCore.docker_mounts = {
-            "vol1": "/vol1/mount",
-            "vol2": "/vol2/mount",
-        }
 
         children = rqd.compiled_proto.report_pb2.ChildrenProcStats()
 
@@ -1006,7 +994,7 @@ class FrameAttendantThreadTests(pyfakefs.fake_filesystem_unittest.TestCase):
         rqCore.machine.isDesktop.return_value = True
         rqCore.machine.getHostInfo.return_value = renderHost
         rqCore.nimby.locked = False
-        rqCore.docker = None
+        rqCore.docker_agent = None
         children = rqd.compiled_proto.report_pb2.ChildrenProcStats()
 
         runFrame = rqd.compiled_proto.rqd_pb2.RunFrame(

--- a/rqd/tests/rqcore_test.py
+++ b/rqd/tests/rqcore_test.py
@@ -853,16 +853,10 @@ class FrameAttendantThreadTests(pyfakefs.fake_filesystem_unittest.TestCase):
 
         # then
         cmd_file = os.path.join(tempDir, 'rqd-cmd-%s-%s' % (runFrame.frame_id, currentTime))
-        rqCore.docker.from_env.return_value.containers.run.assert_called_with(
-            image="centos7_image",
-            detach=True,
+        rqCore.docker_agent.runContainer.assert_called_with(
+            image_key="centos7",
             environment=mock.ANY,
             working_dir=jobTempPath,
-            mounts=rqCore.docker_mounts,
-            privileged=True,
-            pid_mode="host",
-            network="host",
-            stderr=True,
             hostname=mock.ANY,
             mem_reservation=softLimit*1000,
             mem_limit=hardLimit*1000,
@@ -898,16 +892,10 @@ class FrameAttendantThreadTests(pyfakefs.fake_filesystem_unittest.TestCase):
 
         # then
         cmd_file = os.path.join(tempDir, 'rqd-cmd-%s-%s' % (runFrame.frame_id, currentTime))
-        rqCore.docker.from_env.return_value.containers.run.assert_called_with(
-            image="centos7_image",
-            detach=True,
+        rqCore.docker_agent.runContainer.assert_called_with(
+            image_key="centos7",
             environment=mock.ANY,
             working_dir=jobTempPath,
-            mounts=rqCore.docker_mounts,
-            privileged=True,
-            pid_mode="host",
-            network="host",
-            stderr=True,
             hostname=mock.ANY,
             mem_reservation="1GB",
             mem_limit="2GB",


### PR DESCRIPTION
Docker features were spread between `rqconstants.py` and `rqcore.py` making it difficult to assess the impact of changes on the logic. Both configuring and using the Docker API have been moved to `rqdocker.py`.

- Add config attribute DOCKER_GPU_MODE to allow passing "gpu=all" when calling docker run.
- Add optional environment variable OVERRIDE_DOCKER_IMAGES
- Make docker and sentry python dependencies opt-in