### PR TITLE
[cueman] Add Unit Tests for Query and Listing Commands

### DIFF
--- a/cueman/cueman/main.py
+++ b/cueman/cueman/main.py
@@ -356,7 +356,8 @@ def handleArgs(args):
     if args.lf:
         try:
             job = opencue.api.findJob(args.lf)
-            frames = job.getFrames()
+            search = buildFrameSearch(args)
+            frames = job.getFrames(**search)
             cueadmin.output.displayFrames(frames)
         except Exception as e:
             if (

--- a/cueman/tests/test_main.py
+++ b/cueman/tests/test_main.py
@@ -405,17 +405,22 @@ class TestCuemanHandleArgs(unittest.TestCase):
 
     @mock.patch("opencue.api.findJob")
     @mock.patch("cueadmin.output.displayFrames")
-    def test_handleArgs_list_frames(self, mock_display, mock_findJob):
+    @mock.patch("cueman.main.buildFrameSearch")
+    def test_handleArgs_list_frames(
+        self, mock_buildFrameSearch, mock_display, mock_findJob
+    ):
         """Test handleArgs with -lf flag."""
         self.args.lf = "test_job"
         mock_job = mock.Mock()
         mock_frames = ["frame1", "frame2"]
         mock_job.getFrames.return_value = mock_frames
         mock_findJob.return_value = mock_job
+        mock_buildFrameSearch.return_value = {}
 
         main.handleArgs(self.args)
 
         mock_findJob.assert_called_once_with("test_job")
+        mock_buildFrameSearch.assert_called_once_with(self.args)
         mock_job.getFrames.assert_called_once()
         mock_display.assert_called_once_with(mock_frames)
 


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- #1930

**Summarize your change.**

Implement comprehensive unit tests for all query commands that list jobs, frames, processes, and layers with filtering and pagination.

Create `cueman/tests/test_query_commands.py` testing:
- Frame listing (`-lf`) with layer and state filters
- Process listing (`-lp`) with memory and duration filters
- Layer listing (`-ll`) with formatting and statistics
- Job info display (`-info`) with detailed output
- Pagination with page and limit parameters
- Filter combination validation
- Empty result handling
- Large dataset performance considerations

Mock `job.getFrames()`, `job.getLayers()`, `opencue.api.getProcs()` to avoid network calls. Test various data sizes and filter combinations.

**Bug fix:** The `-lf` command was not applying search filters. Updated `handleArgs()` to call `buildFrameSearch()` and pass parameters to `job.getFrames()`, making it consistent with other frame management commands (`-eat`, `-kill`, `-retry`, `-done`).

Enhanced test assertions to verify `buildFrameSearch` is called and getFrames receives correct search parameters.

Co-authored-by: Aniket Singh Yadav <singhyadavaniket43@gmail.com>
Co-authored-by: Ramon Figueiredo <rfigueiredo@imageworks.com>