### PR TITLE
[cueman] Add Comprehensive Unit Tests for buildFrameSearch

### DIFF
--- a/cueman/tests/test_frame_search.py
+++ b/cueman/tests/test_frame_search.py
@@ -1,3 +1,20 @@
+#!/usr/bin/env python
+
+#  Copyright Contributors to the OpenCue Project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
 """
 Unit tests for buildFrameSearch function in cueman.main
 """
@@ -14,12 +31,15 @@ except ImportError:
     except ImportError:
         # pylint: disable=too-few-public-methods
         class JobPb2Mock:
+            """Mock class for job_pb2 when it's not available."""
             RUNNING = 'RUNNING'
             WAITING = 'WAITING'
         job_pb2 = JobPb2Mock()
 
 class TestBuildFrameSearch(unittest.TestCase):
+    """Test cases for the buildFrameSearch function in cueman.main."""
     def setUp(self):
+        """Set up test fixtures with default arguments."""
         self.default_args = mock.Mock()
         self.default_args.layer = None
         self.default_args.range = None
@@ -30,6 +50,7 @@ class TestBuildFrameSearch(unittest.TestCase):
         self.default_args.limit = 1000
 
     def test_default_search(self):
+        """Test default search construction with default memory and duration."""
         with mock.patch("cueadmin.common.handleIntCriterion") as mock_handle:
             mock_handle.side_effect = [
                 [mock.Mock(value=10485)],
@@ -40,6 +61,7 @@ class TestBuildFrameSearch(unittest.TestCase):
         self.assertEqual(result, expected)
 
     def test_layer_filter(self):
+        """Test layer filter integration with single and multiple layers."""
         args = mock.Mock(**self.default_args.__dict__)
         args.layer = ["layer1", "layer2"]
         result = main.buildFrameSearch(args)
@@ -47,6 +69,7 @@ class TestBuildFrameSearch(unittest.TestCase):
         self.assertEqual(result["layer"], ["layer1", "layer2"])
 
     def test_range_filter(self):
+        """Test range filter validation for frame ranges."""
         args = mock.Mock(**self.default_args.__dict__)
         args.range = "1-100"
         result = main.buildFrameSearch(args)
@@ -54,6 +77,7 @@ class TestBuildFrameSearch(unittest.TestCase):
         self.assertEqual(result["range"], "1-100")
 
     def test_state_filter_conversion(self):
+        """Test state filter conversion from string to proper state enum."""
         args = mock.Mock(**self.default_args.__dict__)
         args.state = ["RUNNING", "WAITING"]
         with mock.patch("cueadmin.common.Convert.strToFrameState") as mock_convert:
@@ -63,6 +87,7 @@ class TestBuildFrameSearch(unittest.TestCase):
         self.assertEqual(result["state"], [job_pb2.RUNNING, job_pb2.WAITING])
 
     def test_memory_filter(self):
+        """Test memory filter application with range and conversion."""
         args = mock.Mock(**self.default_args.__dict__)
         args.memory = "2-4"
         with mock.patch("cueadmin.common.handleIntCriterion") as mock_handle:
@@ -72,8 +97,10 @@ class TestBuildFrameSearch(unittest.TestCase):
             ]
             result = main.buildFrameSearch(args)
         self.assertIn("memory", result)
+        self.assertEqual(result["memory"], "4194304")
 
     def test_duration_filter(self):
+        """Test duration filter application with range and conversion."""
         args = mock.Mock(**self.default_args.__dict__)
         args.duration = "1-2"
         with mock.patch("cueadmin.common.handleIntCriterion") as mock_handle:
@@ -83,8 +110,10 @@ class TestBuildFrameSearch(unittest.TestCase):
             ]
             result = main.buildFrameSearch(args)
         self.assertIn("duration", result)
+        self.assertEqual(result["duration"], "7200")
 
     def test_pagination_inclusion(self):
+        """Test that page number is included in search parameters."""
         args = mock.Mock(**self.default_args.__dict__)
         args.page = 2
         result = main.buildFrameSearch(args)
@@ -92,6 +121,7 @@ class TestBuildFrameSearch(unittest.TestCase):
         self.assertEqual(result["page"], 2)
 
     def test_limit_inclusion(self):
+        """Test that result limit is correctly handled."""
         args = mock.Mock(**self.default_args.__dict__)
         args.limit = 500
         result = main.buildFrameSearch(args)
@@ -99,6 +129,7 @@ class TestBuildFrameSearch(unittest.TestCase):
         self.assertEqual(result["limit"], 500)
 
     def test_empty_filters(self):
+        """Test that function returns empty dict when no filters are provided."""
         args = mock.Mock()
         args.layer = None
         args.range = None
@@ -109,6 +140,95 @@ class TestBuildFrameSearch(unittest.TestCase):
         args.limit = None
         result = main.buildFrameSearch(args)
         self.assertEqual(result, {})
+
+    def test_single_layer_filter(self):
+        """Test layer filter with a single layer."""
+        args = mock.Mock(**self.default_args.__dict__)
+        args.layer = ["single_layer"]
+        result = main.buildFrameSearch(args)
+        self.assertIn("layer", result)
+        self.assertEqual(result["layer"], ["single_layer"])
+
+    def test_memory_filter_no_results(self):
+        """Test memory filter when handleIntCriterion returns None."""
+        args = mock.Mock(**self.default_args.__dict__)
+        args.memory = "invalid"
+        with mock.patch("cueadmin.common.handleIntCriterion") as mock_handle:
+            mock_handle.return_value = None
+            result = main.buildFrameSearch(args)
+        self.assertNotIn("memory", result)
+
+    def test_duration_filter_no_results(self):
+        """Test duration filter when handleIntCriterion returns None."""
+        args = mock.Mock(**self.default_args.__dict__)
+        args.duration = "invalid"
+        with mock.patch("cueadmin.common.handleIntCriterion") as mock_handle:
+            mock_handle.return_value = None
+            result = main.buildFrameSearch(args)
+        self.assertNotIn("duration", result)
+
+    def test_combined_filters(self):
+        """Test multiple filters applied simultaneously."""
+        args = mock.Mock()
+        args.layer = ["layer1"]
+        args.range = "1-50"
+        args.state = ["RUNNING"]
+        args.memory = 2.0
+        args.duration = 1.0
+        args.page = 1
+        args.limit = 100
+
+        with mock.patch("cueadmin.common.Convert.strToFrameState") as mock_convert, \
+             mock.patch("cueadmin.common.handleIntCriterion") as mock_handle:
+            mock_convert.return_value = job_pb2.RUNNING
+            mock_handle.side_effect = [
+                [mock.Mock(value=2097152)],  # memory
+                [mock.Mock(value=3600)],      # duration
+            ]
+            result = main.buildFrameSearch(args)
+
+        self.assertIn("layer", result)
+        self.assertIn("range", result)
+        self.assertIn("state", result)
+        self.assertIn("memory", result)
+        self.assertIn("duration", result)
+        self.assertIn("page", result)
+        self.assertIn("limit", result)
+        self.assertEqual(result["layer"], ["layer1"])
+        self.assertEqual(result["range"], "1-50")
+        self.assertEqual(result["state"], [job_pb2.RUNNING])
+        self.assertEqual(result["memory"], "2097152")
+        self.assertEqual(result["duration"], "3600")
+        self.assertEqual(result["page"], 1)
+        self.assertEqual(result["limit"], 100)
+
+    def test_state_single_value(self):
+        """Test state filter with a single state value."""
+        args = mock.Mock(**self.default_args.__dict__)
+        args.state = ["RUNNING"]
+        with mock.patch("cueadmin.common.Convert.strToFrameState") as mock_convert:
+            mock_convert.return_value = job_pb2.RUNNING
+            result = main.buildFrameSearch(args)
+        self.assertIn("state", result)
+        self.assertEqual(result["state"], [job_pb2.RUNNING])
+
+    def test_memory_filter_empty_list(self):
+        """Test memory filter when handleIntCriterion returns an empty list."""
+        args = mock.Mock(**self.default_args.__dict__)
+        args.memory = 0
+        with mock.patch("cueadmin.common.handleIntCriterion") as mock_handle:
+            mock_handle.return_value = []
+            result = main.buildFrameSearch(args)
+        self.assertNotIn("memory", result)
+
+    def test_duration_filter_empty_list(self):
+        """Test duration filter when handleIntCriterion returns an empty list."""
+        args = mock.Mock(**self.default_args.__dict__)
+        args.duration = 0
+        with mock.patch("cueadmin.common.handleIntCriterion") as mock_handle:
+            mock_handle.return_value = []
+            result = main.buildFrameSearch(args)
+        self.assertNotIn("duration", result)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- #1932 

**Summarize your change.**
This pull request adds a new test module, test_frame_search.py, which provides comprehensive unit tests for the buildFrameSearch function in cueman.main.

Test cases included:

- Default search construction: Verifies correct output with default arguments.
- Layer filter integration: Tests handling of single and multiple layer filters.
- Range filter validation: Ensures frame range arguments are processed correctly.
- State filter conversion: Mocks state conversion to validate correct state handling.
- Memory filter application: Tests memory filter logic, including range and conversion.
- Duration filter application: Tests duration filter logic, including range and conversion.
- Pagination parameter inclusion: Checks that page number is included in search parameters.
- Limit parameter inclusion: Verifies correct handling of result limit.
- Empty filter scenarios: Ensures function returns an empty dictionary when no filters are provided.
- Edge case handling: Tests None/empty returns from handleIntCriterion.
- Combined filters: Validates all filters working simultaneously.
- Single value filters: Tests single layer and single state value handling.

Additional improvements:
- Added Apache 2.0 license header for OpenCue compliance
- Added comprehensive docstrings for all classes and methods
- Fixed incomplete assertions in memory_filter and duration_filter tests

Co-authored-by: Aniket Singh Yadav <singhyadavaniket43@gmail.com>
Co-authored-by: Ramon Figueiredo <rfigueiredo@imageworks.com>
