### PR TITLE
[rust/rqd] Remove invalid dummy-cuebot dev dependency

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2002,7 +2002,6 @@ dependencies = [
  "config",
  "dashmap",
  "device_query",
- "dummy-cuebot",
  "futures",
  "futures-core",
  "http",

--- a/rust/crates/rqd/Cargo.toml
+++ b/rust/crates/rqd/Cargo.toml
@@ -64,7 +64,6 @@ libc = "0.2"
 device_query = "3.0"
 
 [dev-dependencies]
-dummy-cuebot = { path = "../dummy-cuebot" }
 tempfile = "3.14.0"
 
 # === Rpm configuration ===


### PR DESCRIPTION
- The dummy-cuebot dependency was incorrectly added as a dev dependency in rqd/Cargo.toml. Since dummy-cuebot is a binary-only crate without a lib target, Cargo was ignoring it and causing test failures.
- Integration tests already invoke dummy-cuebot as a binary executable and don't need it as a library dependency.
- Fixes test failure in frame::running_frame::tests::test_run_failed