### PR TITLE
[cuegui] Fix rqlog syntax highlighting compatibility on Rocky Linux

### DIFF
--- a/cuegui/cuegui/Utils.py
+++ b/cuegui/cuegui/Utils.py
@@ -496,23 +496,15 @@ def popupView(file, facility=None):
         editor_from_env = os.getenv('EDITOR')
         app = cuegui.app()
         if editor_from_env:
-            editor = editor_from_env.strip()
+            job_log_cmd = editor_from_env.split()
         elif app.settings.contains('LogEditor') and (
                 len(app.settings.value("LogEditor").strip()) > 0):
-            editor = app.settings.value("LogEditor").strip()
+            job_log_cmd = app.settings.value("LogEditor").split()
+            if not isinstance(job_log_cmd, list):
+                job_log_cmd = job_log_cmd.split()
         else:
-            editor = cuegui.Constants.DEFAULT_EDITOR.strip()
-
-        # Extract the binary name (first word in the editor string)
-        editor_bin = editor.split()[0].lower()
-
-        # Use plain Vim in xterm with no configs for compatibility on Rocky
-        if editor_bin in ("vim", "gvim", "gview"):
-            job_log_cmd = ["xterm", "-e", "vim", "-u", "NONE", "-N", str(file)]
-        else:
-            job_log_cmd = editor.split()
-            job_log_cmd.append(str(file))
-
+            job_log_cmd = cuegui.Constants.DEFAULT_EDITOR.split()
+        job_log_cmd.append(str(file))
         checkShellOut(job_log_cmd)
 
 

--- a/cuegui/cuegui/config/gvimrc
+++ b/cuegui/cuegui/config/gvimrc
@@ -2,10 +2,10 @@
 " Syntax highlighting:
 " ===================
 
-if filereadable(expand("~/.cuetopia/rqlog.vim"))
-    source ~/.cuetopia/rqlog.vim
+if filereadable(expand("~/.config/.cuetopia/rqlog.vim"))
+    source ~/.config/.cuetopia/rqlog.vim
 else
-    source ./rqlog.vim
+    execute 'source ' . expand('<sfile>:p:h') . '/rqlog.vim'
 endif
 
 " =============

--- a/cuegui/cuegui/config/rqlog.vim
+++ b/cuegui/cuegui/config/rqlog.vim
@@ -2,12 +2,10 @@
 " Syntax highlighting:
 " ===================
 
-" This will override it if you have one: ~/.cuetopia/cjlog.vim
+" This will override it if you have one: ~/.config/.cuetopia/rqlog.vim
 
 " Syntax documentation:
 " http://vimdoc.sourceforge.net/htmldoc/syntax.html#syntax
-
-" If you make some good changes, let me know about them so I can add them to the default - John
 
 highlight Notice       term=bold ctermfg=Blue        guifg=Blue
 highlight Warning      term=bold ctermfg=Magenta     guifg=Purple


### PR DESCRIPTION
- Updated `gvimrc` to source `rqlog.vim` relative to the `gvimrc` path using `execute` and `expand('<sfile>:p:h')` to avoid E484 errors.
- Changed fallback source path from `./rqlog.vim` to relative gvimrc directory for better portability.
- Updated comments and default override paths in `rqlog.vim` to reference `~/.config/.cuetopia` instead of the old `~/.cuetopia`.
- Reverted popupView logic in Utils.py to restore compatibility with user-defined or default log editors (e.g., gview) in both CentOS and Rocky Linux.

This resolves `E890` and `E484` errors encountered when viewing `.rqlog` files with `gview` on Rocky 9.

**Link the Issue(s) this Pull Request is related to.**
[cuegui] Vim crashes when opening frame logs on Rocky 9 due to incompatible configuration files #1729 
