### PR TITLE
Add cuetopia entrypoint to cuegui.

### DIFF
--- a/cuegui/cuegui/__main__.py
+++ b/cuegui/cuegui/__main__.py
@@ -28,8 +28,13 @@ import cuegui.Main
 
 
 def main():
-    """Entrypoint for the CueGUI application."""
+    """Entrypoint for the CueGUI/CueCommmander application."""
     cuegui.Main.cuecommander(sys.argv)
+
+
+def cuetopia():
+    """Entrypoint for the Cuetopia application."""
+    cuegui.Main.cuetopia(sys.argv)
 
 
 if __name__ == '__main__':

--- a/cuegui/setup.py
+++ b/cuegui/setup.py
@@ -53,7 +53,9 @@ setup(
     },
     entry_points={
         'console_scripts': [
-            'cuegui=cuegui.__main__:main'
+            'cuegui=cuegui.__main__:main',
+            'cuetopia=cuegui.__main__:cuetopia',
+            'cuecommander=cuegui.__main__:main'
         ]
     },
     test_suite='tests',


### PR DESCRIPTION
**Summarize your change.**

This changes are motivated by our studio use-case where we want to provide artist with the restricted `Cuetopia` view (job monitoring) but not the `CueCommander` one (hosts + opencue management).

Add 2 new separate entry points for `cuegui`:
* `cuetopia`: to open only Cuetopia
* `cuecommander`: alias to current `cuegui` (CueCommander)
