### PR TITLE
[docs] Add News: OpenCue Project Review 2025

### DIFF
--- a/docs/news/2019-04-18-season-of-docs-2019.md
+++ b/docs/news/2019-04-18-season-of-docs-2019.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Apr 18, 2019: Season of Docs 2019"
 parent: News
-nav_order: 9
+nav_order: 10
 ---
 
 # Season of Docs 2019

--- a/docs/news/2019-07-08-opencue-birds-of-a-feather-at-siggraph.md
+++ b/docs/news/2019-07-08-opencue-birds-of-a-feather-at-siggraph.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Jul 8, 2019: OpenCue Birds of a Feather at SIGGRAPH"
 parent: News
-nav_order: 8
+nav_order: 9
 ---
 
 # OpenCue Birds of a Feather at SIGGRAPH

--- a/docs/news/2019-07-22-opencue-steering-committee-at-siggraph.md
+++ b/docs/news/2019-07-22-opencue-steering-committee-at-siggraph.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Jul 22, 2019: OpenCue Steering Committee at SIGGRAPH"
 parent: News
-nav_order: 7
+nav_order: 8
 ---
 
 # OpenCue Steering Committee at SIGGRAPH

--- a/docs/news/2019-09-20-opencue-at-siggraph-recording.md
+++ b/docs/news/2019-09-20-opencue-at-siggraph-recording.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Sept 20, 2019: OpenCue at SIGGRAPH recording"
 parent: News
-nav_order: 6
+nav_order: 7
 ---
 
 # OpenCue at SIGGRAPH recording

--- a/docs/news/2019-12-05-la-pipeline-developers-meetup.md
+++ b/docs/news/2019-12-05-la-pipeline-developers-meetup.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Dec 5, 2019: LA Pipeline Developers Meetup"
 parent: News
-nav_order: 5
+nav_order: 6
 ---
 
 # JLA Pipeline Developers Meetup

--- a/docs/news/2019-12-18-sony-pictures-imageworks-case-study.md
+++ b/docs/news/2019-12-18-sony-pictures-imageworks-case-study.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Dec 18, 2019: Sony Pictures Imageworks case study"
 parent: News
-nav_order: 4
+nav_order: 5
 ---
 
 # Sony Pictures Imageworks case study

--- a/docs/news/2020-08-27-google-summer-of-code-20-cloud-plugin.md
+++ b/docs/news/2020-08-27-google-summer-of-code-20-cloud-plugin.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Aug 27, 2020: Google Summer of Code '20 - Cloud Plugin"
 parent: News
-nav_order: 3
+nav_order: 4
 ---
 
 # Google Summer of Code '20 - Cloud Plugin

--- a/docs/news/2021-08-04-open-source-days-2021.md
+++ b/docs/news/2021-08-04-open-source-days-2021.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Aug 4, 2021: Open Source Days 2021"
 parent: News
-nav_order: 2
+nav_order: 3
 ---
 
 # Open Source Days 2021

--- a/docs/news/2024-05-24-opencue-project-review-2024.md
+++ b/docs/news/2024-05-24-opencue-project-review-2024.md
@@ -2,20 +2,24 @@
 layout: default
 title: "May 24, 2024: OpenCue Project Review 2024"
 parent: News
-nav_order: 1
+nav_order: 2
 ---
 
 # OpenCue Project Review 2024
 
-### OpenCue presentation at ASWF Open Source Days 2024
+### OpenCue Virtual Town Hall Series
 
 #### May 24, 2024
 
 ---
 
-Thanks to everyone who joined us for the OpenCue Project Review 2024!
+Thanks to everyone who joined us for the OpenCue Virtual Town Hall 2024!
 
 Diego Tavares, Chair of the Technical Steering Committee, presented an overview of the project's progress and upcoming roadmap. The presentation covered OpenCue's evolution, milestones, community contributions, and strategic goals for the next year.
+
+<div style="text-align: center; margin: 30px 0;">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/h4u3DrI2_KI" title="OpenCue Virtual Town Hall 2024" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
 
 ## Highlights from the Presentation:
 

--- a/docs/news/2025-08-10-opencue-project-review-2025.md
+++ b/docs/news/2025-08-10-opencue-project-review-2025.md
@@ -1,0 +1,134 @@
+---
+layout: default
+title: "August 10, 2025: OpenCue Project Review 2025"
+parent: News
+nav_order: 1
+---
+
+# OpenCue Project Review 2025
+
+### OpenCue Virtual Town Hall Series
+
+#### August 10, 2025
+
+---
+
+Thanks to everyone who joined us for the OpenCue Virtual Town Hall 2025!
+
+The Technical Steering Committee presented a comprehensive overview of OpenCue's progress, community growth, and exciting roadmap ahead. The presentation showcased major achievements, new features, and strategic initiatives for the coming year.
+
+<div style="text-align: center; margin: 30px 0;">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/GG7F0UM8T1Q" title="OpenCue Virtual Town Hall 2025" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+## About OpenCue
+
+OpenCue is an open-source render farm management system that distributes workloads from artists across a cluster of computers. It has been used at Sony Pictures Imageworks, rendering all movies and animations since 2019.
+
+## Community Overview
+
+- Active community with 30-40+ contributors from various industries
+- Currently searching for new TSC members
+- Average pull request merge time reduced from 3 months to 8 days
+- 80% contributor retention rate
+- 485% increase in pull requests contributions
+
+## Major Announcements
+
+### CueWeb Release
+Official announcement and release of CueWeb, our new browser-based visual interface featuring:
+- Modern login integration
+- Comprehensive job monitoring
+- Advanced filtering capabilities
+- Intuitive user experience
+
+### Rust RQD Release
+The render node monitoring agent has been completely rewritten in Rust, delivering:
+- **5x smaller** memory footprint
+- **50% reduction** in CPU usage
+- Zero memory leaks
+- Enhanced performance and reliability
+
+## Latest Features
+
+### Containerized Jobs (Docker Support)
+- Run frames in Docker environments
+- Simplified dependency management
+- Execute legacy jobs on modern operating systems
+- Improved job isolation and security
+
+### Grafana Loki Integration
+- Log aggregation and analysis
+- Advanced querying capabilities
+- Real-time charting and visualization
+- Intelligent alerting system
+
+### OpenCue Pip Packages Released
+Installation simplified with official pip packages:
+
+```bash
+pip install opencue-proto opencue-pycue opencue-pyoutline opencue-rqd opencue-cueadmin opencue-cueman opencue-cuesubmit opencue-cuegui
+```
+
+- [opencue-proto](https://pypi.org/project/opencue-proto/)
+  - `pip install opencue-proto`
+- [opencue-pycue](https://pypi.org/project/opencue-pycue/)
+  - `pip install opencue-pycue`
+- [opencue-pyoutline](https://pypi.org/project/opencue-pyoutline/)
+  - `pip install opencue-pyoutline`
+- [opencue-rqd](https://pypi.org/project/opencue-rqd/)
+  - `pip install opencue-rqd`
+- [opencue-cueadmin](https://pypi.org/project/opencue-cueadmin/)
+  - `pip install opencue-cueadmin`
+- [opencue-cueman](https://pypi.org/project/opencue-cueman/)
+  - `pip install opencue-cueman`
+- [opencue-cuesubmit](https://pypi.org/project/opencue-cuesubmit/)
+  - `pip install opencue-cuesubmit`
+- [opencue-cuegui](https://pypi.org/project/opencue-cuegui/)
+  - `pip install opencue-cuegui`
+
+**Note:** Cuebot, Opencue REST Gateway, and CueWeb are deployed using Docker. For more information, see the Opencue's docker compose file (PostgreSQL, Cuebot, Flyway, RQD, OpenCue REST Gateway, and CueWeb): [docker-compose.yml](https://github.com/AcademySoftwareFoundation/OpenCue/blob/master/docker-compose.yml). 
+
+#### Getting Started
+- [Using the OpenCue Sandbox for Testing](https://docs.opencue.io/docs/developer-guide/sandbox-testing/)
+- [Quick starts](https://docs.opencue.io/docs/quick-starts)
+- [Getting Started](https://docs.opencue.io/docs/getting-started)
+
+### New Documentation Website
+Comprehensive documentation now available at [https://docs.opencue.io/](https://docs.opencue.io/) featuring:
+- Video tutorials
+- User guides
+- API documentation
+- Best practices
+
+## Upcoming Features
+
+### Distributed Booking
+- Addresses database bottlenecks for large-scale render farms
+- Enhanced scalability for enterprise deployments
+- Improved job distribution efficiency
+
+### Farm Auto-scaling
+- Native autoscaling capabilities
+- Automatic resource management based on queue pressure
+- Cloud infrastructure optimization
+- Cost-effective resource utilization
+
+## Rust RQD Migration Timeline: 2025-2026
+The complete migration to Rust RQD is planned for completion by 2026, ensuring a smooth transition for all users while maintaining backward compatibility.
+
+## Get Involved
+
+The OpenCue TSC is actively seeking new members! Join our vibrant community to:
+- Contribute to cutting-edge render farm technology
+- Collaborate with industry professionals
+- Shape the future of OpenCue
+- Share your expertise and learn from others
+
+Stay connected with the OpenCue community for more updates as we continue to innovate and evolve the platform with your support!
+
+[Our slides from the presentation are now available online](https://drive.google.com/file/d/1K9RQj9ewKgbuXlnVSnA5So47-6L1NnB2/view?usp=sharing)
+
+---
+
+[Watch the full presentation](https://www.youtube.com/watch?v=GG7F0UM8T1Q) | [Visit our GitHub](https://github.com/AcademySoftwareFoundation/OpenCue) | [Join the discussion](https://lists.aswf.io/g/opencue-dev)


### PR DESCRIPTION
- Add 2025 OpenCue Project Review 2025 (OpenCue Virtual Town Hall Series) with embedded video
- Include PDF slides link for 2025 presentation
- Include video (OpenCue Project Review 2024 - OpenCue Virtual Town Hall Series) in existing documentation
- Update navigation order for news pages

**Link the Issue(s) this Pull Request is related to.**
- #1800