### PR TITLE
[rust/rqd] Fix fallback gid to match python's rqd

### DIFF
--- a/rust/config/rqd.yaml
+++ b/rust/config/rqd.yaml
@@ -138,6 +138,10 @@ runner:
   # Default: 1000
   # default_uid: 1000
 
+  # Default user group id for running jobs if not specified
+  # Default: 20
+  # default_gid: 20
+
   # Type of logger to use for job output (More options coming soon)
   # Options: file
   # Default: file

--- a/rust/crates/rqd/src/config/mod.rs
+++ b/rust/crates/rqd/src/config/mod.rs
@@ -110,9 +110,9 @@ impl Default for MachineConfig {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(default)]
 pub struct RunnerConfig {
-    // TODO: Add config items to sample file and document their usage
     pub run_on_docker: bool,
     pub default_uid: u32,
+    pub default_gid: u32,
     pub logger: LoggerType,
     pub prepend_timestamp: bool,
     pub use_host_path_env_var: bool,
@@ -153,6 +153,7 @@ impl Default for RunnerConfig {
         Self {
             run_on_docker: false,
             default_uid: 1000,
+            default_gid: 20,
             logger: LoggerType::File,
             prepend_timestamp: true,
             use_host_path_env_var: false,

--- a/rust/crates/rqd/src/frame/running_frame.rs
+++ b/rust/crates/rqd/src/frame/running_frame.rs
@@ -149,7 +149,7 @@ impl RunningFrame {
 
         // Protection against frames that want to become root
         let gid = if request.gid <= 0 {
-            10
+            config.default_gid
         } else {
             request.gid as u32
         };


### PR DESCRIPTION
On the python version of RQD, if a layer doesn't specify gid, it defaulted to 20 and not 10 as implemented on the new rust/rqd.
