### PR TITLE
[rqd] Remove grpc-fork and pynput warnings

### DIFF
--- a/rqd/rqd/rqcore.py
+++ b/rqd/rqd/rqcore.py
@@ -74,7 +74,8 @@ class RqCore(object):
             reserved_cores=[],
         )
 
-        self.nimby = Nimby(self)
+        nimbyNoOp = not self.shouldStartNimby()
+        self.nimby = Nimby(self, nimbyNoOp)
 
         self.machine = rqd.rqmachine.Machine(self, self.cores)
         self.network = rqd.rqnetwork.Network(self)

--- a/rqd/rqd/rqnetwork.py
+++ b/rqd/rqd/rqnetwork.py
@@ -32,6 +32,12 @@ import platform
 import subprocess
 import time
 
+# Disable GRPC fork support to avoid the warning:
+#  "fork_posix.cc Other threads are currently calling into gRPC, skipping fork() handlers"
+# Adding this environment variable doesn't change the server behaviour
+os.environ["GRPC_ENABLE_FORK_SUPPORT"] = "false"
+
+# pylint: disable=wrong-import-position
 import grpc
 
 import rqd.compiled_proto.report_pb2

--- a/rqd/rqd/rqnimby.py
+++ b/rqd/rqd/rqnimby.py
@@ -45,12 +45,17 @@ class Nimby(threading.Thread):
         locked (bool): Whether the host is currently locked for rendering.
         last_activity_time (float): Timestamp of the last detected user activity.
     """
-    def __init__(self, rqCore):
+    def __init__(self, rqCore, noOp=False):
         self.is_ready = False
         self.rq_core = rqCore
         self.locked = False
         self.__is_user_active = False
         self.__interrupt = False
+
+        # When running on NoOp mode, nimby will skip initializing pynput and
+        # only report its default values
+        if noOp:
+            return
 
         try:
             Nimby.setup_display()


### PR DESCRIPTION
* Clean up grpc fork warnings:  

> fork_posix.cc Other threads are currently calling into gRPC, skipping fork() handlers

* Clean up pynput warnings from nimby when nimby is inactive. This new logic prevents importing pynput when it is not necessary.
