### PR TITLE
[requirements] Update PySide6 for Python > 3.11 and macOS compatibility

### DIFF
--- a/requirements_gui.txt
+++ b/requirements_gui.txt
@@ -1,4 +1,4 @@
-PySide6==6.7.1;python_version>"3.11"
+PySide6==6.8.2.1;python_version>"3.11"
 PySide6==6.5.3;python_version=="3.11"
 PySide2==5.15.2.1;python_version<="3.10"
 QtPy==1.11.3;python_version<"3.7"


### PR DESCRIPTION
- Updated PySide6 to version 6.8.2.1 for Python > 3.11.
- Ensured compatibility with macOS.