### PR TITLE
[cuegui] Optimize Monitor Hosts OS filter with config-based loading

### DIFF
--- a/cuegui/cuegui/Constants.py
+++ b/cuegui/cuegui/Constants.py
@@ -206,6 +206,8 @@ LOG_HIGHLIGHT_INFO = __config.get('render_logs.highlight.info')
 
 RESOURCE_LIMITS = __config.get('resources')
 
+HOST_OS_FILTERS = __config.get('host_os_filters', [])
+
 OUTPUT_VIEWERS = []
 for viewer in __config.get('output_viewers', {}):
     OUTPUT_VIEWERS.append(viewer)

--- a/cuegui/cuegui/HostMonitorTree.py
+++ b/cuegui/cuegui/HostMonitorTree.py
@@ -248,8 +248,10 @@ class HostMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         try:
             hosts = opencue.api.getHosts(**self.hostSearch.options)
 
-            # Extract OS values and update the filter list in parent
-            if hosts:
+            # Performance optimization: Only extract OS values if not using predefined filters
+            # from config. This avoids unnecessary processing when config-based filters are used.
+            # For large deployments (thousands of hosts), this significantly improves performance
+            if hosts and not cuegui.Constants.HOST_OS_FILTERS:
                 os_values = set(host.data.os for host in hosts if host.data.os)
                 parent = self.parent()
                 if hasattr(parent, 'updateOSFilterList'):

--- a/cuegui/cuegui/config/cuegui.yaml
+++ b/cuegui/cuegui/config/cuegui.yaml
@@ -80,6 +80,13 @@ editor.linux: 'gview -R -m -M -U {config_path}/gvimrc +'
 # comment out to disable sentry
 # sentry.dsn: 'https://someid@your-sentry.com/10'
 
+# Predefined OS values for the Monitor Hosts filter.
+# This list is used to populate the OS filter dropdown without loading all hosts.
+# If this list is not defined or empty, the OS filter will dynamically load OS values from hosts.
+# Common values include: rhel7, rhel9, rocky9, Windows, mac, linux, centos7, ubuntu20, ubuntu22
+# To disable predefined filters and use dynamic loading, comment out the line below or set to: []
+# host_os_filters: ['Linux', 'Windows', 'macOS']
+
 resources:
   # The max cores and max memory based on the available hardware.
   # These values are used by:

--- a/docs/_docs/other-guides/configuring-opencue.md
+++ b/docs/_docs/other-guides/configuring-opencue.md
@@ -123,6 +123,32 @@ This file may be stored in:
 * the [shared config directory](#shared-config-directory)
 * or at a path of your choosing, specified via the `CUEGUI_CONFIG_FILE` environment variable.
 
+#### Performance Optimization for Large-Scale Environments
+
+##### Monitor Hosts OS Filter
+
+When working with large OpenCue deployments (thousands or millions of hosts), the Monitor Hosts plugin in CueCommander
+can experience performance issues when loading the OS filter dropdown. By default, the plugin fetches all
+hosts from the server to extract unique OS values, which can cause significant UI delays.
+
+To optimize this, you can predefine the OS filter values in your `cuegui.yaml`:
+
+```yaml
+# Predefined OS values for the Monitor Hosts filter
+# Avoids loading all hosts just to populate the OS dropdown
+host_os_filters: ['Linux', 'Windows', 'macOS', 'rhel7', 'rhel9', 'rocky9']
+```
+
+Benefits:
+* Instant OS filter dropdown population
+* No initial delay when opening Monitor Hosts with thousands of hosts
+* Reduces unnecessary server load
+
+Configuration options:
+* **Predefined list**: Set `host_os_filters` to a list of OS names used in your environment
+* **Dynamic loading**: Set to `[]` or omit the setting to use the original behavior (loads all hosts to discover OS values)
+* **Custom values**: Adjust the list to match your specific environment's operating systems
+
 ### CueSubmit
 
 [`cuesubmit_config.example.yaml`](https://github.com/AcademySoftwareFoundation/OpenCue/blob/master/cuesubmit/cuesubmit_config.example.yaml)


### PR DESCRIPTION
- Added `host_os_filters` option to `cuegui.yaml` to define predefined OS list
- Modified HostMonitor to use config values when available, skipping full host load
- Retains dynamic loading when config is empty for backward compatibility
- Updated documentation with new configuration and performance tips

Performance:
- Instant OS filter population for large-scale environments
- Reduces initial UI load time and server queries

**Link the Issue(s) this Pull Request is related to.**
https://github.com/AcademySoftwareFoundation/OpenCue/issues/1807