### PR TITLE
[cuegui] Fix Last Line Output persistence in Frame Monitor Tree

### DIFF
--- a/cuegui/cuegui/FrameMonitorTree.py
+++ b/cuegui/cuegui/FrameMonitorTree.py
@@ -259,8 +259,9 @@ class FrameMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
 
         # Redrawing every even number of seconds to see the current frame
         # runtime, LLU and last log line changes. Every second was excessive.
-        if not self.ticksWithoutUpdate % 2:
-            self.redraw()
+        # Always redraw running frames regardless of update status
+        if self.__job and not self.ticksWithoutUpdate % 2:
+            self.redrawRunning()
 
     @staticmethod
     def getCores(frame, format_as_string=False):


### PR DESCRIPTION
The Last Line Output column was disappearing after briefly showing due to incorrect redraw logic in the `tick()` method. Changed to use `redrawRunning()` instead of generic `redraw()` to properly update only running frame columns (runtime, LLU, and last line).

This ensures the Last Line data persists and is visible for monitoring frame progress, matching the behavior from previous Cuetopia version.

**Link the Issue(s) this Pull Request is related to.**
- #1856 