### PR TITLE
[cuegui] Prevent window open state from being overwritten during shutdown

### DIFF
--- a/cuegui/cuegui/MainWindow.py
+++ b/cuegui/cuegui/MainWindow.py
@@ -498,15 +498,18 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # For populating the default state: print self.saveState().toBase64()
 
-        # Save the fact that this window is open or not
-        for windowName in self.windows_names:
-            for window in self.windows:
-                if window.name == windowName:
-                    self.settings.setValue("%s/Open" % windowName, True)
-                    break
-            else:
-                self.settings.setValue("%s/Open" % windowName, False)
+        # Only update open/close state if at least one window is still open
+        if self.windows:
+            # Save the fact that this window is open or not
+            for windowName in self.windows_names:
+                for window in self.windows:
+                    if window.name == windowName:
+                        self.settings.setValue("%s/Open" % windowName, True)
+                        break
+                else:
+                    self.settings.setValue("%s/Open" % windowName, False)
 
+        # Save other window state
         self.settings.setValue("Version", self.app_version)
 
         self.settings.setValue("%s/Title" % self.name,


### PR DESCRIPTION
- Added a check in `__saveSettings` to ensure window open/close state is only saved when at least one window is still open.
- Prevents overwriting all window states with Open=false (.config/.cuecommander/config.ini and .config/.cuetopia/config.ini files) during shutdown (e.g., when exiting via File > Exit Application).
- Ensures accurate restoration of previously opened windows on next launch.

**Link the Issue(s) this Pull Request is related to.**
CueGUI overwrites window Open state as false when exiting CueGUI #1706 