### PR TITLE
[cuebot] Increase jobSpec layer limit

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/service/JobSpec.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/service/JobSpec.java
@@ -89,7 +89,7 @@ public class JobSpec {
      * it. The more layers you have the longer a job takes to dispatch which could lead to
      * dispatches being dropped.
      */
-    public static final int MAX_LAYERS = 1000;
+    public static final int MAX_LAYERS = 2000;
 
     /**
      * The maximum number of frames a job can have. Increase this with care. The more frames a job


### PR DESCRIPTION
This limit was established a long time ago and is no longer compatible with current production loads. Some crowd shots and complex pipelines require more than 1,000 layers.

This PR proposes doubling the limit to assess any impacts on overall performance. If there are no issues, further increases can be suggested in the near future.