### PR TITLE
[cuegui] Fix window state not saved when closing via [X] button

### DIFF
--- a/cuegui/cuegui/MainWindow.py
+++ b/cuegui/cuegui/MainWindow.py
@@ -108,6 +108,10 @@ class MainWindow(QtWidgets.QMainWindow):
         self.app.status.connect(self.showStatusBarMessage)
         self.showStatusBarMessage("Ready")
 
+        # Assume user close CueGUI using [x] button or Right click in CueGUI icon > Quit Windows
+        # unless closing using File > Exit Application (Ctrl + Q)
+        self.__manual_closed = True
+
     def displayStartupNotice(self):
         """Displays the application startup notice."""
         now = int(time.time())
@@ -421,11 +425,26 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def __windowCloseWindow(self):
         """Closes the current window"""
+        # Register that CueGUI was closed using File > Exit Application (Ctrl + Q)
+        self.__manual_closed = False
         self.close()
 
     def __windowCloseApplication(self):
         """Called when the entire application should exit. Signals other windows
         to exit."""
+        # Only update Open state if at least one window is still open
+        if self.windows:
+            # Save the fact that this window is Open
+            for windowName in self.windows_names:
+                for window in self.windows:
+                    # Register that CueGUI was closed using File > Exit Application (Ctrl + Q)
+                    window.__manual_closed = False
+
+                    if window.name == windowName:
+                        # Save state of Window as Open
+                        self.settings.setValue("%s/Open" % windowName, True)
+                        break
+
         self.app.closingApp = True
         self.app.quit.emit()
         # Give the application some time to save the state
@@ -466,6 +485,9 @@ class MainWindow(QtWidgets.QMainWindow):
         # Only save settings on exit if toggled
         if self.saveWindowSettingsCheck.isChecked():
             self.__saveSettings()
+            if self.__manual_closed:
+                # Save state of Window as Closed
+                self.settings.setValue("%s/Open" % self.name, False)
         self.__windowClosed()
 
     def __restoreSettings(self):
@@ -497,17 +519,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.__plugins.saveState()
 
         # For populating the default state: print self.saveState().toBase64()
-
-        # Only update open/close state if at least one window is still open
-        if self.windows:
-            # Save the fact that this window is open or not
-            for windowName in self.windows_names:
-                for window in self.windows:
-                    if window.name == windowName:
-                        self.settings.setValue("%s/Open" % windowName, True)
-                        break
-                else:
-                    self.settings.setValue("%s/Open" % windowName, False)
 
         # Save other window state
         self.settings.setValue("Version", self.app_version)

--- a/cuegui/cuegui/MainWindow.py
+++ b/cuegui/cuegui/MainWindow.py
@@ -110,7 +110,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # Assume user close CueGUI using [x] button or Right click in CueGUI icon > Quit Windows
         # unless closing using File > Exit Application (Ctrl + Q)
-        self.__manual_closed = True
+        self._manual_closed = True
 
     def displayStartupNotice(self):
         """Displays the application startup notice."""
@@ -426,7 +426,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def __windowCloseWindow(self):
         """Closes the current window"""
         # Register that CueGUI was closed using File > Exit Application (Ctrl + Q)
-        self.__manual_closed = False
+        self._manual_closed = False
         self.close()
 
     def __windowCloseApplication(self):
@@ -438,7 +438,7 @@ class MainWindow(QtWidgets.QMainWindow):
             for windowName in self.windows_names:
                 for window in self.windows:
                     # Register that CueGUI was closed using File > Exit Application (Ctrl + Q)
-                    window.__manual_closed = False
+                    window._manual_closed = False # pylint: disable=W0212
 
                     if window.name == windowName:
                         # Save state of Window as Open
@@ -485,7 +485,7 @@ class MainWindow(QtWidgets.QMainWindow):
         # Only save settings on exit if toggled
         if self.saveWindowSettingsCheck.isChecked():
             self.__saveSettings()
-            if self.__manual_closed:
+            if self._manual_closed:
                 # Save state of Window as Closed
                 self.settings.setValue("%s/Open" % self.name, False)
         self.__windowClosed()


### PR DESCRIPTION
This patch improves CueGUI behavior by ensuring the state of each window is correctly saved when the user closes it via the window's [X] button or right click in the "CueGUI icon > Close Windows" instead of the menu "File > Exit Application" or shortcut (Ctrl+Q).

Changes include:
- Introduced `self.__manual_closed` to distinguish between manual window closing and full app exit.
- Set `Open=false` for the closed window when manually closed.
- Modified `__windowCloseApplication` to mark all windows as not manually closed when quitting via menu "File > Exit Application" or "Ctrl+Q".
- Ensured the window name (`self.name`) is used when saving the window's Open state.

Note: The correct way to save the CueGUI windows state and windows that are opened is to use the menu: "File > Exit Application" or "Ctrl+Q"

This ensures CueGUI reopens only the relevant windows next time.

**Link the Issue(s) this Pull Request is related to.**
[cuegui] Window state not saved when CueGUI is closed using the [X] button #1708 
