### PR TITLE
[rust/rqd] Implement NIMBY logic

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Install X11 dev libs
+        run: |
+          sudo apt-get update && sudo apt-get install -y libx11-dev
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
       - name: Build

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -397,6 +397,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +492,20 @@ checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
  "serde",
+]
+
+[[package]]
+name = "device_query"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "429b683ad2cf0d2f0f37f510655854baf18d5f108c3790ab5dd1d09a26874436"
+dependencies = [
+ "macos-accessibility-client",
+ "pkg-config",
+ "readkey",
+ "readmouse",
+ "windows 0.48.0",
+ "x11",
 ]
 
 [[package]]
@@ -1197,6 +1221,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "macos-accessibility-client"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edf7710fbff50c24124331760978fb9086d6de6288dcdb38b25a97f8b1bdebbb"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1545,6 +1579,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "postgres-protocol"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,6 +1827,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "readkey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a36870cefdfcff57edbc0fa62165f42dfd4e5a0d8965117c1ea84c5700e4450"
+
+[[package]]
+name = "readmouse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be105c72a1e6a5a1198acee3d5b506a15676b74a02ecd78060042a447f408d94"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,6 +1922,7 @@ dependencies = [
  "chrono",
  "config",
  "dashmap",
+ "device_query",
  "futures",
  "futures-core",
  "http",
@@ -2229,7 +2282,7 @@ dependencies = [
  "memchr",
  "ntapi",
  "rayon",
- "windows",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -2903,6 +2956,15 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
@@ -3134,6 +3196,16 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "x11"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/rust/config/rqd.fake_linux.yaml
+++ b/rust/config/rqd.fake_linux.yaml
@@ -5,6 +5,8 @@ grpc:
   cuebot_endpoints: ["0.0.0.0:4343", "0.0.0.0:4343"]
   connection_expires_after: 15m
 machine:
+  # nimby_mode: true
+  # nimby_idle_threshold: 60s
   worker_threads: 8
   facility: test
   monitor_interval: 3s

--- a/rust/config/rqd.yaml
+++ b/rust/config/rqd.yaml
@@ -30,7 +30,7 @@ grpc:
 
   # Cuebot server endpoints (can specify multiple for failover)
   # Default: ["localhost:4343"]
-  cuebot_endpoints: ["cuebot.example.com:8082"]  # Replace with actual endpoints
+  cuebot_endpoints: ["cuebot.example.com:8082"] # Replace with actual endpoints
 
   # How long gRPC connections should remain active before expiring
   # Default: 1h (3600 seconds)
@@ -72,6 +72,15 @@ machine:
   # How long a system must be idle before triggering NIMBY lock
   # Default: 15 minutes
   # nimby_idle_threshold: 900s
+
+  # Path to the file containing the display number
+  # This file should contain a single line with the display number and writing it
+  # is not a responsibility of this module
+  # nimby_display_file_path: "/tmp/DISPLAY"
+
+  # How often to retry starting NIMBY mode if it fails
+  # Default: 5 minutes
+  # nimby_start_retry_interval: 300s
 
   # Custom tags to apply to this render node for job targeting
   # Default: []

--- a/rust/config/rqd.yaml
+++ b/rust/config/rqd.yaml
@@ -69,6 +69,10 @@ machine:
   # Default: false
   # nimby_mode: false
 
+  # How long a system must be idle before triggering NIMBY lock
+  # Default: 15 minutes
+  # nimby_idle_threshold: 900s
+
   # Custom tags to apply to this render node for job targeting
   # Default: []
   # custom_tags: ["gpu", "high_memory"]

--- a/rust/config/rqd.yaml
+++ b/rust/config/rqd.yaml
@@ -73,7 +73,7 @@ machine:
   # Default: 15 minutes
   # nimby_idle_threshold: 900s
 
-  # Path to the file containing the display number
+  # Path to a file containing the DISPLAY number (e.g., "username:0")
   # This file should contain a single line with the display number and writing it
   # is not a responsibility of this module
   # nimby_display_file_path: "/tmp/DISPLAY"

--- a/rust/config/rqd.yaml
+++ b/rust/config/rqd.yaml
@@ -82,6 +82,10 @@ machine:
   # Default: 5 minutes
   # nimby_start_retry_interval: 300s
 
+  # Path to the Xauthority file path
+  # This file by default is located at user home directory
+  # nimby_display_xauthority_path: "/home/{username}/Xauthority"
+
   # Custom tags to apply to this render node for job targeting
   # Default: []
   # custom_tags: ["gpu", "high_memory"]

--- a/rust/crates/rqd/Cargo.toml
+++ b/rust/crates/rqd/Cargo.toml
@@ -61,6 +61,7 @@ tower-service = "0.3.3"
 http-body-util = "0.1.3"
 rand = "0.9.1"
 libc = "0.2"
+device_query = "3.0"
 
 [dev-dependencies]
 tempfile = "3.14.0"

--- a/rust/crates/rqd/resources/openrqd.service
+++ b/rust/crates/rqd/resources/openrqd.service
@@ -5,7 +5,7 @@ After=network.target
 
 [Service]
 Environment=OPENCUE_RQD_CONFIG=/etc/openrqd/rqd.yaml
-ExecStart=/usr/bin/openrqd
+ExecStart=/usr/local/bin/openrqd
 LimitNOFILE=500000
 LimitNPROC=500000
 StandardOutput=journal+console

--- a/rust/crates/rqd/src/config/config.rs
+++ b/rust/crates/rqd/src/config/config.rs
@@ -78,6 +78,7 @@ pub struct MachineConfig {
     pub nimby_display_file_path: Option<String>,
     #[serde(with = "humantime_serde")]
     pub nimby_start_retry_interval: Duration,
+    pub nimby_display_xauthority_path: String,
 }
 
 impl Default for MachineConfig {
@@ -99,6 +100,7 @@ impl Default for MachineConfig {
             nimby_idle_threshold: Duration::from_secs(60 * 15), // 15 min
             nimby_display_file_path: None,
             nimby_start_retry_interval: Duration::from_secs(60 * 5), // 5 min
+            nimby_display_xauthority_path: "/home/{username}/Xauthority".to_string(),
         }
     }
 }

--- a/rust/crates/rqd/src/config/config.rs
+++ b/rust/crates/rqd/src/config/config.rs
@@ -75,7 +75,7 @@ pub struct MachineConfig {
     pub worker_threads: usize,
     #[serde(with = "humantime_serde")]
     pub nimby_idle_threshold: Duration,
-    pub nimby_display_file_path: String,
+    pub nimby_display_file_path: Option<String>,
     #[serde(with = "humantime_serde")]
     pub nimby_start_retry_interval: Duration,
 }
@@ -97,7 +97,7 @@ impl Default for MachineConfig {
             core_multiplier: 100,
             worker_threads: 4,
             nimby_idle_threshold: Duration::from_secs(60 * 15), // 15 min
-            nimby_display_file_path: "/tmp/DISPLAY".to_string(),
+            nimby_display_file_path: None,
             nimby_start_retry_interval: Duration::from_secs(60 * 5), // 5 min
         }
     }

--- a/rust/crates/rqd/src/config/config.rs
+++ b/rust/crates/rqd/src/config/config.rs
@@ -126,6 +126,7 @@ pub struct RunnerConfig {
 pub enum LoggerType {
     #[serde(rename = "file")]
     File,
+    // This is a placeholder for new logging solutions
     // #[serde(rename = "loki")]
     // Loki,
 }
@@ -250,7 +251,7 @@ impl Config {
     pub fn load_file_and_env<P: AsRef<str>>(path: P) -> Result<Self, RqdConfigError> {
         let config = ConfigBase::builder()
             .add_source(File::with_name(path.as_ref()))
-            .add_source(Environment::with_prefix("VNPM").separator("_"))
+            .add_source(Environment::with_prefix("RQD").separator("_"))
             .build();
 
         config

--- a/rust/crates/rqd/src/config/config.rs
+++ b/rust/crates/rqd/src/config/config.rs
@@ -75,6 +75,9 @@ pub struct MachineConfig {
     pub worker_threads: usize,
     #[serde(with = "humantime_serde")]
     pub nimby_idle_threshold: Duration,
+    pub nimby_display_file_path: String,
+    #[serde(with = "humantime_serde")]
+    pub nimby_start_retry_interval: Duration,
 }
 
 impl Default for MachineConfig {
@@ -94,6 +97,8 @@ impl Default for MachineConfig {
             core_multiplier: 100,
             worker_threads: 4,
             nimby_idle_threshold: Duration::from_secs(60 * 15), // 15 min
+            nimby_display_file_path: "/tmp/DISPLAY".to_string(),
+            nimby_start_retry_interval: Duration::from_secs(60 * 5), // 5 min
         }
     }
 }

--- a/rust/crates/rqd/src/config/config.rs
+++ b/rust/crates/rqd/src/config/config.rs
@@ -73,6 +73,8 @@ pub struct MachineConfig {
     pub temp_path: String,
     pub core_multiplier: u32,
     pub worker_threads: usize,
+    #[serde(with = "humantime_serde")]
+    pub nimby_idle_threshold: Duration,
 }
 
 impl Default for MachineConfig {
@@ -91,6 +93,7 @@ impl Default for MachineConfig {
             temp_path: "/tmp".to_string(),
             core_multiplier: 100,
             worker_threads: 4,
+            nimby_idle_threshold: Duration::from_secs(60 * 15), // 15 min
         }
     }
 }

--- a/rust/crates/rqd/src/system/linux.rs
+++ b/rust/crates/rqd/src/system/linux.rs
@@ -853,11 +853,6 @@ impl SystemManager for LinuxSystem {
         &self.attributes
     }
 
-    fn init_nimby(&self) -> Result<bool> {
-        // TODO: missing implementation, returning dummy val
-        Ok(false)
-    }
-
     fn collect_gpu_stats(&self) -> MachineGpuStats {
         // TODO: missing implementation, returning dummy val
         MachineGpuStats {

--- a/rust/crates/rqd/src/system/machine.rs
+++ b/rust/crates/rqd/src/system/machine.rs
@@ -87,6 +87,7 @@ impl MachineMonitor {
             let nimby = Nimby::init(
                 config.machine.nimby_idle_threshold,
                 config.machine.nimby_display_file_path.clone(),
+                config.machine.nimby_display_xauthority_path.clone(),
             );
             Arc::new(Some(nimby))
         } else {

--- a/rust/crates/rqd/src/system/machine.rs
+++ b/rust/crates/rqd/src/system/machine.rs
@@ -69,12 +69,6 @@ pub struct MachineMonitor {
     nimby_state: RwLock<LockState>,
 }
 
-impl Drop for MachineMonitor {
-    fn drop(&mut self) {
-        todo!()
-    }
-}
-
 impl MachineMonitor {
     /// Initializes the object without starting the monitor loop
     /// Will gather the initial state of this machine

--- a/rust/crates/rqd/src/system/machine.rs
+++ b/rust/crates/rqd/src/system/machine.rs
@@ -89,6 +89,7 @@ impl MachineMonitor {
                 config.machine.nimby_display_file_path.clone(),
                 config.machine.nimby_display_xauthority_path.clone(),
             );
+            info!("NIMBY mode enabled and initialized");
             Arc::new(Some(nimby))
         } else {
             Arc::new(None)

--- a/rust/crates/rqd/src/system/machine.rs
+++ b/rust/crates/rqd/src/system/machine.rs
@@ -223,7 +223,7 @@ impl MachineMonitor {
                         match nimby.start(&mut term_listener).await {
                             Ok(_) => break,
                             Err(err) => {
-                                debug!(
+                                info!(
                                     "Nimby startup failed, retrying in {}s. {err}",
                                     nimby_start_retry_interval.as_secs()
                                 );

--- a/rust/crates/rqd/src/system/macos.rs
+++ b/rust/crates/rqd/src/system/macos.rs
@@ -754,11 +754,6 @@ impl SystemManager for MacOsSystem {
         &self.attributes
     }
 
-    fn init_nimby(&self) -> Result<bool> {
-        // TODO: missing implementation, returning dummy val
-        Ok(false)
-    }
-
     fn collect_gpu_stats(&self) -> MachineGpuStats {
         // TODO: missing implementation, returning dummy val
         MachineGpuStats {

--- a/rust/crates/rqd/src/system/manager.rs
+++ b/rust/crates/rqd/src/system/manager.rs
@@ -26,11 +26,6 @@ pub trait SystemManager {
     /// List of attributes collected from the machine. Eg. SP_OS
     fn attributes(&self) -> &HashMap<String, String>;
 
-    /// Init NotInMyBackyard logic
-    fn init_nimby(&self) -> Result<bool>;
-
-    /// Returns a map of cores per socket that are not reserved
-
     /// Reserve a number of cores.
     ///
     /// # Returns:

--- a/rust/crates/rqd/src/system/mod.rs
+++ b/rust/crates/rqd/src/system/mod.rs
@@ -1,5 +1,6 @@
 pub mod linux;
 pub mod machine;
+mod nimby;
 
 #[cfg(target_os = "macos")]
 pub mod macos;

--- a/rust/crates/rqd/src/system/nimby.rs
+++ b/rust/crates/rqd/src/system/nimby.rs
@@ -6,8 +6,7 @@
 //! are currently being used by a human user.
 
 use std::{
-    any::Any,
-    env, panic,
+    env,
     path::Path,
     sync::{
         Arc,
@@ -56,7 +55,7 @@ pub struct Nimby {
     last_interaction_epoch_in_secs: Arc<AtomicU64>,
     /// Duration after which a user is considered idle if no interactions occur.
     idle_threshold: Duration,
-    nimby_display_file_path: String,
+    nimby_display_file_path: Option<String>,
 }
 
 impl Nimby {
@@ -79,7 +78,7 @@ impl Nimby {
     /// // Create a NIMBY detector with 5-minute idle threshold
     /// let nimby = Nimby::init(Duration::from_secs(300));
     /// ```
-    pub fn init(idle_threshold: Duration, nimby_display_file_path: String) -> Self {
+    pub fn init(idle_threshold: Duration, nimby_display_file_path: Option<String>) -> Self {
         Nimby {
             last_interaction_epoch_in_secs: Arc::new(AtomicU64::new(0)),
             idle_threshold: idle_threshold,
@@ -135,17 +134,13 @@ impl Nimby {
     /// # }
     /// ```
     pub async fn start(&self, interrupt_signal: &mut Receiver<()>) -> Result<()> {
-        let mut device_state_res =
-            panic::catch_unwind(|| DeviceEventsHandler::new(Duration::from_millis(300)))
-                .map_err(|panic_payload| Self::panic_message(&panic_payload));
-        // If device_state fails to initialize, it usually means this process doesn't have access to
-        // the X display. Give it another try reading the user display value from a DISPLAY file
-        if let Err(_) = device_state_res {
-            device_state_res = self.start_device_monitor_from_display_file().await;
+        if let Some(nimby_display_file_path) = &self.nimby_display_file_path {
+            Self::set_display_from_file(&nimby_display_file_path).await?;
         }
+
         let device_state =
             // If starting device_state failed again, return Error.
-            device_state_res?
+            DeviceEventsHandler::new(Duration::from_millis(300))
                 // None here means the device_handler has alread been initialized
                 .ok_or(miette!("Nimby watcher has already been initialized"))?;
 
@@ -185,39 +180,23 @@ impl Nimby {
         Ok(())
     }
 
-    async fn start_device_monitor_from_display_file(&self) -> Result<Option<DeviceEventsHandler>> {
-        let display_path = Path::new(&self.nimby_display_file_path);
+    async fn set_display_from_file(nimby_display_file_path: &str) -> Result<()> {
+        let display_path = Path::new(nimby_display_file_path);
         let display_from_file = tokio::fs::read_to_string(&display_path)
             .await
             .into_diagnostic()
             .wrap_err(format!(
                 "Failed to load nimby. DISPLAY variable is not set and {} doesn't exist",
-                self.nimby_display_file_path
+                nimby_display_file_path
             ))?;
         let display = display_from_file.lines().last().ok_or(miette!(
             "Failed to load nimby. {} file is empty",
-            self.nimby_display_file_path
+            nimby_display_file_path
         ))?;
         unsafe { env::set_var("DISPLAY", display) };
-
-        // Retry initializing with display file
-        panic::catch_unwind(|| DeviceEventsHandler::new(Duration::from_millis(300)))
-            .map_err(|panic_payload| Self::panic_message(&panic_payload))
+        Ok(())
     }
 
-    fn panic_message(panic_payload: &Box<dyn Any + Send>) -> miette::Report {
-        let panic_message = if let Some(s) = panic_payload.downcast_ref::<String>() {
-            s.clone()
-        } else if let Some(s) = panic_payload.downcast_ref::<&str>() {
-            s.to_string()
-        } else {
-            "DevideEventHandler paniced".to_string()
-        };
-        miette!(
-            "Failed to initialize DeviceEventsHandler on nimby. {}",
-            panic_message
-        )
-    }
     /// Checks if the user is currently considered active based on recent interactions.
     ///
     /// A user is considered active if there has been mouse or keyboard activity

--- a/rust/crates/rqd/src/system/nimby.rs
+++ b/rust/crates/rqd/src/system/nimby.rs
@@ -1,0 +1,212 @@
+//! NIMBY (Not In My BackYard) system for detecting user activity.
+//!
+//! This module provides functionality to monitor user input (mouse and keyboard)
+//! to determine if a user is actively using the system. It's commonly used in
+//! distributed computing systems to prevent job scheduling on machines that
+//! are currently being used by a human user.
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use device_query::{DeviceEvents, DeviceEventsHandler};
+use miette::{Result, miette};
+use tokio::sync::oneshot::Receiver;
+use tracing::{debug, warn};
+
+/// NIMBY (Not In My BackYard) detector for monitoring user activity.
+///
+/// This struct tracks user input events (mouse movement and keyboard presses)
+/// to determine if a user is actively using the system. It maintains a record
+/// of the last interaction time and compares it against a configurable idle
+/// threshold to determine user activity status.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use std::time::Duration;
+/// use tokio::sync::oneshot;
+///
+/// # async fn example() -> miette::Result<()> {
+/// let nimby = Nimby::init(Duration::from_secs(300)); // 5 minute idle threshold
+/// let (tx, rx) = oneshot::channel();
+///
+/// // Start monitoring in a background task
+/// tokio::spawn(async move {
+///     nimby.start(rx).await
+/// });
+///
+/// // Check if user is active
+/// if nimby.is_user_active() {
+///     println!("User is currently active");
+/// }
+/// # Ok(())
+/// # }
+/// ```
+pub struct Nimby {
+    /// Timestamp of the last recorded user interaction.
+    /// Using AtomicU64 for lock-free access
+    last_interaction_epoch: Arc<AtomicU64>,
+    /// Duration after which a user is considered idle if no interactions occur.
+    idle_threshold: Duration,
+}
+
+impl Nimby {
+    /// Creates a new NIMBY detector with the specified idle threshold.
+    ///
+    /// # Arguments
+    ///
+    /// * `idle_threshold` - Duration after which the user is considered idle
+    ///   if no mouse or keyboard activity is detected.
+    ///
+    /// # Returns
+    ///
+    /// A new `Nimby` instance ready to start monitoring user activity.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::time::Duration;
+    ///
+    /// // Create a NIMBY detector with 5-minute idle threshold
+    /// let nimby = Nimby::init(Duration::from_secs(300));
+    /// ```
+    pub fn init(idle_threshold: Duration) -> Self {
+        Nimby {
+            last_interaction_epoch: Arc::new(AtomicU64::new(0)),
+            idle_threshold: idle_threshold,
+        }
+    }
+
+    /// Starts monitoring user activity until an interrupt signal is received.
+    ///
+    /// This method sets up event handlers for mouse movement and keyboard input,
+    /// then waits for an interrupt signal. It includes a 5-second initialization
+    /// period during which events are ignored to prevent false positives during
+    /// system startup.
+    ///
+    /// # Arguments
+    ///
+    /// * `interrupt_signal` - A oneshot receiver that will terminate the monitoring
+    ///   when a signal is sent.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` - When monitoring is successfully stopped via interrupt signal
+    /// * `Err(miette::Error)` - If the device event handler cannot be initialized
+    ///   (typically because it's already been initialized elsewhere)
+    ///
+    /// # Behavior
+    ///
+    /// - Mouse movement and keyboard key-down events update the last interaction time
+    /// - Events during the first 5 seconds after startup are ignored
+    /// - The method blocks until the interrupt signal is received
+    /// - Event handlers are automatically cleaned up when the method returns
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use tokio::sync::oneshot;
+    /// use std::time::Duration;
+    ///
+    /// # async fn example() -> miette::Result<()> {
+    /// let nimby = Nimby::init(Duration::from_secs(300));
+    /// let (tx, rx) = oneshot::channel();
+    ///
+    /// // Start monitoring in background
+    /// let monitor_handle = tokio::spawn(async move {
+    ///     nimby.start(rx).await
+    /// });
+    ///
+    /// // Stop monitoring after some time
+    /// tokio::time::sleep(Duration::from_secs(60)).await;
+    /// let _ = tx.send(());
+    /// monitor_handle.await??;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn start(&self, interrupt_signal: Receiver<()>) -> Result<()> {
+        let device_state = DeviceEventsHandler::new(Duration::from_millis(300))
+            .ok_or(miette!("Nimby watcher has already been initialized"))?;
+        let startup_time = SystemTime::now();
+        let init_wait = Duration::from_secs(5);
+
+        let last_interaction = Arc::clone(&self.last_interaction_epoch);
+        let _mouse_guard = device_state.on_mouse_move(move |_| {
+            let now = SystemTime::now();
+            if now.duration_since(startup_time).unwrap_or(Duration::ZERO) > init_wait {
+                debug!("mouse interaction");
+                let now_epoch = now
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or(Duration::ZERO)
+                    .as_nanos() as u64;
+
+                last_interaction.store(now_epoch, Ordering::Relaxed);
+            }
+        });
+
+        let last_interaction = Arc::clone(&self.last_interaction_epoch);
+        let _keyboard_guard = device_state.on_key_down(move |_| {
+            let now = SystemTime::now();
+            if now.duration_since(startup_time).unwrap_or(Duration::ZERO) > init_wait {
+                debug!("keyboard interaction");
+                let now_epoch = now
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or(Duration::ZERO)
+                    .as_nanos() as u64;
+
+                last_interaction.store(now_epoch, Ordering::Relaxed);
+            }
+        });
+
+        // TODO: Review if async awaiting here is enough to keep the guards alive
+        let _ = interrupt_signal.await;
+        warn!("nimby loop interrupted");
+        Ok(())
+    }
+
+    /// Checks if the user is currently considered active based on recent interactions.
+    ///
+    /// A user is considered active if there has been mouse or keyboard activity
+    /// within the configured idle threshold duration.
+    ///
+    /// # Returns
+    ///
+    /// * `true` - If user activity was detected within the idle threshold
+    /// * `false` - If no activity was detected within the idle threshold,
+    ///   or if no activity has ever been recorded
+    ///
+    /// # Thread Safety
+    ///
+    /// This method is thread-safe and can be called concurrently from multiple
+    /// threads. It handles lock poisoning gracefully by recovering the data
+    /// from poisoned locks.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use std::time::Duration;
+    ///
+    /// let nimby = Nimby::init(Duration::from_secs(300)); // 5 minute threshold
+    ///
+    /// if nimby.is_user_active() {
+    ///     println!("User is active - don't start heavy computation");
+    /// } else {
+    ///     println!("User appears idle - safe to start background tasks");
+    /// }
+    /// ```
+    pub fn is_user_active(&self) -> bool {
+        let last_nanos = self.last_interaction_epoch.load(Ordering::Relaxed);
+
+        if last_nanos == 0 {
+            return false; // No interaction recorded yet
+        }
+
+        let last_time = UNIX_EPOCH + Duration::from_nanos(last_nanos);
+        last_time.elapsed().unwrap_or(Duration::MAX) < self.idle_threshold
+    }
+}


### PR DESCRIPTION
Implemented NIMBY (Not In My BackYard) logic in the new Rust-based RQD, replicating the behavior of the original Python implementation.

- Add NIMBY support to the Rust-based RQD system, preventing jobs from running when a user is actively using the machine.
- Add new `rust/crates/rqd/src/system/nimby.rs` module to detect mouse/keyboard activity using `device_query`
- NIMBY configurable via `rqd.yaml` (nimby_mode, idle_threshold, etc.)
- Dynamically sets `DISPLAY` and `XAUTHORITY` from a file
- Integrated with `MachineMonitor` to `lock/unlock` cores and update host state
- Graceful shutdown support with `broadcast::channel`




