### PR TITLE
Update sandbox README to simplify Python client installation

### DIFF
--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -96,19 +96,6 @@ python3 -m venv sandbox-venv
 source sandbox-venv/bin/activate
 ```
 
-- Upgrade pip to the latest version
-
-```bash
-pip install --upgrade pip
-```
-
-- Install the required Python packages
-
-```bash
-pip install -r requirements.txt
-pip install -r requirements_gui.txt
-```
-
 - Install the OpenCue Python client libraries from source
   - This option is mostly used by developers that contribute to the OpenCue project.
   - It is recommended if you want to test the latest changes in the OpenCue source code.

--- a/sandbox/install-client-sources.sh
+++ b/sandbox/install-client-sources.sh
@@ -9,6 +9,9 @@
 
 set -e
 
+# Upgrade pip to the latest version
+pip install --upgrade pip
+
 # Install all client packages.
 if [[ -n "${OPENCUE_PROTO_PACKAGE_PATH+x}" ]]
 then
@@ -26,4 +29,6 @@ else
   # Build the proto package
   pip install proto/
 fi
+
+# Install the rest of the Python client packages
 pip install pycue/ pyoutline/ cueadmin/ cuesubmit/ cuegui/


### PR DESCRIPTION
- Updated `sandbox/README.md` to remove the unnecessary `pip install -r requirements.txt` step, as dependencies are now managed via `pyproject.yaml` files.
- Clarified and streamlined the Python client installation instructions for the sandbox environment.

**Link the Issue(s) this Pull Request is related to.**
- #1751 