### PR TITLE
[docs] Fix documentation navigation links by removing trailing slashes

### DIFF
--- a/docs/_docs/index.md
+++ b/docs/_docs/index.md
@@ -41,42 +41,42 @@ permalink: /docs/
 
 ---
 
-### [Quick starts](quick-starts/)
+### [Quick starts](quick-starts)
 
 Try OpenCue in the sandbox environment on different operating systems
 
-### [Concepts](concepts/)
+### [Concepts](concepts)
 
 Conceptual guides for all users to introduce OpenCue
 
-### [OpenCue getting started guide](getting-started/)
+### [OpenCue getting started guide](getting-started)
 
 Guides for system admins deploying OpenCue components and installing dependencies
 
-### [User guides](user-guides/)
+### [User guides](user-guides)
 
 Guides for artists and end-users completing common OpenCue user tasks
 
-### [Other guides](other-guides/)
+### [Other guides](other-guides)
 
 Guides for system admins and technical Production Services and Resources (PSR) teams completing common tasks related to managing, supporting, and troubleshooting OpenCue
 
-### [Reference](reference/)
+### [Reference](reference)
 
 Reference guides for all users running OpenCue tools and interfaces
 
-### [Developer Guide](developer-guide/index/)
+### [Developer Guide](developer-guide/index)
 
 Guides and resources for developers contributing to OpenCue or developing applications that integrate with OpenCue
 
-### [Tutorials](tutorials/)
+### [Tutorials](tutorials)
 
 Step-by-step learning guides and workflows
 
-### [News](news/)
+### [News](/news)
 
 Latest news, updates, and community announcements about OpenCue development and events
 
-### [Releases](releases/)
+### [Releases](/releases)
 
 OpenCue release announcements and changelogs

--- a/docs/index.md
+++ b/docs/index.md
@@ -154,7 +154,7 @@ permalink: /
         <p class="section-subtitle">Everything you need to deploy, manage, and extend OpenCue</p>
         
         <div class="docs-grid">
-            <div class="doc-card" onclick="location.href='{{ '/docs/quick-starts/' | relative_url }}';" tabindex="0" role="button" aria-label="Quick starts guide">
+            <div class="doc-card" onclick="location.href='{{ '/docs/quick-starts' | relative_url }}';" tabindex="0" role="button" aria-label="Quick starts guide">
                 <div class="doc-icon">
                     <i class="fas fa-rocket" aria-hidden="true"></i>
                 </div>
@@ -162,7 +162,7 @@ permalink: /
                 <p class="doc-description">Get OpenCue running in minutes with our sandbox guides for Linux, macOS, and Windows.</p>
             </div>
             
-            <div class="doc-card" onclick="location.href='{{ '/docs/concepts/' | relative_url }}';" tabindex="0" role="button" aria-label="Concepts guide">
+            <div class="doc-card" onclick="location.href='{{ '/docs/concepts' | relative_url }}';" tabindex="0" role="button" aria-label="Concepts guide">
                 <div class="doc-icon">
                     <i class="fas fa-lightbulb" aria-hidden="true"></i>
                 </div>
@@ -178,7 +178,7 @@ permalink: /
                 <p class="doc-description">Production deployment instructions for system administrators and DevOps teams.</p>
             </div>
             
-            <div class="doc-card" onclick="location.href='{{ '/docs/user-guides/' | relative_url }}';" tabindex="0" role="button" aria-label="User guides">
+            <div class="doc-card" onclick="location.href='{{ '/docs/user-guides' | relative_url }}';" tabindex="0" role="button" aria-label="User guides">
                 <div class="doc-icon">
                     <i class="fas fa-users" aria-hidden="true"></i>
                 </div>
@@ -186,7 +186,7 @@ permalink: /
                 <p class="doc-description">Day-to-day workflows for artists, supervisors, and production staff.</p>
             </div>
             
-            <div class="doc-card" onclick="location.href='{{ '/docs/reference/' | relative_url }}';" tabindex="0" role="button" aria-label="Reference documentation">
+            <div class="doc-card" onclick="location.href='{{ '/docs/reference' | relative_url }}';" tabindex="0" role="button" aria-label="Reference documentation">
                 <div class="doc-icon">
                     <i class="fas fa-code" aria-hidden="true"></i>
                 </div>
@@ -194,7 +194,7 @@ permalink: /
                 <p class="doc-description">Reference guides for all users running OpenCue tools and interfaces.</p>
             </div>
             
-            <div class="doc-card" onclick="location.href='{{ '/docs/tutorials/' | relative_url }}';" tabindex="0" role="button" aria-label="Tutorials">
+            <div class="doc-card" onclick="location.href='{{ '/docs/tutorials' | relative_url }}';" tabindex="0" role="button" aria-label="Tutorials">
                 <div class="doc-icon">
                     <i class="fas fa-graduation-cap" aria-hidden="true"></i>
                 </div>


### PR DESCRIPTION
- Remove trailing slash from `/docs/quick-starts/` to `/docs/quick-starts`
- Remove trailing slash from `/docs/concepts/` to `/docs/concepts`
- Remove trailing slash from `/docs/user-guides/` to `/docs/user-guides`
- Remove trailing slash from `/docs/reference/` to `/docs/reference`
- Remove trailing slash from `/docs/tutorials/` to `/docs/tutorials`
- Remove trailing slashes from all navigation links in `docs/_docs/index.md` to ensure consistent link behavior and proper navigation across the documentation site.
- Fix the links `news` and `releases` in `docs/_docs/index.md`

**Link the Issue(s) this Pull Request is related to.**
- #1800 