### PR TITLE
[pycue] Remove python-six and use native str for type checks

### DIFF
--- a/pycue/opencue/search.py
+++ b/pycue/opencue/search.py
@@ -53,8 +53,6 @@ from __future__ import division
 from builtins import object
 import logging
 
-import six
-
 # pylint: disable=cyclic-import
 from opencue.compiled_proto import criterion_pb2
 from opencue.compiled_proto import host_pb2
@@ -352,7 +350,7 @@ def _setOptions(criteria, options):
         elif k in ("range", "frames"):
             if not v:
                 continue
-            if isinstance(criteria.frame_range, six.string_types):
+            if isinstance(criteria.frame_range, str):
                 # Once FrameSearch.frameRange is not a string
                 # this can go away
                 criteria.frame_range = v
@@ -361,7 +359,7 @@ def _setOptions(criteria, options):
         elif k == "memory":
             if not v:
                 continue
-            if isinstance(criteria.memory_range, six.string_types):
+            if isinstance(criteria.memory_range, str):
                 # Once FrameSearch.memoryRange is not a string
                 # this can go away
                 criteria.memory_range = v
@@ -381,7 +379,7 @@ def _setOptions(criteria, options):
         elif k == "duration":
             if not v:
                 continue
-            if isinstance(criteria.duration_range, six.string_types):
+            if isinstance(criteria.duration_range, str):
                 # Once FrameSearch.durationRange is not a string
                 # this can go away
                 criteria.duration_range = v

--- a/pycue/opencue/util.py
+++ b/pycue/opencue/util.py
@@ -25,7 +25,6 @@ import logging
 import os
 import time
 
-import six
 import grpc
 
 import opencue
@@ -111,7 +110,7 @@ def proxy(idOrObject, cls):
 
     if hasattr(idOrObject, 'id'):
         return _proxy(idOrObject.id)
-    if isinstance(idOrObject, six.string_types):
+    if isinstance(idOrObject, str):
         return _proxy(idOrObject)
     return _proxies(idOrObject)
 


### PR DESCRIPTION
- Removed `import six` from `search.py` and `utils.py`
- Replaced `isinstance(..., six.string_types)` with `isinstance(..., str)`

OpenCue now targets Python 3 only, so `six` is no longer needed.
- In Python 3, `six.string_types` is just `(str,)`, so we can replace the `isinstance(..., six.string_types)` checks with `isinstance(..., str)` directly.
- `six.string_types` is a tuple used to handle the difference between string types in Python 2 and 3.

**Link the Issue(s) this Pull Request is related to.**
[#1722](https://github.com/AcademySoftwareFoundation/OpenCue/issues/1722)