### PR TITLE
[cuegui] Fix AttributeError when clicking on GroupWidgetItem in JobMonitorTree

### DIFF
--- a/cuegui/cuegui/AbstractTreeWidget.py
+++ b/cuegui/cuegui/AbstractTreeWidget.py
@@ -286,7 +286,8 @@ class AbstractTreeWidget(QtWidgets.QTreeWidget):
         @type  col: int
         @param col: Column number single clicked on"""
         del col
-        cuegui.app().single_click.emit(item.rpcObject)
+        if hasattr(item, 'rpcObject'):
+            cuegui.app().single_click.emit(item.rpcObject)
 
     @staticmethod
     def __itemDoubleClickedEmitToApp(item, col):

--- a/cuegui/cuegui/JobMonitorTree.py
+++ b/cuegui/cuegui/JobMonitorTree.py
@@ -249,9 +249,10 @@ class JobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         @param item: The item clicked on
         @type  col: int
         @param col: The column clicked on"""
-        job = item.rpcObject
-        if col == COLUMN_COMMENT and job.isCommented():
-            self.__menuActions.jobs().viewComments([job])
+        if hasattr(item, 'rpcObject'):
+            job = item.rpcObject
+            if col == COLUMN_COMMENT and job.isCommented():
+                self.__menuActions.jobs().viewComments([job])
 
     def startDrag(self, dropActions):
         """Triggers a drag event"""


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- #1975 

**Summarize your change.**

[cuegui] Fix AttributeError when clicking on GroupWidgetItem in JobMonitorTree
- Add hasattr checks before accessing rpcObject attribute
- GroupWidgetItem doesn't inherit from AbstractWidgetItem and lacks rpcObject
- Prevents errors when clicking on group headers in the job tree