### PR TITLE
[cuegui] Fix handling of "Layer on Simulation Frame" dependency in Depend Wizard

### DIFF
--- a/cuegui/cuegui/DependWizard.py
+++ b/cuegui/cuegui/DependWizard.py
@@ -611,11 +611,8 @@ class PageSelectOnLayer(AbstractWizardPage):
         self.wizard().onLayerOptions = opencue.api.findJob(self.wizard().onJob[0]).getLayers()
 
         if self.wizard().dependType in (LOS,):
-            self.wizard().onLayerOptions = [
-                layer for layer in self.wizard().onLayerOptions
-                if 'simulation' in layer.data.services or
-                   'simulationhi' in layer.data.services or
-                   'houdini' in layer.data.services]
+            self.wizard().onLayerOptions = [layer for layer in self.wizard().onLayerOptions
+                                            if self.__isSimulationLayer(layer)]
 
         if self.wizard().dependType in (JOL, LOL, FOL, FBF, JOF, LOF, FOF):
             self.__onLayerList.setSelectionMode(QtWidgets.QAbstractItemView.MultiSelection)
@@ -630,6 +627,15 @@ class PageSelectOnLayer(AbstractWizardPage):
                 str(self.__onLayerList.item(num).text()) in self._getNames(self.wizard().onLayer))
 
     # pylint: disable=missing-function-docstring
+
+    def __isSimulationLayer(self, layer):
+        sim_service_patterns = ['^simulation.*$', '^houdini$']
+        for service in layer.data.services:
+            for pattern in sim_service_patterns:
+                if re.search(pattern, service) is not None:
+                    return True
+        return False
+
     def validatePage(self):
         self.wizard().onLayer = []
         for num in range(self.__onLayerList.count()):


### PR DESCRIPTION
- Restores functionality for the LOS (Layer on Simulation Frame) dependency type.
- Ensures the "Depend on Layer" list is correctly populated with simulation-related layers only.
- Adds proper validation for simulation services (e.g., "simulation", "houdini").
- Resolves issue where Next button on LOS (Layer on Simulation Frame) flow did not work as expected.

**Link the Issue(s) this Pull Request is related to.**
[cuegui] Fix "Layer on Simulation Frame" dependency type in DependWizard #1746 
