### PR TITLE
[pycue] Update host wrapper: cache lock state and prevent tag duplication

### DIFF
--- a/pycue/opencue/wrappers/host.py
+++ b/pycue/opencue/wrappers/host.py
@@ -68,17 +68,17 @@ class Host(object):
 
     def lock(self):
         """Locks the host so that it no longer accepts new frames"""
-        self.stub.Lock(host_pb2.HostLockRequest(host=self.data), timeout=Cuebot.Timeout)
         # Update the cached lock_state.
         self.data.lock_state = self.LockState.LOCKED
+        self.stub.Lock(host_pb2.HostLockRequest(host=self.data), timeout=Cuebot.Timeout)
 
     def unlock(self):
         """Unlocks the host.
 
         Cancels any actions that were waiting for all running frames to finish."""
-        self.stub.Unlock(host_pb2.HostUnlockRequest(host=self.data), timeout=Cuebot.Timeout)
         # Update the cached lock_state.
         self.data.lock_state = self.LockState.OPEN
+        self.stub.Unlock(host_pb2.HostUnlockRequest(host=self.data), timeout=Cuebot.Timeout)
 
     def delete(self):
         """Deletes the host from the cuebot"""
@@ -136,10 +136,10 @@ class Host(object):
         """
         # Filter out duplicates
         tags = [item for item in tags if item not in self.data.tags]
-        self.stub.AddTags(host_pb2.HostAddTagsRequest(host=self.data, tags=tags),
-                          timeout=Cuebot.Timeout)
         # Update the cached tags.
         self.data.tags.extend(tags)
+        self.stub.AddTags(host_pb2.HostAddTagsRequest(host=self.data, tags=tags),
+                          timeout=Cuebot.Timeout)
 
     def removeTags(self, tags):
         """Removes tags from this host.


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Fixes #1326 

**Summarize your change.**
- Added updates to cached `lock_state` when locking/unlocking hosts.
- Modified `addTags` to filter duplicate tags before making requests.
- Synchronized cached tags with added tags for accuracy.
