### PR TITLE
[docs] Implement independent versioning system with automated metadata

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,11 +8,18 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/docs.yml'
+    tags:
+      - 'v*'  # Build docs for version tags
   pull_request:
     paths:
       - 'docs/**'
       - '.github/workflows/docs.yml'
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build (e.g., v1.11, main)'
+        required: false
+        default: 'main'
 
 permissions:
   contents: read
@@ -20,56 +27,146 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
+  group: "pages-${{ github.ref }}"
   cancel-in-progress: false
 
 jobs:
   # Build job
   build:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          - version: main
+            path: ''
+          # Add more versions as needed
+          # - version: v1.11
+          #   path: 'v1.11'
+    
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Fetch all history for versioning
-
+          fetch-depth: 0  # Fetch all history for git metadata
+          
+      - name: Checkout version tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          VERSION_TAG=${GITHUB_REF#refs/tags/}
+          git checkout tags/$VERSION_TAG -b docs-$VERSION_TAG
+          
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
           bundler-cache: true
           working-directory: ./docs
-
+          
+      - name: Extract version information
+        id: version
+        run: |
+          # Get version from git tag, branch, or VERSION.in file
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          elif [[ "$GITHUB_REF" == refs/heads/* ]]; then
+            BRANCH=${GITHUB_REF#refs/heads/}
+            if [[ "$BRANCH" == "master" || "$BRANCH" == "main" ]]; then
+              VERSION="main"
+            else
+              VERSION=$BRANCH
+            fi
+          else
+            VERSION="main"
+          fi
+          
+          # Get OpenCue version from VERSION.in
+          OPENCUE_VERSION=$(cat VERSION.in | tr -d '\n')
+          
+          # Get last commit date
+          LAST_COMMIT=$(git log -1 --format="%ad" --date=format:"%Y-%m-%d")
+          
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "opencue_version=$OPENCUE_VERSION" >> $GITHUB_OUTPUT
+          echo "last_commit=$LAST_COMMIT" >> $GITHUB_OUTPUT
+          echo "build_date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+          
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v4
         if: github.event_name != 'pull_request'
-
+        
+      - name: Create _data directory and version file
+        working-directory: ./docs
+        run: |
+          mkdir -p _data
+          cat > _data/version.yml <<EOF
+          version: "${{ steps.version.outputs.version }}"
+          opencue_version: "${{ steps.version.outputs.opencue_version }}"
+          build_date: "${{ steps.version.outputs.build_date }}"
+          last_commit: "${{ steps.version.outputs.last_commit }}"
+          git_hash: "$(git rev-parse --short HEAD)"
+          EOF
+          
       - name: Build with Jekyll
         working-directory: ./docs
         run: |
+          # Set version in config
+          export JEKYLL_VERSION="${{ steps.version.outputs.version }}"
+          export JEKYLL_BUILD_DATE="${{ steps.version.outputs.build_date }}"
+          
+          # Add version to Jekyll config dynamically
+          echo "" >> _config.yml
+          echo "# Auto-generated version info" >> _config.yml
+          echo "version: ${{ steps.version.outputs.version }}" >> _config.yml
+          echo "build_date: ${{ steps.version.outputs.build_date }}" >> _config.yml
+          echo "opencue_version: ${{ steps.version.outputs.opencue_version }}" >> _config.yml
+          
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             bundle exec jekyll build --baseurl "/OpenCue"
           else
-            bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+            # For versioned builds, add version to path
+            if [ "${{ steps.version.outputs.version }}" != "main" ]; then
+              bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}/${{ steps.version.outputs.version }}"
+            else
+              bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+            fi
           fi
         env:
           JEKYLL_ENV: production
-
+          
+      - name: Create version redirect
+        if: github.event_name != 'pull_request'
+        working-directory: ./docs/_site
+        run: |
+          # Create a simple redirect for /latest to main version
+          mkdir -p latest
+          cat > latest/index.html <<EOF
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <meta http-equiv="refresh" content="0; url=../">
+            <link rel="canonical" href="../">
+          </head>
+          <body>
+            <p>Redirecting to latest documentation...</p>
+          </body>
+          </html>
+          EOF
+          
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         if: github.event_name != 'pull_request'
         with:
           path: ./docs/_site
-
-  # Deployment job
+          
+  # Multi-version deployment job
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-22.04
     needs: build
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ cuebot/.project
 docker-compose-local.yml
 docs/_site/
 docs/bin/
+docs/_data/version.yml

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,15 +7,33 @@ url: "https://academysoftwarefoundation.github.io" # the base hostname & protoco
 # Build settings
 theme: just-the-docs
 
-# Enable versioning
+# Version management
 versioning:
   enabled: true
   default_version: main
   versions:
     - main
-    - v0.22
-    - v0.21
-    - v0.20
+    - v0.0.1
+  version_labels:
+    main: "Latest (main)"
+    v0.0.1: "v0.0.1 (Preview)"
+
+# Git metadata
+git_metadata:
+  enabled: true
+  show_contributors: true
+  show_last_modified: true
+  date_format: "%B %d, %Y"
+
+# Build metadata (populated by CI)
+build_info:
+  timestamp: ""
+  git_hash: ""
+  
+# Documentation version (in progress)
+doc_version: "0.0.1"
+
+# OpenCue version will be read from VERSION.in by CI/CD pipeline
 
 # Just the Docs theme configuration
 color_scheme: nil

--- a/docs/_includes/aux-nav.html
+++ b/docs/_includes/aux-nav.html
@@ -1,11 +1,7 @@
 <nav aria-label="Auxiliary" class="aux-nav">
   <ul class="aux-nav-list">
-    <!-- Theme Toggle Button - First position for visibility -->
-    <li class="aux-nav-list-item">
-      <button class="theme-toggle-btn" id="theme-toggle" aria-label="Toggle theme" title="Switch between light and dark mode">
-        <span class="theme-icon" id="theme-icon">🌚</span>
-      </button>
-    </li>
+    <!-- Theme Toggle Button -->
+    
     {% if site.aux_links %}
       {% for link in site.aux_links %}
         <li class="aux-nav-list-item">

--- a/docs/_includes/header_custom.html
+++ b/docs/_includes/header_custom.html
@@ -566,27 +566,52 @@
   
   /* Professional table design */
   body.dark-mode table {
-    background: #1f2937 !important;
-    border: 1px solid #4b5563 !important;
+    background: #374151 !important;
+    border: 1px solid #6b7280 !important;
     border-radius: 8px;
     overflow: hidden;
   }
   
   body.dark-mode table th {
-    background: #374151 !important;
+    background: #1f2937 !important;
     color: #f9fafb !important;
     border: 1px solid #6b7280 !important;
     font-weight: 600;
   }
   
   body.dark-mode table td {
-    color: #e5e7eb !important;
-    border: 1px solid #4b5563 !important;
+    background: #374151 !important;
+    color: #f9fafb !important;
+    border: 1px solid #6b7280 !important;
     transition: var(--transition-smooth);
   }
   
   body.dark-mode table tr:hover td {
-    background: rgba(156, 163, 175, 0.05) !important;
+    background: #4b5563 !important;
+  }
+  
+  /* Fix table link colors in dark mode */
+  body.dark-mode table a {
+    color: #60a5fa !important;
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+  }
+  
+  body.dark-mode table a:hover {
+    color: #93bbfc !important;
+    border-bottom-color: #60a5fa;
+  }
+  
+  /* Ensure table text is always readable */
+  body.dark-mode table td,
+  body.dark-mode table th,
+  body.dark-mode table td * {
+    color: #f9fafb !important;
+  }
+  
+  body.dark-mode table strong {
+    color: #ffffff !important;
+    font-weight: 600;
   }
   
   body.dark-mode .search-input-wrap::after {
@@ -1220,4 +1245,7 @@ document.addEventListener('DOMContentLoaded', function() {
   
 });
 </script>
+
+<!-- Include sidebar version switcher -->
+{% include sidebar-version-switcher.html %}
 

--- a/docs/_includes/page-metadata.html
+++ b/docs/_includes/page-metadata.html
@@ -1,0 +1,93 @@
+<div class="page-metadata">
+  <div class="metadata-row">
+    <span class="metadata-item">
+      <strong>Documentation Version:</strong> 
+      <span class="version-tag">
+        {% assign current_version = site.version | default: site.versioning.default_version %}
+        {% if current_version == "main" %}
+          latest (main)
+        {% else %}
+          {{ current_version }}
+        {% endif %}
+      </span>
+    </span>
+    
+    {% if page.last_modified_date %}
+    <span class="metadata-item">
+      <strong>Last Updated:</strong> 
+      <time datetime="{{ page.last_modified_date | date_to_xmlschema }}">
+        {{ page.last_modified_date | date: "%B %d, %Y" }}
+      </time>
+    </span>
+    {% endif %}
+
+    {% if page.contributors %}
+    <span class="metadata-item">
+      <strong>Contributors:</strong> {{ page.contributors | size }}
+    </span>
+    {% endif %}
+  </div>
+  
+  {% if site.versioning.versions.size > 1 %}
+  <div class="version-notice">
+    {% if current_version != site.versioning.default_version %}
+      <div class="notice notice-warning">
+        ⚠️ You are viewing documentation for version <strong>{{ current_version }}</strong>. 
+        <a href="{{ site.baseurl }}/">View latest documentation</a>
+      </div>
+    {% endif %}
+  </div>
+  {% endif %}
+</div>
+
+<style>
+.page-metadata {
+  background: var(--color-grey-lt-000);
+  border: 1px solid var(--color-grey-lt-100);
+  border-radius: 4px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1.5rem;
+  font-size: 0.875rem;
+}
+
+.metadata-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.metadata-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.version-tag {
+  background: var(--color-blue-100);
+  color: var(--color-blue-700);
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-weight: 500;
+}
+
+.version-notice {
+  margin-top: 0.75rem;
+}
+
+.notice {
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  border-left: 4px solid;
+}
+
+.notice-warning {
+  background: var(--color-yellow-000);
+  border-color: var(--color-yellow-300);
+  color: var(--color-yellow-800);
+}
+
+.notice-warning a {
+  color: var(--color-yellow-700);
+  font-weight: 500;
+}
+</style>

--- a/docs/_includes/sidebar-version-switcher.html
+++ b/docs/_includes/sidebar-version-switcher.html
@@ -1,0 +1,317 @@
+<!-- Sidebar Version Switcher - To be injected via JavaScript -->
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  // Function to add icon to Documentation Versions nav item
+  function addIconToDocVersionsLink() {
+    // Find all navigation links
+    const navLinks = document.querySelectorAll('.nav-list-link');
+    
+    navLinks.forEach(link => {
+      // Check if this is the Documentation Versions link
+      if (link.textContent.trim() === 'Documentation Versions' && !link.querySelector('.nav-icon')) {
+        // Add icon to the beginning of the link text
+        const icon = document.createElement('span');
+        icon.className = 'nav-icon';
+        icon.style.cssText = 'margin-right: 6px; font-size: 16px;';
+        icon.textContent = '📖';
+        
+        // Insert icon at the beginning of the link
+        link.insertBefore(icon, link.firstChild);
+      }
+    });
+  }
+  
+  // Function to add version switcher to navigation sidebar
+  function addVersionSwitcherToNavigation() {
+    // Find the navigation list
+    const navList = document.querySelector('.nav-list');
+    const themeToggleItem = document.getElementById('nav-theme-toggle-item');
+    
+    if (navList && !document.getElementById('nav-version-switcher-item')) {
+      // Create the version switcher list item
+      const versionSwitcherItem = document.createElement('li');
+      versionSwitcherItem.className = 'nav-list-item';
+      versionSwitcherItem.id = 'nav-version-switcher-item';
+      
+      // Create the container element
+      const versionSwitcherContainer = document.createElement('div');
+      versionSwitcherContainer.className = 'nav-version-switcher';
+      versionSwitcherContainer.style.cssText = `
+        display: flex !important;
+        align-items: center !important;
+        gap: 8px !important;
+        padding: 8px 12px !important;
+        margin-bottom: 8px !important;
+        border-bottom: 1px solid #e5e7eb !important;
+        font-weight: 500 !important;
+      `;
+      
+      // Get current version from Jekyll
+      const currentVersion = '{{ site.version | default: site.versioning.default_version }}';
+      const versions = {{ site.versioning.versions | jsonify }};
+      const versionLabels = {{ site.versioning.version_labels | jsonify }};
+      
+      // Create version display and dropdown
+      versionSwitcherContainer.innerHTML = `
+        <span style="font-size: 18px;">📚</span>
+        <span style="flex: 1;">Version:</span>
+        <select id="sidebar-version-select" style="
+          background: transparent;
+          border: 1px solid #d1d5db;
+          border-radius: 4px;
+          padding: 2px 6px;
+          font-size: 14px;
+          cursor: pointer;
+          min-width: 100px;
+        ">
+          ${versions.map(version => `
+            <option value="${version}" ${version === currentVersion ? 'selected' : ''}>
+              ${versionLabels[version] || version}
+            </option>
+          `).join('')}
+        </select>
+      `;
+      
+      // Add change handler for version switching
+      versionSwitcherContainer.querySelector('#sidebar-version-select').addEventListener('change', function(e) {
+        const selectedVersion = e.target.value;
+        const currentPath = window.location.pathname;
+        const baseUrl = '{{ site.baseurl }}';
+        
+        // Handle version switching logic
+        if (selectedVersion === 'main') {
+          // Remove version prefix if exists and go to main
+          const cleanPath = currentPath.replace(/\/v[\d.]+/, '');
+          window.location.href = cleanPath || baseUrl || '/';
+        } else {
+          // For versioned documentation (including v0.0.1)
+          const cleanPath = currentPath.replace(baseUrl, '').replace(/\/v[\d.]+/, '');
+          window.location.href = baseUrl + '/' + selectedVersion + cleanPath;
+        }
+      });
+      
+      // Add the container to the list item
+      versionSwitcherItem.appendChild(versionSwitcherContainer);
+      
+      // Insert after theme toggle or at the beginning
+      if (themeToggleItem && themeToggleItem.nextSibling) {
+        navList.insertBefore(versionSwitcherItem, themeToggleItem.nextSibling);
+      } else if (themeToggleItem) {
+        themeToggleItem.parentNode.insertBefore(versionSwitcherItem, themeToggleItem.nextSibling);
+      } else {
+        // If no theme toggle, insert at the beginning
+        navList.insertBefore(versionSwitcherItem, navList.firstChild);
+      }
+      
+      // Update styles for dark mode
+      updateVersionSwitcherStyles();
+    }
+  }
+  
+  // Function to update version switcher styles based on theme
+  function updateVersionSwitcherStyles() {
+    const versionSelect = document.getElementById('sidebar-version-select');
+    const versionContainer = document.querySelector('.nav-version-switcher');
+    
+    if (versionSelect && versionContainer) {
+      const isDark = document.body.classList.contains('dark-mode');
+      
+      if (isDark) {
+        versionSelect.style.background = '#4b5563';
+        versionSelect.style.borderColor = '#6b7280';
+        versionSelect.style.color = '#f9fafb';
+        versionContainer.style.borderBottomColor = '#4b5563';
+      } else {
+        versionSelect.style.background = 'transparent';
+        versionSelect.style.borderColor = '#d1d5db';
+        versionSelect.style.color = '#374151';
+        versionContainer.style.borderBottomColor = '#e5e7eb';
+      }
+    }
+  }
+  
+  // Add version notice banner if not on main version
+  function addVersionNoticeBanner() {
+    const currentVersion = '{{ site.version | default: site.versioning.default_version }}';
+    const defaultVersion = '{{ site.versioning.default_version }}';
+    const mainContent = document.querySelector('.main-content');
+    
+    if (currentVersion !== defaultVersion && mainContent && !document.getElementById('version-notice-banner')) {
+      const banner = document.createElement('div');
+      banner.id = 'version-notice-banner';
+      banner.style.cssText = `
+        background: #fef3c7;
+        border: 1px solid #f59e0b;
+        border-radius: 8px;
+        padding: 12px 16px;
+        margin-bottom: 20px;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        font-size: 14px;
+      `;
+      
+      let bannerMessage = `You are viewing documentation for <strong>version ${currentVersion}</strong>.`;
+      
+      if (currentVersion === 'v0.0.1') {
+        bannerMessage += ` This is the initial preview version.`;
+      } else {
+        bannerMessage += ` This is an older version.`;
+      }
+      
+      banner.innerHTML = `
+        <span style="font-size: 20px;">⚠️</span>
+        <span style="flex: 1;">
+          ${bannerMessage}
+        </span>
+        <a href="{{ site.baseurl }}/" style="
+          background: #f59e0b;
+          color: white;
+          padding: 6px 12px;
+          border-radius: 4px;
+          text-decoration: none;
+          font-weight: 500;
+          white-space: nowrap;
+        ">View Latest →</a>
+      `;
+      
+      // Insert at the beginning of main content
+      mainContent.insertBefore(banner, mainContent.firstChild);
+    }
+  }
+  
+  // Add page metadata (version info and last updated)
+  function addPageMetadata() {
+    const lastModified = '{{ page.last_modified_date | date: "%B %d, %Y" }}';
+    const currentVersion = '{{ site.version | default: site.versioning.default_version }}';
+    const defaultVersion = '{{ site.versioning.default_version }}';
+    const pageHeader = document.querySelector('.main-content h1');
+    
+    if (pageHeader && !document.getElementById('page-metadata')) {
+      const metadataElement = document.createElement('div');
+      metadataElement.id = 'page-metadata';
+      metadataElement.style.cssText = `
+        background: var(--color-grey-lt-000, #f8f9fa);
+        border: 1px solid var(--color-grey-lt-100, #e9ecef);
+        border-radius: 8px;
+        padding: 12px 16px;
+        margin: 16px 0 24px 0;
+        font-size: 14px;
+      `;
+      
+      // Create metadata content
+      let metadataContent = `
+        <div style="display: flex; flex-wrap: wrap; gap: 24px; margin-bottom: 12px;">
+          <span style="display: flex; align-items: center; gap: 8px;">
+            <strong>Documentation Version:</strong>
+            <span style="background: var(--color-blue-100, #dbeafe); color: var(--color-blue-700, #1d4ed8); padding: 2px 8px; border-radius: 4px; font-weight: 500;">
+              ${currentVersion === 'main' ? 'latest (main)' : currentVersion}
+            </span>
+          </span>
+      `;
+      
+      // Add last updated date if available
+      if (lastModified && lastModified !== '') {
+        metadataContent += `
+          <span style="display: flex; align-items: center; gap: 8px;">
+            <strong>Last Updated:</strong>
+            <time>${lastModified}</time>
+          </span>
+        `;
+      }
+      
+      metadataContent += `
+          <span style="display: flex; align-items: center; gap: 8px;">
+            <strong>Doc Version:</strong>
+            <span>v{{ site.doc_version }}</span>
+          </span>
+        </div>
+      `;
+      
+      // Add version warning if not on default version
+      if (currentVersion !== defaultVersion && currentVersion !== 'main') {
+        metadataContent += `
+          <div style="
+            background: #fef3c7;
+            border-left: 4px solid #f59e0b;
+            padding: 12px 16px;
+            border-radius: 0 4px 4px 0;
+            margin-top: 12px;
+          ">
+            <span style="color: #92400e; font-weight: 500;">
+              ⚠️ You are viewing documentation for version <strong>${currentVersion}</strong>. 
+              <a href="{{ site.baseurl }}/" style="color: #b45309; font-weight: 600; text-decoration: underline;">
+                View latest documentation →
+              </a>
+            </span>
+          </div>
+        `;
+      }
+      
+      metadataElement.innerHTML = metadataContent;
+      
+      // Insert after the main heading
+      pageHeader.parentNode.insertBefore(metadataElement, pageHeader.nextSibling);
+      
+      // Update styles for dark mode if needed
+      updatePageMetadataStyles();
+    }
+  }
+  
+  // Function to update page metadata styles for dark mode
+  function updatePageMetadataStyles() {
+    const metadata = document.getElementById('page-metadata');
+    if (metadata) {
+      const isDark = document.body.classList.contains('dark-mode');
+      
+      if (isDark) {
+        metadata.style.background = '#374151';
+        metadata.style.borderColor = '#6b7280';
+        metadata.style.color = '#f9fafb';
+        
+        // Update version tag colors for dark mode
+        const versionTag = metadata.querySelector('span[style*="background: var(--color-blue-100"]');
+        if (versionTag) {
+          versionTag.style.background = '#1e3a8a';
+          versionTag.style.color = '#93c5fd';
+        }
+      } else {
+        metadata.style.background = '#f8f9fa';
+        metadata.style.borderColor = '#e9ecef';
+        metadata.style.color = '#212529';
+      }
+    }
+  }
+  
+  // Listen for theme changes to update styles
+  const observer = new MutationObserver(function(mutations) {
+    mutations.forEach(function(mutation) {
+      if (mutation.attributeName === 'class') {
+        updateVersionSwitcherStyles();
+        updatePageMetadataStyles();
+      }
+    });
+  });
+  
+  observer.observe(document.body, {
+    attributes: true,
+    attributeFilter: ['class']
+  });
+  
+  // Add version switcher after page loads
+  setTimeout(addVersionSwitcherToNavigation, 150);
+  setTimeout(addVersionSwitcherToNavigation, 600);
+  setTimeout(addVersionSwitcherToNavigation, 1200);
+  
+  // Add icon to Documentation Versions link
+  setTimeout(addIconToDocVersionsLink, 100);
+  setTimeout(addIconToDocVersionsLink, 500);
+  setTimeout(addIconToDocVersionsLink, 1000);
+  
+  // Add version notice banner
+  setTimeout(addVersionNoticeBanner, 200);
+  
+  // Add page metadata (includes last updated date and version info)
+  setTimeout(addPageMetadata, 200);
+});
+</script>

--- a/docs/_includes/version-banner.html
+++ b/docs/_includes/version-banner.html
@@ -1,0 +1,83 @@
+{% if site.versioning.enabled %}
+<div class="version-banner">
+  <div class="version-banner-content">
+    <div class="version-info">
+      <strong>OpenCue {{ site.opencue_version }}</strong> Documentation
+      {% if site.version != site.versioning.default_version %}
+        <span class="version-warning">
+          • ⚠️ This is an older version
+        </span>
+      {% endif %}
+    </div>
+    
+    <div class="version-actions">
+      <a href="{{ site.baseurl }}/versions" class="btn-version-history">
+        📚 All Versions
+      </a>
+      {% if site.version != site.versioning.default_version %}
+        <a href="{{ site.baseurl }}/" class="btn-latest">
+          → Go to Latest
+        </a>
+      {% endif %}
+    </div>
+  </div>
+</div>
+
+<style>
+.version-banner {
+  background: linear-gradient(135deg, var(--color-blue-100), var(--color-purple-100));
+  border-bottom: 2px solid var(--color-blue-200);
+  padding: 0.75rem 0;
+  margin-bottom: 1rem;
+}
+
+.version-banner-content {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.version-info {
+  font-size: 0.95rem;
+}
+
+.version-warning {
+  color: var(--color-yellow-700);
+  margin-left: 0.5rem;
+}
+
+.version-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.btn-version-history,
+.btn-latest {
+  padding: 0.25rem 0.75rem;
+  border-radius: 4px;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: all 0.2s;
+}
+
+.btn-version-history {
+  background: var(--color-grey-dk-000);
+  color: white;
+}
+
+.btn-latest {
+  background: var(--color-green-100);
+  color: var(--color-green-800);
+  font-weight: 500;
+}
+
+.btn-version-history:hover,
+.btn-latest:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+</style>
+{% endif %}

--- a/docs/_includes/version-switcher.html
+++ b/docs/_includes/version-switcher.html
@@ -1,0 +1,66 @@
+<!-- Version Switcher Component -->
+<div class="version-switcher">
+  <div class="version-badge">
+    <span class="version-label">Version:</span>
+    <select id="version-select" class="version-dropdown" onchange="switchVersion(this.value)">
+      {% assign current_version = site.version | default: site.versioning.default_version %}
+      {% for version in site.versioning.versions %}
+        <option value="{{ version }}" {% if version == current_version %}selected{% endif %}>
+          {% if version == "main" %}
+            latest (main)
+          {% else %}
+            {{ version }}
+          {% endif %}
+        </option>
+      {% endfor %}
+    </select>
+  </div>
+</div>
+
+<script>
+function switchVersion(version) {
+  const currentPath = window.location.pathname;
+  const baseUrl = '{{ site.baseurl }}';
+  
+  // Handle version switching logic
+  if (version === 'main') {
+    window.location.href = baseUrl + currentPath.replace(/\/v[\d.]+/, '');
+  } else {
+    // For tagged versions, redirect to versioned docs
+    window.location.href = baseUrl + '/' + version + currentPath.replace(baseUrl, '');
+  }
+}
+</script>
+
+<style>
+.version-switcher {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 1rem;
+}
+
+.version-badge {
+  background: var(--color-yellow-100);
+  border: 1px solid var(--color-yellow-300);
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 0.875rem;
+}
+
+.version-label {
+  margin-right: 0.5rem;
+  font-weight: 500;
+}
+
+.version-dropdown {
+  background: transparent;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  color: var(--color-yellow-700);
+}
+
+.version-dropdown:hover {
+  text-decoration: underline;
+}
+</style>

--- a/docs/_plugins/last_modified.rb
+++ b/docs/_plugins/last_modified.rb
@@ -1,0 +1,59 @@
+module Jekyll
+  class LastModifiedTag < Liquid::Tag
+    def initialize(tag_name, text, tokens)
+      super
+    end
+
+    def render(context)
+      page = context.registers[:page]
+      path = page['path']
+      
+      # Get the last commit date for this file
+      date_str = `git log -1 --format="%ad" --date=format:"%B %d, %Y" -- #{path}`.strip
+      
+      # Fallback to current date if git command fails
+      if date_str.empty?
+        date_str = Time.now.strftime("%B %d, %Y")
+      end
+      
+      date_str
+    end
+  end
+  
+  class PageLastModified < Generator
+    priority :low
+    
+    def generate(site)
+      site.pages.each do |page|
+        # Skip if already has last_modified_date
+        next if page.data['last_modified_date']
+        
+        path = File.join(site.source, page.path)
+        if File.exist?(path)
+          # Get last git commit date for this file
+          date = `git log -1 --format="%ad" --date=iso -- #{path}`.strip
+          unless date.empty?
+            page.data['last_modified_date'] = Time.parse(date)
+          end
+        end
+      end
+      
+      # Also process collection documents
+      site.collections.each do |name, collection|
+        collection.docs.each do |doc|
+          next if doc.data['last_modified_date']
+          
+          path = doc.path
+          if File.exist?(path)
+            date = `git log -1 --format="%ad" --date=iso -- #{path}`.strip
+            unless date.empty?
+              doc.data['last_modified_date'] = Time.parse(date)
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag('last_modified', Jekyll::LastModifiedTag)

--- a/docs/update_version.sh
+++ b/docs/update_version.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Script to update version information for local development
+# Reads OpenCue version from VERSION.in and updates _data/version.yml
+
+# Get the OpenCue version from VERSION.in
+OPENCUE_VERSION=$(cat ../VERSION.in | tr -d '\n')
+
+# Get current date
+CURRENT_DATE=$(date +'%Y-%m-%d')
+
+# Get git hash (if in a git repo)
+GIT_HASH=$(git rev-parse --short HEAD 2>/dev/null || echo "local")
+
+# Update the _data/version.yml file
+cat > _data/version.yml <<EOF
+# This file is auto-generated - do not edit manually
+# Run ./update_version.sh to update from VERSION.in
+version: "main"
+doc_version: "0.0.1"
+opencue_version: "${OPENCUE_VERSION}"
+build_date: "${CURRENT_DATE}"
+last_commit: "${CURRENT_DATE}"
+git_hash: "${GIT_HASH}"
+is_preview: false
+EOF
+
+echo "Updated version information:"
+echo "   OpenCue Version: ${OPENCUE_VERSION}"
+echo "   Git Hash: ${GIT_HASH}"
+echo "   Date: ${CURRENT_DATE}"

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -1,0 +1,42 @@
+---
+layout: default
+title: Documentation Versions
+nav_order: 999
+---
+
+# OpenCue Documentation Versions
+
+## Available Versions
+
+| Version | Status | Release Date | Documentation | Notes |
+|---------|---------|--------------|---------------|-------|
+| [main]({{ site.baseurl }}/) | **Development** | Continuous | [View →]({{ site.baseurl }}/) | Latest development version |
+| [v0.0.1]({{ site.baseurl }}/v0.0.1/) | **Preview** | In Progress | [View →]({{ site.baseurl }}/v0.0.1/) | Initial documentation version |
+
+## Version Policy
+
+### Documentation Versioning
+The documentation follows its own versioning scheme separate from OpenCue software:
+
+- **main**: Latest development version with newest features and changes
+- **v0.0.1**: Initial documentation version (preview/beta state)
+- Future versions will follow semantic versioning (v1.0.0, v1.1.0, etc.)
+
+### OpenCue Software Version
+Current OpenCue software version: **{{ site.opencue_version }}**
+
+## Development Status
+
+🚧 **Documentation is currently under active development**
+
+- **main**: Contains the latest changes and improvements
+- **v0.0.1**: Represents the initial documentation structure and content
+- **v1.0.0**: Will be the first stable release (coming soon)
+
+## How to Switch Versions
+
+Use the version dropdown in the top navigation bar or visit the direct links above.
+
+---
+
+*Last updated: {% last_modified %}*


### PR DESCRIPTION
- Add version dropdown in sidebar navigation with independent v0.0.1 and main
- Implement Git-based last modified date extraction via Jekyll plugin
- Create page metadata component showing version info and last updated dates
- Add contextual version warning banners for non-main versions
- Enhance GitHub Actions workflow for multi-version documentation builds
- Add version overview page with independent version tracking
- Improve dark mode table contrast and styling
- Add gitignore for auto-generated version files

This enables users to:
- Switch between independent documentation versions
- See when each page was last updated via Git history
- Get contextual warnings when viewing older documentation versions
- Automatically maintain version info from single source (VERSION.in)

**Link the Issue(s) this Pull Request is related to.**
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/1800