### PR TITLE
[URGENT] Disable compromised tj-actions/changed-files

### DIFF
--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Run Sphinx build
         run: ci/build_sphinx_docs.sh
 
+# Action temporarily disabled due to security concerns on tj-actions/changed-files
 #  check_changed_files:
 #    name: Check Changed Files
 #    runs-on: ubuntu-22.04
@@ -106,6 +107,7 @@ jobs:
       - name: Check Migration Files
         run: ci/check_database_migrations.py
 
+# Action temporarily disabled due to security concerns on tj-actions/changed-files
 #  check_for_version_bump:
 #    name: Check for Version Bump
 #    runs-on: ubuntu-22.04

--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -87,16 +87,16 @@ jobs:
       - name: Run Sphinx build
         run: ci/build_sphinx_docs.sh
 
-  check_changed_files:
-    name: Check Changed Files
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Get Changed Files
-        id: get_changed_files
-        uses: tj-actions/changed-files@v41
-      - name: Check for Version Change
-        run: ci/check_changed_files.py ${{ steps.get_changed_files.outputs.modified_files }} ${{ steps.get_changed_files.outputs.deleted_files }}
+#  check_changed_files:
+#    name: Check Changed Files
+#    runs-on: ubuntu-22.04
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Get Changed Files
+#        id: get_changed_files
+#        uses: tj-actions/changed-files@v41
+#      - name: Check for Version Change
+#        run: ci/check_changed_files.py ${{ steps.get_changed_files.outputs.modified_files }} ${{ steps.get_changed_files.outputs.deleted_files }}
 
   check_migration_files:
     name: Check Database Migration Files
@@ -106,13 +106,13 @@ jobs:
       - name: Check Migration Files
         run: ci/check_database_migrations.py
 
-  check_for_version_bump:
-    name: Check for Version Bump
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Get Changed Files
-        id: get_changed_files
-        uses: tj-actions/changed-files@v41
-      - name: Check for Version Change
-        run: ci/check_version_bump.py ${{ steps.get_changed_files.outputs.all_changed_and_modified_files }}
+#  check_for_version_bump:
+#    name: Check for Version Bump
+#    runs-on: ubuntu-22.04
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Get Changed Files
+#        id: get_changed_files
+#        uses: tj-actions/changed-files@v41
+#      - name: Check for Version Change
+#        run: ci/check_version_bump.py ${{ steps.get_changed_files.outputs.all_changed_and_modified_files }}


### PR DESCRIPTION
The action tj-actions/changed-files is compromissed and needs to be disabled as soon as possible.

https://github.com/tj-actions/changed-files/issues/2463
https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/

Update:
Looks like the repo has been completely disabled now.

Will see if I can make a similar action, so we are not depending on a third party one.