### PR TITLE
[CI/CD] Fix mock dependency conflicts across Python packages

### DIFF
--- a/cueadmin/pyproject.toml
+++ b/cueadmin/pyproject.toml
@@ -45,22 +45,22 @@ markers = [
 # --- Optional Test Dependencies ---
 [project.optional-dependencies]
 test = [
-    "pytest>=8.0.0",
-    "pytest-cov>=4.0.0",
-    "pytest-mock>=3.10.0",
-    "mock>=2.0.0",
-    "pyfakefs>=5.2.3"
+    "mock==2.0.0",
+    "pyfakefs==5.2.3",
+    "pytest",
+    "pytest-cov",
+    "pytest-mock",
 ]
 
 dev = [
-    "pytest>=8.0.0",
-    "pytest-cov>=4.0.0",
-    "pytest-mock>=3.10.0",
-    "mock>=2.0.0",
-    "pyfakefs>=5.2.3",
-    "pylint>=3.0.0",
-    "black>=23.0.0",
-    "isort>=5.12.0"
+    "mock==2.0.0",
+    "pyfakefs==5.2.3",
+    "pytest",
+    "pytest-cov",
+    "pytest-mock",
+    "pylint",
+    "black",
+    "isort"
 ]
 
 # --- Coverage configuration ---

--- a/cueadmin/pyproject.toml
+++ b/cueadmin/pyproject.toml
@@ -48,7 +48,7 @@ test = [
     "pytest>=8.0.0",
     "pytest-cov>=4.0.0",
     "pytest-mock>=3.10.0",
-    "mock>=4.0.0",
+    "mock>=2.0.0",
     "pyfakefs>=5.2.3"
 ]
 
@@ -56,7 +56,7 @@ dev = [
     "pytest>=8.0.0",
     "pytest-cov>=4.0.0",
     "pytest-mock>=3.10.0",
-    "mock>=4.0.0",
+    "mock>=2.0.0",
     "pyfakefs>=5.2.3",
     "pylint>=3.0.0",
     "black>=23.0.0",

--- a/cuegui/pyproject.toml
+++ b/cuegui/pyproject.toml
@@ -42,7 +42,7 @@ python_functions = ["test_*"] # Default test function pattern
 # --- Optional Test Dependencies ---
 [project.optional-dependencies]
 test = [
-    "mock==2.0.0",
-    "pyfakefs==5.2.3",
-    "pytest"
+    "mock>=2.0.0",
+    "pyfakefs>=5.2.3",
+    "pytest>=6.0.0"
 ]

--- a/cuegui/pyproject.toml
+++ b/cuegui/pyproject.toml
@@ -42,7 +42,7 @@ python_functions = ["test_*"] # Default test function pattern
 # --- Optional Test Dependencies ---
 [project.optional-dependencies]
 test = [
-    "mock>=2.0.0",
-    "pyfakefs>=5.2.3",
-    "pytest>=6.0.0"
+    "mock==2.0.0",
+    "pyfakefs==5.2.3",
+    "pytest"
 ]

--- a/cueman/pyproject.toml
+++ b/cueman/pyproject.toml
@@ -9,10 +9,7 @@ name = "opencue_cueman"
 dynamic = ["version"]
 dependencies = [
     "opencue_pycue",
-    "opencue_cueadmin",
-    "mock>=2.0.0",
-    "pyfakefs>=5.2.3",
-    "pytest>=6.0"
+    "opencue_cueadmin"
 ]
 requires-python = ">3.7"
 description = "Cueman is a command-line job management tool for OpenCue that provides efficient job control operations. It offers a streamlined interface for managing jobs, frames, and processes with advanced filtering and batch operation capabilities."
@@ -52,7 +49,7 @@ test = [
     "pytest>=8.0.0",
     "pytest-cov>=4.0.0",
     "pytest-mock>=3.10.0",
-    "mock>=4.0.0",
+    "mock>=2.0.0",
     "pyfakefs>=5.2.3"
 ]
 
@@ -60,7 +57,7 @@ dev = [
     "pytest>=8.0.0",
     "pytest-cov>=4.0.0",
     "pytest-mock>=3.10.0",
-    "mock>=4.0.0",
+    "mock>=2.0.0",
     "pyfakefs>=5.2.3",
     "pylint>=3.0.0",
     "black>=23.0.0",

--- a/cueman/pyproject.toml
+++ b/cueman/pyproject.toml
@@ -46,22 +46,22 @@ markers = [
 # --- Optional Test Dependencies ---
 [project.optional-dependencies]
 test = [
-    "pytest>=8.0.0",
-    "pytest-cov>=4.0.0",
-    "pytest-mock>=3.10.0",
-    "mock>=2.0.0",
-    "pyfakefs>=5.2.3"
+    "mock==2.0.0",
+    "pyfakefs==5.2.3",
+    "pytest",
+    "pytest-cov",
+    "pytest-mock",
 ]
 
 dev = [
-    "pytest>=8.0.0",
-    "pytest-cov>=4.0.0",
-    "pytest-mock>=3.10.0",
-    "mock>=2.0.0",
-    "pyfakefs>=5.2.3",
-    "pylint>=3.0.0",
-    "black>=23.0.0",
-    "isort>=5.12.0"
+    "mock==2.0.0",
+    "pyfakefs==5.2.3",
+    "pytest",
+    "pytest-cov",
+    "pytest-mock",
+    "pylint",
+    "black",
+    "isort"
 ]
 
 # --- Coverage configuration ---


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/1990

**Summarize your change.**
- Align mock version requirements to mock==2.0.0 across all packages
- Use pinned versions constraints of `cuegui` ("mock==2.0.0", "pyfakefs==5.2.3") in `cueman` and `cueadmin`
- Resolves pip installation conflicts in CI pipeline