### PR TITLE
[CI/CD] Fix Docker Hub authentication errors in GitHub Actions pipelines

### DIFF
--- a/.github/workflows/packaging-pipeline.yml
+++ b/.github/workflows/packaging-pipeline.yml
@@ -9,7 +9,7 @@ jobs:
   build_opencue_packages:
     name: Build Python Packages
     runs-on: ubuntu-22.04
-    container: python:3.7
+    container: docker.io/library/python:3.7
     outputs:
       opencue_proto_path: ${{ steps.package_outputs.outputs.opencue_proto_path }}
       opencue_rqd_path: ${{ steps.package_outputs.outputs.opencue_rqd_path }}
@@ -263,7 +263,7 @@ jobs:
       - integration_test
       - build_opencue_packages
     runs-on: ubuntu-22.04
-    container: python:3.11
+    container: docker.io/library/python:3.11
     name: "Upload python packages to testpypi repo"
     environment: testpypi
     continue-on-error: true

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -10,7 +10,7 @@ jobs:
   build_opencue_packages:
     name: Build Python Packages
     runs-on: ubuntu-22.04
-    container: python:3.7
+    container: docker.io/library/python:3.7
     outputs:
       opencue_proto_path: ${{ steps.package_outputs.outputs.opencue_proto_path }}
       opencue_rqd_path: ${{ steps.package_outputs.outputs.opencue_rqd_path }}
@@ -140,7 +140,7 @@ jobs:
   upload_python_packages_pypi:
     needs: build_opencue_packages
     runs-on: ubuntu-22.04
-    container: python:3.11
+    container: docker.io/library/python:3.11
     name: "Upload python packages to pypi repo"
     environment: release
     env:

--- a/.github/workflows/testing-pipeline.yml
+++ b/.github/workflows/testing-pipeline.yml
@@ -10,7 +10,7 @@ jobs:
   build_opencue_packages:
     name: Build Python Packages
     runs-on: ubuntu-22.04
-    container: python:3.7
+    container: docker.io/library/python:3.7
     outputs:
       opencue_proto_path: ${{ steps.package_outputs.outputs.opencue_proto_path }}
       opencue_pycue_path: ${{ steps.package_outputs.outputs.opencue_pycue_path }}
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.9", "3.10", "3.11"]
-    container: python:${{ matrix.python-version }}
+    container: docker.io/library/python:${{ matrix.python-version }}
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/1992

**Summarize your change.**
- Update Python container references from 'python:X.Y' to 'docker.io/library/python:X.Y' to resolve unauthorized pull errors due to Docker Hub rate limits.
- Affects testing, packaging, and release pipeline workflows