### PR TITLE
[cuegui] Fix 'Clear' option in the Lock State filter

### DIFF
--- a/cuegui/cuegui/HostMonitor.py
+++ b/cuegui/cuegui/HostMonitor.py
@@ -313,9 +313,8 @@ class HostMonitor(QtWidgets.QWidget):
         __hostSearch = self.hostMonitorTree.hostSearch
         if action.text() == "Clear":
             self.__clearLockStateFilter(__hostSearch)
-            return
-
-        self.__updateLockStateFilter(__hostSearch, action)
+        else:
+            self.__updateLockStateFilter(__hostSearch, action)
 
         self.hostMonitorTree.updateRequest()
 


### PR DESCRIPTION
- When the user clicked in the "Clear" option of the lock state filter the "self.hostMonitorTree.updateRequest()" where not called to update the items in the TreeWidget

**Link the Issue(s) this Pull Request is related to.**
[Fix 'Clear' option in the Lock State filter #1685](https://github.com/AcademySoftwareFoundation/OpenCue/issues/1685)