### PR TITLE
[docs] Fix documentation navigation order and remove duplicate video

### DIFF
--- a/docs/_docs/developer-guide/contributing.md
+++ b/docs/_docs/developer-guide/contributing.md
@@ -2,7 +2,7 @@
 title: "Contributing to OpenCue"
 linkTitle: "Contributing to OpenCue"
 parent: "Developer Guide"
-nav_order: 56
+nav_order: 60
 layout: default
 date: 2020-05-04
 description: >

--- a/docs/_docs/developer-guide/cuecommander-technical-reference.md
+++ b/docs/_docs/developer-guide/cuecommander-technical-reference.md
@@ -2,7 +2,7 @@
 title: "CueCommander Technical Reference"
 layout: default
 parent: "Developer Guide"
-nav_order: 59
+nav_order: 63
 linkTitle: "CueCommander Technical Reference"
 date: 2025-01-13
 description: >

--- a/docs/_docs/developer-guide/cuetopia-technical-reference.md
+++ b/docs/_docs/developer-guide/cuetopia-technical-reference.md
@@ -2,7 +2,7 @@
 title: "Cuetopia Technical Reference"
 layout: default
 parent: "Developer Guide"
-nav_order: 58
+nav_order: 62
 linkTitle: "Cuetopia Technical Reference"
 date: 2025-01-07
 description: >

--- a/docs/_docs/developer-guide/index.md
+++ b/docs/_docs/developer-guide/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Developer Guide"
-nav_order: 55
+nav_order: 59
 has_children: true
 layout: default
 linkTitle: "Developer Guide"

--- a/docs/_docs/developer-guide/rest-gateway-development.md
+++ b/docs/_docs/developer-guide/rest-gateway-development.md
@@ -1,6 +1,6 @@
 ---
 title: "REST Gateway Development"
-nav_order: 60
+nav_order: 64
 parent: Developer Guide
 layout: default
 linkTitle: "Developing the OpenCue REST Gateway"

--- a/docs/_docs/developer-guide/sandbox-testing.md
+++ b/docs/_docs/developer-guide/sandbox-testing.md
@@ -1,6 +1,6 @@
 ---
 title: "Using the OpenCue Sandbox for Testing"
-nav_order: 57
+nav_order: 61
 parent: "Developer Guide"
 layout: default
 date: 2025-08-06

--- a/docs/_docs/getting-started/deploying-rest-gateway.md
+++ b/docs/_docs/getting-started/deploying-rest-gateway.md
@@ -1,6 +1,6 @@
 ---
 title: "Deploying OpenCue REST Gateway"
-nav_order: 21
+nav_order: 20
 parent: Getting Started
 layout: default
 linkTitle: "Deploying REST Gateway"

--- a/docs/_docs/getting-started/installing-cueadmin.md
+++ b/docs/_docs/getting-started/installing-cueadmin.md
@@ -1,6 +1,6 @@
 ---
 title: "Installing CueAdmin"
-nav_order: 18
+nav_order: 17
 parent: Getting Started
 layout: default
 linkTitle: "Installing CueAdmin"

--- a/docs/_docs/getting-started/installing-cuegui.md
+++ b/docs/_docs/getting-started/installing-cuegui.md
@@ -1,6 +1,6 @@
 ---
 title: "Installing CueGUI"
-nav_order: 19
+nav_order: 18
 parent: Getting Started
 layout: default
 linkTitle: "Installing CueGUI"

--- a/docs/_docs/getting-started/installing-cuesubmit.md
+++ b/docs/_docs/getting-started/installing-cuesubmit.md
@@ -1,6 +1,6 @@
 ---
 title: "Installing CueSubmit"
-nav_order: 20
+nav_order: 19
 parent: Getting Started
 layout: default
 linkTitle: "Installing CueSubmit"

--- a/docs/_docs/getting-started/installing-pycue-and-pyoutline.md
+++ b/docs/_docs/getting-started/installing-pycue-and-pyoutline.md
@@ -1,6 +1,6 @@
 ---
 title: "Installing PyCue and PyOutline"
-nav_order: 17
+nav_order: 16
 parent: Getting Started
 layout: default
 linkTitle: "Installing PyCue and PyOutline"

--- a/docs/_docs/index.md
+++ b/docs/_docs/index.md
@@ -41,23 +41,6 @@ permalink: /docs/
 
 ---
 
-<!-- OpenCue Walkthrough Video Section -->
-<section class="video-section" aria-labelledby="walkthrough-video-heading">
-    <div class="video-container">
-        <h2 id="walkthrough-video-heading" class="section-title">OpenCue Walkthrough Tutorial</h2>
-        <div class="video-wrapper">
-            <iframe 
-                src="https://www.youtube-nocookie.com/embed/v4i83ccrz5w" 
-                title="OpenCue Walkthrough - Submitting and Monitoring Render Jobs"
-                frameborder="0" 
-                allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" 
-                allowfullscreen
-                loading="lazy">
-            </iframe>
-        </div>
-    </div>
-</section>
-
 ### [Quick starts](quick-starts)
 
 Try OpenCue in the sandbox environment on different operating systems

--- a/docs/_docs/other-guides/applying-database-migrations.md
+++ b/docs/_docs/other-guides/applying-database-migrations.md
@@ -2,7 +2,7 @@
 title: "Applying database migrations"
 layout: default
 parent: Other Guides
-nav_order: 31
+nav_order: 32
 linkTitle: "Applying database migrations"
 date: 2019-08-22
 description: >

--- a/docs/_docs/other-guides/configuring-limits.md
+++ b/docs/_docs/other-guides/configuring-limits.md
@@ -2,7 +2,7 @@
 title: "Configuring limits"
 layout: default
 parent: Other Guides
-nav_order: 29
+nav_order: 30
 linkTitle: "Configuring limits"
 date: 2020-03-26
 description: >

--- a/docs/_docs/other-guides/configuring-opencue.md
+++ b/docs/_docs/other-guides/configuring-opencue.md
@@ -2,7 +2,7 @@
 title: "Configuring OpenCue"
 layout: default
 parent: Other Guides
-nav_order: 28
+nav_order: 29
 linkTitle: "Configuring OpenCue"
 date: 2023-01-26
 description: >

--- a/docs/_docs/other-guides/containerized_frames.md
+++ b/docs/_docs/other-guides/containerized_frames.md
@@ -2,7 +2,7 @@
 title: "Running RQD at Docker mode"
 layout: default
 parent: Other Guides
-nav_order: 35
+nav_order: 36
 linkTitle: "Running RQD at Docker mode"
 date: 2024-11-06
 description: >

--- a/docs/_docs/other-guides/cueweb.md
+++ b/docs/_docs/other-guides/cueweb.md
@@ -2,7 +2,7 @@
 title: "CueWeb System"
 layout: default
 parent: Other Guides
-nav_order: 36
+nav_order: 38
 linkTitle: "CueWeb system"
 date: 2025-02-04
 description: >

--- a/docs/_docs/other-guides/customizing-rqd.md
+++ b/docs/_docs/other-guides/customizing-rqd.md
@@ -2,7 +2,7 @@
 title: "Customizing RQD rendering hosts"
 layout: default
 parent: Other Guides
-nav_order: 30
+nav_order: 31
 linkTitle: "Customizing RQD rendering hosts"
 date: 2019-12-10
 description: >

--- a/docs/_docs/other-guides/deploying-rest-gateway.md
+++ b/docs/_docs/other-guides/deploying-rest-gateway.md
@@ -1,6 +1,6 @@
 ---
 title: "Deploying REST Gateway"
-nav_order: 35
+nav_order: 37
 parent: Other Guides
 layout: default
 linkTitle: "Deploying the OpenCue REST Gateway"

--- a/docs/_docs/other-guides/framelogging-with-loki.md
+++ b/docs/_docs/other-guides/framelogging-with-loki.md
@@ -2,7 +2,7 @@
 title: "Configuring OpenCue with Loki for framelogs"
 layout: default
 parent: Other Guides
-nav_order: 37
+nav_order: 39
 linkTitle: "Configuring OpenCue with Loki for framelogs"
 date: 2024-11-27
 description: >

--- a/docs/_docs/other-guides/index.md
+++ b/docs/_docs/other-guides/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Other Guides
-nav_order: 27
+nav_order: 28
 has_children: true
 permalink: /docs/other-guides
 ---

--- a/docs/_docs/other-guides/monitoring-with-prometheus-loki-and-grafana.md
+++ b/docs/_docs/other-guides/monitoring-with-prometheus-loki-and-grafana.md
@@ -2,7 +2,7 @@
 title: "Monitoring with Prometheus, Loki, and Grafana"
 layout: default
 parent: Other Guides
-nav_order: 34
+nav_order: 35
 linkTitle: "Monitoring with Prometheus, Loki, and Grafana"
 date: 2021-08-01
 description: >

--- a/docs/_docs/other-guides/troubleshooting-deployment.md
+++ b/docs/_docs/other-guides/troubleshooting-deployment.md
@@ -2,7 +2,7 @@
 title: "Troubleshooting deployment"
 layout: default
 parent: Other Guides
-nav_order: 32
+nav_order: 33
 linkTitle: "Troubleshooting deployment"
 date: 2019-02-22
 description: >

--- a/docs/_docs/other-guides/troubleshooting-rendering.md
+++ b/docs/_docs/other-guides/troubleshooting-rendering.md
@@ -2,7 +2,7 @@
 title: "Troubleshooting rendering"
 layout: default
 parent: Other Guides
-nav_order: 33
+nav_order: 34
 linkTitle: "Troubleshooting rendering"
 date: 2019-02-22
 description: >

--- a/docs/_docs/reference/CueGUI-app.md
+++ b/docs/_docs/reference/CueGUI-app.md
@@ -2,7 +2,7 @@
 title: "CueGUI app"
 layout: default
 parent: Reference
-nav_order: 39
+nav_order: 41
 linkTitle: "CueGUI app"
 date: 2019-02-22
 description: >

--- a/docs/_docs/reference/commands/cueadmin.md
+++ b/docs/_docs/reference/commands/cueadmin.md
@@ -2,7 +2,7 @@
 title: "cueadmin command"
 layout: default
 parent: Reference
-nav_order: 40
+nav_order: 42
 linkTitle: "cueadmin command"
 date: 2025-08-11
 description: >

--- a/docs/_docs/reference/commands/pycuerun.md
+++ b/docs/_docs/reference/commands/pycuerun.md
@@ -2,7 +2,7 @@
 title: "pycuerun command"
 layout: default
 parent: Reference
-nav_order: 41
+nav_order: 43
 linkTitle: "pycuerun command"
 date: 2019-05-23
 description: >

--- a/docs/_docs/reference/cuecommander-technical-reference.md
+++ b/docs/_docs/reference/cuecommander-technical-reference.md
@@ -2,7 +2,7 @@
 title: "CueCommander Technical Reference"
 layout: default
 parent: Reference
-nav_order: 43
+nav_order: 45
 linkTitle: "CueCommander Technical Reference"
 date: 2025-01-13
 description: >

--- a/docs/_docs/reference/index.md
+++ b/docs/_docs/reference/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Reference
-nav_order: 38
+nav_order: 40
 has_children: true
 permalink: /docs/reference
 ---

--- a/docs/_docs/reference/rest-api-reference.md
+++ b/docs/_docs/reference/rest-api-reference.md
@@ -1,6 +1,6 @@
 ---
 title: "REST API Reference"
-nav_order: 45
+nav_order: 49
 parent: Reference
 layout: default
 linkTitle: "OpenCue REST API Reference"

--- a/docs/_docs/reference/rust-rqd.md
+++ b/docs/_docs/reference/rust-rqd.md
@@ -1,6 +1,6 @@
 ---
 title: "Rust RQD"
-nav_order: 42
+nav_order: 44
 parent: Reference
 layout: default
 linkTitle: "Rust RQD"

--- a/docs/_docs/reference/tools/cueadmin.md
+++ b/docs/_docs/reference/tools/cueadmin.md
@@ -1,6 +1,6 @@
 ---
 title: "CueAdmin - CLI Administration Tool"
-nav_order: 45
+nav_order: 47
 parent: "Command Line Tools"
 grand_parent: "Reference"
 layout: default

--- a/docs/_docs/reference/tools/cueman.md
+++ b/docs/_docs/reference/tools/cueman.md
@@ -1,6 +1,6 @@
 ---
 title: "Cueman - CLI Job Management Tool"
-nav_order: 46
+nav_order: 48
 parent: "Command Line Tools"
 grand_parent: "Reference"
 layout: default

--- a/docs/_docs/reference/tools/index.md
+++ b/docs/_docs/reference/tools/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Command Line Tools"
-nav_order: 44
+nav_order: 46
 parent: "Reference"
 has_children: true
 layout: default

--- a/docs/_docs/tutorials/cueadmin-tutorial.md
+++ b/docs/_docs/tutorials/cueadmin-tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: "CueAdmin Tutorial"
-nav_order: 52
+nav_order: 56
 parent: "Tutorials"
 layout: default
 date: 2025-08-11

--- a/docs/_docs/tutorials/cueman-tutorial.md
+++ b/docs/_docs/tutorials/cueman-tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: "Cueman Tutorial"
-nav_order: 53
+nav_order: 57
 parent: "Tutorials"
 layout: default
 date: 2025-08-06

--- a/docs/_docs/tutorials/dcc-integration.md
+++ b/docs/_docs/tutorials/dcc-integration.md
@@ -2,7 +2,7 @@
 title: "DCC Integration Tutorial"
 layout: default
 parent: Tutorials
-nav_order: 54
+nav_order: 58
 linkTitle: "DCC Integration Tutorial"
 date: 2025-01-29
 description: >

--- a/docs/_docs/tutorials/getting-started-tutorial.md
+++ b/docs/_docs/tutorials/getting-started-tutorial.md
@@ -2,7 +2,7 @@
 title: "Getting Started with OpenCue"
 layout: default
 parent: Tutorials
-nav_order: 47
+nav_order: 51
 linkTitle: "Getting Started with OpenCue"
 date: 2025-01-29
 description: >

--- a/docs/_docs/tutorials/index.md
+++ b/docs/_docs/tutorials/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Tutorials
-nav_order: 46
+nav_order: 50
 has_children: true
 permalink: /docs/tutorials
 ---

--- a/docs/_docs/tutorials/managing-jobs-frames.md
+++ b/docs/_docs/tutorials/managing-jobs-frames.md
@@ -2,7 +2,7 @@
 title: "Managing Jobs and Frames"
 layout: default
 parent: Tutorials
-nav_order: 50
+nav_order: 54
 linkTitle: "Managing Jobs and Frames"
 date: 2025-01-29
 description: >

--- a/docs/_docs/tutorials/multi-layer-jobs.md
+++ b/docs/_docs/tutorials/multi-layer-jobs.md
@@ -2,7 +2,7 @@
 title: "Creating Multi-Layer Jobs"
 layout: default
 parent: Tutorials
-nav_order: 51
+nav_order: 55
 linkTitle: "Creating Multi-Layer Jobs"
 date: 2025-01-29
 description: >

--- a/docs/_docs/tutorials/rest-api-tutorial.md
+++ b/docs/_docs/tutorials/rest-api-tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: "REST API Tutorial"
-nav_order: 54
+nav_order: 58
 parent: Tutorials
 layout: default
 linkTitle: "Getting Started with OpenCue REST API"

--- a/docs/_docs/tutorials/submitting-first-job.md
+++ b/docs/_docs/tutorials/submitting-first-job.md
@@ -2,7 +2,7 @@
 title: "Submitting Your First Job"
 layout: default
 parent: Tutorials
-nav_order: 48
+nav_order: 52
 linkTitle: "Submitting Your First Job"
 date: 2025-01-29
 description: >

--- a/docs/_docs/tutorials/using-cuegui.md
+++ b/docs/_docs/tutorials/using-cuegui.md
@@ -2,7 +2,7 @@
 title: "Using CueGUI for Job Monitoring"
 layout: default
 parent: Tutorials
-nav_order: 49
+nav_order: 53
 linkTitle: "Using CueGUI for Job Monitoring" 
 date: 2025-01-29
 description: >


### PR DESCRIPTION
- Reorganize nav_order across all documentation pages for consistent hierarchy
- Remove duplicate OpenCue Walkthrough Tutorial video from "OpenCue overview" page (video remains on the main docs page)

**Link the Issue(s) this Pull Request is related to.**
- #1800