### PR TITLE
[docs] OpenCue documentation stable version - Update docs version to 1.11.66

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -13,10 +13,10 @@ versioning:
   default_version: main
   versions:
     - main
-    - v0.0.1
+    - v1.11.66
   version_labels:
     main: "Latest (main)"
-    v0.0.1: "v0.0.1 (Preview)"
+    v1.11.66: "v1.11.66"
 
 # Git metadata
 git_metadata:
@@ -31,7 +31,7 @@ build_info:
   git_hash: ""
   
 # Documentation version (in progress)
-doc_version: "0.0.1"
+doc_version: "1.11.66"
 
 # OpenCue version will be read from VERSION.in by CI/CD pipeline
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -10,13 +10,13 @@ theme: just-the-docs
 # Version management
 versioning:
   enabled: true
-  default_version: main
+  default_version: v1.11.66
   versions:
-    - main
     - v1.11.66
+    - main
   version_labels:
-    main: "Latest (main)"
-    v1.11.66: "v1.11.66"
+    v1.11.66: "v1.11.66 (Latest)"
+    main: "main (Development)"
 
 # Git metadata
 git_metadata:

--- a/docs/_docs/getting-started/index.md
+++ b/docs/_docs/getting-started/index.md
@@ -9,12 +9,3 @@ permalink: /docs/getting-started
 # OpenCue getting started guide
 
 Guides for system admins deploying OpenCue components and installing dependencies
-
-## All OpenCue documentation
-
----
-
-🚧 **Note:** Documentation is currently under active development. 
-
-- Please use the latest version from the [Opencue master branch](https://github.com/AcademySoftwareFoundation/OpenCue) for the moment. We are working to release a new version of OpenCue soon.
-- For quick start on Linux or macOS, follow the guide [Using the OpenCue Sandbox for Testing](developer-guide/sandbox-testing/)

--- a/docs/_docs/index.md
+++ b/docs/_docs/index.md
@@ -32,15 +32,6 @@ permalink: /docs/
 
 ## All OpenCue documentation
 
----
-
-🚧 **Note:** Documentation is currently under active development. 
-
-- Please use the latest version from the [Opencue master branch](https://github.com/AcademySoftwareFoundation/OpenCue) for the moment. We are working to release a new version of OpenCue soon.
-- For quick start on Linux or macOS, follow the guide [Using the OpenCue Sandbox for Testing](developer-guide/sandbox-testing/)
-
----
-
 ### [Quick starts](quick-starts)
 
 Try OpenCue in the sandbox environment on different operating systems

--- a/docs/_includes/sidebar-version-switcher.html
+++ b/docs/_includes/sidebar-version-switcher.html
@@ -77,15 +77,17 @@ document.addEventListener('DOMContentLoaded', function() {
         const selectedVersion = e.target.value;
         const currentPath = window.location.pathname;
         const baseUrl = '{{ site.baseurl }}';
-        
+
         // Handle version switching logic
-        if (selectedVersion === 'main') {
-          // Remove version prefix if exists and go to main
-          const cleanPath = currentPath.replace(/\/v[\d.]+/, '');
+        // Both the default version and main point to the same latest content
+        const defaultVersion = '{{ site.versioning.default_version }}';
+        if (selectedVersion === 'main' || selectedVersion === defaultVersion) {
+          // Remove version prefix if exists and go to main/latest
+          const cleanPath = currentPath.replace(/\/v[\d.]+/, '').replace(/\/main/, '');
           window.location.href = cleanPath || baseUrl || '/';
         } else {
-          // For versioned documentation (including v1.11.66)
-          const cleanPath = currentPath.replace(baseUrl, '').replace(/\/v[\d.]+/, '');
+          // For other versioned documentation
+          const cleanPath = currentPath.replace(baseUrl, '').replace(/\/v[\d.]+/, '').replace(/\/main/, '');
           window.location.href = baseUrl + '/' + selectedVersion + cleanPath;
         }
       });
@@ -135,8 +137,9 @@ document.addEventListener('DOMContentLoaded', function() {
     const currentVersion = '{{ site.version | default: site.versioning.default_version }}';
     const defaultVersion = '{{ site.versioning.default_version }}';
     const mainContent = document.querySelector('.main-content');
-    
-    if (currentVersion !== defaultVersion && mainContent && !document.getElementById('version-notice-banner')) {
+
+    // Don't show banner for the default version or main since they're both the latest
+    if (currentVersion !== defaultVersion && currentVersion !== 'main' && mainContent && !document.getElementById('version-notice-banner')) {
       const banner = document.createElement('div');
       banner.id = 'version-notice-banner';
       banner.style.cssText = `
@@ -152,12 +155,9 @@ document.addEventListener('DOMContentLoaded', function() {
       `;
       
       let bannerMessage = `You are viewing documentation for <strong>version ${currentVersion}</strong>.`;
-      
-      if (currentVersion === 'v1.11.66') {
-        bannerMessage += ` This is the current release version.`;
-      } else {
-        bannerMessage += ` This is an older version.`;
-      }
+
+      // Since the default version is the latest, this banner should only show for older versions
+      bannerMessage += ` This is an older version.`;
       
       banner.innerHTML = `
         <span style="font-size: 20px;">⚠️</span>
@@ -205,7 +205,7 @@ document.addEventListener('DOMContentLoaded', function() {
           <span style="display: flex; align-items: center; gap: 8px;">
             <strong>Documentation Version:</strong>
             <span style="background: var(--color-blue-100, #dbeafe); color: var(--color-blue-700, #1d4ed8); padding: 2px 8px; border-radius: 4px; font-weight: 500;">
-              ${currentVersion === 'main' ? 'latest (main)' : currentVersion}
+              ${currentVersion === 'main' || currentVersion === '{{ site.versioning.default_version }}' ? `${currentVersion} (latest)` : currentVersion}
             </span>
           </span>
       `;
@@ -228,7 +228,7 @@ document.addEventListener('DOMContentLoaded', function() {
         </div>
       `;
       
-      // Add version warning if not on default version
+      // Add version warning if not on default version or main
       if (currentVersion !== defaultVersion && currentVersion !== 'main') {
         metadataContent += `
           <div style="

--- a/docs/_includes/sidebar-version-switcher.html
+++ b/docs/_includes/sidebar-version-switcher.html
@@ -84,7 +84,7 @@ document.addEventListener('DOMContentLoaded', function() {
           const cleanPath = currentPath.replace(/\/v[\d.]+/, '');
           window.location.href = cleanPath || baseUrl || '/';
         } else {
-          // For versioned documentation (including v0.0.1)
+          // For versioned documentation (including v1.11.66)
           const cleanPath = currentPath.replace(baseUrl, '').replace(/\/v[\d.]+/, '');
           window.location.href = baseUrl + '/' + selectedVersion + cleanPath;
         }
@@ -153,8 +153,8 @@ document.addEventListener('DOMContentLoaded', function() {
       
       let bannerMessage = `You are viewing documentation for <strong>version ${currentVersion}</strong>.`;
       
-      if (currentVersion === 'v0.0.1') {
-        bannerMessage += ` This is the initial preview version.`;
+      if (currentVersion === 'v1.11.66') {
+        bannerMessage += ` This is the current release version.`;
       } else {
         bannerMessage += ` This is an older version.`;
       }

--- a/docs/_includes/sidebar-version-switcher.html
+++ b/docs/_includes/sidebar-version-switcher.html
@@ -222,7 +222,7 @@ document.addEventListener('DOMContentLoaded', function() {
       
       metadataContent += `
           <span style="display: flex; align-items: center; gap: 8px;">
-            <strong>Doc Version:</strong>
+            <strong>Versions:</strong>
             <span>v{{ site.doc_version }}</span>
           </span>
         </div>

--- a/docs/update_version.sh
+++ b/docs/update_version.sh
@@ -2,6 +2,7 @@
 
 # Script to update version information for local development
 # Reads OpenCue version from VERSION.in and updates _data/version.yml
+# Documentation version follows OpenCue software version
 
 # Get the OpenCue version from VERSION.in
 OPENCUE_VERSION=$(cat ../VERSION.in | tr -d '\n')
@@ -16,8 +17,8 @@ GIT_HASH=$(git rev-parse --short HEAD 2>/dev/null || echo "local")
 cat > _data/version.yml <<EOF
 # This file is auto-generated - do not edit manually
 # Run ./update_version.sh to update from VERSION.in
-version: "main"
-doc_version: "0.0.1"
+version: "v${OPENCUE_VERSION}"
+doc_version: "${OPENCUE_VERSION}"
 opencue_version: "${OPENCUE_VERSION}"
 build_date: "${CURRENT_DATE}"
 last_commit: "${CURRENT_DATE}"

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -10,27 +10,27 @@ nav_order: 999
 
 | Version | Status | Release Date | Documentation | Notes |
 |---------|---------|--------------|---------------|-------|
-| [main]({{ site.baseurl }}/) | **Development** | Continuous | [View →]({{ site.baseurl }}/) | Latest development version |
-| [v1.11.66]({{ site.baseurl }}/v1.11.66/) | **Release** | 2025 | [View →]({{ site.baseurl }}/v1.11.66/) | Current release version |
+| [v1.11.66]({{ site.baseurl }}/) | **Latest** | 2025 | [View →]({{ site.baseurl }}/) | Current stable release (latest) |
+| [main]({{ site.baseurl }}/) | **Development** | Continuous | [View →]({{ site.baseurl }}/) | Development branch (same as v1.11.66) |
 
 ## Version Policy
 
 ### Documentation Versioning
 The documentation follows its own versioning scheme separate from OpenCue software:
 
-- **main**: Latest development version with newest features and changes
-- **vXXX.XXX.XXX**: Current release documentation
+- **v1.11.66**: Current stable release (latest content)
+- **main**: Development branch (currently same as v1.11.66)
 
 ### OpenCue Software Version
 Current OpenCue software version: **{{ site.opencue_version }}**
 
 ## Development Status
 
-🚧 **Documentation is currently under active development**
+📘 **Documentation Status**
 
-- **main**: Contains the latest changes and improvements
-- **v1.11.66**: Current stable release documentation
-- **v1.0.0**: Will be the first stable release (coming soon)
+- **v1.11.66**: Current stable release - all documentation points here
+- **main**: Development version - currently same content as v1.11.66
+- Future versions will be created as new releases are made
 
 ## How to Switch Versions
 

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -11,7 +11,7 @@ nav_order: 999
 | Version | Status | Release Date | Documentation | Notes |
 |---------|---------|--------------|---------------|-------|
 | [main]({{ site.baseurl }}/) | **Development** | Continuous | [View →]({{ site.baseurl }}/) | Latest development version |
-| [v0.0.1]({{ site.baseurl }}/v0.0.1/) | **Preview** | In Progress | [View →]({{ site.baseurl }}/v0.0.1/) | Initial documentation version |
+| [v1.11.66]({{ site.baseurl }}/v1.11.66/) | **Release** | 2025 | [View →]({{ site.baseurl }}/v1.11.66/) | Current release version |
 
 ## Version Policy
 
@@ -19,8 +19,7 @@ nav_order: 999
 The documentation follows its own versioning scheme separate from OpenCue software:
 
 - **main**: Latest development version with newest features and changes
-- **v0.0.1**: Initial documentation version (preview/beta state)
-- Future versions will follow semantic versioning (v1.0.0, v1.1.0, etc.)
+- **vXXX.XXX.XXX**: Current release documentation
 
 ### OpenCue Software Version
 Current OpenCue software version: **{{ site.opencue_version }}**
@@ -30,7 +29,7 @@ Current OpenCue software version: **{{ site.opencue_version }}**
 🚧 **Documentation is currently under active development**
 
 - **main**: Contains the latest changes and improvements
-- **v0.0.1**: Represents the initial documentation structure and content
+- **v1.11.66**: Current stable release documentation
 - **v1.0.0**: Will be the first stable release (coming soon)
 
 ## How to Switch Versions

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -16,10 +16,11 @@ nav_order: 999
 ## Version Policy
 
 ### Documentation Versioning
-The documentation follows its own versioning scheme separate from OpenCue software:
+The documentation follows the OpenCue software versioning:
 
-- **v1.11.66**: Current stable release (latest content)
+- **v1.11.66**: Current OpenCue release documentation
 - **main**: Development branch (currently same as v1.11.66)
+- Documentation versions are aligned with OpenCue software releases
 
 ### OpenCue Software Version
 Current OpenCue software version: **{{ site.opencue_version }}**

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: <i class='fas fa-code-branch'></i>&nbsp;Doc Versions
+title: <i class='fas fa-code-branch'></i>&nbsp;Versions
 nav_order: 999
 ---
 


### PR DESCRIPTION
- Set v1.11.66 as the default documentation version
- Configure both v1.11.66 and main to point to latest content
- Mark v1.11.66 as the current stable release in labels and structure
- Remove "under active development" notices
- Make version switcher logic generic using Jekyll config variables
- Remove hardcoded version references in JavaScript for maintainability
- Update _config.yml and related settings for new release
- The documentation (docs/) now follows the OpenCue software versioning (VERSION.in)
- Changed the label in the page metadata display from "Doc Version" to "Versions"

**Link the Issue(s) this Pull Request is related to.**
- #1800 