### PR TITLE
[CueBot] Fix hitaki data-source outdated attributes

### DIFF
--- a/cuebot/src/main/resources/opencue.properties
+++ b/cuebot/src/main/resources/opencue.properties
@@ -5,9 +5,29 @@ datasource.cue-data-source.driver-class-name=org.postgresql.Driver
 datasource.cue-data-source.jdbc-url=jdbc:postgresql://dbhost/dbname
 datasource.cue-data-source.username=cue
 datasource.cue-data-source.password=password
-# Discard connections after 6 hours, this allows for gradual
-# connection rebalancing.
-datasource.cue-data-source.maxAge=21600000
+
+# HikariCP Configuration
+# Maximum lifetime of a connection in milliseconds (5 hours = 18000000 ms)
+# This should be shorter than PostgreSQL's connection timeout
+datasource.cue-data-source.max-lifetime=18000000
+
+# Maximum time to wait for a connection from the pool (30 seconds)
+datasource.cue-data-source.connection-timeout=30000
+
+# Maximum time a connection can remain idle (10 minutes)
+datasource.cue-data-source.idle-timeout=600000
+
+# Minimum number of idle connections to maintain
+datasource.cue-data-source.minimum-idle=5
+
+# Maximum number of connections in the pool
+datasource.cue-data-source.maximum-pool-size=20
+
+# Connection test query to validate connections
+datasource.cue-data-source.connection-test-query=SELECT 1
+
+# How often to check for idle connections that can be evicted (30 seconds)
+datasource.cue-data-source.leak-detection-threshold=30000
 
 grpc.cue_port=${CUEBOT_GRPC_CUE_PORT:8443}
 grpc.rqd_server_port=${CUEBOT_GRPC_RQD_SERVER_PORT:8444}


### PR DESCRIPTION
The server has been reporting the warning bellow. This configuration change replaces `maxAge` with `max-lifetime`. 

Besides that, new attributes were added to handle idle connections, leaks and pool size.

```
HikariPool-1 - Failed to validate connection org.postgresql.jdbc.PgConnection@27e38df7 (This connection has been closed.). Possibly consider using a shorter maxLifetime value.
```
