### PR TITLE
Fix client install script after packaging refactor (#1681)

### DIFF
--- a/sandbox/install-client-sources.sh
+++ b/sandbox/install-client-sources.sh
@@ -7,5 +7,7 @@ if [[ -n "${OPENCUE_PROTO_PACKAGE_PATH+x}" ]]
 then
   echo "Installing pre-built cuebot package"
   pip install ${OPENCUE_PROTO_PACKAGE_PATH}
+else
+  pip install proto/
 fi
-pip install pycue pyoutline cueadmin cuesubmit cuegui
+pip install pycue/ pyoutline/ cueadmin/ cuesubmit/ cuegui/

--- a/sandbox/install-client-sources.sh
+++ b/sandbox/install-client-sources.sh
@@ -3,11 +3,9 @@
 set -e
 
 # Install all client packages.
-if [[ -v OPENCUE_PROTO_PACKAGE_PATH ]]
+if [[ -n "${OPENCUE_PROTO_PACKAGE_PATH+x}" ]]
 then
   echo "Installing pre-built cuebot package"
   pip install ${OPENCUE_PROTO_PACKAGE_PATH}
-else
-  pip install cuebot/
 fi
-pip install pycue/ pyoutline/ cueadmin/ cuesubmit/ cuegui/
+pip install pycue pyoutline cueadmin cuesubmit cuegui


### PR DESCRIPTION
Replaces deprecated OPENCUE_PROTO_PACKAGE_PATH env check to align with new packaging structure introduced in #1681, where proto is now its own package (opencue_proto) and all packages are prefixed with "opencue_".

- Updated condition to use Bash idiomatic check for defined variables
- Adds `pip install proto/` to ensure the opencue_proto package is installed
- Removed legacy fallback install of cuebot source directory
- Ensures all package paths explicitly use trailing slashes (e.g., pycue/) to direct `pip` to local directories instead of fetching from PyPI

This ensures compatibility with the refactored pyproject.toml-based installation flow and enables support for Python 3.11+ environments.