### PR TITLE
[cueadmin/cuegui/pyoutline/rqd] Remove `six` fependency from CueAdmin, CueGUI, PyOutline, and RQD modules

### DIFF
--- a/cueadmin/cueadmin/common.py
+++ b/cueadmin/cueadmin/common.py
@@ -27,8 +27,6 @@ import logging
 import sys
 import traceback
 
-import six
-
 import opencue
 import opencue.wrappers.job
 import opencue.wrappers.proc
@@ -275,7 +273,7 @@ def handleFloatCriterion(mixed, convert=None):
 
     if isinstance(mixed, (float, int)):
         result = opencue.api.criterion_pb2.GreaterThanFloatSearchCriterion(value=_convert(mixed))
-    elif isinstance(mixed, six.string_types):
+    elif isinstance(mixed, str):
         if mixed.startswith("gt"):
             result = opencue.api.criterion_pb2.GreaterThanFloatSearchCriterion(
                 value=_convert(mixed[2:]))
@@ -323,7 +321,7 @@ def handleIntCriterion(mixed, convert=None):
 
     if isinstance(mixed, (float, int)):
         result = opencue.api.criterion_pb2.GreaterThanIntegerSearchCriterion(value=_convert(mixed))
-    elif isinstance(mixed, six.string_types):
+    elif isinstance(mixed, str):
         if mixed.startswith("gt"):
             result = opencue.api.criterion_pb2.GreaterThanIntegerSearchCriterion(
                 value=_convert(mixed[2:]))

--- a/cuegui/cuegui/MenuActions.py
+++ b/cuegui/cuegui/MenuActions.py
@@ -32,7 +32,6 @@ import time
 
 from qtpy import QtGui
 from qtpy import QtWidgets
-import six
 
 import FileSequence
 import opencue
@@ -172,7 +171,7 @@ class AbstractActions(object):
 
             if not callback:
                 callback = actionName
-            if isinstance(callback, six.string_types):
+            if isinstance(callback, str):
                 callback = getattr(self, callback)
 
             action.triggered.connect(callback)  # pylint: disable=no-member

--- a/cuegui/cuegui/UnbookDialog.py
+++ b/cuegui/cuegui/UnbookDialog.py
@@ -27,7 +27,6 @@ import re
 
 from qtpy import QtCore
 from qtpy import QtWidgets
-import six
 
 import opencue
 
@@ -168,7 +167,7 @@ class UnbookDialog(cuegui.AbstractDialog.AbstractDialog):
         if isinstance(mixed, (float, int)):
             result = opencue.api.criterion_pb2.GreaterThanIntegerSearchCriterion(
                 value=_convert(mixed))
-        elif isinstance(mixed, six.string_types):
+        elif isinstance(mixed, str):
             if mixed.startswith("gt"):
                 result = opencue.api.criterion_pb2.GreaterThanIntegerSearchCriterion(
                     value=_convert(mixed[2:]))

--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -36,7 +36,6 @@ import yaml
 from qtpy import QtCore
 from qtpy import QtGui
 from qtpy import QtWidgets
-import six
 
 import FileSequence
 
@@ -260,7 +259,7 @@ def findJob(job):
     @rtype:  job or None"""
     if isJob(job):
         return job
-    if not isinstance(job, six.string_types):
+    if not isinstance(job, str):
         return None
     if isStringId(job):
         if re.search("^Job.", job):

--- a/pyoutline/outline/backend/cue.py
+++ b/pyoutline/outline/backend/cue.py
@@ -33,7 +33,6 @@ from xml.dom.minidom import parseString
 from xml.etree import ElementTree as Et
 
 from packaging.version import Version
-import six
 
 import FileSequence
 import opencue
@@ -428,7 +427,7 @@ def scrub_tags(tags):
     """
     Ensure that layer tags pass in as a string are formatted properly.
     """
-    if isinstance(tags, six.string_types):
+    if isinstance(tags, str):
         tags = [tag.strip() for tag in tags.split("|")
                 if tag.strip().isalnum()]
     return " | ".join(tags)

--- a/pyoutline/outline/config.py
+++ b/pyoutline/outline/config.py
@@ -33,14 +33,7 @@ import os
 import pathlib
 import platform
 import tempfile
-
-import six
-
-from six.moves import configparser
-if six.PY2:
-    ConfigParser = configparser.SafeConfigParser
-else:
-    ConfigParser = configparser.ConfigParser
+import configparser
 
 __all__ = ['config', 'read_config_from_disk']
 __file_path__ = pathlib.Path(__file__)
@@ -93,7 +86,7 @@ def read_config_from_disk():
     default_user_dir = pathlib.Path(
         tempfile.gettempdir()) / 'opencue' / 'outline' / getpass.getuser()
 
-    _config = ConfigParser()
+    _config = configparser.ConfigParser()
     config_file = None
 
     for config_file_env_var in __CONFIG_FILE_ENV_VARS:

--- a/pyoutline/outline/layer.py
+++ b/pyoutline/outline/layer.py
@@ -23,7 +23,6 @@ from __future__ import division
 from builtins import str
 from builtins import range
 from builtins import object
-import future.types
 from future.utils import with_metaclass
 import os
 import sys

--- a/pyoutline/outline/layer.py
+++ b/pyoutline/outline/layer.py
@@ -30,8 +30,6 @@ import sys
 import logging
 import tempfile
 
-import six
-
 import FileSequence
 
 import outline
@@ -489,16 +487,6 @@ class Layer(with_metaclass(LayerType, object)):
 
         for arg, rtype in self.__req_args:
             if arg == key and rtype:
-                # Python 2/3 compatibility. Be a little more flexible with acceptable string
-                #   types, especially in Python 2. Client code may be using the old Python 2
-                #   string type or the unicode-based, backported future.types.newstr.
-                string_types = (__builtins__.get('str'),)
-                if hasattr(future.types, 'newstr'):
-                    string_types += (future.types.newstr,)
-
-                if rtype in string_types:
-                    rtype = six.string_types
-
                 if not isinstance(value, rtype):
                     msg = "The arg %s for the %s module must be a %s"
                     raise outline.exception.LayerException(msg % (arg,

--- a/pyoutline/outline/loader.py
+++ b/pyoutline/outline/loader.py
@@ -29,8 +29,6 @@ import time
 import uuid
 import yaml
 
-import six
-
 import FileSequence
 
 import outline.constants
@@ -107,9 +105,7 @@ def load_json(json_str):
 
     def decode_layer(layer):
         """
-        Python 2.5.1 doesn't accept unicode strings as keyword
-        arguments in class constructors.  For this reason, they
-        must be converted to byte strings.
+        Converts keys to strings to ensure compatibility with Python 3
         """
         result = {}
         for k, v in layer.items():
@@ -747,11 +743,11 @@ class Outline(object):
             logger.warning(
                 "Overwriting outline env var: %s, from %s to %s", key, self.__env[key], value)
 
-        if not isinstance(key, six.string_types):
+        if not isinstance(key, str):
             raise outline.exception.OutlineException(
                 "Invalid key type for env var: %s" % type(key))
 
-        if not isinstance(value, six.string_types):
+        if not isinstance(value, str):
             raise outline.exception.OutlineException(
                 "Invalid value type for env var: %s" % type(value))
 

--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -31,6 +31,7 @@ import platform
 import subprocess
 import sys
 import traceback
+import configparser
 
 if platform.system() == 'Linux':
     import pwd
@@ -185,12 +186,10 @@ try:
         # Hostname can come from here: rqutil.getHostname()
         __override_section = "Override"
         __host_env_var_section = "UseHostEnvVar"
-        import six
-        from six.moves import configparser
-        if six.PY2:
-            ConfigParser = configparser.SafeConfigParser
-        else:
-            ConfigParser = configparser.RawConfigParser
+
+        # Directly use RawConfigParser from configparser
+        ConfigParser = configparser.RawConfigParser
+
         # Allow some config file sections to contain only keys
         config = ConfigParser(allow_no_value=True)
         # Respect case from the config file keys

--- a/rqd/tests/rqconstants_test.py
+++ b/rqd/tests/rqconstants_test.py
@@ -26,11 +26,10 @@ import os.path
 import shutil
 import tempfile
 import uuid
+import importlib
 
 import mock
 import pyfakefs.fake_filesystem_unittest
-
-import six
 
 import rqd.rqconstants
 import rqd.rqcore
@@ -47,12 +46,6 @@ from .rqmachine_test import (
 )
 
 
-if not six.PY2:
-    import importlib
-
-    reload = importlib.reload
-
-
 class MockConfig(object):
     def __init__(self, tempdir, content):
         config = os.path.join(tempdir, str(uuid.uuid4()))
@@ -63,7 +56,7 @@ class MockConfig(object):
 
     def __enter__(self):
         self.patcher.start()
-        reload(rqd.rqconstants)
+        importlib.reload(rqd.rqconstants)
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):


### PR DESCRIPTION
- Remove the legacy `six` dependency across multiple OpenCue components in alignment with Python 3-only support.

1) cueadmin
- Removed `six` import from `common.py`
- Replaced `six.string_types` with native `str` checks

2) cuegui
- Removed `six` usage from:
  - `MenuActions.py`
  - `UnbookDialog.py`
  - `Utils.py`
- Replaced `six.string_types` with `str`

3) pyoutline
- Removed all `six` and `six.moves` references from:
  - `config.py`
  - `cue.py`
  - `layer.py`
  - `loader.py`
- Replaced legacy type checks with native `str`

Cleaned up string handling and config parser logic

4) rqd
- Removed `six` from `rqconstants.py` and `rqconstants_test.py`
- Replaced `six.moves.configparser` with direct import of `configparser.RawConfigParser`
- Removed Python 2 conditionals and updated test logic

These changes are strictly related to cleanup and modernization, with no change in behavior.

**Link the Issue(s) this Pull Request is related to.**
#1724