### PR TITLE
[cueadmin] Fix compiled_proto import on output.py

### DIFF
--- a/cueadmin/cueadmin/output.py
+++ b/cueadmin/cueadmin/output.py
@@ -230,7 +230,7 @@ def displayFrames(frames):
 
         print(framesFormat % (
             cueadmin.format.cutoff(frame.data.name, 35),
-            opencue_proto.job_pb2.FrameState.Name(frame.data.state),
+            job_pb2.FrameState.Name(frame.data.state),
             frame.data.last_resource,
             startTime,
             stopTime,


### PR DESCRIPTION
This module doesn't need to depend on the proto module, specially as it simply used job_pb2 to infer the string out of an enum value.

This import was breaking our internal packaging setup and I believe this change won't impact the pyproject setup as it is.
