### PR TITLE
[cuegui] Fix dependency window sizing for better job name visibility

### DIFF
--- a/cuegui/cuegui/DependDialog.py
+++ b/cuegui/cuegui/DependDialog.py
@@ -39,7 +39,7 @@ class DependDialog(QtWidgets.QDialog):
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
         self.setSizeGripEnabled(True)
 
-        self.resize(1000, 600)
+        self.resize(1200, 800)
 
         name = "Dependencies for "
         if cuegui.Utils.isJob(rpcOject):

--- a/cuegui/cuegui/DependMonitorTree.py
+++ b/cuegui/cuegui/DependMonitorTree.py
@@ -60,6 +60,11 @@ class DependMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
 
         cuegui.AbstractTreeWidget.AbstractTreeWidget.__init__(self, parent)
 
+        # Set columns to auto-resize to content
+        header = self.header()
+        for col in range(self.columnCount()):
+            header.setSectionResizeMode(col, QtWidgets.QHeaderView.ResizeToContents)
+
         self.__menuActions = cuegui.MenuActions.MenuActions(
             self, self.updateSoon, self.selectedObjects)
 

--- a/cuegui/cuegui/DependWizard.py
+++ b/cuegui/cuegui/DependWizard.py
@@ -388,7 +388,7 @@ class PageDependType(AbstractWizardPage):
         self.setSubTitle("What type of dependency would you like %s to have?" % self.__msg())
 
         # it is not respecting or providing my size hints otherwise
-        self.wizard().setMinimumSize(500, 500)
+        self.wizard().setMinimumSize(1200, 800)
 
     # pylint: disable=missing-function-docstring
     def validatePage(self):


### PR DESCRIPTION
- Increase Dependency Wizard window size from 500x500 to 1200x800
- Increase Dependencies dialog window size from 1000x600 to 1200x800
- Configure dependency tree columns to auto-resize to content
- Resolves scrolling issues with long job names in dependency dialogs

**Link the Issue(s) this Pull Request is related to.**
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/1852