### PR TITLE
Add build pipeline for packaging all OpenCue modules in CI workflow

### DIFF
--- a/.github/workflows/packaging-pipeline.yml
+++ b/.github/workflows/packaging-pipeline.yml
@@ -6,15 +6,101 @@ on:
     branches: [ master ]
 
 jobs:
+  build_opencue_packages:
+    name: Build opencue packages
+    runs-on: ubuntu-22.04
+    container: python:3.7
+    outputs:
+      opencue_proto_path: ${{ steps.build_opencue_proto.outputs.opencue_proto_path }}
+      opencue_pycue_path: ${{ steps.build_pycue.outputs.opencue_pycue_path }}
+      opencue_pyoutline_path: ${{ steps.build_pyoutline.outputs.opencue_pyoutline_path }}
+      opencue_cueadmin_path: ${{ steps.build_cueadmin.outputs.opencue_cueadmin_path }}
+      opencue_cuesubmit_path: ${{ steps.build_cuesubmit.outputs.opencue_cuesubmit_path }}
+      opencue_rqd_path: ${{ steps.build_rqd.outputs.opencue_rqd_path }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          fetch-depth: 0
+      - name: Mark repository as safe (Fix for https://github.com/actions/checkout/issues/1048)
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
+      - name: Prepare building packages
+        run: |
+          pip install build
+
+      - name: Build opencue_proto package
+        id: build_opencue_proto
+        run: |
+          python -m build ./proto
+          echo "opencue_proto_path=$(ls ./proto/dist/opencue_proto-*.whl)" >> $GITHUB_OUTPUT
+
+      - name: Build opencue_pycue package
+        id: build_pycue
+        run: |
+          python -m build ./pycue
+          echo "opencue_pycue_path=$(ls ./pycue/dist/opencue_pycue-*.whl)" >> $GITHUB_OUTPUT
+
+      - name: Build opencue_pyoutline package
+        id: build_pyoutline
+        run: |
+          python -m build ./pyoutline
+          echo "opencue_pyoutline_path=$(ls ./pyoutline/dist/opencue_pyoutline-*.whl)" >> $GITHUB_OUTPUT
+
+      - name: Build opencue_cueadmin package
+        id: build_cueadmin
+        run: |
+          python -m build ./cueadmin
+          echo "opencue_cueadmin_path=$(ls ./cueadmin/dist/opencue_cueadmin-*.whl)" >> $GITHUB_OUTPUT
+
+      - name: Build opencue_cuesubmit package
+        id: build_cuesubmit
+        run: |
+          python -m build ./cuesubmit
+          echo "opencue_cuesubmit_path=$(ls ./cuesubmit/dist/opencue_cuesubmit-*.whl)" >> $GITHUB_OUTPUT
+
+      - name: Build opencue_rqd package
+        id: build_rqd
+        run: |
+          python -m build ./rqd
+          echo "opencue_rqd_path=$(ls ./rqd/dist/opencue_rqd-*.whl)" >> $GITHUB_OUTPUT
+
+      - name: Upload opencue packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: opencue_packages
+          path: |
+            proto/dist/*.*
+            pycue/dist/*.*
+            pyoutline/dist/*.*
+            cueadmin/dist/*.*
+            cuesubmit/dist/*.*
+            rqd/dist/*.*
   integration_test:
+    needs: build_opencue_packages
     name: Run Integration Test
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Mark repository as safe (Fix for https://github.com/actions/checkout/issues/1048)
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+      - name: Download a single artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: opencue_packages
       - name: Run test
-        run: ci/run_integration_test.sh
+        run: |
+          export OPENCUE_PROTO_PACKAGE_PATH="${{ needs.build_opencue_packages.outputs.opencue_proto_path }}"
+          export OPENCUE_PYCUE_PACKAGE_PATH="${{ needs.build_opencue_packages.outputs.opencue_pycue_path }}"
+          export OPENCUE_PYOUTLINE_PACKAGE_PATH="${{ needs.build_opencue_packages.outputs.opencue_pyoutline_path }}"
+          export OPENCUE_CUEADMIN_PACKAGE_PATH="${{ needs.build_opencue_packages.outputs.opencue_cueadmin_path }}"
+          export OPENCUE_CUESUBMIT_PACKAGE_PATH="${{ needs.build_opencue_packages.outputs.opencue_cuesubmit_path }}"
+          export OPENCUE_RQD_PACKAGE_PATH="${{ needs.build_opencue_packages.outputs.opencue_rqd_path }}"
+          ci/run_integration_test.sh
 
       - name: Archive log files
         uses: actions/upload-artifact@v4

--- a/.github/workflows/packaging-pipeline.yml
+++ b/.github/workflows/packaging-pipeline.yml
@@ -27,41 +27,47 @@ jobs:
 
       - name: Prepare building packages
         run: |
-          pip install build
+          pip install build==1.1.1
 
       - name: Build opencue_proto package
         id: build_opencue_proto
         run: |
+          set -e
           python -m build ./proto
           echo "opencue_proto_path=$(ls ./proto/dist/opencue_proto-*.whl)" >> $GITHUB_OUTPUT
 
       - name: Build opencue_pycue package
         id: build_pycue
         run: |
+          set -e
           python -m build ./pycue
           echo "opencue_pycue_path=$(ls ./pycue/dist/opencue_pycue-*.whl)" >> $GITHUB_OUTPUT
 
       - name: Build opencue_pyoutline package
         id: build_pyoutline
         run: |
+          set -e
           python -m build ./pyoutline
           echo "opencue_pyoutline_path=$(ls ./pyoutline/dist/opencue_pyoutline-*.whl)" >> $GITHUB_OUTPUT
 
       - name: Build opencue_cueadmin package
         id: build_cueadmin
         run: |
+          set -e
           python -m build ./cueadmin
           echo "opencue_cueadmin_path=$(ls ./cueadmin/dist/opencue_cueadmin-*.whl)" >> $GITHUB_OUTPUT
 
       - name: Build opencue_cuesubmit package
         id: build_cuesubmit
         run: |
+          set -e
           python -m build ./cuesubmit
           echo "opencue_cuesubmit_path=$(ls ./cuesubmit/dist/opencue_cuesubmit-*.whl)" >> $GITHUB_OUTPUT
 
       - name: Build opencue_rqd package
         id: build_rqd
         run: |
+          set -e
           python -m build ./rqd
           echo "opencue_rqd_path=$(ls ./rqd/dist/opencue_rqd-*.whl)" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/packaging-pipeline.yml
+++ b/.github/workflows/packaging-pipeline.yml
@@ -151,6 +151,7 @@ jobs:
 
     name: Build ${{ matrix.NAME }}
     runs-on: ubuntu-22.04
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -214,6 +215,7 @@ jobs:
     name: Create Other Build Artifacts
     needs: build_components
     runs-on: ubuntu-22.04
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/packaging-pipeline.yml
+++ b/.github/workflows/packaging-pipeline.yml
@@ -3,7 +3,7 @@ name: OpenCue Packaging Pipeline
 # Trigger this pipeline on new commits to master.
 on:
   push:
-    branches: [ fix-packaging-testing ]
+    branches: [ master ]
 
 jobs:
   build_opencue_packages:

--- a/.github/workflows/packaging-pipeline.yml
+++ b/.github/workflows/packaging-pipeline.yml
@@ -34,42 +34,42 @@ jobs:
         run: |
           set -e
           python -m build ./proto
-          echo "opencue_proto_path=$(ls ./proto/dist/opencue_proto-*.whl)" >> $GITHUB_OUTPUT
+          echo "opencue_proto_path=$(find ./proto/dist -name 'opencue_proto-*.whl' -print -quit)" >> $GITHUB_OUTPUT
 
       - name: Build opencue_pycue package
         id: build_pycue
         run: |
           set -e
           python -m build ./pycue
-          echo "opencue_pycue_path=$(ls ./pycue/dist/opencue_pycue-*.whl)" >> $GITHUB_OUTPUT
+          echo "opencue_pycue_path=$(find ./pycue/dist -name 'opencue_pycue-*.whl' -print -quit)" >> $GITHUB_OUTPUT
 
       - name: Build opencue_pyoutline package
         id: build_pyoutline
         run: |
           set -e
           python -m build ./pyoutline
-          echo "opencue_pyoutline_path=$(ls ./pyoutline/dist/opencue_pyoutline-*.whl)" >> $GITHUB_OUTPUT
+          echo "opencue_pyoutline_path=$(find ./pyoutline/dist -name 'opencue_pyoutline-*.whl' -print -quit)" >> $GITHUB_OUTPUT
 
       - name: Build opencue_cueadmin package
         id: build_cueadmin
         run: |
           set -e
           python -m build ./cueadmin
-          echo "opencue_cueadmin_path=$(ls ./cueadmin/dist/opencue_cueadmin-*.whl)" >> $GITHUB_OUTPUT
+          echo "opencue_cueadmin_path=$(find ./cueadmin/dist -name 'opencue_cueadmin-*.whl' -print -quit)" >> $GITHUB_OUTPUT
 
       - name: Build opencue_cuesubmit package
         id: build_cuesubmit
         run: |
           set -e
           python -m build ./cuesubmit
-          echo "opencue_cuesubmit_path=$(ls ./cuesubmit/dist/opencue_cuesubmit-*.whl)" >> $GITHUB_OUTPUT
+          echo "opencue_cuesubmit_path=$(find ./cuesubmit/dist -name 'opencue_cuesubmit-*.whl' -print -quit)" >> $GITHUB_OUTPUT
 
       - name: Build opencue_rqd package
         id: build_rqd
         run: |
           set -e
           python -m build ./rqd
-          echo "opencue_rqd_path=$(ls ./rqd/dist/opencue_rqd-*.whl)" >> $GITHUB_OUTPUT
+          echo "opencue_rqd_path=$(find ./rqd/dist -name 'opencue_rqd-*.whl' -print -quit)" >> $GITHUB_OUTPUT
 
       - name: Upload opencue packages
         uses: actions/upload-artifact@v4

--- a/.github/workflows/packaging-pipeline.yml
+++ b/.github/workflows/packaging-pipeline.yml
@@ -3,7 +3,7 @@ name: OpenCue Packaging Pipeline
 # Trigger this pipeline on new commits to master.
 on:
   push:
-    branches: [ master ]
+    branches: [ fix-packaging-testing ]
 
 jobs:
   build_opencue_packages:

--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -35,42 +35,42 @@ jobs:
         run: |
           set -e
           python -m build ./proto
-          echo "opencue_proto_path=$(ls ./proto/dist/opencue_proto-*.whl)" >> $GITHUB_OUTPUT
+          echo "opencue_proto_path=$(find ./proto/dist -name 'opencue_proto-*.whl' -print -quit)" >> $GITHUB_OUTPUT
 
       - name: Build opencue_pycue package
         id: build_pycue
         run: |
           set -e
           python -m build ./pycue
-          echo "opencue_pycue_path=$(ls ./pycue/dist/opencue_pycue-*.whl)" >> $GITHUB_OUTPUT
+          echo "opencue_pycue_path=$(find ./pycue/dist -name 'opencue_pycue-*.whl' -print -quit)" >> $GITHUB_OUTPUT
 
       - name: Build opencue_pyoutline package
         id: build_pyoutline
         run: |
           set -e
           python -m build ./pyoutline
-          echo "opencue_pyoutline_path=$(ls ./pyoutline/dist/opencue_pyoutline-*.whl)" >> $GITHUB_OUTPUT
+          echo "opencue_pyoutline_path=$(find ./pyoutline/dist -name 'opencue_pyoutline-*.whl' -print -quit)" >> $GITHUB_OUTPUT
 
       - name: Build opencue_cueadmin package
         id: build_cueadmin
         run: |
           set -e
           python -m build ./cueadmin
-          echo "opencue_cueadmin_path=$(ls ./cueadmin/dist/opencue_cueadmin-*.whl)" >> $GITHUB_OUTPUT
+          echo "opencue_cueadmin_path=$(find ./cueadmin/dist -name 'opencue_cueadmin-*.whl' -print -quit)" >> $GITHUB_OUTPUT
 
       - name: Build opencue_cuesubmit package
         id: build_cuesubmit
         run: |
           set -e
           python -m build ./cuesubmit
-          echo "opencue_cuesubmit_path=$(ls ./cuesubmit/dist/opencue_cuesubmit-*.whl)" >> $GITHUB_OUTPUT
+          echo "opencue_cuesubmit_path=$(find ./cuesubmit/dist -name 'opencue_cuesubmit-*.whl' -print -quit)" >> $GITHUB_OUTPUT
 
       - name: Build opencue_rqd package
         id: build_rqd
         run: |
           set -e
           python -m build ./rqd
-          echo "opencue_rqd_path=$(ls ./rqd/dist/opencue_rqd-*.whl)" >> $GITHUB_OUTPUT
+          echo "opencue_rqd_path=$(find ./rqd/dist -name 'opencue_rqd-*.whl' -print -quit)" >> $GITHUB_OUTPUT
 
       - name: Upload opencue packages
         uses: actions/upload-artifact@v4

--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -18,6 +18,7 @@ jobs:
       opencue_cueadmin_path: ${{ steps.build_cueadmin.outputs.opencue_cueadmin_path }}
       opencue_cuesubmit_path: ${{ steps.build_cuesubmit.outputs.opencue_cuesubmit_path }}
       opencue_rqd_path: ${{ steps.build_rqd.outputs.opencue_rqd_path }}
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -28,41 +28,47 @@ jobs:
 
       - name: Prepare building packages
         run: |
-          pip install build
+          pip install build==1.1.1
 
       - name: Build opencue_proto package
         id: build_opencue_proto
         run: |
+          set -e
           python -m build ./proto
           echo "opencue_proto_path=$(ls ./proto/dist/opencue_proto-*.whl)" >> $GITHUB_OUTPUT
 
       - name: Build opencue_pycue package
         id: build_pycue
         run: |
+          set -e
           python -m build ./pycue
           echo "opencue_pycue_path=$(ls ./pycue/dist/opencue_pycue-*.whl)" >> $GITHUB_OUTPUT
 
       - name: Build opencue_pyoutline package
         id: build_pyoutline
         run: |
+          set -e
           python -m build ./pyoutline
           echo "opencue_pyoutline_path=$(ls ./pyoutline/dist/opencue_pyoutline-*.whl)" >> $GITHUB_OUTPUT
 
       - name: Build opencue_cueadmin package
         id: build_cueadmin
         run: |
+          set -e
           python -m build ./cueadmin
           echo "opencue_cueadmin_path=$(ls ./cueadmin/dist/opencue_cueadmin-*.whl)" >> $GITHUB_OUTPUT
 
       - name: Build opencue_cuesubmit package
         id: build_cuesubmit
         run: |
+          set -e
           python -m build ./cuesubmit
           echo "opencue_cuesubmit_path=$(ls ./cuesubmit/dist/opencue_cuesubmit-*.whl)" >> $GITHUB_OUTPUT
 
       - name: Build opencue_rqd package
         id: build_rqd
         run: |
+          set -e
           python -m build ./rqd
           echo "opencue_rqd_path=$(ls ./rqd/dist/opencue_rqd-*.whl)" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
This is to fix the release pipeline.

It takes the same parts of the testing pipeline to first build the python packages and use them for building the docker images.

I have tested the integration tests that seems to work, but I cannot test the other steps, which requires AWS credentials.

This is needed for #1779 to work properly and generally to allow the packaging to work again after the rework of the build setup for the python libraries.