### PR TITLE
[cuegui] Fix KeyError when unmonitoring finished/archived jobs

### DIFF
--- a/cuegui/cuegui/AbstractTreeWidget.py
+++ b/cuegui/cuegui/AbstractTreeWidget.py
@@ -352,7 +352,9 @@ class AbstractTreeWidget(QtWidgets.QTreeWidget):
         self.takeTopLevelItem(self.indexOfTopLevelItem(item))
         objectClass = item.rpcObject.__class__.__name__
         objectId = item.rpcObject.id()
-        del self._items['{}.{}'.format(objectClass, objectId)]
+        # Use pop with default value to avoid KeyError when item doesn't exist
+        # This can happen with archived jobs or when items are already removed
+        self._items.pop('{}.{}'.format(objectClass, objectId), None)
 
     def removeAllItems(self):
         """Removes all items from the tree."""

--- a/cuegui/cuegui/JobMonitorTree.py
+++ b/cuegui/cuegui/JobMonitorTree.py
@@ -389,18 +389,17 @@ class JobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         self.__jobTimeLoaded.pop(item.rpcObject, "")
         try:
             jobKey = cuegui.Utils.getObjectKey(item.rpcObject)
-            # Remove the item from the main _items dictionary as well as the
-            # __dependentJobs and the reverseDependent dictionaries
-            # pylint: disable=protected-access
-            cuegui.AbstractTreeWidget.AbstractTreeWidget._removeItem(self, item)
+            # Remove the item from the __dependentJobs and the reverseDependent dictionaries
             dependent_jobs = self.__dependentJobs.get(jobKey, [])
             for djob in dependent_jobs:
-                del self.__reverseDependents[djob]
-            del self.__reverseDependents[jobKey]
-        except KeyError:
+                self.__reverseDependents.pop(djob, None)
+            self.__reverseDependents.pop(jobKey, None)
+            self.__dependentJobs.pop(jobKey, None)
+        except (KeyError, AttributeError):
             # Dependent jobs are not stored in as keys the main self._items
             # dictionary, trying to remove dependent jobs from self._items
             # raises a KeyError, which we can safely ignore
+            # AttributeError can occur if the rpcObject doesn't have an id() method
             pass
 
     def removeAllItems(self):


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/1963

**Summarize your change.**
- Replace `dict` `del` operations with safe `pop()` to prevent `KeyError`
- Remove duplicate `_removeItem` call in `JobMonitorTree`
- Handle missing items gracefully in removal operations
- Add `AttributeError` handling for edge cases

Fixes issue where unmonitoring jobs older than 48 hours would fail with `KeyError` in `AbstractTreeWidget._removeItem`