### PR TITLE
[rust/rqd] Ensure dummy-cuebot is built before running rqd integration tests

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "dummy-cuebot"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "config",
@@ -1455,7 +1455,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "opencue-proto"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "prost",
  "prost-types",
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "rqd"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2002,7 +2002,6 @@ dependencies = [
  "config",
  "dashmap",
  "device_query",
- "dummy-cuebot",
  "futures",
  "futures-core",
  "http",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,11 +1,11 @@
 [workspace]
 members = ["crates/opencue-proto", "crates/rqd", "crates/dummy-cuebot"]
+resolver = "3"
 
 [workspace.package]
 authors = ["Diego Tavares <dtavares@imageworks.com>"]
 edition = "2024"
-resolver = "3"
-version = "0.1.0"
+version = "0.1.3"
 
 [workspace.dependencies]
 async-trait = "0.1"

--- a/rust/crates/rqd/Cargo.toml
+++ b/rust/crates/rqd/Cargo.toml
@@ -64,7 +64,6 @@ libc = "0.2"
 device_query = "3.0"
 
 [dev-dependencies]
-dummy-cuebot = { path = "../dummy-cuebot" }
 tempfile = "3.14.0"
 
 # === Rpm configuration ===


### PR DESCRIPTION
Integration tests are failing on some environment when the compilation order puts dummy-cuebot after rqd.