### PR TITLE
[cuegui] Add "Boot Time" column to HostMonitorTree and update AttributesPlugin to include boot time with year

### DIFF
--- a/cuegui/cuegui/HostMonitorTree.py
+++ b/cuegui/cuegui/HostMonitorTree.py
@@ -131,11 +131,15 @@ class HostMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                            "a report from the host. A host is configured to report\n"
                            "in every 60 seconds so a number larger than this\n"
                            "indicates a problem")
-        self.addColumn("Hardware", 70, id=17,
+        self.addColumn("Boot Time", 100, id=17,
+                       data=lambda host: cuegui.Utils.dateToMMDDHHMM(host.data.boot_time),
+                       sort=lambda host: host.data.boot_time,
+                       tip="The time when the host was last booted.")
+        self.addColumn("Hardware", 70, id=18,
                        data=lambda host: HardwareState.Name(host.data.state),
                        tip="The state of the hardware as Up or Down.\n\n"
                            "On a frame it is the amount of memory used.")
-        self.addColumn("Locked", 90, id=18,
+        self.addColumn("Locked", 90, id=19,
                        data=lambda host: LockState.Name(host.data.lock_state),
                        tip="A host can be:\n"
                            "Locked \t\t It was manually locked to prevent booking\n"
@@ -143,15 +147,15 @@ class HostMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                            "NimbyLocked \t It is a desktop machine and there is\n"
                            "\t\t someone actively using it or not enough \n"
                            "\t\t resources are available on a desktop.")
-        self.addColumn("ThreadMode", 80, id=19,
+        self.addColumn("ThreadMode", 80, id=20,
                        data=lambda host: ThreadMode.Name(host.data.thread_mode),
                        tip="A frame that runs on this host will:\n"
                            "All:  Use all cores.\n"
                            "Auto: Use the number of cores as decided by the cuebot.\n")
-        self.addColumn("OS", 50, id=20,
+        self.addColumn("OS", 50, id=21,
                        data=lambda host: host.data.os,
                        tip="Host operational system or distro.")
-        self.addColumn("Tags/Job", 50, id=21,
+        self.addColumn("Tags/Job", 50, id=22,
                        data=lambda host: ",".join(host.data.tags),
                        tip="The tags applied to the host.\n\n"
                            "On a frame it is the name of the job.")

--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -387,6 +387,15 @@ def dateToMMDDHHMM(sec):
     return time.strftime("%m/%d %H:%M", time.localtime(sec))
 
 
+def dateToMMDDYYYYHHMM(sec):
+    """Returns date in the format %m/%d/%Y %H:%M
+    @rtype:  str
+    @return: Date in the format %m/%d/%Y %H:%M"""
+    if sec == 0:
+        return "--/-- --:--"
+    return time.strftime("%m/%d/%Y %H:%M", time.localtime(sec))
+
+
 def memoryToString(kmem, unit=None):
     """Returns an amount of memory in a human-friendly string."""
     k = 1024

--- a/cuegui/cuegui/plugins/AttributesPlugin.py
+++ b/cuegui/cuegui/plugins/AttributesPlugin.py
@@ -410,7 +410,7 @@ class HostAttributes(AbstractAttributes):
                 "state": str(host.data.state),
                 "lock": str(host.data.lock_state),
                 "load": "%.2f" % (host.data.load/float(100)),
-                "bootTime": cuegui.Utils.dateToMMDDHHMM(host.data.boot_time),
+                "bootTime": cuegui.Utils.dateToMMDDYYYYHHMM(host.data.boot_time),
                 "pingTime": cuegui.Utils.dateToMMDDHHMM(host.data.ping_time),
                 "pingLast": int(time.time() - host.data.ping_time),
                 "tags": ",".join(host.data.tags),


### PR DESCRIPTION
- Added "Boot Time" column to `HostMonitorTree` to display and sort by boot time
- Updated `AttributesPlugin.py` to include year in `bootTime` attribute

**Link the Issue(s) this Pull Request is related to.**
[#1663](https://github.com/AcademySoftwareFoundation/OpenCue/issues/1663)

**Summarize your change.**
Add a "Boot Time" column to the "Monitor Hosts" window to display and sort hosts by their boot time. This enhancement will make it easier to identify hosts that need a reboot by allowing users to sort the list of hosts by their boot time. 
- The "Boot Time" will be displayed in the format `dd/mm hh:mm` in the "Monitor Hosts" without the year to not use too much space in the data grip 
- The boot time will be displayed in the format `dd/mm/yyyy hh:mm` in the "Attributes Plugin"

