### PR TITLE
Update cuebot base image to OpenJDK 18 slim-bullseye

### DIFF
--- a/cuebot/Dockerfile
+++ b/cuebot/Dockerfile
@@ -42,7 +42,7 @@ RUN chmod +x create_rpm.sh && ./create_rpm.sh cuebot "$(cat VERSION)"
 # -----------------
 # RUN
 # -----------------
-FROM openjdk:18-slim-bookworm
+FROM openjdk:18-slim-bullseye
 
 # Install curl for healthchecking
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*

--- a/cuebot/Dockerfile
+++ b/cuebot/Dockerfile
@@ -42,7 +42,7 @@ RUN chmod +x create_rpm.sh && ./create_rpm.sh cuebot "$(cat VERSION)"
 # -----------------
 # RUN
 # -----------------
-FROM openjdk:18-slim-buster
+FROM openjdk:18-slim-bookworm
 
 # Install curl for healthchecking
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Aligned the base image to bookworm for improved security updates and compatibility while maintaining OpenJDK 18.

**Link the Issue(s) this Pull Request is related to.**
This fixes #1777 

**Summarize your change.**
Updated to debian bookworm for cuebot docker image
