### PR TITLE
[docs] Fix image paths to remove /OpenCue prefix

### DIFF
--- a/docs/_docs/concepts/glossary.md
+++ b/docs/_docs/concepts/glossary.md
@@ -156,7 +156,7 @@ in a layer with a tag will only render on a host that also shares that tag.
 
 ## Relationships
 
-![OpenCue relationships](/OpenCue/assets/images/opencue_object_relations.png)
+![OpenCue relationships](/assets/images/opencue_object_relations.png)
 
 This diagram depicts the connections between the primary objects within OpenCue
 As you can see the majority of connections follow a one-to-many type of

--- a/docs/_docs/concepts/opencue-overview.md
+++ b/docs/_docs/concepts/opencue-overview.md
@@ -64,7 +64,7 @@ components:
 Figure 1 illustrates how the various components interact in a large-scale
 deployment of OpenCue.
 
-![Overview of OpenCue architecture and components](/OpenCue/assets/images/opencue_architecture.svg)
+![Overview of OpenCue architecture and components](/assets/images/opencue_architecture.svg)
 
 ## What's next?
 

--- a/docs/_docs/concepts/spi-case-study.md
+++ b/docs/_docs/concepts/spi-case-study.md
@@ -52,7 +52,7 @@ render farm. Cuebot servers also store all persistent state and transactions
 in the database server. Figure 1 illustrates how the various OpenCue
 infrastructure components interact:
 
-![OpenCue infrastructure components](/OpenCue/assets/images/opencue_spi_infrastructure.svg)
+![OpenCue infrastructure components](/assets/images/opencue_spi_infrastructure.svg)
 
 Figure 1. OpenCue infrastructure components
 

--- a/docs/_docs/getting-started/installing-cuegui.md
+++ b/docs/_docs/getting-started/installing-cuegui.md
@@ -115,7 +115,7 @@ CUEBOT_HOSTS=$CUEBOT_HOSTNAME_OR_IP cuegui
 
 The CueGUI executable launches and the Cuetopia window appears:
 
-![CueGUI Cuetopia window](/OpenCue/assets/images/cuetopia_default_verify.png)
+![CueGUI Cuetopia window](/assets/images/cuetopia_default_verify.png)
 
 ## What's next?
 

--- a/docs/_docs/other-guides/cueweb.md
+++ b/docs/_docs/other-guides/cueweb.md
@@ -61,20 +61,20 @@ Job actions: Unmonitor, Pause, Retry dead frames, Eat dead frames, Kill.
 Upon logging in through Okta/Google/GitHub or another authentication method configured using [NextAuth.js](https://next-auth.js.org/) (Figures 1 or 2), users are welcomed by CueWeb's main dashboard, as shown in Figure 3 (light mode) or Figure 4 (dark mode).  The CueWeb main page contains a paginated table that is populated with the OpenCue jobs. 
 
 #### Figure 1: CueWeb authentication page (light mode)
-![CueWeb authentication page (light mode)](/OpenCue/assets/images/cueweb/figure1-auth-light.png)
+![CueWeb authentication page (light mode)](/assets/images/cueweb/figure1-auth-light.png)
 
 #### Figure 2: CueWeb authentication page (dark mode)
-![CueWeb authentication page (dark mode)](/OpenCue/assets/images/cueweb/figure2-auth-dark.png)
+![CueWeb authentication page (dark mode)](/assets/images/cueweb/figure2-auth-dark.png)
 
 **Note:** If the CueWeb login is disabled, the image below displays the initial CueWeb page. This page includes a button labelled "CueWeb Home", which opens the main CueWeb interface. For instructions on how to disable the CueWeb login, refer to the [cueweb/README.md](https://github.com/AcademySoftwareFoundation/OpenCue/blob/master/cueweb/README.md) file.
 
-![CueWeb home button page](/OpenCue/assets/images/cueweb/cueweb-home-button.png)
+![CueWeb home button page](/assets/images/cueweb/cueweb-home-button.png)
 
 #### Figure 3: CueWeb main page (light mode)
-![CueWeb main page (light mode)](/OpenCue/assets/images/cueweb/figure3-main-light.png)
+![CueWeb main page (light mode)](/assets/images/cueweb/figure3-main-light.png)
 
 #### Figure 4: CueWeb main page (dark mode)
-![CueWeb main page (dark mode)](/OpenCue/assets/images/cueweb/figure4-main-dark.png)
+![CueWeb main page (dark mode)](/assets/images/cueweb/figure4-main-dark.png)
 
 ## CueWeb dashboard (Jobs data table) - Similar to [CueGUI Cuetopia](https://www.opencue.io/docs/user-guides/monitoring-your-jobs/)'s functionalities
 
@@ -85,39 +85,39 @@ Here's what you can expect:
 - **Customizable jobs tables:** Tailor your dashboard by selecting which columns to display, enhancing readability and focus on critical jobs metrics (see Figure 5)
 
 #### Figure 5: Column visibility dropdown to choose display data table columns
-![Column visibility dropdown](/OpenCue/assets/images/cueweb/figure5-column-visibility.png)
+![Column visibility dropdown](/assets/images/cueweb/figure5-column-visibility.png)
 
 - **Efficient job filtering:** Filter jobs by state - `Finished`, `Failing`, `Dependency`, `In Progress`, `Paused` - to streamline management tasks  (see Figure 6).
 
 #### Figure 6: Data table filtering based on job state
-![Data table filtering based on job state](/OpenCue/assets/images/cueweb/figure6-job-filtering.png)
+![Data table filtering based on job state](/assets/images/cueweb/figure6-job-filtering.png)
 
 * **Advanced monitoring options:** Un-monitor jobs selectively or in bulk, providing flexibility in data visualization (see Figures 7 and 8).
 
 #### Figure 7: Un-monitoring selected jobs (data table before un-monitor selection)
-![Un-monitoring selected jobs (before)](/OpenCue/assets/images/cueweb/figure7-unmonitor-before.png)
+![Un-monitoring selected jobs (before)](/assets/images/cueweb/figure7-unmonitor-before.png)
 
 #### Figure 8:  Un-monitoring selected jobs (data table after un-monitor selection)
-![Un-monitoring selected jobs (after)](/OpenCue/assets/images/cueweb/figure8-unmonitor-after.png)
+![Un-monitoring selected jobs (after)](/assets/images/cueweb/figure8-unmonitor-after.png)
 
 * **Detailed inspections:** A pop-up detail view for layers and frames associated with a selected job (see Figure 8 for light mode and Figure 10 for dark mode), offering deep dives into specific frame logs as shown in Figure 11 for light mode and Figure 12 for dark mode.
 
 #### Figure 9: Pop-up window to view layers and frames information (light mode) 
-![Pop-up window layers and frames (light mode)](/OpenCue/assets/images/cueweb/figure9-popup-light.png)
+![Pop-up window layers and frames (light mode)](/assets/images/cueweb/figure9-popup-light.png)
 
 #### Figure 10: Pop-up window to view layers and frames information (dark mode) 
-![Pop-up window layers and frames (dark mode)](/OpenCue/assets/images/cueweb/figure10-popup-dark.png)
+![Pop-up window layers and frames (dark mode)](/assets/images/cueweb/figure10-popup-dark.png)
 
 #### Figure 11: Frame information and logs visualization (light mode) 
-![Frame information and logs visualization (light mode)](/OpenCue/assets/images/cueweb/figure11-frame-logs-light.png)
+![Frame information and logs visualization (light mode)](/assets/images/cueweb/figure11-frame-logs-light.png)
 
 #### Figure 12: Frame information and logs visualization (dark mode) 
-![Frame information and logs visualization (dark mode)](/OpenCue/assets/images/cueweb/figure12-frame-logs-dark.png)
+![Frame information and logs visualization (dark mode)](/assets/images/cueweb/figure12-frame-logs-dark.png)
 
 - **Job searching:** Search for a job by typing in a show name followed by a hyphen and then the shot followed by a hyphen (ex: "show-shot-") or by typing in a regex query followed by a "!" (ex: ".*character-name*!"). This will trigger a dropdown populated with jobs for that query (see Figure 13). Clicking jobs in this dropdown will add them to the jobs table. Jobs in the jobs table will be highlighted `green` in the dropdown.
 
 #### Figure 13: Job search functionality 
-![Job search functionality](/OpenCue/assets/images/cueweb/figure13-job-search.png)
+![Job search functionality](/assets/images/cueweb/figure13-job-search.png)
 
 ### CueWeb Actions for Jobs / Layers / Frames
 
@@ -126,26 +126,26 @@ The CueWeb system includes actions like `eat dead frames`, `retry dead frames`, 
 Figure 14 shows the `job` context menu with options to `un-monitor`, `pause`, `retry dead frames`, `eat dead frames` and `kill` jobs and Figure 15 shows the successful message after selecting `kill` a job.
 
 #### Figure 14: CueWeb with job context menu open
-![CueWeb with job context menu open](/OpenCue/assets/images/cueweb/figure14-job-context-menu.png)
+![CueWeb with job context menu open](/assets/images/cueweb/figure14-job-context-menu.png)
 
 #### Figure 15: Pop-up showing a successful message after selecting `kill` a job
-![Pop-up showing successful kill job message](/OpenCue/assets/images/cueweb/figure15-kill-job-success.png)
+![Pop-up showing successful kill job message](/assets/images/cueweb/figure15-kill-job-success.png)
 
 Figure 16 shows the `layer` context menu with options to `kill`, `eat`, `retry`, and `retry dead frames` and Figure 17 shows the successful message after selecting `retry` a layer.
 
 #### Figure 16: CueWeb with layer context menu open
-![CueWeb with layer context menu open](/OpenCue/assets/images/cueweb/figure16-layer-context-menu.png)
+![CueWeb with layer context menu open](/assets/images/cueweb/figure16-layer-context-menu.png)
 
 #### Figure 17: Pop-up showing a successful message after selecting `retry` a layer
-![Pop-up showing successful retry layer message](/OpenCue/assets/images/cueweb/figure17-retry-layer-success.png)
+![Pop-up showing successful retry layer message](/assets/images/cueweb/figure17-retry-layer-success.png)
 
 Finally, Figure 18 shows the `frame` context menu with options to `kill`, `eat`, and `retry` and Figure 19 shows the successful message after selecting `eat` a frame.
 
 #### Figure 18: CueWeb with frame context menu open
-![CueWeb with frame context menu open](/OpenCue/assets/images/cueweb/figure18-frame-context-menu.png)
+![CueWeb with frame context menu open](/assets/images/cueweb/figure18-frame-context-menu.png)
 
 #### Figure 19: Pop-up showing a successful message after selecting `eat` a frame
-![Pop-up showing successful eat frame message](/OpenCue/assets/images/cueweb/figure19-eat-frame-success.png)
+![Pop-up showing successful eat frame message](/assets/images/cueweb/figure19-eat-frame-success.png)
 
 
 ## Conclusion

--- a/docs/_docs/other-guides/framelogging-with-loki.md
+++ b/docs/_docs/other-guides/framelogging-with-loki.md
@@ -68,4 +68,4 @@ log.loki.url=<loki-url>
 
 
 ## LokiView widget
-![LokiView Widget](/OpenCue/assets/images/lokiview_widget.png)
+![LokiView Widget](/assets/images/lokiview_widget.png)

--- a/docs/_docs/other-guides/monitoring-with-prometheus-loki-and-grafana.md
+++ b/docs/_docs/other-guides/monitoring-with-prometheus-loki-and-grafana.md
@@ -80,13 +80,13 @@ sandbox environment.
 3. Change the `admin` password if prompted.
 4. To view the sample dashboards included with the sandbox, click **Dashboards > Manage**.
 
-   ![Manage Grafana dashboards](/OpenCue/assets/images/grafana_manage_dashboards.png)
+   ![Manage Grafana dashboards](/assets/images/grafana_manage_dashboards.png)
 
    Once displayed, these dashboards will show metrics exported from Cuebot and the PostgreSQL database:
 
-   ![Grafana Cuebot metrics](/OpenCue/assets/images/grafana_cuebot_metrics.png)
+   ![Grafana Cuebot metrics](/assets/images/grafana_cuebot_metrics.png)
 
-   ![Grafana PostgreSQL metrics](/OpenCue/assets/images/grafana_cuebot_metrics.png)
+   ![Grafana PostgreSQL metrics](/assets/images/grafana_cuebot_metrics.png)
 
 ## Customizing exported data
 

--- a/docs/_docs/quick-starts/quick-start-linux.md
+++ b/docs/_docs/quick-starts/quick-start-linux.md
@@ -204,7 +204,7 @@ Terminal window:
     The following screenshot illustrates the layout of CueSubmit as a
     standalone app:
 
-    ![The default CueSubmit window](/OpenCue/assets/images/cuesubmit_quickstart.png) 
+    ![The default CueSubmit window](/assets/images/cuesubmit_quickstart.png) 
 
 1.  By default, the OpenCue sandbox environment doesn't include any rendering
     software. To experiment with the user interface, you can execute simple
@@ -237,7 +237,7 @@ Terminal window:
     The following screenshot illustrates the layout of CueGUI Cuetopia
     monitoring app:
 
-    ![The default CueGUI Cuetopia window](/OpenCue/assets/images/cuegui_quickstart.png) 
+    ![The default CueGUI Cuetopia window](/assets/images/cuegui_quickstart.png) 
 
 1.  Click **Load**.
 

--- a/docs/_docs/quick-starts/quick-start-mac.md
+++ b/docs/_docs/quick-starts/quick-start-mac.md
@@ -213,7 +213,7 @@ Terminal window:
     The following screenshot illustrates the layout of CueSubmit as a
     standalone app:
 
-    ![The default CueSubmit window](/OpenCue/assets/images/cuesubmit_quickstart.png) 
+    ![The default CueSubmit window](/assets/images/cuesubmit_quickstart.png) 
 
 1.  By default, the OpenCue sandbox environment doesn't include any rendering
     software. To experiment with the user interface, you can execute simple
@@ -246,7 +246,7 @@ Terminal window:
     The following screenshot illustrates the layout of CueGUI Cuetopia
     monitoring app:
 
-    ![The default CueGUI Cuetopia window](/OpenCue/assets/images/cuegui_quickstart.png) 
+    ![The default CueGUI Cuetopia window](/assets/images/cuegui_quickstart.png) 
 
 1.  Click **Load**.
 

--- a/docs/_docs/reference/CueGUI-app.md
+++ b/docs/_docs/reference/CueGUI-app.md
@@ -25,7 +25,7 @@ over any of the column headers displays an explanation for the column.
 
 The following screenshot displays the CueGUI *Monitor Jobs* view:
 
-![CueGUI Monitor Jobs view](/OpenCue/assets/images/cuegui_monitor_jobs.png)
+![CueGUI Monitor Jobs view](/assets/images/cuegui_monitor_jobs.png)
 
 ## Booking to your local workstation
 
@@ -36,7 +36,7 @@ and select **Use local cores...**.
 
 The following screenshot displays the CueGUI *Assign Local Cores* dialog:
 
-![CueGUI Assign Local Cores dialog](/OpenCue/assets/images/cuegui_use_local.png)
+![CueGUI Assign Local Cores dialog](/assets/images/cuegui_use_local.png)
 
 ## Viewing logs
 
@@ -62,19 +62,19 @@ CueGUI provides convenient copy buttons to quickly copy job, layer, and frame na
 
 To copy a job name to the clipboard, right-click on a job in the *Monitor Jobs* view and select **Copy Job Name**. The exact job name will be copied to your clipboard.
 
-![Copy Job Name context menu](/OpenCue/assets/images/cuegui/cuegui_copy_job_name.png)
+![Copy Job Name context menu](/assets/images/cuegui/cuegui_copy_job_name.png)
 
 ### Copying layer names
 
 To copy a layer name, right-click on a layer in the job details view and select **Copy Layer Name**. This copies the layer name to your clipboard.
 
-![Copy Layer Name context menu](/OpenCue/assets/images/cuegui/cuegui_copy_layer_name.png)
+![Copy Layer Name context menu](/assets/images/cuegui/cuegui_copy_layer_name.png)
 
 ### Copying frame names
 
 To copy a frame name, right-click on a frame in the frame list and select **Copy Frame Name**. The frame name will be copied to your clipboard.
 
-![Copy Frame Name context menu](/OpenCue/assets/images/cuegui/cuegui_copy_frame_name.png)
+![Copy Frame Name context menu](/assets/images/cuegui/cuegui_copy_frame_name.png)
 
 All copy buttons use the same icon as the "Copy Log Path" feature for visual consistency. When multiple items are selected, all selected names will be copied to the clipboard separated by spaces.
 
@@ -119,13 +119,13 @@ To open the dialog right-click on a job in the *Monitor Jobs* view and select
 
 The following screenshot displays the CueGUI *Comments* dialog:
 
-![CueGUI Comments dialog](/OpenCue/assets/images/cuegui_comments.png)
+![CueGUI Comments dialog](/assets/images/cuegui_comments.png)
 
 ## Searching for jobs
 
 In the top-left there is a search box to load jobs:
 
-![CueGUI search box](/OpenCue/assets/images/cuegui_search.png)
+![CueGUI search box](/assets/images/cuegui_search.png)
 
 You can perform the following tasks from the search box:
 

--- a/docs/_docs/user-guides/cuetopia-monitoring-guide.md
+++ b/docs/_docs/user-guides/cuetopia-monitoring-guide.md
@@ -33,7 +33,7 @@ This guide provides comprehensive documentation for Cuetopia, which includes the
 
 The Monitor Jobs plugin is the primary interface for monitoring active and completed render jobs. It provides a comprehensive overview of all jobs with real-time status updates.
 
-![Monitor Jobs Interface](/OpenCue/assets/images/cuegui/cuetopia_monitor_jobs.png)
+![Monitor Jobs Interface](/assets/images/cuegui/cuetopia_monitor_jobs.png)
 
 ### Interface Components
 
@@ -139,7 +139,7 @@ Right-clicking on a job provides these actions:
 
 The Monitor Job Details plugin provides detailed information about a selected job's layers and frames. It can be opened manually from the menu or appears automatically when you double-click a job in the Monitor Jobs view.
 
-![Job Details Interface](/OpenCue/assets/images/cuegui/cuetopia_monitor_jobs_details.png)
+![Job Details Interface](/assets/images/cuegui/cuetopia_monitor_jobs_details.png)
 
 ### Layout Structure
 
@@ -230,7 +230,7 @@ Frames are color-coded by status:
 
 The Job Graph plugin provides a visual node-based representation of job layers and their dependencies.
 
-![Job Graph Interface](/OpenCue/assets/images/cuegui/cuetopia_job_graph.png)
+![Job Graph Interface](/assets/images/cuegui/cuetopia_job_graph.png)
 
 ### Graph Features
 

--- a/docs/_docs/user-guides/monitoring-jobs.md
+++ b/docs/_docs/user-guides/monitoring-jobs.md
@@ -63,13 +63,13 @@ Before you start to monitor jobs in CueGUI, complete the following steps:
     windows. The following screenshot illustrates the default Cuetopia window
     you run to follow this guide:
     
-    ![Cuetopia default view](/OpenCue/assets/images/cuetopia_default.png)
+    ![Cuetopia default view](/assets/images/cuetopia_default.png)
 
 1.  Click **Window** > **Raise Window: CueCommander**.
 
     The following screenshot illustrates the default CueCommander window:
     
-    ![CueCommander default view](/OpenCue/assets/images/cuecommander_default.png)
+    ![CueCommander default view](/assets/images/cuecommander_default.png)
     
     You don't typically run CueCommander to monitor individual
 	OpenCue jobs and you don't need it to follow this guide.
@@ -84,7 +84,7 @@ To monitor a job:
     Monitor Jobs **Load** search field:
     
     ![Search for jobs by show name or username, or auto-load your
-    jobs.](/OpenCue/assets/images/cuegui_search.png)
+    jobs.](/assets/images/cuegui_search.png)
     
     To autoload your own jobs, check the **Autoload Mine** box.
 
@@ -93,7 +93,7 @@ To monitor a job:
     Cuetopia displays a list of jobs in the search results.
     
     ![Monitoring the status of OpenCue
-    jobs](/OpenCue/assets/images/cuetopia_monitor_job.png)
+    jobs](/assets/images/cuetopia_monitor_job.png)
 
 1.  Double-click the name of a job to view the details of the job in the
     Monitor Job Details plugin.
@@ -104,21 +104,21 @@ To monitor a job:
     contains 101 frames:
     
     ![Monitoring the status of individual job layers and
-    frames](/OpenCue/assets/images/cuetopia_monitor_layer.png)
+    frames](/assets/images/cuetopia_monitor_layer.png)
 
 1.  Double-click a frame to view the associated logs.
     
     Cuetopia displays the logs for the frame in the LogView view:
     
     ![Viewing the logs associated with a
-    frame](/OpenCue/assets/images/cuetopia_monitor_logs.png)
+    frame](/assets/images/cuetopia_monitor_logs.png)
 
 ## Un-monitoring jobs
 
 You can unmonitor all or some of the jobs in the Monitor Jobs plugin:
 
 ![Unmonitor all or some of the jobs listed in the Monitor Jobs
-plugin](/OpenCue/assets/images/cuetopia_unmonitor_jobs.png)
+plugin](/assets/images/cuetopia_unmonitor_jobs.png)
 
 *   To unmonitor all finished jobs, click **Finished**.
 *   To unmonitor all jobs, click **All**.
@@ -127,7 +127,7 @@ plugin](/OpenCue/assets/images/cuetopia_unmonitor_jobs.png)
     1.  Click the following button:
 
         ![Unmonitor selected
-        jobs](/OpenCue/assets/images/cuetopia_unmonitor_selected.png)
+        jobs](/assets/images/cuetopia_unmonitor_selected.png)
 
 ## Monitoring Hosts with CueCommander
 
@@ -157,7 +157,7 @@ The OS filter allows you to filter hosts based on their operating system:
 4. The host list updates to show only hosts matching the selected OS values
 5. Use the **Clear** option to remove all OS filters
 
-![Monitor Hosts with OS Filter](/OpenCue/assets/images/cuegui/cuecommander_monitor_os_filter.png)
+![Monitor Hosts with OS Filter](/assets/images/cuegui/cuecommander_monitor_os_filter.png)
 
 The OS filter list dynamically updates based on the operating systems detected in your host environment. When you first open CueCommander, the filter displays "Not Loaded" to indicate that host data hasn't been retrieved yet. Once hosts are loaded, the filter automatically populates with the actual OS values found in your system.
 

--- a/docs/_docs/user-guides/submitting-jobs.md
+++ b/docs/_docs/user-guides/submitting-jobs.md
@@ -85,7 +85,7 @@ To submit a Blender job to OpenCue:
     
     The following screenshot illustrates a completed job info form:
     
-    ![CueSubmit job info form](/OpenCue/assets/images/cuesubmit_job_info.png)
+    ![CueSubmit job info form](/assets/images/cuesubmit_job_info.png)
 
 1.  For **Job Type**, select **Blender**.
 
@@ -122,12 +122,12 @@ To submit a Blender job to OpenCue:
     
     The following screenshot illustrates a completed layer info form:
 
-    ![CueSubmit Blender layer info](/OpenCue/assets/images/cuesubmit_blender_layer_info.png)
+    ![CueSubmit Blender layer info](/assets/images/cuesubmit_blender_layer_info.png)
 
 1.  Review the summary information in **Submission Details** to verify your
     settings, as illustrated by the following screenshot:
     
-    ![CueSubmit submission details summary](/OpenCue/assets/images/cuesubmit_blender_submission_details.png)
+    ![CueSubmit submission details summary](/assets/images/cuesubmit_blender_submission_details.png)
 
 1.  Optionally, to add more layers to this job, click **+**.
 
@@ -171,7 +171,7 @@ To submit a shell job to OpenCue:
     
     The following screenshot illustrates a completed job info form:
     
-    ![CueSubmit job info form](/OpenCue/assets/images/cuesubmit_job_info.png)
+    ![CueSubmit job info form](/assets/images/cuesubmit_job_info.png)
 
 1.  Set **Job Type** to **Shell**.
 
@@ -213,12 +213,12 @@ To submit a shell job to OpenCue:
     
     The following screenshot illustrates a completed layer info form:
 
-    ![CueSubmit shell layer info](/OpenCue/assets/images/cuesubmit_shell_layer_info.png)
+    ![CueSubmit shell layer info](/assets/images/cuesubmit_shell_layer_info.png)
 
 1.  Review the summary information in **Submission Details** to verify your
     settings, as illustrated by the following screenshot:
     
-    ![CueSubmit shell submission details summary](/OpenCue/assets/images/cuesubmit_shell_submission_details.png)
+    ![CueSubmit shell submission details summary](/assets/images/cuesubmit_shell_submission_details.png)
 
 1.  Optionally, to add more layers to this job, click **+**.
 

--- a/docs/news/2019-07-08-opencue-birds-of-a-feather-at-siggraph.md
+++ b/docs/news/2019-07-08-opencue-birds-of-a-feather-at-siggraph.md
@@ -27,4 +27,4 @@ the ASWF on July 30 and to RSVP, see the
 
 We look forward to meeting you!
 
-![Open source day '19 hosted by the ASWF](/OpenCue/assets/images/news/OpenSourceDay_SocialCard_final.png)
+![Open source day '19 hosted by the ASWF](/assets/images/news/OpenSourceDay_SocialCard_final.png)

--- a/docs/news/2020-08-27-google-summer-of-code-20-cloud-plugin.md
+++ b/docs/news/2020-08-27-google-summer-of-code-20-cloud-plugin.md
@@ -156,17 +156,17 @@ The Cloud plugin should be available to launch from the menu bar by navigating:
 1. To start create a cloud pool group, use the `Add Cloud Group` button to launch the
 dialog that will allow you to create a cloud group.
 
-![Add Cloud Group Dialog](/OpenCue/assets/images/news/AddCloudGroupDialog.png)
+![Add Cloud Group Dialog](/assets/images/news/AddCloudGroupDialog.png)
 
 2. If the API request is successful you should now see an entry in the Cloud Plugin's main interface.
 
-![After cloud group addition](/OpenCue/assets/images/news/MainInterfacePostAddition.png)
+![After cloud group addition](/assets/images/news/MainInterfacePostAddition.png)
 
 3. The right-click content menu has two additional functionality:
     1. Resizing (scaling up/down) the number of instances in a group.
     2. Deleting the group altogether.
 
-![Cloud Plugin Context Menu](/OpenCue/assets/images/news/CloudPluginContextMenu.png)
+![Cloud Plugin Context Menu](/assets/images/news/CloudPluginContextMenu.png)
 
 4. Once these cloud instances startup and RQD launches, you should see these nodes appear in the Monitor Hosts plugin, after which OpenCue will be able to send jobs to these hosts.
 


### PR DESCRIPTION
- Updated all image references starting with `/OpenCue/assets/images/` to use `/assets/images/` instead for correct rendering in the documentation site.

**Link the Issue(s) this Pull Request is related to.**
- #1800 