### PR TITLE
[cuegui] Remove "Use Local Cores" option from Layer and Frame context menus

### DIFF
--- a/cuegui/cuegui/FrameMonitorTree.py
+++ b/cuegui/cuegui/FrameMonitorTree.py
@@ -914,9 +914,6 @@ class FrameContextMenu(QtWidgets.QMenu):
         elif count == 2:
             self.__menuActions.frames().addAction(self, "xdiff2")
 
-        if int(self.app.settings.value("DisableDeeding", 0)) == 0:
-            self.__menuActions.frames().addAction(self, "useLocalCores")
-
         if cuegui.Constants.OUTPUT_VIEWERS:
             job = widget.getJob()
             if job is not None:

--- a/cuegui/cuegui/JobMonitorGraph.py
+++ b/cuegui/cuegui/JobMonitorGraph.py
@@ -62,7 +62,6 @@ class JobMonitorGraph(AbstractGraphWidget):
         self.__menuActions.layers().addAction(dependMenu, "markdone")
         menu.addMenu(dependMenu)
         menu.addSeparator()
-        self.__menuActions.layers().addAction(menu, "useLocalCores")
         self.__menuActions.layers().addAction(menu, "reorder")
         self.__menuActions.layers().addAction(menu, "stagger")
         menu.addSeparator()

--- a/cuegui/cuegui/LayerMonitorTree.py
+++ b/cuegui/cuegui/LayerMonitorTree.py
@@ -266,9 +266,6 @@ class LayerMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
 
         if len(__selectedObjects) == 1:
             menu.addSeparator()
-            if int(self.app.settings.value("DisableDeeding", 0)) == 0:
-                self.__menuActions.layers().addAction(menu, "useLocalCores") \
-                    .setEnabled(not readonly)
             if len({layer.data.range for layer in __selectedObjects}) == 1:
                 self.__menuActions.layers().addAction(menu, "reorder").setEnabled(not readonly)
             self.__menuActions.layers().addAction(menu, "stagger").setEnabled(not readonly)

--- a/cuegui/cuegui/LayerMonitorTree.py
+++ b/cuegui/cuegui/LayerMonitorTree.py
@@ -266,9 +266,18 @@ class LayerMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
 
         if len(__selectedObjects) == 1:
             menu.addSeparator()
-            if len({layer.data.range for layer in __selectedObjects}) == 1:
-                self.__menuActions.layers().addAction(menu, "reorder").setEnabled(not readonly)
-            self.__menuActions.layers().addAction(menu, "stagger").setEnabled(not readonly)
+            try:
+                if int(self.app.settings.value("DisableDeeding", 0)) == 0:
+                    if len({layer.data.range for layer in __selectedObjects}) == 1:
+                        reorder_action = self.__menuActions.layers().addAction(menu, "reorder")
+                        reorder_action.setEnabled(not readonly)
+                    self.__menuActions.layers().addAction(menu, "stagger").setEnabled(not readonly)
+            except (ValueError, TypeError):
+                # If parsing fails, show the menu items by default
+                if len({layer.data.range for layer in __selectedObjects}) == 1:
+                    reorder_action = self.__menuActions.layers().addAction(menu, "reorder")
+                    reorder_action.setEnabled(not readonly)
+                self.__menuActions.layers().addAction(menu, "stagger").setEnabled(not readonly)
 
         menu.addSeparator()
         self.__menuActions.layers().addAction(menu, "setProperties").setEnabled(not readonly)


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/1958

**Summarize your change.**
- The "Use Local Cores" functionality only works correctly at the Job level due to cue booking logic that assigns frames in order. When used at Layer or Frame level, it causes confusion as frames are still booked in sequence regardless of selection, and currently throws errors about no pending frames meeting criteria.
- Keeping the option only at Job level where it functions as intended.