### PR TITLE
[rqd] Fix for type hinting that doesn't work in python 3.8

### DIFF
--- a/rqd/rqd/rqdocker.py
+++ b/rqd/rqd/rqdocker.py
@@ -13,6 +13,8 @@
 #  limitations under the License.
 
 """Docker container integration for Rqd"""
+# TODO Remove after this program no longer support Python 3.8.*
+from __future__ import annotations
 
 import os
 from typing import Tuple


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Found this error in the [rqd-python-v2](https://github.com/AcademySoftwareFoundation/OpenCue/pull/1654) testing PR
Adds a small import that fixes the type hinting that only works in python 3.9+