### PR TITLE
[cuebot] Fix DispatchSupportService's NullPointerException

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java
@@ -203,11 +203,18 @@ public class DispatchSupportService implements DispatchSupport {
     @Transactional(propagation = Propagation.NEVER)
     public void runFrame(VirtualProc proc, DispatchFrame frame) {
         try {
+            if (proc == null || frame == null) {
+                throw new DispatcherException(
+                    "runFrame failed: proc or frame is null. proc=" + proc
+                    + ", frame=" + frame);
+            }
+
             rqdClient.launchFrame(prepareRqdRunFrame(proc, frame), proc);
             dispatchedProcs.getAndIncrement();
         } catch (Exception e) {
-            throw new DispatcherException(
-                    proc.getName() + " could not be booked on " + frame.getName() + ", " + e);
+            String procName = (proc != null && proc.getName() != null) ? proc.getName() : "unknown-proc";
+            String frameName = (frame != null && frame.getName() != null) ? frame.getName() : "unknown-frame";
+            throw new DispatcherException(procName + " could not be booked on " + frameName + ", " + e);
         }
     }
 


### PR DESCRIPTION
Fixes a NullPointerException in DispatchSupportService.runFrame by adding early null checks for both proc and frame.

- Ensures that the error message in the catch block doesn't trigger an additional exception.
- Adds a more descriptive error if proc or frame is null, aiding in debugging.
- Wraps getName() calls with null-safe checks.

This change prevents the original exception from being masked and ensures proper diagnostics when a frame fails to book.

**Link the Issue(s) this Pull Request is related to.**
[#1696](https://github.com/AcademySoftwareFoundation/OpenCue/issues/1696)

This bug was introduced in this PR: 
[rqd] [cuegui] Add support for Loki for frame logs: https://github.com/AcademySoftwareFoundation/OpenCue/pull/1577