### PR TITLE
[cueadmin]  Add allocation management tests

### DIFF
--- a/cueman/tests/test_allocation_command.py
+++ b/cueman/tests/test_allocation_command.py
@@ -4,7 +4,7 @@ Unit tests for allocation management behaviors using opencue.api.
 import unittest
 from unittest.mock import patch, MagicMock
 
-import opencue.api as api
+from opencue import api
 
 class TestAllocationCommands(unittest.TestCase):
     @patch('opencue.api.createAllocation')


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- #1919 

**Summarize your change.**
This PR adds unit tests for allocation management in` cueman` that patch and exercise the real `opencue.api `entry points.

- test_create_alloc_valid — calls getFacility + createAllocation; asserts both are invoked with expected args.
- test_create_alloc_duplicate_name — createAllocation raises ValueError on duplicate name.
- test_delete_alloc_empty — findAllocation + getHosts (empty) then delete; delete is called once.
- test_delete_alloc_non_empty — findAllocation + getHosts (non-empty); verifies delete is not called and guard raises RuntimeError.
- test_rename_alloc_valid — findAllocation().setName with a valid new name; asserts call.
- test_rename_alloc_duplicate — setName raises ValueError on duplicate target name.
- test_transfer_hosts_between_allocs — moves hosts via dst.reparentHosts(src.getHosts()) using two findAllocation calls (src, dst).
- test_tag_alloc_update — findAllocation().setTag updates allocation tag.
- test_list_allocations — getAllocations returns two items; asserts length and call.
- test_allocation_query_filter — simple tag-based filter over getAllocations results.
- test_get_allocation_error_handling — getAllocation raises generic API error; asserts exception.
- test_create_alloc_tag_validation — createAllocation raises ValueError when tag is invalid.