### PR TITLE
[CI/CD] Remove redundant step for uploading opencue packages in CI workflow

### DIFF
--- a/.github/workflows/packaging-pipeline.yml
+++ b/.github/workflows/packaging-pipeline.yml
@@ -41,13 +41,6 @@ jobs:
           echo "opencue_cueman_path=$(find ./packages -name 'opencue_cueman-*.whl' -print -quit)" >> $GITHUB_OUTPUT
           echo "opencue_cuegui_path=$(find ./packages -name 'opencue_cuegui-*.whl' -print -quit)" >> $GITHUB_OUTPUT
 
-      - name: Upload opencue packages
-        uses: actions/upload-artifact@v4
-        with:
-          name: opencue_packages
-          path: |
-            packages
-
   integration_test:
     needs: build_opencue_packages
     name: Run Integration Test


### PR DESCRIPTION
This is to fix a conflicting step in the packaging pipeline