### PR TITLE
[cuegui] Make local booking action opt-out

### DIFF
--- a/cuegui/cuegui/FrameMonitorTree.py
+++ b/cuegui/cuegui/FrameMonitorTree.py
@@ -911,7 +911,7 @@ class FrameContextMenu(QtWidgets.QMenu):
         elif count == 2:
             self.__menuActions.frames().addAction(self, "xdiff2")
 
-        if bool(int(self.app.settings.value("AllowDeeding", 0))):
+        if int(self.app.settings.value("DisableDeeding", 0)) == 0:
             self.__menuActions.frames().addAction(self, "useLocalCores")
 
         if cuegui.Constants.OUTPUT_VIEWERS:

--- a/cuegui/cuegui/JobMonitorTree.py
+++ b/cuegui/cuegui/JobMonitorTree.py
@@ -427,7 +427,7 @@ class JobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         self.__menuActions.jobs().addAction(menu, "subscribeToJob")
         self.__menuActions.jobs().addAction(menu, "viewComments")
 
-        if bool(int(self.app.settings.value("AllowDeeding", 0))):
+        if int(self.app.settings.value("DisableDeeding", 0)) == 0:
             self.__menuActions.jobs().addAction(menu, "useLocalCores")
 
         if cuegui.Constants.OUTPUT_VIEWERS:

--- a/cuegui/cuegui/LayerMonitorTree.py
+++ b/cuegui/cuegui/LayerMonitorTree.py
@@ -260,7 +260,7 @@ class LayerMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
 
         if len(__selectedObjects) == 1:
             menu.addSeparator()
-            if bool(int(self.app.settings.value("AllowDeeding", 0))):
+            if int(self.app.settings.value("DisableDeeding", 0)) == 0:
                 self.__menuActions.layers().addAction(menu, "useLocalCores") \
                     .setEnabled(not readonly)
             if len({layer.data.range for layer in __selectedObjects}) == 1:


### PR DESCRIPTION
All menu options for local booking had been made opt-in using .ini files on 34c2bded, this PR brings the option back to the default configuration. Studios that don't want the option enabled by default should add `DisableDeeding=1` to cuetopia.ini and cuecommander.ini.
