### PR TITLE
[rqd] Check if uid is valid before launching frame

### DIFF
--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -85,9 +85,14 @@ KILL_SIGNAL = 9
 if platform.system() == 'Linux':
     RQD_UID = pwd.getpwnam("daemon")[2]
     RQD_GID = pwd.getpwnam("daemon")[3]
+    # Linux's defaul uid limits are documented at
+    #  https://www.man7.org/linux/man-pages/man5/login.defs.5.html
+    RQD_MIN_UID = 1000
+    RQD_MAX_UID = 60000
 else:
     RQD_UID = 0
     RQD_GID = 0
+RQD_DAEMON_UID = RQD_UID
 
 # Nimby behavior:
 # Number of seconds to wait before checking if the user has become idle.

--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -85,7 +85,7 @@ KILL_SIGNAL = 9
 if platform.system() == 'Linux':
     RQD_UID = pwd.getpwnam("daemon")[2]
     RQD_GID = pwd.getpwnam("daemon")[3]
-    # Linux's defaul uid limits are documented at
+    # Linux's default uid limits are documented at
     #  https://www.man7.org/linux/man-pages/man5/login.defs.5.html
     RQD_MIN_UID = 1000
     RQD_MAX_UID = 60000

--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -1042,14 +1042,21 @@ class FrameAttendantThread(threading.Thread):
         self._tempLocations.append(tempStatFile)
 
         # Prevent frame from attempting to run as ROOT
+        gid = runFrame.gid
         if runFrame.gid <= 0:
             gid = rqd.rqconstants.LAUNCH_FRAME_USER_GID
-        else:
-            gid = runFrame.gid
+
+        # Prevent invalid uids, fallback to daemon uid
+        uid = runFrame.uid
+        if not (uid >= rqd.rqconstants.RQD_MIN_UID
+            and uid <= rqd.rqconstants.RQD_MAX_UID):
+            msg = "Frame launched with an invalid uid=%s. Falling back to daemon uid" % runFrame.uid
+            self.rqlog.write(msg, prependTimestamp=rqd.rqconstants.RQD_PREPEND_TIMESTAMP)
+            uid = rqd.rqconstants.RQD_DAEMON_UID
 
         # Never give frame ROOT permissions
-        if runFrame.uid == 0 or gid == 0:
-            msg = ("Frame %s cannot run as ROOT" % frameInfo.frameId)
+        if uid == 0 or gid == 0:
+            msg = "Frame %s cannot run as ROOT" % frameInfo.frameId
             self.rqlog.write(msg, prependTimestamp=rqd.rqconstants.RQD_PREPEND_TIMESTAMP)
             raise RuntimeError(msg)
 
@@ -1067,7 +1074,7 @@ class FrameAttendantThread(threading.Thread):
 useradd -u %s -g %s -p %s %s >& /dev/null || true;
 exec su -s %s %s -c "echo \$$; /bin/nice /usr/bin/time -p -o %s %s %s"
 """ % (
-            runFrame.uid,
+            uid,
             gid,
             tempPassword,
             runFrame.user_name,

--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -1048,8 +1048,7 @@ class FrameAttendantThread(threading.Thread):
 
         # Prevent invalid uids, fallback to daemon uid
         uid = runFrame.uid
-        if not (uid >= rqd.rqconstants.RQD_MIN_UID
-            and uid <= rqd.rqconstants.RQD_MAX_UID):
+        if uid < rqd.rqconstants.RQD_MIN_UID or uid > rqd.rqconstants.RQD_MAX_UID:
             msg = "Frame launched with an invalid uid=%s. Falling back to daemon uid" % runFrame.uid
             self.rqlog.write(msg, prependTimestamp=rqd.rqconstants.RQD_PREPEND_TIMESTAMP)
             uid = rqd.rqconstants.RQD_DAEMON_UID


### PR DESCRIPTION
If the frame uid is outside of linux defined UID_MAX and UID_MIN fallback to the uid of the daemon user. Read https://www.man7.org/linux/man-pages/man5/login.defs.5.html for more information about uid limits. At this time, limits are hardcoded on rqconstants as the linux default values, which sounds reasonable as this default config limit is rarely modified.
