### PR TITLE
[docs] Fix local documentation preview URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If you make changes to `OpenCue/docs`, please build and test the documentation b
 
 4. **Preview the documentation**
    
-   Open http://localhost:4000/OpenCue/ in your browser to review your changes.
+Open http://localhost:4000 in your browser to review your changes.
 
 For detailed documentation setup instructions, testing procedures, and contribution guidelines, see [docs/README.md](https://github.com/AcademySoftwareFoundation/OpenCue/blob/master/docs/README.md).
 


### PR DESCRIPTION
- Updated the preview instructions to use the correct local address (http://localhost:4000) instead of the outdated http://localhost:4000/OpenCue/

**Link the Issue(s) this Pull Request is related to.**
- #1800 