### PR TITLE
Ignore compiled proto files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ cuebot/.classpath
 cuebot/.project
 /proto/opencue_proto/
 /pycue/opencue/compiled_proto/
+/rqd/rqd/compiled_proto/


### PR DESCRIPTION
- Add `/pycue/opencue/compiled_proto/` and `/rqd/rqd/compiled_proto/` to `.gitignore` to exclude compiled proto files