### PR TITLE
[cuegui] Apply layer filter in Frame Monitor only on double-click

### DIFF
--- a/cuegui/cuegui/LayerMonitorTree.py
+++ b/cuegui/cuegui/LayerMonitorTree.py
@@ -152,7 +152,7 @@ class LayerMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         cuegui.AbstractTreeWidget.AbstractTreeWidget.__init__(self, parent)
 
         # pylint: disable=no-member
-        self.itemSelectionChanged.connect(self.__itemSelectionChangedFilterLayer)
+        self.itemDoubleClicked.connect(self.__itemDoubleClickedFilterLayer)
         cuegui.app().select_layers.connect(self.__handle_select_layers)
 
         # Used to build right click context menus
@@ -283,10 +283,10 @@ class LayerMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
 
         menu.exec_(e.globalPos())
 
-    def __itemSelectionChangedFilterLayer(self):
-        """Filter FrameMonitor to selected Layers.
-        Emits signal to filter FrameMonitor to selected Layers.
-        Also emits signal for other widgets to select Layers.
+    def __itemDoubleClickedFilterLayer(self):
+        """Filter FrameMonitor to double-clicked Layers.
+        Emits signal to filter FrameMonitor to double-clicked Layers.
+        Also emits signal for other widgets to double-clicked Layers.
         """
         layers = self.selectedObjects()
         layer_names = [layer.data.name for layer in layers]


### PR DESCRIPTION
- Changed behavior in LayerMonitorTree to emit filter and selection signals only when a layer row is double-clicked, instead of on single selection.
- When you click once the layer line, the frame filter should not change, only if you double-click or change in the frame filter.
- This is to make the filtering of the frames more deliberate as its current one-click autofilter takes away the option to still see all the job frames.

Notes:
- `self.itemSelectionChanged` is a Qt signal that is emitted when the selection in the QTreeWidget changes.
- `self.itemDoubleClicked` is a Qt signal that only fires when the user double-clicks a row.

This PR is related to the changes made on the PRs:

1) feat: Add job node graph plugin #888
https://github.com/AcademySoftwareFoundation/OpenCue/pull/888

2) [cuegui] feat: Add job node graph plugin v2 #1400 https://github.com/AcademySoftwareFoundation/OpenCue/pull/1400

**Link the Issue(s) this Pull Request is related to.**
#1704 - [cuegui] Make frame filtering in Layer Monitor Tree trigger only on double-click 