### PR TITLE
[cuegui] Increase memory and core limits on the redirect widget

### DIFF
--- a/cuegui/cuegui/config/cuegui.yaml
+++ b/cuegui/cuegui/config/cuegui.yaml
@@ -86,8 +86,8 @@ resources:
   #   - layer-properties
   #   - redirect plugin
   #   - service properties
-  max_cores: 32
-  max_memory: 128
+  max_cores: 256
+  max_memory: 512
   max_gpus: 8
   max_gpu_memory: 128
   # Redirect Plugin maximum allowed core-hour cutoff.

--- a/cuegui/tests/LayerDialog_tests.py
+++ b/cuegui/tests/LayerDialog_tests.py
@@ -156,7 +156,7 @@ class LayerPropertiesDialogTests(unittest.TestCase):
 
     def test__should_fail_on_memory_too_high(self):
         self.layer_properties_dialog._LayerPropertiesDialog__mem.slider.setValue(
-            self.layer_properties_dialog.mem_max_kb * 2)
+            self.layer_properties_dialog.mem_max_kb + 1)
         self.assertFalse(self.layer_properties_dialog.verify())
 
     def test__should_fail_on_memory_too_low(self):

--- a/cuegui/tests/Utils_tests.py
+++ b/cuegui/tests/Utils_tests.py
@@ -74,10 +74,10 @@ class UtilsTests(unittest.TestCase):
         result = cuegui.Utils.getResourceConfig()
 
         self.assertEqual({
-            'max_cores': 32,
+            'max_cores': 256,
             'max_gpu_memory': 128,
             'max_gpus': 8,
-            'max_memory': 128,
+            'max_memory': 512,
             'max_proc_hour_cutoff': 30,
             'redirect_wasted_cores_threshold': 100,
         }, result)


### PR DESCRIPTION
The limit was defined in an era when 32 cores were more than what people thought to be possible.