### PR TITLE
Update PyYAML dependency to version 6.0.1

### DIFF
--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -118,6 +118,26 @@ jobs:
           export OPENCUE_RQD_PACKAGE_PATH="${{ needs.build_opencue_packages.outputs.opencue_rqd_path }}"
           pip install $OPENCUE_PROTO_PACKAGE_PATH $OPENCUE_PYCUE_PACKAGE_PATH $OPENCUE_PYOUTLINE_PACKAGE_PATH $OPENCUE_CUEADMIN_PACKAGE_PATH $OPENCUE_CUESUBMIT_PACKAGE_PATH $OPENCUE_RQD_PACKAGE_PATH
 
+  install_opencue_packages_3_7:
+    needs: build_opencue_packages
+    name: Test installing packages with python 3.7
+    runs-on: ubuntu-22.04
+    container: python:3.7
+    steps:
+      - name: Download a single artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: opencue_packages
+      - name: Install package
+        run: |
+          export OPENCUE_PROTO_PACKAGE_PATH="${{ needs.build_opencue_packages.outputs.opencue_proto_path }}"
+          export OPENCUE_PYCUE_PACKAGE_PATH="${{ needs.build_opencue_packages.outputs.opencue_pycue_path }}"
+          export OPENCUE_PYOUTLINE_PACKAGE_PATH="${{ needs.build_opencue_packages.outputs.opencue_pyoutline_path }}"
+          export OPENCUE_CUEADMIN_PACKAGE_PATH="${{ needs.build_opencue_packages.outputs.opencue_cueadmin_path }}"
+          export OPENCUE_CUESUBMIT_PACKAGE_PATH="${{ needs.build_opencue_packages.outputs.opencue_cuesubmit_path }}"
+          export OPENCUE_RQD_PACKAGE_PATH="${{ needs.build_opencue_packages.outputs.opencue_rqd_path }}"
+          pip install $OPENCUE_PROTO_PACKAGE_PATH $OPENCUE_PYCUE_PACKAGE_PATH $OPENCUE_PYOUTLINE_PACKAGE_PATH $OPENCUE_CUEADMIN_PACKAGE_PATH $OPENCUE_CUESUBMIT_PACKAGE_PATH $OPENCUE_RQD_PACKAGE_PATH
+
   test_python_2023:
     needs: build_opencue_packages
     name: Run Python Unit Tests (CY2023)

--- a/cuegui/cuegui/plugins/StuckFramePlugin.py
+++ b/cuegui/cuegui/plugins/StuckFramePlugin.py
@@ -1509,7 +1509,7 @@ class StuckFrameMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
 
         else:
             with open(yaml_path, 'r', encoding='utf-8') as yaml_ob:
-                old_dict = yaml.load(yaml_ob)
+                old_dict = yaml.load(yaml_ob, Loader=yaml.SafeLoader)
 
             with open(yaml_path, 'w', encoding='utf-8') as yaml_ob:
 
@@ -1589,7 +1589,7 @@ class LogFinal():
 
         else:
             with open(yaml_path, 'r', encoding='utf-8') as yaml_ob:
-                old_dict = yaml.load(yaml_ob)
+                old_dict = yaml.load(yaml_ob, Loader=yaml.SafeLoader)
             with open(yaml_path, 'w', encoding='utf-8') as yaml_ob:
                 for key in frames_dict:  # updates old dict
                     old_dict[key] = frames_dict[key]

--- a/pycue/pyproject.toml
+++ b/pycue/pyproject.toml
@@ -10,7 +10,7 @@ name = "opencue_pycue"
 dynamic = ["version"]
 dependencies = [
     "opencue_proto",
-    "PyYAML==6.0.2",
+    "PyYAML==6.0.1",
     "six==1.16.0",
     "future==1.0.0"
 ]

--- a/pycue/pyproject.toml
+++ b/pycue/pyproject.toml
@@ -10,7 +10,7 @@ name = "opencue_pycue"
 dynamic = ["version"]
 dependencies = [
     "opencue_proto",
-    "PyYAML==5.3",
+    "PyYAML==6.0.2",
     "six==1.16.0",
     "future==1.0.0"
 ]

--- a/pycue/pyproject.toml
+++ b/pycue/pyproject.toml
@@ -10,7 +10,7 @@ name = "opencue_pycue"
 dynamic = ["version"]
 dependencies = [
     "opencue_proto",
-    "PyYAML==5.1",
+    "PyYAML==6.0.2",
     "six==1.16.0",
     "future==1.0.0"
 ]

--- a/pycue/pyproject.toml
+++ b/pycue/pyproject.toml
@@ -10,7 +10,7 @@ name = "opencue_pycue"
 dynamic = ["version"]
 dependencies = [
     "opencue_proto",
-    "PyYAML==6.0.2",
+    "PyYAML==5.3",
     "six==1.16.0",
     "future==1.0.0"
 ]

--- a/pyoutline/outline/io.py
+++ b/pyoutline/outline/io.py
@@ -445,7 +445,7 @@ def file_spec_constructor(loader, node):
     """
     Unserializes a yamlized FileSpec.
     """
-    value = yaml.load(loader.construct_scalar(node), Loader=yaml.FullLoader)
+    value = yaml.load(loader.construct_scalar(node), Loader=yaml.Loader)
     return FileSpec(value[0], **value[1])
 
 

--- a/pyoutline/outline/loader.py
+++ b/pyoutline/outline/loader.py
@@ -76,7 +76,7 @@ def load_outline(path):
     ext = os.path.splitext(path)
     if ext[1] == ".yaml" or path.find("cue_archive") != -1:
         with open(path, encoding='utf-8') as file_object:
-            ol = yaml.load(file_object, Loader=yaml.FullLoader)
+            ol = yaml.load(file_object, Loader=yaml.Loader)
         Outline.current = ol
         if not isinstance(ol, Outline):
             raise outline.exception.OutlineException("The file %s did not produce "

--- a/pyoutline/outline/session.py
+++ b/pyoutline/outline/session.py
@@ -142,7 +142,7 @@ class Session(object):
         logger.info("loading session: %s", session)
         with open(session, encoding='utf-8') as file_object:
             try:
-                data = yaml.load(file_object, Loader=yaml.FullLoader)
+                data = yaml.load(file_object, Loader=yaml.Loader)
             except Exception as exp:
                 msg = "failed to load session from %s, %s"
                 raise outline.exception.SessionException(msg % (session, exp))
@@ -345,7 +345,7 @@ class Session(object):
         logger.debug("opening data path for %s : %s", name, path)
         with open(path, encoding='utf-8') as file_object:
             try:
-                return yaml.load(file_object, Loader=yaml.FullLoader)
+                return yaml.load(file_object, Loader=yaml.Loader)
             except Exception as exp:
                 msg = "failed to load yaml data from %s, %s"
                 raise outline.exception.SessionException(msg % (path, exp))


### PR DESCRIPTION
Upgraded PyYAML from 5.1 to 6.0.1 to ensure compatibility with newer features and security updates. This change aligns with best practices for dependency management.

Also added test for installing all packages in python 3.7
