### PR TITLE
[rust/rqd] Refactor core reservation logic

### DIFF
--- a/rust/crates/opencue-proto/src/lib.rs
+++ b/rust/crates/opencue-proto/src/lib.rs
@@ -2,7 +2,6 @@ use core::fmt;
 
 use host::Host;
 use job::{Frame, Job};
-use report::CoreDetail;
 use rqd::RunFrame;
 use uuid::Uuid;
 
@@ -125,115 +124,5 @@ impl fmt::Display for Job {
 impl fmt::Display for Host {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}/({})", self.name, self.id)
-    }
-}
-
-impl CoreDetail {
-    /// Update CoreDetail by reserving a number of cores
-    ///
-    /// # Arguments
-    ///
-    /// * `core_count_with_multiplier` - Number of cores to reserve multiplied by core_multiplier
-    ///
-    /// # Returns
-    ///
-    /// * `Ok(())` if cores were reserved successfully
-    /// * `Err(String)` if trying to reserve more cores than are available
-    pub fn register_reservation(
-        &mut self,
-        core_count_with_multiplier: usize,
-    ) -> Result<(), String> {
-        if self.idle_cores - (core_count_with_multiplier as i32) < 0 {
-            Err(format!(
-                "Tried to reserve {} out of {} cores available",
-                core_count_with_multiplier, self.idle_cores,
-            ))
-        } else {
-            self.idle_cores -= core_count_with_multiplier as i32;
-            self.booked_cores += core_count_with_multiplier as i32;
-            Ok(())
-        }
-    }
-
-    /// Update CoreDetail by releasing a number of previously reserved cores
-    ///
-    /// # Arguments
-    ///
-    /// * `core_count_with_multiplier` - The number of cores to release multiplied by core_multiplier
-    ///
-    /// # Returns
-    ///
-    /// * `Ok(())` if cores were released successfully
-    /// * `Err(String)` if trying to release more cores than are currently reserved
-    pub fn register_release(&mut self, core_count_with_multiplier: u32) -> Result<(), String> {
-        if self.booked_cores < core_count_with_multiplier as i32 {
-            Err(format!(
-                "Tried to release {} out of {} cores reserved",
-                core_count_with_multiplier, self.booked_cores,
-            ))
-        } else {
-            self.idle_cores += core_count_with_multiplier as i32;
-            self.booked_cores -= core_count_with_multiplier as i32;
-            Ok(())
-        }
-    }
-
-    /// Update CoreDetail by locking a specified number of cores. If the amount requested is
-    /// not available, the maximum available will be reserved.
-    ///
-    /// # Arguments
-    ///
-    /// * `count_with_multiplier` - Number of cores to lock multiplied by core_multiplier
-    ///
-    /// # Returns
-    ///
-    /// * `u32` - The actual number of cores that were locked (may be less than requested if not enough are available)
-    pub fn lock_cores(&mut self, count_with_multiplier: u32) -> u32 {
-        let amount_not_locked = self.total_cores - self.locked_cores;
-        let amount_to_lock = std::cmp::min(amount_not_locked, count_with_multiplier as i32);
-
-        if amount_to_lock > 0 {
-            self.locked_cores += amount_to_lock;
-            self.idle_cores -= std::cmp::min(amount_to_lock, self.idle_cores)
-        }
-
-        amount_to_lock as u32
-    }
-
-    /// Update CoreDetail by locking all available cores
-    ///
-    /// This will set idle_cores to 0 and locked_cores to total_cores
-    pub fn lock_all_cores(&mut self) {
-        self.idle_cores = 0;
-        self.locked_cores = self.total_cores;
-    }
-
-    /// Update CoreDetail by unlocking a specified number of cores that were previously locked.
-    ///
-    /// # Arguments
-    ///
-    /// * `count_with_multiplier` - Number of cores to unlock multiplied by core_multiplier
-    ///
-    /// # Returns
-    ///
-    /// * `u32` - The actual number of cores that were unlocked (may be less than requested if fewer cores are locked)
-    pub fn unlock_cores(&mut self, count_with_multiplier: u32) -> u32 {
-        let amount_to_unlock = std::cmp::min(count_with_multiplier as i32, self.locked_cores);
-
-        if amount_to_unlock > 0 {
-            self.locked_cores -= amount_to_unlock;
-            self.idle_cores += amount_to_unlock;
-        }
-        amount_to_unlock as u32
-    }
-
-    /// Update CoreDetail by unlocking all locked cores
-    ///
-    /// This will unlock all locked cores and add them to idle_cores
-    pub fn unlock_all_cores(&mut self) {
-        if self.locked_cores > 0 {
-            self.idle_cores += self.locked_cores;
-            self.locked_cores = 0;
-        }
     }
 }

--- a/rust/crates/rqd/src/frame/manager.rs
+++ b/rust/crates/rqd/src/frame/manager.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Local};
+use itertools::Either;
 use miette::{Diagnostic, Result, miette};
 use opencue_proto::{
     host::HardwareState,
@@ -64,17 +65,14 @@ impl FrameManager {
 
         // **Attention**: If an error happens between here and spawning a frame, the resources
         // reserved need to be released.
-        //
-        // Cuebot unfortunatelly uses a hardcoded frame environment variable to signal if
-        // a frame is hyperthreaded. Rqd should only reserve cores if a frame is hyperthreaded.
-        let hyperthreaded = run_frame
-            .environment
-            .get("CUE_THREADABLE")
-            .is_some_and(|v| v == "1");
+
         let num_cores = (run_frame.num_cores as u32).div_ceil(self.config.machine.core_multiplier);
+
+        // Reserving cores will always yield a list of reserved thread_ids. If hyperthreading is off,
+        // the list should be ignored
         let thread_ids = self
             .machine
-            .reserve_cores(num_cores as usize, run_frame.resource_id(), hyperthreaded)
+            .reserve_cores(Either::Left(num_cores as usize), run_frame.resource_id())
             .await
             .map_err(|err| {
                 FrameManagerError::Aborted(format!(
@@ -90,7 +88,13 @@ impl FrameManager {
                 let reserved_res = self.machine.reserve_gpus(run_frame.num_gpus as u32).await;
                 if reserved_res.is_err() {
                     // Release cores reserved on the last step
-                    self.machine.release_cores(num_cores, &thread_ids).await;
+                    if let Err(err) = self.machine.release_cores(&run_frame.resource_id()).await {
+                        warn!(
+                            "Failed to release cores reserved for {} during gpu reservation failure. {}",
+                            &run_frame.resource_id(),
+                            err
+                        )
+                    };
                 }
                 Some(reserved_res.map_err(|err| {
                     FrameManagerError::Aborted(format!(
@@ -101,11 +105,21 @@ impl FrameManager {
             }
         };
 
+        // Cuebot unfortunatelly uses a hardcoded frame environment variable to signal if
+        // a frame is hyperthreaded. Rqd should only reserve cores if a frame is hyperthreaded.
+        let hyperthreaded = run_frame
+            .environment
+            .get("CUE_THREADABLE")
+            .is_some_and(|v| v == "1");
+        // Ignore the list of allocated threads if hyperthreading is off
+        let thread_ids = hyperthreaded.then_some(thread_ids);
+
+        let resource_id = run_frame.resource_id();
         let running_frame = Arc::new(RunningFrame::init(
             run_frame,
             uid,
             self.config.runner.clone(),
-            thread_ids.clone(),
+            thread_ids,
             gpu_list,
             self.machine.get_host_name().await,
         ));
@@ -113,8 +127,13 @@ impl FrameManager {
         if self.config.runner.run_on_docker {
             self.spawn_docker_frame(running_frame, false);
         } else if self.spawn_running_frame(running_frame, false).is_err() {
-            // Release cores reserved on the last step
-            self.machine.release_cores(num_cores, &thread_ids).await;
+            // Release cores reserved if spawning the frame failed
+            if let Err(err) = self.machine.release_cores(&resource_id).await {
+                warn!(
+                    "Failed to release cores reserved for {} during spawn failure. {}",
+                    &resource_id, err
+                );
+            }
         }
 
         Ok(())
@@ -161,19 +180,21 @@ impl FrameManager {
                 Ok(running_frame) => {
                     // Update reservations. If a thread_ids list exists, the frame was booked using affinity
                     if let Err(err) = match &running_frame.thread_ids {
-                        Some(thread_ids) => self
-                            .machine
-                            .reserve_cores_by_id(thread_ids, running_frame.request.resource_id())
-                            .await
-                            .map(Some),
+                        Some(thread_ids) => {
+                            self.machine
+                                .reserve_cores(
+                                    Either::Right(thread_ids.clone()),
+                                    running_frame.request.resource_id(),
+                                )
+                                .await
+                        }
                         None => {
                             let num_cores = (running_frame.request.num_cores as u32)
                                 .div_ceil(self.config.machine.core_multiplier);
                             self.machine
                                 .reserve_cores(
-                                    num_cores as usize,
+                                    Either::Left(num_cores as usize),
                                     running_frame.request.resource_id(),
-                                    false,
                                 )
                                 .await
                         }
@@ -181,13 +202,16 @@ impl FrameManager {
                         errors.push(err.to_string());
                     }
 
-                    let num_cores = (running_frame.request.num_cores as u32)
-                        .div_ceil(self.config.machine.core_multiplier);
-                    let thread_ids = &running_frame.thread_ids.clone();
+                    let resource_id = running_frame.request.resource_id();
                     if self.config.runner.run_on_docker {
                         todo!("Recovering frames when running on docker is not yet supported")
                     } else if self.spawn_running_frame(running_frame, true).is_err() {
-                        self.machine.release_cores(num_cores, thread_ids).await;
+                        if let Err(err) = self.machine.release_cores(&resource_id).await {
+                            warn!(
+                                "Failed to release cores reserved for {} during recover spawn error. {}",
+                                &resource_id, err
+                            );
+                        }
                     }
                 }
                 Err(err) => {

--- a/rust/crates/rqd/src/system/macos.rs
+++ b/rust/crates/rqd/src/system/macos.rs
@@ -22,32 +22,15 @@ use sysinfo::{
     DiskRefreshKind, Disks, MemoryRefreshKind, Pid, ProcessRefreshKind, ProcessStatus,
     ProcessesToUpdate, RefreshKind,
 };
-use tracing::{debug, warn};
+use tracing::debug;
 use uuid::Uuid;
 
-use crate::config::MachineConfig;
+use crate::{config::MachineConfig, system::reservation::ProcessorStructure};
 
-use super::manager::{
-    CoreReservation, CpuStat, MachineGpuStats, MachineStat, ProcessStats, ReservationError,
-    SystemManager,
-};
+use super::manager::{MachineGpuStats, MachineStat, ProcessStats, SystemManager};
 
 pub struct MacOsSystem {
     config: MachineConfig,
-
-    /// Map of procids indexed by physid and coreid
-    ///   phys_id => [core_ids]
-    cores_by_phys_id: HashMap<u32, Vec<u32>>,
-
-    /// Map of threads indexed by unique_ids ({physid}_{coreid})
-    /// A composed id is necessary as core_ids are not unique
-    ///   physid_coreid => [thread_ids]
-    threads_by_core_unique_id: HashMap<String, Vec<u32>>,
-    /// Lookup table of core_ids by thread id
-    /// thread_id => (phys_id, core_id)
-    thread_id_lookup_table: HashMap<u32, (u32, u32)>,
-
-    cpu_stat: CpuStat,
     // Information colleced once at init time
     static_info: MachineStaticInfo,
     hardware_state: HardwareState,
@@ -59,17 +42,11 @@ pub struct MacOsSystem {
 }
 
 #[derive(Debug)]
-struct ProcessorInfoData {
+pub struct ProcessorInfoData {
     hyperthreading_multiplier: u32,
     num_sockets: u32,
     cores_per_socket: u32,
-}
-
-struct CpuInfoWithProcs {
-    processor_info: ProcessorInfoData,
-    cores_by_phys_id: HashMap<u32, Vec<u32>>,
-    threads_by_core_unique_id: HashMap<String, Vec<u32>>,
-    phys_id_and_core_id_by_thread_id: HashMap<u32, (u32, u32)>,
+    pub processor_structure: ProcessorStructure,
 }
 
 struct MachineStaticInfo {
@@ -135,16 +112,13 @@ impl MacOsSystem {
 
         Ok(Self {
             config: config.clone(),
-            cores_by_phys_id: data.cores_by_phys_id,
-            threads_by_core_unique_id: data.threads_by_core_unique_id,
-            thread_id_lookup_table: data.phys_id_and_core_id_by_thread_id,
             static_info: MachineStaticInfo {
                 hostname: Self::get_hostname(config.use_ip_as_hostname)?,
                 total_memory,
                 total_swap,
-                num_sockets: data.processor_info.num_sockets,
-                cores_per_socket: data.processor_info.cores_per_socket,
-                hyperthreading_multiplier: data.processor_info.hyperthreading_multiplier,
+                num_sockets: data.num_sockets,
+                cores_per_socket: data.cores_per_socket,
+                hyperthreading_multiplier: data.hyperthreading_multiplier,
                 boot_time_secs: Self::read_boot_time(&config.proc_stat_path).unwrap_or(0),
                 tags: Self::setup_tags(config),
             },
@@ -154,13 +128,10 @@ impl MacOsSystem {
                 ("SP_OS".to_string(), identified_os),
                 (
                     "hyperthreadingMultiplier".to_string(),
-                    data.processor_info.hyperthreading_multiplier.to_string(),
+                    data.hyperthreading_multiplier.to_string(),
                 ),
                 // SwapOut is an aditional attribute that is missing on this implementation
             ]),
-            cpu_stat: CpuStat {
-                reserved_cores_by_physid: HashMap::new(),
-            },
             sysinfo_system: Mutex::new(sysinfo::System::new()),
             session_processes: DashMap::new(),
             monitored_sessions: DashSet::new(),
@@ -184,10 +155,10 @@ impl MacOsSystem {
     ///    processor.
     /// 2. `HashMap<u32, <u32, u32>>` - Mapping of processor id to physical id and core id.
     /// 3. `HashMap<u32, Vec<u32>>` - Mapping of thread ids per process id
-    fn read_cpuinfo(cpuinfo_path: &str) -> Result<CpuInfoWithProcs> {
-        let mut procs_by_physid: HashMap<u32, Vec<u32>> = HashMap::new();
-        let mut threads_by_core_id: HashMap<String, Vec<u32>> = HashMap::new();
-        let mut phys_id_and_core_id_by_thread_id: HashMap<u32, (u32, u32)> = HashMap::new();
+    pub fn read_cpuinfo(cpuinfo_path: &str) -> Result<ProcessorInfoData> {
+        let mut cores_by_phys_id: HashMap<u32, Vec<u32>> = HashMap::new();
+        let mut threads_by_core_unique_id: HashMap<String, Vec<u32>> = HashMap::new();
+        let mut thread_id_lookup_table: HashMap<u32, (u32, u32)> = HashMap::new();
         let cpuinfo = File::open(cpuinfo_path).into_diagnostic()?;
         let reader = BufReader::new(cpuinfo);
 
@@ -244,17 +215,17 @@ impl MacOsSystem {
                         e.insert(());
                         num_sockets += 1;
                     }
-                    procs_by_physid
+                    cores_by_phys_id
                         .entry(phys_id)
                         .and_modify(|cores| {
                             cores.push(core_id);
                         })
                         .or_insert(vec![core_id]);
-                    threads_by_core_id
+                    threads_by_core_unique_id
                         .entry(format!("{}_{}", phys_id, core_id))
                         .and_modify(|threads| threads.push(thread_id))
                         .or_insert(vec![thread_id]);
-                    phys_id_and_core_id_by_thread_id.insert(thread_id, (phys_id, core_id));
+                    thread_id_lookup_table.insert(thread_id, (phys_id, core_id));
                 } else {
                     Err(miette!(
                         "Invalid values on proc file {}. curr_core_map={:?}",
@@ -272,15 +243,16 @@ impl MacOsSystem {
         if num_sockets == 0 {
             Err(miette!("Invalid CPU with no sockets (physical id)"))
         } else {
-            Ok(CpuInfoWithProcs {
-                processor_info: ProcessorInfoData {
-                    hyperthreading_multiplier: hyper_modifier,
-                    num_sockets,
-                    cores_per_socket: num_threads / num_sockets,
-                },
-                cores_by_phys_id: procs_by_physid,
-                threads_by_core_unique_id: threads_by_core_id,
-                phys_id_and_core_id_by_thread_id,
+            let processor_structure = ProcessorStructure::init(
+                threads_by_core_unique_id,
+                cores_by_phys_id,
+                thread_id_lookup_table,
+            );
+            Ok(ProcessorInfoData {
+                hyperthreading_multiplier: hyper_modifier,
+                num_sockets,
+                cores_per_socket: num_threads / num_sockets,
+                processor_structure,
             })
         }
     }
@@ -474,52 +446,6 @@ impl MacOsSystem {
                 self.config.temp_path
             )),
         }
-    }
-
-    fn save_reservation(&mut self, phys_id: u32, core_id: u32, reserver_id: Uuid) {
-        self.cpu_stat
-            .reserved_cores_by_physid
-            .entry(phys_id)
-            .or_insert_with(|| CoreReservation::new(reserver_id))
-            .insert(core_id);
-    }
-
-    /// Gets the the list of all cores available to be reserved, organized by their socker id (phys_id)
-    ///
-    /// # Returns
-    ///  - Vec(phys_id, Vec<core_id>)
-    fn calculate_available_cores(&self) -> Result<Vec<(&u32, Vec<u32>)>, ReservationError> {
-        let reserved_cores = &self.cpu_stat.reserved_cores_by_physid;
-        let all_cores_map = &self.cores_by_phys_id;
-
-        // Iterate over all phys_id=>core_id's and filter out cores that have been reserved
-        let available_cores = all_cores_map
-            .iter()
-            .filter_map(
-                |(phys_id, core_ids_map)| match reserved_cores.get(phys_id) {
-                    Some(reserved_core_ids) => {
-                        // Filter out cores that are present in any of the sockets on the
-                        // reserved_cores map
-                        let available_cores: Vec<u32> = core_ids_map
-                            .iter()
-                            .cloned()
-                            .filter(|core_id| !reserved_core_ids.iter().contains(core_id))
-                            .collect();
-                        // Filter out sockets that are completelly reserved
-                        if !available_cores.is_empty() {
-                            Some((phys_id, available_cores))
-                        } else {
-                            None
-                        }
-                    }
-                    // If the phys_id doesn't exit on the reserved_cores map, consider the sockets available
-                    None => Some((phys_id, core_ids_map.to_vec())),
-                },
-            )
-            // Sort sockets with more available cores first
-            .sorted_by(|a, b| Ord::cmp(&b.1.len(), &a.1.len()));
-
-        Ok(available_cores.collect())
     }
 
     /// Refresh the cache of children procs.
@@ -747,90 +673,6 @@ impl SystemManager for MacOsSystem {
         }
     }
 
-    fn release_core_by_thread(&mut self, thread_id: &u32) -> Result<(u32, u32), ReservationError> {
-        let (phys_id, core_id) = self
-            .thread_id_lookup_table
-            .get(thread_id)
-            .ok_or(ReservationError::CoreNotFoundForThread(vec![*thread_id]))?;
-        self.cpu_stat
-            .reserved_cores_by_physid
-            .get_mut(phys_id)
-            .ok_or(ReservationError::ReservationNotFound(*core_id))?
-            .remove(core_id);
-        Ok((*phys_id, *core_id))
-    }
-
-    /// Returns a list of threadids from the reserved core
-    fn reserve_cores(
-        &mut self,
-        count: usize,
-        frame_id: Uuid,
-    ) -> Result<Vec<u32>, ReservationError> {
-        let mut selected_threads = Vec::with_capacity(count * 2);
-        let available_cores = self.calculate_available_cores()?;
-        let mut num_reserved_cores = 0;
-
-        let cores_to_reserve: Vec<(u32, u32)> = available_cores
-            .into_iter()
-            .flat_map(|(phys_id, core_ids)| {
-                core_ids.into_iter().map(move |core_id| (*phys_id, core_id))
-            })
-            .take(count)
-            .collect();
-
-        for (phys_id, core_id) in cores_to_reserve {
-            let core_unique_id = format!("{}_{}", phys_id, core_id);
-            if let Some(threads) = self.threads_by_core_unique_id.get(&core_unique_id) {
-                for thread_id in threads {
-                    selected_threads.push((phys_id, core_id, *thread_id));
-                }
-                num_reserved_cores += 1;
-            } else {
-                warn!("Failed to find thread for coreid={}", core_id)
-            }
-        }
-
-        if num_reserved_cores != count {
-            Err(ReservationError::NotEnoughResourcesAvailable)?
-        }
-        for (phys_id, core_id, _thread_id) in selected_threads.clone() {
-            self.save_reservation(phys_id, core_id, frame_id);
-        }
-
-        Ok(selected_threads
-            .into_iter()
-            .map(|(_, _, thread_id)| thread_id)
-            .collect())
-    }
-
-    fn reserve_cores_by_id(
-        &mut self,
-        thread_ids: &[u32],
-        resource_id: Uuid,
-    ) -> Result<Vec<u32>, ReservationError> {
-        // First collect unmatched thread IDs to avoid borrowing issues
-        let unmatched_thread_ids: Vec<u32> = thread_ids
-            .iter()
-            .filter(|thread_id| !self.thread_id_lookup_table.contains_key(thread_id))
-            .cloned()
-            .collect();
-
-        if !unmatched_thread_ids.is_empty() {
-            return Err(ReservationError::CoreNotFoundForThread(
-                unmatched_thread_ids,
-            ));
-        }
-
-        // Now process the reservations after validation
-        for thread_id in thread_ids {
-            if let Some((phys_id, core_id)) = self.thread_id_lookup_table.get(thread_id) {
-                self.save_reservation(*phys_id, *core_id, resource_id);
-            }
-        }
-
-        Ok(thread_ids.to_owned())
-    }
-
     fn create_user_if_unexisting(&self, username: &str, uid: u32, gid: u32) -> Result<u32> {
         // First check if the user already exists
         if let Some(user) = users::get_user_by_name(username) {
@@ -954,14 +796,9 @@ mod tests {
     use std::{collections::HashMap, sync::Mutex};
 
     use dashmap::{DashMap, DashSet};
-    use itertools::Itertools;
     use opencue_proto::host::HardwareState;
-    use uuid::Uuid;
 
-    use crate::system::{
-        macos::{MacOsSystem, MachineStaticInfo},
-        manager::{CpuStat, ReservationError, SystemManager},
-    };
+    use crate::system::macos::{MacOsSystem, MachineStaticInfo};
 
     #[test]
     /// Use this unit test to quickly exercice a single cpuinfo file by changing the path on the
@@ -1038,24 +875,13 @@ mod tests {
 
             let data = MacOsSystem::read_cpuinfo(&file_path).expect("Failed to read file");
             // Assert that the mapping between processor ID, physical ID, and core ID is correct
-            println!(
-                "procid_by_physid_and_core_id={:?}",
-                data.threads_by_core_unique_id
-            );
-            println!(
-                "physid_and_coreid_by_procid={:?}",
-                data.phys_id_and_core_id_by_thread_id
-            );
+            assert_eq!(expected_sockets, data.num_sockets, "Assert num_sockets");
             assert_eq!(
-                expected_sockets, data.processor_info.num_sockets,
-                "Assert num_sockets"
-            );
-            assert_eq!(
-                expected_cores_per_proc, data.processor_info.cores_per_socket,
+                expected_cores_per_proc, data.cores_per_socket,
                 "Assert cores_per_proc"
             );
             assert_eq!(
-                expected_hyper_multi, data.processor_info.hyperthreading_multiplier,
+                expected_hyper_multi, data.hyperthreading_multiplier,
                 "Assert hyperthreading_multiplier"
             );
         }
@@ -1219,41 +1045,6 @@ mod tests {
     }
 
     #[test]
-    fn test_reserve_and_release_integration() {
-        let project_dir = env!("CARGO_MANIFEST_DIR");
-
-        let config = MachineConfig {
-            cpuinfo_path: format!("{}/resources/cpuinfo/cpuinfo_drack_4-2-2", project_dir),
-            distro_release_path: "".to_string(),
-            proc_stat_path: "".to_string(),
-            ..Default::default()
-        };
-
-        let mut system = MacOsSystem::init(&config).unwrap();
-        let frame_id = uuid::Uuid::new_v4();
-
-        // Reserve cores
-        use crate::system::manager::SystemManager;
-        let reserved_result = system.reserve_cores(2, frame_id);
-        assert!(reserved_result.is_ok());
-        let reserved_threads = reserved_result.unwrap();
-        assert_eq!(reserved_threads.len(), 2);
-
-        // Release one core
-        let thread_to_release = reserved_threads[0];
-        let release_result = system.release_core_by_thread(&thread_to_release);
-        assert!(release_result.is_ok());
-
-        // Verify partial release
-        let remaining_available = system.calculate_available_cores().unwrap();
-        let total_available: usize = remaining_available
-            .iter()
-            .map(|(_, cores)| cores.len())
-            .sum();
-        assert_eq!(total_available, 3); // Should have 3 available cores now
-    }
-
-    #[test]
     fn test_refresh_procs() {
         let project_dir = env!("CARGO_MANIFEST_DIR");
 
@@ -1296,335 +1087,12 @@ mod tests {
     }
 
     #[test]
-    fn test_reserve_cores_success() {
-        let mut system = setup_test_system(4, 2, 1); // 4 cores total, 2 physical CPUs
-
-        // Reserve 2 cores
-        let result = system.reserve_cores(2, Uuid::new_v4());
-
-        assert!(result.is_ok());
-        let reserved = result.unwrap();
-        // Returns two threads per reserved core
-        assert_eq!(reserved.len(), 2);
-        let available_cores = system
-            .calculate_available_cores()
-            .unwrap_or_default()
-            .iter()
-            .map(|(_physid, cores)| cores.len())
-            .sum::<usize>();
-        assert_eq!(available_cores, 2);
-    }
-
-    #[test]
-    fn test_reserve_cores_insufficient_resources() {
-        let mut system = setup_test_system(4, 2, 2);
-
-        // Try to reserve more cores than available
-        let result = system.reserve_cores(5, Uuid::new_v4());
-        assert!(matches!(
-            result,
-            Err(ReservationError::NotEnoughResourcesAvailable)
-        ));
-        let available_cores = system
-            .calculate_available_cores()
-            .unwrap_or_default()
-            .iter()
-            .map(|(_physid, cores)| cores.len())
-            .sum::<usize>();
-        assert_eq!(available_cores, 4); // Should remain unchanged
-    }
-
-    #[test]
-    fn test_reserve_cores_all_available() {
-        let mut system = setup_test_system(4, 2, 2);
-
-        // Reserve all cores
-        let result = system.reserve_cores(4, Uuid::new_v4());
-        assert!(result.is_ok());
-        let reserved = result.unwrap();
-        // Returns two threads per reserved core
-        assert_eq!(reserved.len(), 8);
-        let available_cores = system
-            .calculate_available_cores()
-            .unwrap_or_default()
-            .iter()
-            .map(|(_physid, cores)| cores.len())
-            .sum::<usize>();
-        assert_eq!(available_cores, 0);
-    }
-
-    #[test]
-    fn test_reserve_cores_affinity() {
-        let mut system = setup_test_system(12, 3, 1);
-
-        // Reserve 2 cores
-        let result = system.reserve_cores(7, Uuid::new_v4());
-        assert!(result.is_ok());
-
-        // Check that cores are distributed across physical CPUs when possible
-        let reserved_count_per_socket: Vec<usize> = system
-            .cpu_stat
-            .reserved_cores_by_physid
-            .values()
-            .map(|proc_ids| proc_ids.iter().len())
-            .sorted()
-            .collect();
-        assert_eq!(
-            vec![3, 4],
-            reserved_count_per_socket,
-            "Cores should be grouped as much as possible into physical CPUs",
-        );
-    }
-
-    #[test]
-    fn test_reserve_cores_sequential_reservations() {
-        let mut system = setup_test_system(4, 2, 1);
-
-        // First reservation
-        let result1 = system.reserve_cores(2, Uuid::new_v4());
-        assert!(result1.is_ok());
-        let available_cores = system
-            .calculate_available_cores()
-            .unwrap_or_default()
-            .iter()
-            .map(|(_physid, cores)| cores.len())
-            .sum::<usize>();
-        assert_eq!(available_cores, 2);
-
-        // Second reservation
-        let result2 = system.reserve_cores(1, Uuid::new_v4());
-        assert!(result2.is_ok());
-        let available_cores = system
-            .calculate_available_cores()
-            .unwrap_or_default()
-            .iter()
-            .map(|(_physid, cores)| cores.len())
-            .sum::<usize>();
-        assert_eq!(available_cores, 1);
-
-        // Third reservation - should fail
-        let result3 = system.reserve_cores(2, Uuid::new_v4());
-        assert!(matches!(
-            result3,
-            Err(ReservationError::NotEnoughResourcesAvailable)
-        ));
-    }
-
-    #[test]
-    fn test_reserve_cores_by_id_success() {
-        let mut system = setup_test_system(4, 2, 1);
-        let frame_id = Uuid::new_v4();
-
-        // Reserve cores by specific IDs
-        let core_list = vec![0, 1];
-        let result = system.reserve_cores_by_id(&core_list, frame_id);
-
-        assert!(result.is_ok());
-        let reserved_threads = result.unwrap();
-        assert_eq!(reserved_threads.len(), 2); // One thread per core (no hyperthreading)
-
-        // Verify cores are actually reserved
-        let available_cores = system
-            .calculate_available_cores()
-            .unwrap_or_default()
-            .iter()
-            .map(|(_physid, cores)| cores.len())
-            .sum::<usize>();
-        assert_eq!(available_cores, 2);
-    }
-
-    #[test]
-    fn test_reserve_cores_by_id_partial_available() {
-        let mut system = setup_test_system(4, 2, 1);
-        let frame_id = Uuid::new_v4();
-
-        // First reserve some cores normally
-        let _result1 = system.reserve_cores(1, Uuid::new_v4());
-
-        // Try to reserve by ID including unavailable cores
-        let core_list = vec![0, 1, 2]; // Assuming core 0 might be reserved
-        let result = system.reserve_cores_by_id(&core_list, frame_id);
-
-        assert!(result.is_ok());
-        let reserved_threads = result.unwrap();
-        // Should only reserve available cores from the list
-        assert!(!reserved_threads.is_empty());
-    }
-
-    #[test]
-    fn test_release_core_by_thread_success() {
-        let mut system = setup_test_system(4, 2, 1);
-        let frame_id = Uuid::new_v4();
-
-        // Reserve cores first
-        let reserved_threads = system.reserve_cores(2, frame_id).unwrap();
-        let thread_to_release = reserved_threads[0];
-
-        // Release one thread
-        let result = system.release_core_by_thread(&thread_to_release);
-        assert!(result.is_ok());
-        let (phys_id, core_id) = result.unwrap();
-        assert!(phys_id < 2); // Within expected physical CPU range
-        assert!(core_id < 2); // Within expected core range
-
-        // Verify core is released
-        let available_cores = system
-            .calculate_available_cores()
-            .unwrap_or_default()
-            .iter()
-            .map(|(_physid, cores)| cores.len())
-            .sum::<usize>();
-        assert_eq!(available_cores, 3); // Should have 3 available cores now
-    }
-
-    #[test]
-    fn test_release_core_by_thread_invalid_thread() {
-        let mut system = setup_test_system(4, 2, 1);
-
-        // Try to release non-existent thread
-        let result = system.release_core_by_thread(&999);
-        assert!(matches!(
-            result,
-            Err(ReservationError::CoreNotFoundForThread(_))
-        ));
-    }
-
-    #[test]
-    fn test_reserve_cores_zero_count() {
-        let mut system = setup_test_system(4, 2, 1);
-
-        // Try to reserve 0 cores
-        let result = system.reserve_cores(0, Uuid::new_v4());
-        assert!(result.is_ok());
-        let reserved = result.unwrap();
-        assert_eq!(reserved.len(), 0);
-    }
-
-    #[test]
-    fn test_save_reservation() {
-        let mut system = setup_test_system(4, 2, 1);
-        let frame_id = Uuid::new_v4();
-
-        // Save a reservation
-        system.save_reservation(0, 1, frame_id);
-
-        // Verify reservation exists
-        assert!(system.cpu_stat.reserved_cores_by_physid.contains_key(&0));
-        assert!(
-            system.cpu_stat.reserved_cores_by_physid[&0]
-                .iter()
-                .any(|&x| x == 1)
-        );
-    }
-
-    #[test]
-    fn test_calculate_available_cores_all_reserved() {
-        let mut system = setup_test_system(2, 1, 1);
-        let frame_id = Uuid::new_v4();
-
-        // Reserve all cores
-        let _reserved = system.reserve_cores(2, frame_id).unwrap();
-
-        let available = system.calculate_available_cores();
-        assert!(available.is_ok());
-
-        let cores = available.unwrap();
-        assert_eq!(cores.len(), 0); // No cores available
-    }
-
-    #[test]
-    fn test_calculate_available_cores_partial_reservation() {
-        let mut system = setup_test_system(4, 2, 1);
-        let frame_id = Uuid::new_v4();
-
-        // Reserve cores on one physical CPU
-        system.save_reservation(0, 0, frame_id);
-        system.save_reservation(0, 1, frame_id);
-
-        let available = system.calculate_available_cores();
-        assert!(available.is_ok());
-
-        let cores = available.unwrap();
-        assert_eq!(cores.len(), 1); // Only one physical CPU has available cores
-        assert_eq!(cores[0].1.len(), 2); // Two cores available on that CPU
-    }
-
-    #[test]
-    fn test_reserve_cores_with_mixed_availability() {
-        let mut system = setup_test_system(6, 3, 1);
-        let frame_id1 = Uuid::new_v4();
-        let frame_id2 = Uuid::new_v4();
-
-        // Reserve some cores manually
-        system.save_reservation(0, 0, frame_id1);
-        system.save_reservation(1, 0, frame_id1);
-
-        // Try to reserve more cores
-        let result = system.reserve_cores(3, frame_id2);
-        assert!(result.is_ok());
-
-        let reserved = result.unwrap();
-        assert_eq!(reserved.len(), 3);
-    }
-
-    #[test]
-    fn test_release_core_by_thread_not_reserved() {
-        let mut system = setup_test_system(4, 2, 1);
-
-        // Try to release a thread that was never reserved
-        let result = system.release_core_by_thread(&0);
-        assert!(matches!(
-            result,
-            Err(ReservationError::ReservationNotFound(_))
-        ));
-    }
-
-    #[test]
-    fn test_thread_id_lookup_consistency() {
-        let system = setup_test_system(8, 2, 2);
-
-        // Verify all thread IDs in the lookup table are consistent
-        for (thread_id, (phys_id, core_id)) in &system.thread_id_lookup_table {
-            let core_unique_id = format!("{}_{}", phys_id, core_id);
-            assert!(
-                system
-                    .threads_by_core_unique_id
-                    .contains_key(&core_unique_id)
-            );
-            let threads = &system.threads_by_core_unique_id[&core_unique_id];
-            assert!(threads.contains(thread_id));
-        }
-    }
-
-    #[test]
-    fn test_reserve_cores_exceeds_available_after_reservation() {
-        let mut system = setup_test_system(3, 1, 1);
-        let frame_id1 = Uuid::new_v4();
-        let frame_id2 = Uuid::new_v4();
-
-        // Reserve 2 cores
-        let _result1 = system.reserve_cores(2, frame_id1);
-        assert!(_result1.is_ok());
-
-        // Try to reserve 2 more (should fail as only 1 is available)
-        let result2 = system.reserve_cores(2, frame_id2);
-        assert!(matches!(
-            result2,
-            Err(ReservationError::NotEnoughResourcesAvailable)
-        ));
-    }
-
-    #[test]
     fn test_system_with_single_core() {
         let system = setup_test_system(1, 1, 1);
 
         assert_eq!(system.static_info.num_sockets, 1);
         assert_eq!(system.static_info.cores_per_socket, 1);
         assert_eq!(system.static_info.hyperthreading_multiplier, 1);
-
-        let available = system.calculate_available_cores().unwrap();
-        assert_eq!(available.len(), 1);
-        assert_eq!(available[0].1.len(), 1);
     }
 
     #[test]
@@ -1633,12 +1101,6 @@ mod tests {
 
         assert_eq!(system.static_info.num_sockets, 2);
         assert_eq!(system.static_info.cores_per_socket, 8);
-        assert_eq!(system.threads_by_core_unique_id.len(), 16); // 16 unique cores
-
-        // Verify each core has 4 threads
-        for threads in system.threads_by_core_unique_id.values() {
-            assert_eq!(threads.len(), 4);
-        }
     }
 
     #[test]
@@ -1666,7 +1128,7 @@ mod tests {
         physical_cpus: u32,
         threads_per_core: u32,
     ) -> MacOsSystem {
-        let mut cores_by_phys_id = HashMap::new();
+        let mut cores_by_phys_id: HashMap<u32, Vec<u32>> = HashMap::new();
         let mut threads_by_core_unique_id: HashMap<String, Vec<u32>> = HashMap::new();
         let mut thread_id_lookup_table: HashMap<u32, (u32, u32)> = HashMap::new();
 
@@ -1688,14 +1150,9 @@ mod tests {
             cores_by_phys_id.insert(phys_id, (0..cores_per_cpu).collect());
         }
 
+        let config = MachineConfig::default();
         MacOsSystem {
-            config: MachineConfig::default(),
-            cores_by_phys_id,
-            threads_by_core_unique_id,
-            thread_id_lookup_table,
-            cpu_stat: CpuStat {
-                reserved_cores_by_physid: HashMap::new(),
-            },
+            config,
             static_info: MachineStaticInfo {
                 hostname: "test".to_string(),
                 total_memory: 0,

--- a/rust/crates/rqd/src/system/manager.rs
+++ b/rust/crates/rqd/src/system/manager.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    time::Instant,
-};
+use std::collections::HashMap;
 
 use miette::{Diagnostic, Result};
 use opencue_proto::{host::HardwareState, report::ChildrenProcStats};
@@ -25,32 +22,6 @@ pub trait SystemManager {
 
     /// List of attributes collected from the machine. Eg. SP_OS
     fn attributes(&self) -> &HashMap<String, String>;
-
-    /// Reserve a number of cores.
-    ///
-    /// # Returns:
-    ///
-    /// * Vector of thread ids belonging to reserved cores
-    fn reserve_cores(&mut self, count: usize, frame_id: Uuid)
-    -> Result<Vec<u32>, ReservationError>;
-
-    /// Reserve specific cores by id.
-    ///
-    /// # Returns:
-    ///
-    /// * Vector of core ids
-    fn reserve_cores_by_id(
-        &mut self,
-        cpu_list: &[u32],
-        resource_id: Uuid,
-    ) -> Result<Vec<u32>, ReservationError>;
-
-    /// Release a core using the id of one of its threads
-    ///
-    /// # Returns:
-    ///
-    /// * Tuple with phys_id and core_id the released thread belongs to
-    fn release_core_by_thread(&mut self, thread_id: &u32) -> Result<(u32, u32), ReservationError>;
 
     /// Creates an user if it doesn't already exist
     fn create_user_if_unexisting(&self, username: &str, uid: u32, gid: u32) -> Result<u32>;
@@ -83,46 +54,10 @@ pub enum ReservationError {
     NotEnoughResourcesAvailable,
 
     #[error("Could not find resource with provided key: {0}")]
-    ReservationNotFound(u32),
+    ReservationNotFound(Uuid),
 
     #[error("Could not find core owner of this thread id")]
     CoreNotFoundForThread(Vec<u32>),
-}
-
-#[derive(Debug, Clone)]
-pub struct CpuStat {
-    /// List of cores currently reserved
-    pub reserved_cores_by_physid: HashMap<u32, CoreReservation>,
-    // pub available_cores: u32,
-}
-
-#[derive(Debug, Clone)]
-pub struct CoreReservation {
-    pub reserved_cores: HashSet<u32>,
-    pub _reserver_id: Uuid,
-    pub _start_time: Instant,
-}
-
-impl CoreReservation {
-    pub fn new(reserver_id: Uuid) -> Self {
-        CoreReservation {
-            reserved_cores: HashSet::new(),
-            _reserver_id: reserver_id,
-            _start_time: Instant::now(),
-        }
-    }
-
-    pub fn iter(&self) -> std::collections::hash_set::Iter<'_, u32> {
-        self.reserved_cores.iter()
-    }
-
-    pub fn insert(&mut self, core_id: u32) -> bool {
-        self.reserved_cores.insert(core_id)
-    }
-
-    pub fn remove(&mut self, core_id: &u32) -> bool {
-        self.reserved_cores.remove(core_id)
-    }
 }
 
 /// Represents attributes on a machine that should never change without restarting the

--- a/rust/crates/rqd/src/system/mod.rs
+++ b/rust/crates/rqd/src/system/mod.rs
@@ -1,7 +1,15 @@
+use uuid::Uuid;
+
 pub mod linux;
 pub mod machine;
 mod nimby;
+mod reservation;
 
 #[cfg(target_os = "macos")]
 pub mod macos;
 pub mod manager;
+
+pub type ResourceId = Uuid;
+pub type CoreId = u32;
+pub type PhysId = u32;
+pub type ThreadId = u32;

--- a/rust/crates/rqd/src/system/reservation.rs
+++ b/rust/crates/rqd/src/system/reservation.rs
@@ -1,0 +1,781 @@
+use std::{
+    cmp,
+    collections::{HashMap, HashSet},
+    time::{Duration, Instant},
+};
+
+use itertools::Itertools;
+use miette::Result;
+use opencue_proto::report::CoreDetail;
+use tracing::warn;
+use uuid::Uuid;
+
+use crate::system::{manager::ReservationError, *};
+
+/// Lookup tables representing Physical and Virtual cores and their threads
+/// Ids on this structure are used for booking
+#[derive(Debug, Clone)]
+pub struct ProcessorStructure {
+    /// {phys_id}_{core_id} -> [thread_ids]
+    threads_by_core_unique_id: HashMap<String, Vec<ThreadId>>,
+    /// phys_id -> [core_ids]
+    cores_by_phys_id: HashMap<PhysId, Vec<CoreId>>,
+    /// thread_id => (phys_id, core_id)
+    thread_id_lookup_table: HashMap<ThreadId, (PhysId, CoreId)>,
+}
+
+impl ProcessorStructure {
+    pub fn init(
+        threads_by_core_unique_id: HashMap<String, Vec<ThreadId>>,
+        cores_by_phys_id: HashMap<PhysId, Vec<CoreId>>,
+        thread_id_lookup_table: HashMap<ThreadId, (PhysId, CoreId)>,
+    ) -> Self {
+        ProcessorStructure {
+            threads_by_core_unique_id,
+            cores_by_phys_id,
+            thread_id_lookup_table,
+        }
+    }
+
+    pub fn num_cores(&self) -> u32 {
+        self.threads_by_core_unique_id.len() as u32
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CoreBooking {
+    pub cores: HashSet<(PhysId, CoreId)>,
+    // Some kind of reservation expiration could be implemented to make this logic even more reliable
+    pub start_time: Instant,
+}
+
+impl CoreBooking {
+    pub fn new() -> Self {
+        CoreBooking {
+            cores: HashSet::new(),
+            start_time: Instant::now(),
+        }
+    }
+
+    pub fn insert(&mut self, core_id: (PhysId, CoreId)) -> bool {
+        self.cores.insert(core_id)
+    }
+
+    pub fn expired(&self, timeout: Duration) -> bool {
+        self.start_time.elapsed() > timeout
+    }
+}
+
+pub struct CoreStateManager {
+    // reserved_cores_by_physid: HashMap<u32, CoreBooking>,
+    bookings: HashMap<ResourceId, CoreBooking>,
+    processor_structure: ProcessorStructure,
+    locked_cores: u32,
+    reservation_grace_period: Duration,
+}
+
+impl CoreStateManager {
+    pub fn new(processor_structure: ProcessorStructure) -> Self {
+        CoreStateManager {
+            bookings: HashMap::default(),
+            processor_structure,
+            locked_cores: 0,
+            reservation_grace_period: Duration::from_secs(60),
+        }
+    }
+
+    /// Reserves a specified number of CPU cores for a given resource.
+    ///
+    /// This method attempts to reserve the requested number of cores by selecting from
+    /// available cores across all physical processors. It prioritizes physical processors
+    /// with more available cores to optimize resource allocation.
+    ///
+    /// # Arguments
+    ///
+    /// * `num_cores` - The number of cores to reserve
+    /// * `resource_id` - The UUID of the resource requesting the cores
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Vec<ThreadId>)` - A vector of thread IDs associated with the reserved cores.
+    ///   Each core typically has multiple threads (e.g., 2 threads per core for hyperthreading).
+    /// * `Err(ReservationError::NotEnoughResourcesAvailable)` - If the requested number of
+    ///   cores cannot be satisfied due to insufficient available resources.
+    ///
+    /// # Behavior
+    ///
+    /// - Cores are selected from available cores across all physical processors
+    /// - Physical processors with more available cores are prioritized
+    /// - All threads associated with each reserved core are returned
+    /// - The reservation is tracked internally and associated with the provided resource ID
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let resource_id = Uuid::new_v4();
+    /// let thread_ids = manager.reserve_cores(2, resource_id)?;
+    /// println!("Reserved {} thread IDs for 2 cores", thread_ids.len());
+    /// ```
+    pub fn reserve_cores(
+        &mut self,
+        num_cores: usize,
+        resource_id: ResourceId,
+    ) -> Result<Vec<ThreadId>, ReservationError> {
+        let mut selected_threads = Vec::with_capacity(num_cores * 2);
+        let available_cores = self.calculate_available_cores();
+        let mut num_reserved_cores = 0;
+
+        let cores_to_reserve: Vec<(PhysId, CoreId)> = available_cores
+            .flat_map(|(phys_id, core_ids)| {
+                core_ids.into_iter().map(move |core_id| (phys_id, core_id))
+            })
+            .take(num_cores)
+            .collect();
+
+        for (phys_id, core_id) in cores_to_reserve {
+            let core_unique_id = format!("{}_{}", phys_id, core_id);
+            if let Some(threads) = self
+                .processor_structure
+                .threads_by_core_unique_id
+                .get(&core_unique_id)
+            {
+                for thread_id in threads {
+                    selected_threads.push((phys_id, core_id, *thread_id));
+                }
+                num_reserved_cores += 1;
+            } else {
+                warn!("Failed to find thread for coreid={}", core_id)
+            }
+        }
+
+        if num_reserved_cores != num_cores {
+            Err(ReservationError::NotEnoughResourcesAvailable)?
+        }
+        for (phys_id, core_id, _thread_id) in selected_threads.clone() {
+            self.bookings
+                .entry(resource_id)
+                .or_insert(CoreBooking::new())
+                .insert((phys_id, core_id));
+        }
+
+        Ok(selected_threads
+            .into_iter()
+            .map(|(_, _, thread_id)| thread_id)
+            .collect())
+    }
+
+    /// Get a list of all cores booked for this phys_id
+    fn get_bookings(&self, phys_id: &PhysId) -> impl Iterator<Item = CoreId> {
+        self.bookings.values().flat_map(|booking| {
+            let cores: Vec<CoreId> = booking
+                .cores
+                .iter()
+                .filter(|&(phys_id_all, _)| *phys_id == *phys_id_all)
+                .map(|(_, core_id)| *core_id)
+                .collect();
+            cores
+        })
+    }
+
+    fn calculate_available_cores(&self) -> impl Iterator<Item = (PhysId, Vec<CoreId>)> {
+        self.processor_structure
+            .cores_by_phys_id
+            .iter()
+            .map(|(phys_id, all_cores)| {
+                let bookings_for_physid: Vec<CoreId> = self.get_bookings(phys_id).collect();
+                let available_cores: Vec<CoreId> = all_cores
+                    .iter()
+                    .filter(|core_id| !bookings_for_physid.contains(core_id))
+                    .cloned()
+                    .collect();
+                // Subtract all_cores by booked_cores for this physid
+
+                (*phys_id, available_cores)
+            })
+            // Sort sockets with more available cores first
+            .sorted_by(|a, b| Ord::cmp(&b.1.len(), &a.1.len()))
+    }
+
+    // TODO: Experimental. This solution allows double booking and should only be used at
+    // recovery mode, when there are no frames running.
+    #[deprecated(
+        note = "This function is only safe when used before the booking loop gets activated. \
+        Its usage is reserved to the recovery logic"
+    )]
+    pub fn reserve_cores_by_id(
+        &mut self,
+        thread_ids: Vec<ThreadId>,
+        resource_id: ResourceId,
+    ) -> Result<Vec<ThreadId>, ReservationError> {
+        // First collect unmatched thread IDs to avoid borrowing issues
+        let unmatched_thread_ids: Vec<ThreadId> = thread_ids
+            .iter()
+            .filter(|thread_id| {
+                !self
+                    .processor_structure
+                    .thread_id_lookup_table
+                    .contains_key(thread_id)
+            })
+            .cloned()
+            .collect();
+
+        if !unmatched_thread_ids.is_empty() {
+            return Err(ReservationError::CoreNotFoundForThread(
+                unmatched_thread_ids,
+            ));
+        }
+
+        // Now process the reservations after validation
+        for thread_id in &thread_ids {
+            if let Some((phys_id, core_id)) = self
+                .processor_structure
+                .thread_id_lookup_table
+                .get(thread_id)
+            {
+                self.bookings
+                    .entry(resource_id)
+                    .or_insert(CoreBooking::new())
+                    .insert((*phys_id, *core_id));
+            }
+        }
+
+        Ok(thread_ids.to_owned())
+    }
+
+    /// Releases all cores associated with a given resource ID.
+    ///
+    /// This method removes the booking for the specified resource and returns the list of
+    /// cores that were previously reserved. Once released, these cores become available
+    /// for new reservations.
+    ///
+    /// # Arguments
+    ///
+    /// * `resource_id` - The UUID of the resource whose cores should be released
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Vec<(PhysId, CoreId)>)` - A vector of tuples containing the physical processor ID
+    ///   and core ID for each core that was released
+    /// * `Err(ReservationError::ReservationNotFound)` - If no booking exists for the given resource ID
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let resource_id = Uuid::new_v4();
+    /// // ... reserve some cores first ...
+    /// let released_cores = manager.release_cores(&resource_id)?;
+    /// println!("Released {} cores", released_cores.len());
+    /// ```
+    pub fn release_cores(
+        &mut self,
+        resource_id: &Uuid,
+    ) -> Result<Vec<(PhysId, CoreId)>, ReservationError> {
+        self.bookings
+            .remove(resource_id)
+            .map(|booking| booking.cores.into_iter().collect())
+            .ok_or(ReservationError::ReservationNotFound(*resource_id))
+    }
+
+    /// Lock a specified number of cores. If the amount requested is not available, the maximum
+    /// available will be locked.
+    ///
+    /// # Arguments
+    ///
+    /// * `count` - Number of cores to lock
+    ///
+    /// # Returns
+    ///
+    /// * `u32` - The actual number of cores that were locked (may be less than requested if not enough are available)
+    pub fn lock_cores(&mut self, count: u32) -> u32 {
+        let amount_not_locked = self.processor_structure.num_cores() - self.locked_cores;
+        let amount_to_lock = std::cmp::min(amount_not_locked, count);
+
+        if amount_to_lock > 0 {
+            self.locked_cores += amount_to_lock;
+        }
+
+        amount_to_lock as u32
+    }
+
+    /// Lock all cores
+    pub fn lock_all_cores(&mut self) {
+        self.locked_cores = self.processor_structure.num_cores();
+    }
+
+    /// Unlock a specified number of cores that were previously locked.
+    ///
+    /// # Arguments
+    ///
+    /// * `count` - Number of cores to unlock
+    ///
+    /// # Returns
+    ///
+    /// * `u32` - The actual number of cores that were unlocked (may be less than requested if fewer cores are locked)
+    pub fn unlock_cores(&mut self, count: u32) -> u32 {
+        let previously_locked = self.locked_cores;
+        self.locked_cores = self.locked_cores.saturating_sub(count);
+
+        cmp::min(count, previously_locked)
+    }
+
+    /// Unlock all cores
+    pub fn unlock_all_cores(&mut self) {
+        self.locked_cores = 0;
+    }
+
+    /// Generates a detailed report of core usage statistics.
+    ///
+    /// This method calculates and returns comprehensive information about the current state
+    /// of CPU cores, including total, idle, locked, and booked cores. The values are
+    /// multiplied by the provided core multiplier to account for hyperthreading or other
+    /// virtualization scenarios.
+    ///
+    /// # Arguments
+    ///
+    /// * `core_multiplier` - A multiplier applied to all core counts (typically 2 for hyperthreading)
+    ///
+    /// # Returns
+    ///
+    /// A `CoreDetail` struct containing:
+    /// - `total_cores`: Total number of cores available (physical cores × multiplier)
+    /// - `idle_cores`: Number of cores that are neither booked nor locked (minimum of non-booked and unlocked cores × multiplier)
+    /// - `locked_cores`: Number of cores that have been administratively locked (locked cores × multiplier)
+    /// - `booked_cores`: Number of cores that have been reserved for active jobs (booked cores × multiplier)
+    /// - `reserved_cores`: HashMap of reserved cores by category (currently empty)
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let report = manager.get_core_info_report(2); // 2x for hyperthreading
+    /// println!("Total cores: {}", report.total_cores);
+    /// println!("Available cores: {}", report.idle_cores);
+    /// ```
+    pub fn get_core_info_report(&self, core_multiplier: u32) -> CoreDetail {
+        let total_cores = self.processor_structure.num_cores() as i32;
+        let locked_cores = self.locked_cores as i32;
+
+        // Idle cores needs to take both cores that are booked and locked.
+        // At the end, the number of idle cores is the min between non_booked and unlocked cores
+        let available_cores = self.calculate_available_cores();
+        let non_booked_cores = available_cores
+            .map(|(_, cores)| cores.len() as u32)
+            .sum::<u32>() as i32;
+        let unlocked_cores = total_cores - locked_cores;
+        let idle_cores = cmp::min(non_booked_cores, unlocked_cores) as i32;
+
+        let booked_cores = self
+            .bookings
+            .values()
+            .map(|booking| booking.cores.len() as i32)
+            .sum::<i32>();
+
+        CoreDetail {
+            total_cores: total_cores * core_multiplier as i32,
+            idle_cores: idle_cores * core_multiplier as i32,
+            locked_cores: locked_cores * core_multiplier as i32,
+            booked_cores: booked_cores * core_multiplier as i32,
+            reserved_cores: HashMap::default(),
+        }
+    }
+
+    /// Removes reservations that are no longer active or have expired.
+    ///
+    /// This method cleans up the bookings by retaining only those reservations that either:
+    /// - Have a resource ID that is still active (present in `active_resource_ids`)
+    /// - Have not yet expired based on the configured reservation grace period
+    ///
+    /// # Arguments
+    ///
+    /// * `active_resource_ids` - A vector of resource IDs that are currently active
+    pub fn sanitize_reservations(&mut self, active_resource_ids: &Vec<ResourceId>) {
+        self.bookings.retain(|resource_id, booking| {
+            active_resource_ids.contains(&resource_id)
+                || !booking.expired(self.reservation_grace_period)
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use uuid::Uuid;
+
+    fn create_test_processor_structure() -> ProcessorStructure {
+        let mut threads_by_core_unique_id = HashMap::new();
+        let mut cores_by_phys_id = HashMap::new();
+        let mut thread_id_lookup_table = HashMap::new();
+
+        // Physical processor 0 with 2 cores, each with 2 threads
+        threads_by_core_unique_id.insert("0_0".to_string(), vec![0, 1]);
+        threads_by_core_unique_id.insert("0_1".to_string(), vec![2, 3]);
+        cores_by_phys_id.insert(0, vec![0, 1]);
+        thread_id_lookup_table.insert(0, (0, 0));
+        thread_id_lookup_table.insert(1, (0, 0));
+        thread_id_lookup_table.insert(2, (0, 1));
+        thread_id_lookup_table.insert(3, (0, 1));
+
+        // Physical processor 1 with 2 cores, each with 2 threads
+        threads_by_core_unique_id.insert("1_0".to_string(), vec![4, 5]);
+        threads_by_core_unique_id.insert("1_1".to_string(), vec![6, 7]);
+        cores_by_phys_id.insert(1, vec![0, 1]);
+        thread_id_lookup_table.insert(4, (1, 0));
+        thread_id_lookup_table.insert(5, (1, 0));
+        thread_id_lookup_table.insert(6, (1, 1));
+        thread_id_lookup_table.insert(7, (1, 1));
+
+        ProcessorStructure::init(
+            threads_by_core_unique_id,
+            cores_by_phys_id,
+            thread_id_lookup_table,
+        )
+    }
+
+    #[test]
+    fn test_processor_structure_init() {
+        let processor_structure = create_test_processor_structure();
+        assert_eq!(processor_structure.num_cores(), 4);
+        assert_eq!(processor_structure.threads_by_core_unique_id.len(), 4);
+        assert_eq!(processor_structure.cores_by_phys_id.len(), 2);
+        assert_eq!(processor_structure.thread_id_lookup_table.len(), 8);
+    }
+
+    #[test]
+    fn test_processor_structure_num_cores() {
+        let processor_structure = create_test_processor_structure();
+        assert_eq!(processor_structure.num_cores(), 4);
+    }
+
+    #[test]
+    fn test_core_booking_new() {
+        let booking = CoreBooking::new();
+        assert!(booking.cores.is_empty());
+    }
+
+    #[test]
+    fn test_core_booking_insert() {
+        let mut booking = CoreBooking::new();
+        let core_id = (0, 0);
+
+        // First insert should return true
+        assert!(booking.insert(core_id));
+        assert_eq!(booking.cores.len(), 1);
+        assert!(booking.cores.contains(&core_id));
+
+        // Second insert of same core should return false
+        assert!(!booking.insert(core_id));
+        assert_eq!(booking.cores.len(), 1);
+    }
+
+    #[test]
+    fn test_core_state_manager_new() {
+        let processor_structure = create_test_processor_structure();
+        let manager = CoreStateManager::new(processor_structure);
+        assert_eq!(manager.bookings.len(), 0);
+        assert_eq!(manager.locked_cores, 0);
+    }
+
+    #[test]
+    fn test_reserve_cores_success() {
+        let processor_structure = create_test_processor_structure();
+        let mut manager = CoreStateManager::new(processor_structure);
+        let resource_id = Uuid::new_v4();
+
+        let result = manager.reserve_cores(2, resource_id);
+        assert!(result.is_ok());
+
+        let thread_ids = result.unwrap();
+        assert_eq!(thread_ids.len(), 4); // 2 cores * 2 threads per core
+        assert!(manager.bookings.contains_key(&resource_id));
+        assert_eq!(manager.bookings[&resource_id].cores.len(), 2);
+    }
+
+    #[test]
+    fn test_reserve_cores_not_enough_available() {
+        let processor_structure = create_test_processor_structure();
+        let mut manager = CoreStateManager::new(processor_structure);
+        let resource_id = Uuid::new_v4();
+
+        // Try to reserve more cores than available
+        let result = manager.reserve_cores(10, resource_id);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            ReservationError::NotEnoughResourcesAvailable
+        ));
+    }
+
+    #[test]
+    fn test_reserve_cores_multiple_reservations() {
+        let processor_structure = create_test_processor_structure();
+        let mut manager = CoreStateManager::new(processor_structure);
+        let resource_id1 = Uuid::new_v4();
+        let resource_id2 = Uuid::new_v4();
+
+        // Reserve 2 cores for first resource
+        let result1 = manager.reserve_cores(2, resource_id1);
+        assert!(result1.is_ok());
+
+        // Reserve 2 cores for second resource
+        let result2 = manager.reserve_cores(2, resource_id2);
+        assert!(result2.is_ok());
+
+        assert_eq!(manager.bookings.len(), 2);
+
+        // Try to reserve more cores - should fail as all are taken
+        let resource_id3 = Uuid::new_v4();
+        let result3 = manager.reserve_cores(1, resource_id3);
+        assert!(result3.is_err());
+    }
+
+    #[test]
+    fn test_reserve_cores_by_id_success() {
+        let processor_structure = create_test_processor_structure();
+        let mut manager = CoreStateManager::new(processor_structure);
+        let resource_id = Uuid::new_v4();
+        let thread_ids = vec![0, 1, 2, 3];
+
+        #[allow(deprecated)]
+        let result = manager.reserve_cores_by_id(thread_ids.clone(), resource_id);
+        assert!(result.is_ok());
+
+        let returned_thread_ids = result.unwrap();
+        assert_eq!(returned_thread_ids, thread_ids);
+        assert!(manager.bookings.contains_key(&resource_id));
+        assert_eq!(manager.bookings[&resource_id].cores.len(), 2); // 2 cores covered by the threads
+    }
+
+    #[test]
+    fn test_reserve_cores_by_id_invalid_thread() {
+        let processor_structure = create_test_processor_structure();
+        let mut manager = CoreStateManager::new(processor_structure);
+        let resource_id = Uuid::new_v4();
+        let thread_ids = vec![0, 1, 99]; // 99 doesn't exist
+
+        #[allow(deprecated)]
+        let result = manager.reserve_cores_by_id(thread_ids, resource_id);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            ReservationError::CoreNotFoundForThread(_)
+        ));
+    }
+
+    #[test]
+    fn test_release_cores_success() {
+        let processor_structure = create_test_processor_structure();
+        let mut manager = CoreStateManager::new(processor_structure);
+        let resource_id = Uuid::new_v4();
+
+        // Reserve cores first
+        let _result = manager.reserve_cores(2, resource_id);
+        assert!(manager.bookings.contains_key(&resource_id));
+
+        // Release cores
+        let release_result = manager.release_cores(&resource_id);
+        assert!(release_result.is_ok());
+
+        let released_cores = release_result.unwrap();
+        assert_eq!(released_cores.len(), 2);
+        assert!(!manager.bookings.contains_key(&resource_id));
+    }
+
+    #[test]
+    fn test_release_cores_not_found() {
+        let processor_structure = create_test_processor_structure();
+        let mut manager = CoreStateManager::new(processor_structure);
+        let resource_id = Uuid::new_v4();
+
+        let result = manager.release_cores(&resource_id);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            ReservationError::ReservationNotFound(_)
+        ));
+    }
+
+    #[test]
+    fn test_lock_cores() {
+        let processor_structure = create_test_processor_structure();
+        let mut manager = CoreStateManager::new(processor_structure);
+
+        // Lock 2 cores
+        let locked = manager.lock_cores(2);
+        assert_eq!(locked, 2);
+        assert_eq!(manager.locked_cores, 2);
+
+        // Lock 1 more core
+        let locked = manager.lock_cores(1);
+        assert_eq!(locked, 1);
+        assert_eq!(manager.locked_cores, 3);
+
+        // Try to lock more cores than available
+        let locked = manager.lock_cores(5);
+        assert_eq!(locked, 1); // Only 1 core left
+        assert_eq!(manager.locked_cores, 4);
+    }
+
+    #[test]
+    fn test_lock_all_cores() {
+        let processor_structure = create_test_processor_structure();
+        let mut manager = CoreStateManager::new(processor_structure);
+
+        manager.lock_all_cores();
+        assert_eq!(manager.locked_cores, 4);
+    }
+
+    #[test]
+    fn test_unlock_cores() {
+        let processor_structure = create_test_processor_structure();
+        let mut manager = CoreStateManager::new(processor_structure);
+
+        // Lock some cores first
+        manager.lock_cores(3);
+        assert_eq!(manager.locked_cores, 3);
+
+        // Unlock 2 cores
+        let unlocked = manager.unlock_cores(2);
+        assert_eq!(unlocked, 2);
+        assert_eq!(manager.locked_cores, 1);
+
+        // Try to unlock more cores than are locked
+        let unlocked = manager.unlock_cores(5);
+        assert_eq!(unlocked, 1); // Only 1 core was locked
+        assert_eq!(manager.locked_cores, 0);
+    }
+
+    #[test]
+    fn test_unlock_all_cores() {
+        let processor_structure = create_test_processor_structure();
+        let mut manager = CoreStateManager::new(processor_structure);
+
+        manager.lock_cores(3);
+        assert_eq!(manager.locked_cores, 3);
+
+        manager.unlock_all_cores();
+        assert_eq!(manager.locked_cores, 0);
+    }
+
+    #[test]
+    fn test_get_core_info_report() {
+        let processor_structure = create_test_processor_structure();
+        let mut manager = CoreStateManager::new(processor_structure);
+        let resource_id = Uuid::new_v4();
+
+        // Initial state - all cores available
+        let report = manager.get_core_info_report(2); // core_multiplier = 2
+        assert_eq!(report.total_cores, 8); // 4 cores * 2 multiplier
+        assert_eq!(report.idle_cores, 8);
+        assert_eq!(report.locked_cores, 0);
+        assert_eq!(report.booked_cores, 0);
+
+        // Reserve 2 cores
+        let _result = manager.reserve_cores(2, resource_id);
+        let report = manager.get_core_info_report(2);
+        assert_eq!(report.total_cores, 8);
+        assert_eq!(report.idle_cores, 4); // 2 cores * 2 multiplier still available
+        assert_eq!(report.locked_cores, 0);
+        assert_eq!(report.booked_cores, 4); // 2 cores * 2 multiplier booked
+
+        // Lock 1 core
+        manager.lock_cores(1);
+        let report = manager.get_core_info_report(2);
+        assert_eq!(report.total_cores, 8);
+        assert_eq!(report.idle_cores, 4); // min(non_booked=2, unlocked=3) = 2, * 2 multiplier = 4
+        assert_eq!(report.locked_cores, 2); // 1 core * 2 multiplier
+        assert_eq!(report.booked_cores, 4);
+    }
+
+    #[test]
+    fn test_get_bookings() {
+        let processor_structure = create_test_processor_structure();
+        let mut manager = CoreStateManager::new(processor_structure);
+        let resource_id = Uuid::new_v4();
+
+        // Reserve some cores
+        let _result = manager.reserve_cores(2, resource_id);
+
+        // Get bookings for all physical processors and verify total
+        let bookings_0: Vec<CoreId> = manager.get_bookings(&0).collect();
+        let bookings_1: Vec<CoreId> = manager.get_bookings(&1).collect();
+
+        // Should have exactly 2 cores booked total across both processors
+        assert_eq!(bookings_0.len() + bookings_1.len(), 2);
+
+        // At least one processor should have book
+        assert!(!bookings_0.is_empty() || !bookings_1.is_empty());
+    }
+
+    #[test]
+    fn test_calculate_available_cores() {
+        let processor_structure = create_test_processor_structure();
+        let mut manager = CoreStateManager::new(processor_structure);
+        let resource_id = Uuid::new_v4();
+
+        // Initially all cores should be available
+        let available: Vec<(PhysId, Vec<CoreId>)> = manager.calculate_available_cores().collect();
+        assert_eq!(available.len(), 2); // 2 physical processors
+
+        let total_available: usize = available.iter().map(|(_, cores)| cores.len()).sum();
+        assert_eq!(total_available, 4); // 4 cores total
+
+        // Reserve 2 cores
+        let _result = manager.reserve_cores(2, resource_id);
+
+        // Check available cores after reservation
+        let available: Vec<(PhysId, Vec<CoreId>)> = manager.calculate_available_cores().collect();
+        let total_available: usize = available.iter().map(|(_, cores)| cores.len()).sum();
+        assert_eq!(total_available, 2); // 2 cores still available
+    }
+
+    #[test]
+    fn test_core_allocation_strategy() {
+        let processor_structure = create_test_processor_structure();
+        let mut manager = CoreStateManager::new(processor_structure);
+        let resource_id = Uuid::new_v4();
+
+        // Reserve 1 core and check that it prioritizes the socket with more available cores
+        let result = manager.reserve_cores(1, resource_id);
+        assert!(result.is_ok());
+
+        let thread_ids = result.unwrap();
+        assert_eq!(thread_ids.len(), 2); // 1 core * 2 threads per core
+
+        // Verify that the booking was made
+        assert!(manager.bookings.contains_key(&resource_id));
+        assert_eq!(manager.bookings[&resource_id].cores.len(), 1);
+    }
+
+    #[test]
+    fn test_locked_cores_affect_idle_calculation() {
+        let processor_structure = create_test_processor_structure();
+        let mut manager = CoreStateManager::new(processor_structure);
+
+        // Lock 2 cores
+        manager.lock_cores(2);
+
+        let report = manager.get_core_info_report(1);
+        assert_eq!(report.total_cores, 4);
+        assert_eq!(report.locked_cores, 2);
+        assert_eq!(report.idle_cores, 2); // min(non_booked=4, unlocked=2) = 2
+        assert_eq!(report.booked_cores, 0);
+    }
+
+    #[test]
+    fn test_mixed_locked_and_booked_cores() {
+        let processor_structure = create_test_processor_structure();
+        let mut manager = CoreStateManager::new(processor_structure);
+        let resource_id = Uuid::new_v4();
+
+        // Lock 1 core and book 2 cores
+        manager.lock_cores(1);
+        let _result = manager.reserve_cores(2, resource_id);
+
+        let report = manager.get_core_info_report(1);
+        assert_eq!(report.total_cores, 4);
+        assert_eq!(report.locked_cores, 1);
+        assert_eq!(report.booked_cores, 2);
+        // Idle cores should be min(non_booked=2, unlocked=3) = 2
+        assert_eq!(report.idle_cores, 2);
+    }
+}


### PR DESCRIPTION
Use a single source of truth for core reservations to avoid synchronization issues. The previous logic had some potential synchronization issues that could lead to resource leaking.