### PR TITLE
[cueman] Add Comprehensive Unit Tests for Job Termination Logic in cueman

### DIFF
--- a/cueman/pyproject.toml
+++ b/cueman/pyproject.toml
@@ -9,7 +9,10 @@ name = "opencue_cueman"
 dynamic = ["version"]
 dependencies = [
     "opencue_pycue",
-    "opencue_cueadmin"
+    "opencue_cueadmin",
+    "mock>=2.0.0",
+    "pyfakefs>=5.2.3",
+    "pytest>=6.0"
 ]
 requires-python = ">3.7"
 description = "Cueman is a command-line job management tool for OpenCue that provides efficient job control operations. It offers a streamlined interface for managing jobs, frames, and processes with advanced filtering and batch operation capabilities."


### PR DESCRIPTION
Create unit tests for the terminateJobs() function covering batch termination,
reason logging, and exception handling.

Tests added to /cueman/tests/test_main.py:
- Single and batch job termination with reason tracking
- Kill reason formatting with username from getpass.getuser()
- Empty job list handling
- Exception propagation during kill operations
- Logging output verification with proper logger mocking
- Termination across various job states (RUNNING, WAITING, DEAD, SUCCEEDED)

Implementation notes:
- Removed tests for non-existent confirm_termination function
- Removed tests for unsupported force parameter
- Updated all mocking to match actual terminateJobs implementation
- Mock job.kill(), getpass.getuser(), and logger for proper isolation

Add pytest to main dependencies for improved testing workflow

- Move pytest from optional test dependencies to main dependencies
- Ensures pytest is available when cueman is installed
- Simplifies test execution without requiring separate test dependency installation

**Link the Issue(s) this Pull Request is related to.**
#1935 

Co-authored-by: Aniket Singh Yadav <singhyadavaniket43@gmail.com>
Co-authored-by: Ramon Figueiredo <rfigueiredo@imageworks.com>