### PR TITLE
[CI/CD] Update pipelines: switch to PyPI for release

### DIFF
--- a/.github/workflows/packaging-pipeline.yml
+++ b/.github/workflows/packaging-pipeline.yml
@@ -258,6 +258,31 @@ jobs:
             aws s3 cp ${GITHUB_WORKSPACE}/artifacts/${artifact} s3://${S3_BUCKET}/opencue/${BUILD_ID}/
           done
 
+  upload_python_packages_test:
+    needs:
+      - integration_test
+      - build_opencue_packages
+    runs-on: ubuntu-22.04
+    container: python:3.11
+    name: "Upload python packages to testpypi repo"
+    environment: testpypi
+    env:
+      TWINE_USERNAME: "__token__"
+      TWINE_PASSWORD: "${{ secrets.TEST_PYPI_API_TOKEN }}"
+      TWINE_REPOSITORY: "testpypi"
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: opencue_packages
+          path: packages
+
+      - name: Upload packages
+        run: |
+          python3 -m pip install --upgrade twine
+          python3 -m twine upload --verbose packages/opencue_*
+
   create_other_artifacts:
     name: Create Other Build Artifacts
     needs:

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -137,16 +137,15 @@ jobs:
           name: rust-binaries-${{ matrix.target }}
           path: release/
 
-  upload_python_packages_test:
+  upload_python_packages_pypi:
     needs: build_opencue_packages
     runs-on: ubuntu-22.04
     container: python:3.11
-    name: "Upload python packages to testpypi repo"
-    environment: testpypi
+    name: "Upload python packages to pypi repo"
+    environment: release
     env:
       TWINE_USERNAME: "__token__"
-      TWINE_PASSWORD: "${{ secrets.TEST_PYPI_API_TOKEN }}"
-      TWINE_REPOSITORY: "testpypi"
+      TWINE_PASSWORD: "${{ secrets.PYPI_API_TOKEN }}"
 
     steps:
       - name: Download artifact


### PR DESCRIPTION
- Updated `release-pipeline.yml` to upload Python packages to PyPI instead of TestPyPI.
- Reintroduced TestPyPI upload step in `packaging-pipeline.yml`.
