### PR TITLE
[cuebot/cuegui] Protect Running and Succeeded frames against retries

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/FrameDetail.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/FrameDetail.java
@@ -17,11 +17,9 @@ package com.imageworks.spcue;
 
 import java.sql.Timestamp;
 
-import com.imageworks.spcue.grpc.job.FrameState;
 
 public class FrameDetail extends FrameEntity implements FrameInterface {
 
-    public FrameState state;
     public int number;
     public int dependCount;
     public int retryCount;

--- a/cuebot/src/main/java/com/imageworks/spcue/FrameEntity.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/FrameEntity.java
@@ -15,10 +15,13 @@
 
 package com.imageworks.spcue;
 
+import com.imageworks.spcue.grpc.job.FrameState;
+
 public class FrameEntity extends LayerEntity implements FrameInterface {
 
     public String layerId;
     public int version;
+    public FrameState state;
 
     public FrameEntity() {}
 
@@ -36,5 +39,9 @@ public class FrameEntity extends LayerEntity implements FrameInterface {
 
     public int getVersion() {
         return version;
+    }
+
+    public FrameState getState() {
+        return state;
     }
 }

--- a/cuebot/src/main/java/com/imageworks/spcue/FrameInterface.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/FrameInterface.java
@@ -14,6 +14,8 @@
 
 package com.imageworks.spcue;
 
+import com.imageworks.spcue.grpc.job.FrameState;
+
 public interface FrameInterface extends LayerInterface {
 
     public String getFrameId();
@@ -25,4 +27,6 @@ public interface FrameInterface extends LayerInterface {
      * @return the time stamp that represents the last time this frame was updated.
      */
     public int getVersion();
+
+    public FrameState getState();
 }

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/FrameDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/FrameDaoJdbc.java
@@ -53,6 +53,7 @@ import com.imageworks.spcue.util.CueUtil;
 import com.imageworks.spcue.util.FrameSet;
 import com.imageworks.spcue.util.SqlUtil;
 
+// spotless:off
 public class FrameDaoJdbc extends JdbcDaoSupport implements FrameDao {
 
     private static final String UPDATE_FRAME_STOPPED_NORSS = "UPDATE " + "frame " + "SET "
@@ -316,13 +317,29 @@ public class FrameDaoJdbc extends JdbcDaoSupport implements FrameDao {
         }
     };
 
-    public static final String FIND_ORPHANED_FRAMES = "SELECT " + "frame.pk_frame, "
-            + "frame.pk_layer, " + "frame.str_name, " + "frame.int_version, " + "job.pk_job, "
-            + "job.pk_show, " + "job.pk_facility " + "FROM " + "frame, " + "job " + "WHERE "
-            + "job.pk_job = frame.pk_job " + "AND " + "frame.str_state = 'RUNNING' " + "AND "
-            + "job.str_state = 'PENDING' " + "AND "
-            + "(SELECT COUNT(1) FROM proc WHERE proc.pk_frame = frame.pk_frame) = 0 " + "AND "
-            + "current_timestamp - frame.ts_updated > interval '300' second";
+    public static final String FIND_ORPHANED_FRAMES =
+        "SELECT " +
+            "frame.pk_frame, " +
+            "frame.pk_layer, " +
+            "frame.str_name, " +
+            "frame.int_version, " +
+            "frame.str_state, " +
+            "job.pk_job, " +
+            "job.pk_show, " +
+            "job.pk_facility " +
+            "FROM " +
+            "frame, " +
+            "job " +
+            "WHERE " +
+            "job.pk_job = frame.pk_job " +
+            "AND " +
+            "frame.str_state = 'RUNNING' " +
+            "AND " +
+            "job.str_state = 'PENDING' " +
+            "AND " +
+            "(SELECT COUNT(1) FROM proc WHERE proc.pk_frame = frame.pk_frame) = 0 " +
+            "AND " +
+            "current_timestamp - frame.ts_updated > interval '300' second";
 
     @Override
     public List<FrameInterface> getOrphanedFrames() {
@@ -844,3 +861,5 @@ public class FrameDaoJdbc extends JdbcDaoSupport implements FrameDao {
                 frameId, override.getState().toString());
     }
 }
+
+// spotless:on

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/FrameDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/FrameDaoJdbc.java
@@ -279,6 +279,7 @@ public class FrameDaoJdbc extends JdbcDaoSupport implements FrameDao {
             frame.showId = rs.getString("pk_show");
             frame.facilityId = rs.getString("pk_facility");
             frame.version = rs.getInt("int_version");
+            frame.state = FrameState.valueOf(rs.getString("str_state"));
             return frame;
         }
     };

--- a/cuebot/src/main/java/com/imageworks/spcue/service/JobManagerSupport.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/service/JobManagerSupport.java
@@ -408,6 +408,15 @@ public class JobManagerSupport {
             logger.info("failed to obtain information for " + "proc running on frame: " + frame);
         }
 
+        if (frame.getState() == FrameState.RUNNING) {
+            logger.warn("Invalid retry request. Cannot retry a running frame");
+            return;
+        }
+        if (frame.getState() == FrameState.SUCCEEDED) {
+            logger.warn("Invalid retry request. Cannot retry a succeeded frame");
+            return;
+        }
+
         if (manualStopFrame(frame, FrameState.WAITING)) {
             if (proc != null) {
                 redirectManager.addRedirect(proc, (JobInterface) proc, false, source);

--- a/cuegui/cuegui/FrameMonitorTree.py
+++ b/cuegui/cuegui/FrameMonitorTree.py
@@ -597,7 +597,7 @@ class FrameMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
     def contextMenuEvent(self, e):
         """When right clicking on an item, this raises a context menu"""
         menu = FrameContextMenu(self, self._actionFilterSelectedLayers,
-                                readonly=(cuegui.Constants.FINISHED_JOBS_READONLY_FRAME and
+                                job_completed=(cuegui.Constants.FINISHED_JOBS_READONLY_FRAME and
                                           self.__jobState == opencue.api.job_pb2.FINISHED))
         menu.exec_(e.globalPos())
 
@@ -890,7 +890,7 @@ class FrameEtaDataBuffer(object):
 class FrameContextMenu(QtWidgets.QMenu):
     """Context menu for frames."""
 
-    def __init__(self, widget, filterSelectedLayersCallback, readonly=False):
+    def __init__(self, widget, filterSelectedLayersCallback, job_completed=False):
         super(FrameContextMenu, self).__init__()
         self.app = cuegui.app()
 
@@ -902,6 +902,11 @@ class FrameContextMenu(QtWidgets.QMenu):
         self.__menuActions.frames().addAction(self, "tail")
         self.__menuActions.frames().addAction(self, "view")
         self.__menuActions.frames().addAction(self, "copyLogPath")
+
+        can_retry = True
+        for frame in widget.selectedObjects():
+            invalid_states = [job_pb2.FrameState.Value('RUNNING'), job_pb2.FrameState.Value('SUCCEEDED')]
+            can_retry = can_retry and frame.data.state not in invalid_states
 
         if count == 1:
             if widget.selectedObjects()[0].data.retry_count >= 1:
@@ -958,14 +963,14 @@ class FrameContextMenu(QtWidgets.QMenu):
 
         self.__menuActions.frames().createAction(self, "Filter Selected Layers", None,
                                                  filterSelectedLayersCallback, "stock-filters")
-        self.__menuActions.frames().addAction(self, "reorder").setEnabled(not readonly)
+        self.__menuActions.frames().addAction(self, "reorder").setEnabled(not job_completed)
         self.addSeparator()
         if cuegui.Constants.OUTPUT_VIEWER_DIRECT_CMD_CALL:
             self.__menuActions.frames().addAction(self, "previewMain")
         self.__menuActions.frames().addAction(self, "previewAovs")
         self.addSeparator()
-        self.__menuActions.frames().addAction(self, "retry").setEnabled(not readonly)
-        self.__menuActions.frames().addAction(self, "eat").setEnabled(not readonly)
-        self.__menuActions.frames().addAction(self, "kill").setEnabled(not readonly)
-        self.__menuActions.frames().addAction(self, "eatandmarkdone").setEnabled(not readonly)
+        self.__menuActions.frames().addAction(self, "retry").setEnabled(can_retry and not job_completed)
+        self.__menuActions.frames().addAction(self, "eat").setEnabled(not job_completed)
+        self.__menuActions.frames().addAction(self, "kill").setEnabled(not job_completed)
+        self.__menuActions.frames().addAction(self, "eatandmarkdone").setEnabled(not job_completed)
         self.__menuActions.frames().addAction(self, "viewProcesses")

--- a/cuegui/cuegui/FrameMonitorTree.py
+++ b/cuegui/cuegui/FrameMonitorTree.py
@@ -905,7 +905,8 @@ class FrameContextMenu(QtWidgets.QMenu):
 
         can_retry = True
         for frame in widget.selectedObjects():
-            invalid_states = [job_pb2.FrameState.Value('RUNNING'), job_pb2.FrameState.Value('SUCCEEDED')]
+            invalid_states = [job_pb2.FrameState.Value('RUNNING'),
+                job_pb2.FrameState.Value('SUCCEEDED')]
             can_retry = can_retry and frame.data.state not in invalid_states
 
         if count == 1:
@@ -969,7 +970,8 @@ class FrameContextMenu(QtWidgets.QMenu):
             self.__menuActions.frames().addAction(self, "previewMain")
         self.__menuActions.frames().addAction(self, "previewAovs")
         self.addSeparator()
-        self.__menuActions.frames().addAction(self, "retry").setEnabled(can_retry and not job_completed)
+        self.__menuActions.frames().addAction(self, "retry").setEnabled(
+            can_retry and not job_completed)
         self.__menuActions.frames().addAction(self, "eat").setEnabled(not job_completed)
         self.__menuActions.frames().addAction(self, "kill").setEnabled(not job_completed)
         self.__menuActions.frames().addAction(self, "eatandmarkdone").setEnabled(not job_completed)


### PR DESCRIPTION
Retrying running and succeeded frames can lead to incoherent states when it comes to frame-on-frame and layer-on-frame dependencies.

This PR prevents such requests on cuebot and also disable the menu actions on the GUI.
