### PR TITLE
[cueadmin] Add Copyright Contributors to the OpenCue Project

### DIFF
--- a/cueadmin/cueadmin/__init__.py
+++ b/cueadmin/cueadmin/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright Contributors to the OpenCue Project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.


### PR DESCRIPTION
Include the Copyright comments to the `cueadmin/cueadmin/__init__.py` file.

**Link the Issue(s) this Pull Request is related to.**
[cueadmin] Add missing copyright and contributor header to cueadmin/cueadmin/__init__.py #1786
