### PR TITLE
[rqd] Ensure source on docker mounted volumes exist

### DIFF
--- a/rqd/rqd/rqdocker.py
+++ b/rqd/rqd/rqdocker.py
@@ -137,6 +137,9 @@ class RqDocker:
             try:
                 mount_str = config.get(cls.DOCKER_MOUNTS, mount_name)
                 mount_dict = RqDocker.parse_mount(mount_str)
+                # Ensure source exists
+                if not os.path.exists(mount_dict["source"]):
+                    os.makedirs(mount_dict["source"])
                 mount = docker.types.Mount(mount_dict["target"],
                                             mount_dict["source"],
                                             type=mount_dict["type"],


### PR DESCRIPTION
Docker requires that the source of a mounted volume exists prior to running the container. This change simply checks and creates the directory if absent.
