### PR TITLE
[rqd] Add support for specifying network interface for rqd

### DIFF
--- a/rqd/rqd/rqconstants.py
+++ b/rqd/rqd/rqconstants.py
@@ -62,6 +62,7 @@ RQD_RETRY_STARTUP_CONNECT_DELAY = 30
 RQD_RETRY_CRITICAL_REPORT_DELAY = 30
 RQD_USE_IP_AS_HOSTNAME = True
 RQD_USE_IPV6_AS_HOSTNAME = False
+RQD_NETWORK_INTERFACE = None
 
 # Use the PATH environment variable from the RQD host.
 RQD_USE_PATH_ENV_VAR = False
@@ -222,6 +223,8 @@ try:
         if config.has_option(__override_section, "RQD_USE_IPV6_AS_HOSTNAME"):
             RQD_USE_IPV6_AS_HOSTNAME = config.getboolean(__override_section,
                                                          "RQD_USE_IPV6_AS_HOSTNAME")
+        if config.has_option(__override_section, "RQD_NETWORK_INTERFACE"):
+            RQD_NETWORK_INTERFACE = config.get(__override_section, "RQD_NETWORK_INTERFACE")
         if config.has_option(__override_section, "RQD_USE_PATH_ENV_VAR"):
             RQD_USE_PATH_ENV_VAR = config.getboolean(__override_section, "RQD_USE_PATH_ENV_VAR")
         if config.has_option(__override_section, "RQD_USE_ALL_HOST_ENV_VARS"):

--- a/rqd/rqd/rqnetwork.py
+++ b/rqd/rqd/rqnetwork.py
@@ -199,7 +199,11 @@ class GrpcServer(object):
         self.server = grpc.server(
             futures.ThreadPoolExecutor(max_workers=rqd.rqconstants.RQD_GRPC_MAX_WORKERS))
         self.servicers = ['RqdInterfaceServicer']
-        self.server.add_insecure_port('[::]:{0}'.format(rqd.rqconstants.RQD_GRPC_PORT))
+        listenAddress = "[::]"
+        if rqd.rqconstants.RQD_NETWORK_INTERFACE:
+            listenAddress = rqd.rqutil.getInterfaceIp(rqd.rqconstants.RQD_NETWORK_INTERFACE,
+                                                      ipv6=rqd.rqconstants.RQD_USE_IPV6_AS_HOSTNAME)
+        self.server.add_insecure_port(f'{listenAddress}:{rqd.rqconstants.RQD_GRPC_PORT}')
 
     def addServicers(self):
         """Registers the gRPC servicers defined in rqdservicers.py."""

--- a/rqd/rqd/rqutil.py
+++ b/rqd/rqd/rqutil.py
@@ -27,11 +27,11 @@ import functools
 import logging
 import os
 import platform
-import psutil
 import socket
 import subprocess
 import threading
 import uuid
+import psutil
 
 import rqd.rqconstants
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -792,6 +792,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "h2"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,6 +1198,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnetwork"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,6 +1408,12 @@ dependencies = [
  "cfg_aliases",
  "libc",
 ]
+
+[[package]]
+name = "no-std-net"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
 
 [[package]]
 name = "nom"
@@ -1642,6 +1663,97 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "pnet"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "682396b533413cc2e009fbb48aadf93619a149d3e57defba19ff50ce0201bd0d"
+dependencies = [
+ "ipnetwork",
+ "pnet_base",
+ "pnet_datalink",
+ "pnet_packet",
+ "pnet_sys",
+ "pnet_transport",
+]
+
+[[package]]
+name = "pnet_base"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc190d4067df16af3aba49b3b74c469e611cad6314676eaf1157f31aa0fb2f7"
+dependencies = [
+ "no-std-net",
+]
+
+[[package]]
+name = "pnet_datalink"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79e70ec0be163102a332e1d2d5586d362ad76b01cec86f830241f2b6452a7b7"
+dependencies = [
+ "ipnetwork",
+ "libc",
+ "pnet_base",
+ "pnet_sys",
+ "winapi",
+]
+
+[[package]]
+name = "pnet_macros"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13325ac86ee1a80a480b0bc8e3d30c25d133616112bb16e86f712dcf8a71c863"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "pnet_macros_support"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed67a952585d509dd0003049b1fc56b982ac665c8299b124b90ea2bdb3134ab"
+dependencies = [
+ "pnet_base",
+]
+
+[[package]]
+name = "pnet_packet"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c96ebadfab635fcc23036ba30a7d33a80c39e8461b8bd7dc7bb186acb96560f"
+dependencies = [
+ "glob",
+ "pnet_base",
+ "pnet_macros",
+ "pnet_macros_support",
+]
+
+[[package]]
+name = "pnet_sys"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d4643d3d4db6b08741050c2f3afa9a892c4244c085a72fcda93c9c2c9a00f4b"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "pnet_transport"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f604d98bc2a6591cf719b58d3203fd882bdd6bf1db696c4ac97978e9f4776bf"
+dependencies = [
+ "libc",
+ "pnet_base",
+ "pnet_packet",
+ "pnet_sys",
+]
 
 [[package]]
 name = "postgres-protocol"
@@ -2011,10 +2123,12 @@ dependencies = [
  "humantime-serde",
  "itertools 0.13.0",
  "libc",
+ "log",
  "miette",
  "nix",
  "opencue-proto",
  "pin-project-lite",
+ "pnet",
  "prost",
  "rand 0.9.1",
  "regex",

--- a/rust/config/rqd.yaml
+++ b/rust/config/rqd.yaml
@@ -28,6 +28,10 @@ grpc:
   # Default: 8444
   rqd_port: 4778
 
+  # RPC Interface to listen on
+  # Default:  (Empty string means all interfaces)
+  # rqd_interface: ""
+
   # Cuebot server endpoints (can specify multiple for failover)
   # Default: ["localhost:4343"]
   cuebot_endpoints: ["cuebot.example.com:8082"] # Replace with actual endpoints

--- a/rust/crates/rqd/Cargo.toml
+++ b/rust/crates/rqd/Cargo.toml
@@ -62,6 +62,8 @@ http-body-util = "0.1.3"
 rand = "0.9.1"
 libc = "0.2"
 device_query = "3.0"
+pnet = "0.35.0"
+log = "0.4.27"
 
 [dev-dependencies]
 tempfile = "3.14.0"

--- a/rust/crates/rqd/src/config/mod.rs
+++ b/rust/crates/rqd/src/config/mod.rs
@@ -50,7 +50,7 @@ impl Default for GrpcConfig {
     fn default() -> GrpcConfig {
         GrpcConfig {
             rqd_port: 8444,
-            rqd_interface: "".to_string(),
+            rqd_interface: None,
             cuebot_endpoints: vec!["localhost:4343".to_string()],
             connection_expires_after: Duration::from_secs(3600), // 1h. from_hour is experimental
             backoff_delay_min: Duration::from_millis(10),

--- a/rust/crates/rqd/src/config/mod.rs
+++ b/rust/crates/rqd/src/config/mod.rs
@@ -35,7 +35,7 @@ impl Default for LoggingConfig {
 #[serde(default)]
 pub struct GrpcConfig {
     pub rqd_port: u16,
-    pub rqd_interface: String,
+    pub rqd_interface: Option<String>,
     pub cuebot_endpoints: Vec<String>,
     #[serde(with = "humantime_serde")]
     pub connection_expires_after: Duration,

--- a/rust/crates/rqd/src/config/mod.rs
+++ b/rust/crates/rqd/src/config/mod.rs
@@ -35,6 +35,7 @@ impl Default for LoggingConfig {
 #[serde(default)]
 pub struct GrpcConfig {
     pub rqd_port: u16,
+    pub rqd_interface: String,
     pub cuebot_endpoints: Vec<String>,
     #[serde(with = "humantime_serde")]
     pub connection_expires_after: Duration,
@@ -49,6 +50,7 @@ impl Default for GrpcConfig {
     fn default() -> GrpcConfig {
         GrpcConfig {
             rqd_port: 8444,
+            rqd_interface: "".to_string(),
             cuebot_endpoints: vec!["localhost:4343".to_string()],
             connection_expires_after: Duration::from_secs(3600), // 1h. from_hour is experimental
             backoff_delay_min: Duration::from_millis(10),

--- a/rust/crates/rqd/src/servant/mod.rs
+++ b/rust/crates/rqd/src/servant/mod.rs
@@ -24,28 +24,31 @@ pub async fn serve(
     machine: Arc<MachineImpl>,
     frame_manager: Arc<FrameManager>,
 ) -> Result<()> {
-    let rqd_interface: String = config.grpc.rqd_interface.clone();
-    let mut ip_address: Ipv4Addr = Ipv4Addr::new(0, 0, 0, 0);
-    if !rqd_interface.is_empty() {
-        if let Some(interface) = pnet::datalink::interfaces()
-            .into_iter()
-            .find(|interface| interface.name == rqd_interface)
-        {
-            if let Some(IpNetwork::V4(ipv4_network)) = interface.ips.iter().find(|ip| ip.is_ipv4()) {
-                ip_address = ipv4_network.ip();
-            } else {
-                warn!(
-                    "Could not find an IPv4 address for interface '{}'. Binding to 0.0.0.0",
+    let ip_address: Ipv4Addr = match config.grpc.rqd_interface {
+        None => Ipv4Addr::new(0, 0, 0, 0),
+        Some(rqd_interface) => {
+            let interface = pnet::datalink::interfaces()
+                .into_iter()
+                .find(|interface| interface.name == rqd_interface)
+                .ok_or(tonic::Status::unavailable(format!(
+                    "Could not find network interface '{}'",
                     rqd_interface
-                );
-            }
-        } else {
-            warn!(
-                "Could not find network interface '{}'. Binding to 0.0.0.0",
-                rqd_interface
-            );
+                )))?;
+            // Find V4 interface
+            interface
+                .ips
+                .iter()
+                .find_map(|address| match address {
+                    IpNetwork::V4(a) => Some(a.ip()),
+                    IpNetwork::V6(_) => None, // Unexpected condition
+                })
+                .ok_or(tonic::Status::unavailable(format!(
+                    "Could not find ipv4 network ip for '{}'",
+                    rqd_interface
+                )))?
         }
-    }
+    };
+
     let address: SocketAddr = SocketAddr::new(IpAddr::V4(ip_address), config.grpc.rqd_port);
 
     let running_frame_servant = RunningFrameServant::init(Arc::clone(&frame_manager));

--- a/rust/crates/rqd/src/servant/mod.rs
+++ b/rust/crates/rqd/src/servant/mod.rs
@@ -12,42 +12,50 @@ use std::{
     sync::Arc,
 };
 use tonic::transport::Server;
-use tracing::warn;
 
 pub mod rqd_servant;
 pub mod running_frame_servant;
 
 pub type Result<T> = core::result::Result<T, tonic::Status>;
 
-pub async fn serve(
-    config: Config,
-    machine: Arc<MachineImpl>,
-    frame_manager: Arc<FrameManager>,
-) -> Result<()> {
-    let ip_address: Ipv4Addr = match config.grpc.rqd_interface {
-        None => Ipv4Addr::new(0, 0, 0, 0),
+/// Determines the IPv4 address to bind to based on the provided interface name.
+fn get_ip_for_interface(rqd_interface: Option<String>) -> Result<Ipv4Addr> {
+    match rqd_interface {
+        None => Ok(Ipv4Addr::new(0, 0, 0, 0)),
         Some(rqd_interface) => {
             let interface = pnet::datalink::interfaces()
                 .into_iter()
                 .find(|interface| interface.name == rqd_interface)
-                .ok_or(tonic::Status::unavailable(format!(
-                    "Could not find network interface '{}'",
-                    rqd_interface
-                )))?;
+                .ok_or_else(|| {
+                    tonic::Status::unavailable(format!(
+                        "Could not find network interface '{}'",
+                        rqd_interface
+                    ))
+                })?;
             // Find V4 interface
             interface
                 .ips
                 .iter()
                 .find_map(|address| match address {
                     IpNetwork::V4(a) => Some(a.ip()),
-                    IpNetwork::V6(_) => None, // Unexpected condition
+                    IpNetwork::V6(_) => None,
                 })
-                .ok_or(tonic::Status::unavailable(format!(
-                    "Could not find ipv4 network ip for '{}'",
-                    rqd_interface
-                )))?
+                .ok_or_else(|| {
+                    tonic::Status::unavailable(format!(
+                        "Could not find ipv4 network ip for '{}'",
+                        rqd_interface
+                    ))
+                })
         }
-    };
+    }
+}
+
+pub async fn serve(
+    config: Config,
+    machine: Arc<MachineImpl>,
+    frame_manager: Arc<FrameManager>,
+) -> Result<()> {
+    let ip_address = get_ip_for_interface(config.grpc.rqd_interface)?;
 
     let address: SocketAddr = SocketAddr::new(IpAddr::V4(ip_address), config.grpc.rqd_port);
 
@@ -60,4 +68,65 @@ pub async fn serve(
         .serve(address)
         .await
         .map_err(|err| tonic::Status::from_error(Box::new(err)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn get_ip_for_interface_none_should_return_default() {
+        // Arrange: No interface name is provided.
+        let interface_name = None;
+
+        // Act: Call the function.
+        let result = get_ip_for_interface(interface_name);
+
+        // Assert: The result should be Ok and contain the default "any" address.
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Ipv4Addr::new(0, 0, 0, 0));
+    }
+
+    #[test]
+    fn get_ip_for_interface_non_existent_should_error() {
+        // Arrange: A non-existent interface name is provided.
+        let interface_name = Some("this-interface-does-not-exist".to_string());
+
+        // Act: Call the function.
+        let result = get_ip_for_interface(interface_name);
+
+        // Assert: The result should be an "Unavailable" error.
+        assert!(result.is_err());
+        let status = result.err().unwrap();
+        assert_eq!(status.code(), tonic::Code::Unavailable);
+        assert!(status
+            .message()
+            .contains("Could not find network interface"));
+    }
+
+    #[test]
+    fn get_ip_for_interface_loopback_should_return_localhost_ip() {
+        // Arrange: Find the system's loopback interface to make the test environment-agnostic.
+        let loopback_interface = pnet::datalink::interfaces()
+            .into_iter()
+            .find(|iface| iface.is_loopback());
+
+        if let Some(iface) = loopback_interface {
+            // Act: Call the function with the found loopback interface name.
+            let result = get_ip_for_interface(Some(iface.name));
+
+            // Assert: The result should be Ok and contain the loopback IP (127.0.0.1).
+            let ip = result.unwrap_or_else(|e| {
+                panic!(
+                    "Expected to find an IPv4 for loopback interface, but got an error: {}",
+                    e
+                )
+            });
+            assert_eq!(ip, Ipv4Addr::new(127, 0, 0, 1));
+        } else {
+            // If no loopback interface is found, we skip the test with a message.
+            println!("Skipping loopback test: no loopback interface found.");
+        }
+    }
 }

--- a/rust/crates/rqd/src/servant/mod.rs
+++ b/rust/crates/rqd/src/servant/mod.rs
@@ -4,6 +4,7 @@ use crate::{config::Config, frame::manager::FrameManager};
 use opencue_proto::rqd::{
     rqd_interface_server::RqdInterfaceServer, running_frame_server::RunningFrameServer,
 };
+use pnet::ipnetwork::IpNetwork;
 use rqd_servant::{MachineImpl, RqdServant};
 use running_frame_servant::RunningFrameServant;
 use std::{
@@ -11,6 +12,7 @@ use std::{
     sync::Arc,
 };
 use tonic::transport::Server;
+use tracing::warn;
 
 pub mod rqd_servant;
 pub mod running_frame_servant;
@@ -22,8 +24,29 @@ pub async fn serve(
     machine: Arc<MachineImpl>,
     frame_manager: Arc<FrameManager>,
 ) -> Result<()> {
-    let address: SocketAddr =
-        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), config.grpc.rqd_port);
+    let rqd_interface: String = config.grpc.rqd_interface.clone();
+    let mut ip_address: Ipv4Addr = Ipv4Addr::new(0, 0, 0, 0);
+    if !rqd_interface.is_empty() {
+        if let Some(interface) = pnet::datalink::interfaces()
+            .into_iter()
+            .find(|interface| interface.name == rqd_interface)
+        {
+            if let Some(IpNetwork::V4(ipv4_network)) = interface.ips.iter().find(|ip| ip.is_ipv4()) {
+                ip_address = ipv4_network.ip();
+            } else {
+                warn!(
+                    "Could not find an IPv4 address for interface '{}'. Binding to 0.0.0.0",
+                    rqd_interface
+                );
+            }
+        } else {
+            warn!(
+                "Could not find network interface '{}'. Binding to 0.0.0.0",
+                rqd_interface
+            );
+        }
+    }
+    let address: SocketAddr = SocketAddr::new(IpAddr::V4(ip_address), config.grpc.rqd_port);
 
     let running_frame_servant = RunningFrameServant::init(Arc::clone(&frame_manager));
     let rqd_servant = RqdServant::init(machine, Arc::clone(&frame_manager));


### PR DESCRIPTION
**Summarize your change.**
- Introduced `RQD_NETWORK_INTERFACE` to allow specifying the network interface for binding the gRPC server.
- Added `getInterfaceIp` utility function to resolve the IP of a provided network interface.
- Updated several methods to respect the new configuration attribute.


This enables support for selecting which specific interface to listen on and also which ip to report cuebot server.