### PR TITLE
[CI/CD] Re-enable integration test script step in packaging pipeline

### DIFF
--- a/.github/workflows/packaging-pipeline.yml
+++ b/.github/workflows/packaging-pipeline.yml
@@ -70,7 +70,7 @@ jobs:
           export OPENCUE_CUEMAN_PACKAGE_PATH="${{ needs.build_opencue_packages.outputs.opencue_cueman_path }}"
           export OPENCUE_CUESUBMIT_PACKAGE_PATH="${{ needs.build_opencue_packages.outputs.opencue_cuesubmit_path }}"
           export OPENCUE_RQD_PACKAGE_PATH="${{ needs.build_opencue_packages.outputs.opencue_rqd_path }}"
-          # ci/run_integration_test.sh
+          ci/run_integration_test.sh
 
       - name: Archive log files
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Forgot that I had disabled integration testing in packaging workflow to speed up testing

This re-enabled it again.