### PR TITLE
[cuegui] Fix Unmonitor Finished feature for grouped job views

### DIFF
--- a/cuegui/cuegui/AbstractTreeWidget.py
+++ b/cuegui/cuegui/AbstractTreeWidget.py
@@ -349,8 +349,9 @@ class AbstractTreeWidget(QtWidgets.QTreeWidget):
             item.setSelected(False)
 
         if item.parent():
-            self.invisibleRootItem().removeChild(item)
-        self.takeTopLevelItem(self.indexOfTopLevelItem(item))
+            item.parent().removeChild(item)
+        else:
+            self.takeTopLevelItem(self.indexOfTopLevelItem(item))
         objectClass = item.rpcObject.__class__.__name__
         objectId = item.rpcObject.id()
         # Use pop with default value to avoid KeyError when item doesn't exist

--- a/cuegui/cuegui/JobMonitorTree.py
+++ b/cuegui/cuegui/JobMonitorTree.py
@@ -469,14 +469,13 @@ class JobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
 
         # Clean up empty groups after removing items
         for group_key in groups_to_check:
-            if group_key in self.__groupItems:
-                group_item = self.__groupItems[group_key]
-                if group_item.childCount() == 0:
-                    # Remove empty group
-                    index = self.indexOfTopLevelItem(group_item)
-                    if index >= 0:
-                        self.takeTopLevelItem(index)
-                    del self.__groupItems[group_key]
+            group_item = self.__groupItems.get(group_key, None)
+            if group_item and group_item.childCount() == 0:
+                # Remove empty group
+                index = self.indexOfTopLevelItem(group_item)
+                if index >= 0:
+                    self.takeTopLevelItem(index)
+                del self.__groupItems[group_key]
 
     def getUserColors(self):
         """Returns the colored jobs to be saved"""

--- a/cuegui/cuegui/JobMonitorTree.py
+++ b/cuegui/cuegui/JobMonitorTree.py
@@ -434,8 +434,49 @@ class JobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
 
     def removeFinishedItems(self):
         """Removes finished jobs"""
+        # When in grouped modes, we need to search within group items as well
+        items_to_remove = []
+        groups_to_check = set()
+
+        # First check root level items
         for item in self.findItems("Finished", QtCore.Qt.MatchFixedString, COLUMN_STATE):
+            items_to_remove.append(item)
+
+        # If we're in a grouped mode, also check within group items
+        if self.__groupByMode in ["Show-Shot", "Show-Shot-Username"]:
+            # Iterate through all group items
+            for group_key, group_item in self.__groupItems.items():
+                # Check children of each group
+                for i in range(group_item.childCount()):
+                    child = group_item.child(i)
+                    # Check if this child job is finished
+                    if (hasattr(child, 'rpcObject') and
+                            child.rpcObject.data.state == opencue.api.job_pb2.FINISHED):
+                        items_to_remove.append(child)
+                        groups_to_check.add(group_key)
+        elif self.__groupByMode == "Dependent":
+            # For dependent mode, check children of parent jobs
+            for parent_item in self._items.values():
+                for i in range(parent_item.childCount()):
+                    child = parent_item.child(i)
+                    if (hasattr(child, 'rpcObject') and
+                            child.rpcObject.data.state == opencue.api.job_pb2.FINISHED):
+                        items_to_remove.append(child)
+
+        # Remove all found finished items
+        for item in items_to_remove:
             self.removeItem(item)
+
+        # Clean up empty groups after removing items
+        for group_key in groups_to_check:
+            if group_key in self.__groupItems:
+                group_item = self.__groupItems[group_key]
+                if group_item.childCount() == 0:
+                    # Remove empty group
+                    index = self.indexOfTopLevelItem(group_item)
+                    if index >= 0:
+                        self.takeTopLevelItem(index)
+                    del self.__groupItems[group_key]
 
     def getUserColors(self):
         """Returns the colored jobs to be saved"""


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/1977

**Summarize your change.**
The "Unmonitor Finished" button was not working when jobs were grouped by "Show-Shot" or "Show-Shot-Username" because it only searched for finished jobs at the root level of the tree.

- Update `removeFinishedItems()` to search within group items
- Fix `_removeItem()` to properly handle parent-child relationships
- Clean up empty groups after removing their children
- Maintain compatibility with Clear and Dependent grouping modes