### PR TITLE
[rust/rqd] Optimize retry mechanism and add logging info

### DIFF
--- a/rust/config/rqd.yaml
+++ b/rust/config/rqd.yaml
@@ -56,6 +56,10 @@ grpc:
   # Default: 10.0
   # backoff_jitter_percentage: 10.0
 
+  # Number of attempts to retry on Transport Error
+  # Default: 20
+  # backoff_retry_attempts: 10
+
 # =============================================================================
 # MACHINE CONFIGURATION
 # =============================================================================

--- a/rust/crates/rqd/src/config/mod.rs
+++ b/rust/crates/rqd/src/config/mod.rs
@@ -44,6 +44,7 @@ pub struct GrpcConfig {
     #[serde(with = "humantime_serde")]
     pub backoff_delay_max: Duration,
     pub backoff_jitter_percentage: f64,
+    pub backoff_retry_attempts: usize,
 }
 
 impl Default for GrpcConfig {
@@ -56,6 +57,7 @@ impl Default for GrpcConfig {
             backoff_delay_min: Duration::from_millis(10),
             backoff_delay_max: Duration::from_secs(60),
             backoff_jitter_percentage: 10.0,
+            backoff_retry_attempts: 20,
         }
     }
 }

--- a/rust/crates/rqd/src/report/report_client.rs
+++ b/rust/crates/rqd/src/report/report_client.rs
@@ -89,7 +89,7 @@ impl ReportClient {
 
         // Requests will retry indefinitely
         let retry_policy = BackoffPolicy {
-            attempts: None,
+            attempts: Some(config.backoff_retry_attempts),
             backoff,
         };
         let retry_layer = RetryLayer::new(retry_policy);

--- a/rust/crates/rqd/src/report/retry/backoff_policy.rs
+++ b/rust/crates/rqd/src/report/retry/backoff_policy.rs
@@ -45,8 +45,8 @@ impl BackoffPolicy {
     pub fn has_attempts_left(&mut self) -> bool {
         match self.attempts {
             Some(0) => false,
-            Some(ref mut attemps_left) => {
-                *attemps_left -= 1;
+            Some(ref mut attempts_left) => {
+                *attempts_left -= 1;
                 true
             }
             None => true,


### PR DESCRIPTION
* When rqd fails to connect, don't swallow the failure message.
* When on Retrying state, avoid cycling back to Initializing but start a new request immediatly and
transition to Cloning.