### PR TITLE
[docs] Standardize Cueman naming convention across documentation

### DIFF
--- a/docs/_docs/reference/index.md
+++ b/docs/_docs/reference/index.md
@@ -14,7 +14,7 @@ Reference guides for all users running OpenCue tools and interfaces
 
 ### [Command Line Tools](tools/)
 Documentation for OpenCue's command-line tools
-- **[CueMan](tools/cueman/)** - Advanced job and frame management CLI
+- **[Cueman](tools/cueman/)** - Advanced job and frame management CLI
 - **[CueAdmin](commands/cueadmin/)** - Administrative command-line tool
 - **[PyCueRun](commands/pycuerun/)** - Python job submission tool
 

--- a/docs/_docs/reference/tools/cueman.md
+++ b/docs/_docs/reference/tools/cueman.md
@@ -1,22 +1,22 @@
 ---
-title: "CueMan - CLI Job Management Tool"
+title: "Cueman - CLI Job Management Tool"
 nav_order: 3
 parent: "Command Line Tools"
 grand_parent: "Reference"
 layout: default
 date: 2025-08-06
 description: >
-  CueMan is a command-line job management tool for OpenCue that provides 
+  Cueman is a command-line job management tool for OpenCue that provides 
   efficient job control operations with advanced filtering and batch capabilities.
 ---
 
-# CueMan - CLI Job Management Tool
+# Cueman - CLI Job Management Tool
 
-CueMan is a powerful command-line interface for managing OpenCue jobs, frames, and processes. It provides streamlined operations for job control, frame management, and batch processing with advanced filtering capabilities.
+Cueman is a command-line interface for managing OpenCue jobs, frames, and processes. It provides streamlined operations for job control, frame management, and batch processing with advanced filtering capabilities.
 
 ## Overview
 
-CueMan extends the functionality of `cueadmin` and the OpenCue Python API, enabling users to efficiently manage render farm operations through an intuitive command-line interface.
+Cueman extends the functionality of `cueadmin` and the OpenCue Python API, enabling users to efficiently manage render farm operations through an intuitive command-line interface.
 
 ### Key Features
 
@@ -417,7 +417,7 @@ cueman             # Running without args shows help
 
 ## Additional Resources
 
-- [CueMan Tutorial](/OpenCue/docs/tutorials/cueman-tutorial/) - Comprehensive tutorial with real-world scenarios
-- [CueMan GitHub](https://github.com/AcademySoftwareFoundation/OpenCue/tree/master/cueman) - Source code and documentation
+- [Cueman Tutorial](/OpenCue/docs/tutorials/cueman-tutorial/) - Tutorial with real-world scenarios
+- [Cueman GitHub](https://github.com/AcademySoftwareFoundation/OpenCue/tree/master/cueman) - Source code and documentation
 - [OpenCue Documentation](/OpenCue/docs/) - Complete OpenCue documentation
 - [CueAdmin Reference](/OpenCue/docs/reference/commands/cueadmin/) - Related command-line tool

--- a/docs/_docs/reference/tools/index.md
+++ b/docs/_docs/reference/tools/index.md
@@ -19,8 +19,8 @@ OpenCue provides several command-line tools for managing and interacting with th
 ### [CueAdmin](/OpenCue/docs/reference/commands/cueadmin/)
 The primary administrative tool for OpenCue, used for managing jobs, hosts, shows, and other system components.
 
-### [CueMan](/OpenCue/docs/reference/tools/cueman/)
-A powerful job management tool that extends cueadmin with advanced filtering, batch operations, and user-friendly features for efficient farm management.
+### [Cueman](/OpenCue/docs/reference/tools/cueman/)
+A job management tool that extends cueadmin with advanced filtering, batch operations, and user-friendly features for efficient farm management.
 
 ### [PyCueRun](/OpenCue/docs/reference/commands/pycuerun/)
 A tool for submitting and running Python-based jobs on the OpenCue render farm.

--- a/docs/_docs/tutorials/cueman-tutorial.md
+++ b/docs/_docs/tutorials/cueman-tutorial.md
@@ -1,23 +1,23 @@
 ---
-title: "CueMan Tutorial"
+title: "Cueman Tutorial"
 nav_order: 7
 parent: "Tutorials"
 layout: default
 date: 2025-08-06
 description: >
-  Learn how to use CueMan for efficient OpenCue job management with 
+  Learn how to use Cueman for efficient OpenCue job management with 
   practical examples and real-world scenarios.
 ---
 
-# CueMan Tutorial
+# Cueman Tutorial
 
-This tutorial will guide you through using CueMan for OpenCue job management with practical examples and real-world scenarios.
+This tutorial will guide you through using Cueman for OpenCue job management with practical examples and real-world scenarios.
 
 ## Prerequisites
 
 Before starting this tutorial, ensure you have:
 - Access to an OpenCue server
-- CueMan installed (`pip install opencue-cueman`)
+- Cueman installed (`pip install opencue-cueman`)
 - Environment variables configured:
   ```bash
   export OPENCUE_HOSTS="your-cuebot-server:8443"
@@ -28,7 +28,7 @@ Before starting this tutorial, ensure you have:
 
 ### Getting Help
 
-Start by exploring CueMan's capabilities:
+Start by exploring Cueman's capabilities:
 
 ```bash
 # Display all available commands
@@ -164,7 +164,7 @@ cueman -eat show_shot_lighting_v001 -layer preview_layer
 
 ### Combining Multiple Filters
 
-CueMan's power comes from combining filters:
+Cueman's power comes from combining filters:
 
 ```bash
 # List running frames on render_layer using more than 8GB
@@ -472,11 +472,10 @@ You've learned how to:
 - Handle real-world production scenarios
 - Monitor and troubleshoot render farm issues
 
-CueMan provides powerful capabilities for OpenCue management. Start with simple operations and gradually incorporate more advanced features as you become comfortable with the tool.
+Cueman provides capabilities for OpenCue management. Start with simple operations and gradually incorporate more advanced features as you become comfortable with the tool.
 
 ## Next Steps
 
-- Explore the [CueMan Reference](/OpenCue/docs/reference/tools/cueman/) for complete command documentation
+- Explore the [Cueman Reference](/OpenCue/docs/reference/tools/cueman/) for complete command documentation
 - Practice with test jobs before using on production
-- Create scripts combining CueMan commands for automated workflows
-- Share your experiences and tips with the OpenCue community
+- Create scripts combining Cueman commands for automated workflows


### PR DESCRIPTION
- Update all references from "CueMan" to "Cueman" for consistency
  - Affected files: tutorial, reference index, tools index, and cueman reference page
- Maintains consistent capitalization throughout the documentation
- Minor Cueman documentation improvements

**Link the Issue(s) this Pull Request is related to.**
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/1800