### PR TITLE
[rqd] Fix issue on rssUpdate

### DIFF
--- a/rqd/rqd/__main__.py
+++ b/rqd/rqd/__main__.py
@@ -178,7 +178,7 @@ def setupLogging():
 def setup_sentry():
     """Set up sentry if a SENTRY_DSN_PATH is configured"""
     sentry_dsn_path = rqd.rqconstants.SENTRY_DSN_PATH
-    if sentry_dsn_path is not None:
+    if sentry_dsn_path is None:
         return
 
     # Not importing sentry at the toplevel to avoid an unecessary dependency

--- a/rqd/rqd/rqmachine.py
+++ b/rqd/rqd/rqmachine.py
@@ -302,7 +302,7 @@ class Machine(object):
             values = list(frames.values())
             for frame in values:
                 pid = str(frame.pid)
-                if pid is not None and frame.pid > 0:
+                if pid is not None and frame.pid > 0 and pid in pids:
                     visited = [pid]
                     children = [pids[pid]]
                     self._collectChildren(pid, pids, visited, children)


### PR DESCRIPTION
When a frame is still on the frame cache and its process has completed, it should be skipped from rssUpdate to avoid a key error. Crawling its children is not necessary as unfinished children will have been reparented.