### PR TITLE
[rqd] Add option to launch containers as read-only

### DIFF
--- a/rqd/rqd.example.conf
+++ b/rqd/rqd.example.conf
@@ -35,6 +35,7 @@ PIXAR_LICENSE_FILE
 RUN_ON_DOCKER=False
 DOCKER_SHELL_PATH=/usr/bin/sh
 DOCKER_GPU_MODE=False
+DOCKER_READ_ONLY=False
 
 # This section is only required if RUN_ON_DOCKER=True
 # List of volume mounts following docker run's format, but replacing = with :


### PR DESCRIPTION
Adds a new configuration option on rqd.conf to define if containers should be launched on read-only mode.