### PR TITLE
[cuegui] Fix log viewer crash on Rocky 9 by launching Vim in xterm with safe flags

### DIFF
--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -496,15 +496,23 @@ def popupView(file, facility=None):
         editor_from_env = os.getenv('EDITOR')
         app = cuegui.app()
         if editor_from_env:
-            job_log_cmd = editor_from_env.split()
+            editor = editor_from_env.strip()
         elif app.settings.contains('LogEditor') and (
                 len(app.settings.value("LogEditor").strip()) > 0):
-            job_log_cmd = app.settings.value("LogEditor").split()
-            if not isinstance(job_log_cmd, list):
-                job_log_cmd = job_log_cmd.split()
+            editor = app.settings.value("LogEditor").strip()
         else:
-            job_log_cmd = cuegui.Constants.DEFAULT_EDITOR.split()
-        job_log_cmd.append(str(file))
+            editor = cuegui.Constants.DEFAULT_EDITOR.strip()
+
+        # Extract the binary name (first word in the editor string)
+        editor_bin = editor.split()[0].lower()
+
+        # Use plain Vim in xterm with no configs for compatibility on Rocky
+        if editor_bin in ("vim", "gvim", "gview"):
+            job_log_cmd = ["xterm", "-e", "vim", "-u", "NONE", "-N", str(file)]
+        else:
+            job_log_cmd = editor.split()
+            job_log_cmd.append(str(file))
+
         checkShellOut(job_log_cmd)
 
 


### PR DESCRIPTION
- Extracts editor binary to avoid false matches (e.g. gvimrc triggering Vim detection)
- When the editor is vim/gvim/gview, opens it using:
  xterm -e vim -u NONE -N <file>
- This avoids loading broken system/user .vimrc files on Rocky Linux
- Falls back to default editor behavior for all other cases

**Link the Issue(s) this Pull Request is related to.**
[cuegui] Vim crashes when opening frame logs on Rocky 9 due to incompatible configuration files #1729 
