### PR TITLE
[cuegui] Fix Dependency Wizard navigation for Job-on-Job (JOJ) dependency type

### DIFF
--- a/cuegui/cuegui/DependWizard.py
+++ b/cuegui/cuegui/DependWizard.py
@@ -403,7 +403,7 @@ class PageDependType(AbstractWizardPage):
         """Returns the next page id
         @return: next page id
         @rtype:  int"""
-        if not self.wizard().dependType:
+        if self.wizard().dependType is None:
             return PAGE_SELECT_DEPEND_TYPE
         if self.frames:
             return PAGE_SELECT_ONJOB


### PR DESCRIPTION
- Job-on-Job (JOJ) has an enum value of 0, which previously evaluated as False in the `nextId` check: `if not self.wizard().dependType`
- This caused the wizard to incorrectly loop back to the initial page and block forward progress.

The condition was updated to explicitly check for `None` instead of falsiness.

**Link the Issue(s) this Pull Request is related to.**
[cuegui] Dependency Wizard "Job on Job" option do not advance in CueGUI #1733

Co-authored-by: Ramon Figueiredo <rfigueiredo@imageworks.com>
Co-authored-by: Buthaina Mahmoud <bmahmoud@imageworks.com>