### PR TITLE
[cuegui] Fix slider performance issue on LayerDialog

### DIFF
--- a/cuegui/cuegui/LayerDialog.py
+++ b/cuegui/cuegui/LayerDialog.py
@@ -116,8 +116,8 @@ class LayerPropertiesDialog(QtWidgets.QDialog):
 
         self.mem_max_gb = float(self._cfg().get('max_memory', 80.0))
         self.mem_min_gb = 0.25
-        self.mem_max_kb = int(self.mem_max_gb * 1024 * 1024)
-        self.mem_min_kb = int(self.mem_min_gb * 1024 * 1024)
+        self.mem_max_mb = int(self.mem_max_gb * 1024)
+        self.mem_min_mb = int(self.mem_min_gb * 1024)
 
         self.gpu_mem_max_kb = 256 * 1024 * 1024
         self.gpu_mem_min_kb = 0
@@ -131,9 +131,9 @@ class LayerPropertiesDialog(QtWidgets.QDialog):
         # Memory
         self.__mem = SlideSpinner(self)
         self.__mem.slider.setMinimumWidth(200)
-        self.__mem.slider.setRange(self.mem_min_kb, self.mem_max_kb)
-        self.__mem.slider.setTickInterval(self.mem_min_kb)
-        self.__mem.slider.setSingleStep(self.mem_min_kb)
+        self.__mem.slider.setRange(self.mem_min_mb, self.mem_max_mb)
+        self.__mem.slider.setTickInterval(128 * self.mem_min_mb)
+        self.__mem.slider.setSingleStep(128 * self.mem_min_mb)
         self.__mem.spinner.setSuffix(" GB")
         self.__mem.spinner.setRange(self.mem_min_gb, self.mem_max_gb)
 
@@ -301,7 +301,7 @@ class LayerPropertiesDialog(QtWidgets.QDialog):
             return
         # Verify our own values.
         mem_value = self.__mem.slider.value()
-        if mem_value < self.mem_min_kb or mem_value > self.mem_max_kb:
+        if mem_value < self.mem_min_mb or mem_value > self.mem_max_mb:
             warning("The memory setting is too high.")
             return False
         gpu_mem_value = self.__gpu_mem.slider.value()
@@ -317,7 +317,7 @@ class LayerPropertiesDialog(QtWidgets.QDialog):
         """
         for layer in self.__layers:
             if self.__mem.isEnabled():
-                layer.setMinMemory(self.__mem.slider.value())
+                layer.setMinMemory(self.__mem.slider.value() * 1024)
             if self.__mem_opt.isEnabled():
                 layer.enableMemoryOptimizer(self.__mem_opt.isChecked())
             if self.__core.isEnabled():
@@ -348,7 +348,7 @@ class LayerPropertiesDialog(QtWidgets.QDialog):
         for layer in self.__layers:
             if layer.data.min_memory > result:
                 result = layer.data.min_memory
-        return result
+        return result / 1024.0
 
     def getMaxGpuMemory(self):
         """Gets the layer max GPU memory."""
@@ -422,10 +422,10 @@ class LayerPropertiesDialog(QtWidgets.QDialog):
         return result
 
     def __translateToMemSpinbox(self, value):
-        self.__mem.spinner.setValue(float(value) / 1048576.0)
+        self.__mem.spinner.setValue(float(value) / 1024.0)
 
     def __translateToMemSlider(self, value):
-        self.__mem.slider.setValue(int(value * 1048576.0))
+        self.__mem.slider.setValue(int(value * 1024.0))
 
     def __translateToGpuMemSpinbox(self, value):
         self.__gpu_mem.spinner.setValue(float(value * self.gpu_mem_tick_kb) / 1024.0 / 1024.0)

--- a/cuegui/tests/LayerDialog_tests.py
+++ b/cuegui/tests/LayerDialog_tests.py
@@ -88,10 +88,10 @@ class LayerPropertiesDialogTests(unittest.TestCase):
         default_config = cuegui.Utils.getResourceConfig()
 
         self.assertEqual(
-            int(self.layer_properties_dialog.mem_min_gb * 1024 * 1024),
+            int(self.layer_properties_dialog.mem_min_gb * 1024),
             self.layer_properties_dialog._LayerPropertiesDialog__mem.slider.minimum())
         self.assertEqual(
-            default_config['max_memory'] * 1024 * 1024,
+            default_config['max_memory'] * 1024,
             self.layer_properties_dialog._LayerPropertiesDialog__mem.slider.maximum())
         # Layer with the higher min_memory determines the initial value.
         self.assertEqual(

--- a/cuegui/tests/LayerDialog_tests.py
+++ b/cuegui/tests/LayerDialog_tests.py
@@ -95,7 +95,7 @@ class LayerPropertiesDialogTests(unittest.TestCase):
             self.layer_properties_dialog._LayerPropertiesDialog__mem.slider.maximum())
         # Layer with the higher min_memory determines the initial value.
         self.assertEqual(
-            6291456, self.layer_properties_dialog._LayerPropertiesDialog__mem.slider.value())
+            6144, self.layer_properties_dialog._LayerPropertiesDialog__mem.slider.value())
 
         # Is memory optimizer is on for any layer, it shows as checked in the dialog.
         self.assertTrue(self.layer_properties_dialog._LayerPropertiesDialog__mem_opt.isChecked())
@@ -156,12 +156,12 @@ class LayerPropertiesDialogTests(unittest.TestCase):
 
     def test__should_fail_on_memory_too_high(self):
         self.layer_properties_dialog._LayerPropertiesDialog__mem.slider.setValue(
-            self.layer_properties_dialog.mem_max_kb + 1)
+            self.layer_properties_dialog.mem_max_mb * 2)
         self.assertFalse(self.layer_properties_dialog.verify())
 
     def test__should_fail_on_memory_too_low(self):
         self.layer_properties_dialog._LayerPropertiesDialog__mem.slider.setValue(
-            self.layer_properties_dialog.mem_min_kb / 3)
+            self.layer_properties_dialog.mem_min_mb / 3)
         self.assertFalse(self.layer_properties_dialog.verify())
 
     def test__should_fail_on_gpu_too_high(self):
@@ -185,7 +185,7 @@ class LayerPropertiesDialogTests(unittest.TestCase):
         self.layer_properties_dialog._LayerPropertiesDialog__limits._LayerLimitsWidget__layers = [
             layer1_mock, layer2_mock]
 
-        new_mem_value = self.layer_properties_dialog.mem_max_kb
+        new_mem_value = self.layer_properties_dialog.mem_max_mb
         self.layer_properties_dialog._LayerPropertiesDialog__mem.parent().parent().enable(True)
         self.layer_properties_dialog._LayerPropertiesDialog__mem.slider.setValue(new_mem_value)
 

--- a/cuegui/tests/LayerDialog_tests.py
+++ b/cuegui/tests/LayerDialog_tests.py
@@ -232,8 +232,8 @@ class LayerPropertiesDialogTests(unittest.TestCase):
             limits_to_enable=new_limits)
 
         self.layer_properties_dialog.apply()
-        layer1_mock.setMinMemory.assert_called_with(new_mem_value)
-        layer2_mock.setMinMemory.assert_called_with(new_mem_value)
+        layer1_mock.setMinMemory.assert_called_with(new_mem_value * 1024)
+        layer2_mock.setMinMemory.assert_called_with(new_mem_value * 1024)
         layer1_mock.enableMemoryOptimizer.assert_called_with(new_mem_opt_is_enabled)
         layer2_mock.enableMemoryOptimizer.assert_called_with(new_mem_opt_is_enabled)
         layer1_mock.setMinCores.assert_called_with(100 * new_min_cores)


### PR DESCRIPTION
Increasing the max_memory_limit on PR#1657 had a collateral effect on LayerDialog causing int overflows and slowness on the Layer dialog.

The proposed solution is to stop using kb as the granularity of the slider and start using MB. We lose precision, but I don't think people would be that precious about it.
