### PR TITLE
[CI/CD] Fix docs pipeline failing on tag deployments

### DIFF
--- a/.github/workflows/docs-pipeline.yml
+++ b/.github/workflows/docs-pipeline.yml
@@ -173,7 +173,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-22.04
     needs: build
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/1996

**Summarize your change.**

[CI/CD] Fix docs pipeline failing on tag deployments

- Remove tag-triggered deployments from docs pipeline deploy job.
- Tags can still trigger builds for validation, but only master/main
- branch pushes will deploy to github-pages environment.

Resolves deployment protection rule violations when release tags are created.