### PR TITLE
[rust/rqd] Add dummy-cuebot as a dev dependency for rqd

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2002,6 +2002,7 @@ dependencies = [
  "config",
  "dashmap",
  "device_query",
+ "dummy-cuebot",
  "futures",
  "futures-core",
  "http",

--- a/rust/crates/rqd/Cargo.toml
+++ b/rust/crates/rqd/Cargo.toml
@@ -64,6 +64,7 @@ libc = "0.2"
 device_query = "3.0"
 
 [dev-dependencies]
+dummy-cuebot = { path = "../dummy-cuebot" }
 tempfile = "3.14.0"
 
 # === Rpm configuration ===


### PR DESCRIPTION
Rqd relies on having dummy cuebot built to run integration tests
