### PR TITLE
[cueman] Add unit tests and validation for frame operations

### DIFF
--- a/.github/workflows/docs-pipeline.yml
+++ b/.github/workflows/docs-pipeline.yml
@@ -173,7 +173,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-22.04
     needs: build
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/cueman/README.md
+++ b/cueman/README.md
@@ -217,10 +217,10 @@ cueman -retry job_name -state DEAD
 ## Frame Manipulation
 
 ```bash
-# Stagger frames by increment
+# Stagger frames by increment (must be positive integer)
 cueman -stagger job_name 1-100 5
 
-# Reorder frames
+# Reorder frames (position must be FIRST, LAST, or REVERSE)
 cueman -reorder job_name 1-100 FIRST
 cueman -reorder job_name 50-100 LAST
 cueman -reorder job_name 1-100 REVERSE

--- a/cueman/cueman/main.py
+++ b/cueman/cueman/main.py
@@ -728,11 +728,13 @@ def buildFrameSearch(args):
         s["layer"] = args.layer
     if args.range:
         if not re.match(r"^\d+$|^\d+-\d+$", args.range):
-            raise ValueError("Invalid range format: %s" % args.range)
+            logger.error("Invalid range format: %s" % args.range)
+            sys.exit(1)
         if "-" in args.range:
             r = args.range.partition("-")
             if r[0] > r[2]:
-                raise ValueError("Invalid range: start frame greater than end frame")
+                logger.error("Invalid range: start frame greater than end frame")
+                sys.exit(1)
         s["range"] = args.range
     if args.state:
         s["state"] = [common.Convert.strToFrameState(st) for st in args.state]

--- a/cueman/cueman/main.py
+++ b/cueman/cueman/main.py
@@ -593,6 +593,9 @@ def handleArgs(args):
     elif args.reorder:
         name, frame_range, position = args.reorder
         try:
+            if position not in ["FIRST", "LAST", "REVERSE"]:
+                logger.error("Error: Position must be one of FIRST, LAST, or REVERSE.")
+                sys.exit(1)
             job = opencue.api.findJob(name)
             layers = args.layer
             common.confirm(

--- a/cueman/cueman/main.py
+++ b/cueman/cueman/main.py
@@ -731,12 +731,12 @@ def buildFrameSearch(args):
         s["layer"] = args.layer
     if args.range:
         if not re.match(r"^\d+$|^\d+-\d+$", args.range):
-            logger.error("Invalid range format: %s" % args.range)
+            logger.error("Invalid range format: %s", args.range)
             sys.exit(1)
         if "-" in args.range:
             r = args.range.partition("-")
             if r[0] > r[2]:
-                logger.error("Invalid range: start frame greater than end frame")
+                logger.error("Invalid range format: %s", args.range)
                 sys.exit(1)
         s["range"] = args.range
     if args.state:

--- a/cueman/cueman/main.py
+++ b/cueman/cueman/main.py
@@ -724,6 +724,12 @@ def buildFrameSearch(args):
     if args.layer:
         s["layer"] = args.layer
     if args.range:
+        if not re.match(r"^\d+$|^\d+-\d+$", args.range):
+            raise ValueError("Invalid range format: %s" % args.range)
+        if "-" in args.range:
+            r = args.range.partition("-")
+            if r[0] > r[2]:
+                raise ValueError("Invalid range: start frame greater than end frame")
         s["range"] = args.range
     if args.state:
         s["state"] = [common.Convert.strToFrameState(st) for st in args.state]

--- a/cueman/cueman/main.py
+++ b/cueman/cueman/main.py
@@ -566,6 +566,9 @@ def handleArgs(args):
     elif args.stagger:
         name, frame_range, increment = args.stagger
         try:
+            if not increment.isdigit() or int(increment) < 1:
+                logger.error("Error: Increment must be a positive integer.")
+                sys.exit(1)
             job = opencue.api.findJob(name)
             layers = args.layer
             common.confirm(

--- a/cueman/cueman_tutorial.md
+++ b/cueman/cueman_tutorial.md
@@ -376,6 +376,8 @@ cueman -stagger job_name 1-100 5
 cueman -stagger job_name 1-50 10 -layer sim_layer
 ```
 
+**Note:** Increment must be a positive integer. Zero, negative, and non-numeric values will be rejected.
+
 ### Reorder Frames
 Change frame execution order:
 
@@ -392,6 +394,8 @@ cueman -reorder job_name 1-100 REVERSE
 # Reorder specific layer
 cueman -reorder job_name 1-50 FIRST -layer hero_layer
 ```
+
+**Note:** Position must be one of: `FIRST`, `LAST`, or `REVERSE`. Other values will be rejected.
 
 ## Real-World Scenarios
 

--- a/cueman/tests/test_frame_operations.py
+++ b/cueman/tests/test_frame_operations.py
@@ -66,11 +66,11 @@ class TestFrameOperations (unittest.TestCase):
         mock_job = MagicMock()
         mock_findJob.return_value = mock_job
 
-        args = self._ns(eat="test_job", layer="render_layer", range="1-10", force=True)
+        args = self._ns(eat="test_job", layer=["render_layer"], range="1-10", force=True)
         cuemain.handleArgs(args)
 
         mock_findJob.assert_called_once_with("test_job")
-        mock_job.eatFrames.assert_called_once_with(layer="render_layer" , range="1-10")
+        mock_job.eatFrames.assert_called_once_with(layer=["render_layer"], range="1-10")
 
 
     @patch("opencue.api.findJob")
@@ -79,11 +79,11 @@ class TestFrameOperations (unittest.TestCase):
         mock_job = MagicMock()
         mock_findJob.return_value = mock_job
 
-        args = self._ns(kill="test_job", layer="render_layer", range="1-10", force=True)
+        args = self._ns(kill="test_job", layer=["render_layer"], range="1-10", force=True)
         cuemain.handleArgs(args)
 
         mock_findJob.assert_called_once_with("test_job")
-        mock_job.killFrames.assert_called_once_with(layer="render_layer", range="1-10")
+        mock_job.killFrames.assert_called_once_with(layer=["render_layer"], range="1-10")
 
 
     @patch("opencue.api.findJob")
@@ -92,11 +92,11 @@ class TestFrameOperations (unittest.TestCase):
         mock_job = MagicMock()
         mock_findJob.return_value = mock_job
 
-        args = self._ns(retry="test_job", layer="render_layer", range="1-10", force=True)
+        args = self._ns(retry="test_job", layer=["render_layer"], range="1-10", force=True)
         cuemain.handleArgs(args)
 
         mock_findJob.assert_called_once_with("test_job")
-        mock_job.retryFrames.assert_called_once_with(layer="render_layer", range="1-10")
+        mock_job.retryFrames.assert_called_once_with(layer=["render_layer"], range="1-10")
 
 
     # -------------- eatFrame state filtering tests --------------
@@ -210,7 +210,7 @@ class TestFrameOperations (unittest.TestCase):
     # -------------- Mark done functionality test --------------
 
     @patch("opencue.api.findJob")
-    def test_done_fundtionality(self, mock_findJob):
+    def test_done_functionality(self, mock_findJob):
         """Test mark done functionality"""
         mock_job = MagicMock()
         mock_job.markdoneFrames = MagicMock()
@@ -342,12 +342,12 @@ class TestFrameOperations (unittest.TestCase):
         mock_findJob.return_value = mock_job
         mock_promptYesNo.return_value = True
 
-        args = self._ns(eat="test_job", layer="render_layer", range="1-10", force=False)
+        args = self._ns(eat="test_job", layer=["render_layer"], range="1-10", force=False)
         cuemain.handleArgs(args)
 
         mock_findJob.assert_called_once_with("test_job")
         mock_promptYesNo.assert_called_once_with("Eat specified frames on job test_job", False)
-        mock_job.eatFrames.assert_called_once_with(layer="render_layer" , range="1-10")
+        mock_job.eatFrames.assert_called_once_with(layer=["render_layer"], range="1-10")
 
 
     @patch("opencue.api.findJob")
@@ -359,12 +359,12 @@ class TestFrameOperations (unittest.TestCase):
         mock_findJob.return_value = mock_job
         mock_promptYesNo.return_value = True
 
-        args = self._ns(kill="test_job", layer="render_layer", range="1-10", force=False)
+        args = self._ns(kill="test_job", layer=["render_layer"], range="1-10", force=False)
         cuemain.handleArgs(args)
 
         mock_findJob.assert_called_once_with("test_job")
         mock_promptYesNo.assert_called_once_with("Kill specified frames on job test_job", False)
-        mock_job.killFrames.assert_called_once_with(layer="render_layer" , range="1-10")
+        mock_job.killFrames.assert_called_once_with(layer=["render_layer"], range="1-10")
 
 
     @patch("opencue.api.findJob")
@@ -376,12 +376,12 @@ class TestFrameOperations (unittest.TestCase):
         mock_findJob.return_value = mock_job
         mock_promptYesNo.return_value = True
 
-        args = self._ns(retry="test_job", layer="render_layer", range="1-10", force=False)
+        args = self._ns(retry="test_job", layer=["render_layer"], range="1-10", force=False)
         cuemain.handleArgs(args)
 
         mock_findJob.assert_called_once_with("test_job")
         mock_promptYesNo.assert_called_once_with("Retry specified frames on job test_job", False)
-        mock_job.retryFrames.assert_called_once_with(layer="render_layer" , range="1-10")
+        mock_job.retryFrames.assert_called_once_with(layer=["render_layer"], range="1-10")
 
 
     @patch("opencue.api.findJob")
@@ -393,13 +393,13 @@ class TestFrameOperations (unittest.TestCase):
         mock_findJob.return_value = mock_job
         mock_promptYesNo.return_value = True
 
-        args = self._ns(done="test_job", layer="render_layer", range="1-10", force=False)
+        args = self._ns(done="test_job", layer=["render_layer"], range="1-10", force=False)
         cuemain.handleArgs(args)
 
         mock_findJob.assert_called_once_with("test_job")
         mock_promptYesNo.assert_called_once_with("Mark done specified frames on job test_job",
                                                  False)
-        mock_job.markdoneFrames.assert_called_once_with(layer="render_layer" , range="1-10")
+        mock_job.markdoneFrames.assert_called_once_with(layer=["render_layer"], range="1-10")
 
 
 if __name__ == '__main__':

--- a/cueman/tests/test_frame_operations.py
+++ b/cueman/tests/test_frame_operations.py
@@ -332,5 +332,75 @@ class TestFrameOperations (unittest.TestCase):
 
         self.assertEqual(e.exception.code, 1)
 
+
+    # -------------- Reorder operations with position valdiation test --------------
+
+    @patch("opencue.api.findJob")
+    @patch("cueadmin.util.promptYesNo")
+    def test_eat_confirmation_prompt(self, mock_promptYesNo, mock_findJob):
+        """Test prompt confirmation for eatFrames operation"""
+        mock_job = MagicMock()
+        mock_job.eatFrames = MagicMock()
+        mock_findJob.return_value = mock_job
+        mock_promptYesNo.return_value = True
+
+        args = self._ns(eat="test_job", layer="render_layer", range="1-10", force=False)
+        cuemain.handleArgs(args)
+
+        mock_findJob.assert_called_once_with("test_job")
+        mock_promptYesNo.assert_called_once_with("Eat specified frames on job test_job", False)
+        mock_job.eatFrames.assert_called_once_with(layer="render_layer" , range="1-10")
+
+    @patch("opencue.api.findJob")
+    @patch("cueadmin.util.promptYesNo")
+    def test_kill_confirmation_prompt(self, mock_promptYesNo, mock_findJob):
+        """Test prompt confirmation for killFrames operation"""
+        mock_job = MagicMock()
+        mock_job.killFrames = MagicMock()
+        mock_findJob.return_value = mock_job
+        mock_promptYesNo.return_value = True
+
+        args = self._ns(kill="test_job", layer="render_layer", range="1-10", force=False)
+        cuemain.handleArgs(args)
+
+        mock_findJob.assert_called_once_with("test_job")
+        mock_promptYesNo.assert_called_once_with("Kill specified frames on job test_job", False)
+        mock_job.killFrames.assert_called_once_with(layer="render_layer" , range="1-10")
+
+
+    @patch("opencue.api.findJob")
+    @patch("cueadmin.util.promptYesNo")
+    def test_retry_confirmation_prompt(self, mock_promptYesNo, mock_findJob):
+        """Test prompt confirmation for retryFrames operation"""
+        mock_job = MagicMock()
+        mock_job.retryFrames = MagicMock()
+        mock_findJob.return_value = mock_job
+        mock_promptYesNo.return_value = True
+
+        args = self._ns(retry="test_job", layer="render_layer", range="1-10", force=False)
+        cuemain.handleArgs(args)
+
+        mock_findJob.assert_called_once_with("test_job")
+        mock_promptYesNo.assert_called_once_with("Retry specified frames on job test_job", False)
+        mock_job.retryFrames.assert_called_once_with(layer="render_layer" , range="1-10")
+
+
+    @patch("opencue.api.findJob")
+    @patch("cueadmin.util.promptYesNo")
+    def test_done_confirmation_prompt(self, mock_promptYesNo, mock_findJob):
+        """Test prompt confirmation for done Frames operation"""
+        mock_job = MagicMock()
+        mock_job.markdoneFrames = MagicMock()
+        mock_findJob.return_value = mock_job
+        mock_promptYesNo.return_value = True
+
+        args = self._ns(done="test_job", layer="render_layer", range="1-10", force=False)
+        cuemain.handleArgs(args)
+
+        mock_findJob.assert_called_once_with("test_job")
+        mock_promptYesNo.assert_called_once_with("Mark done specified frames on job test_job", False)
+        mock_job.markdoneFrames.assert_called_once_with(layer="render_layer" , range="1-10")
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/cueman/tests/test_frame_operations.py
+++ b/cueman/tests/test_frame_operations.py
@@ -259,5 +259,60 @@ class TestFrameOperations (unittest.TestCase):
         mock_findJob.assert_called_once_with("test_job")
         mock_job.markdoneFrames.assert_called_once()
 
+
+    # -------------- Stagger Operation test --------------
+
+    @patch("opencue.api.findJob")
+    def test_stagger_increments(self, mock_findJob):
+        """Test stagger operations with increment validation """
+        mock_job = MagicMock()
+        mock_findJob.return_value = mock_job
+        
+        args = self._ns(stagger=["test_job", "1-10", "2"], force=True)
+        cuemain.handleArgs(args)
+
+        mock_findJob.assert_called_once_with("test_job")
+        mock_job.staggerFrames.assert_called_once_with("1-10", 2)
+
+
+    @patch("opencue.api.findJob")
+    def test_stagger_zero_increments(self, mock_findJob):
+        """Test stagger operations with increment validation """
+        mock_job = MagicMock()
+        mock_findJob.return_value = mock_job
+        
+        args = self._ns(stagger=["test_job", "1-10", "0"], force=True)
+        with self.assertRaises(SystemExit) as e:
+            cuemain.handleArgs(args)
+
+        self.assertEqual(e.exception.code, 1)
+
+
+    @patch("opencue.api.findJob")
+    def test_stagger_negative_increments(self, mock_findJob):
+        """Test stagger operations with increment validation """
+        mock_job = MagicMock()
+        mock_findJob.return_value = mock_job
+        
+        args = self._ns(stagger=["test_job", "1-10", "-1"], force=True)
+        with self.assertRaises(SystemExit) as e:
+            cuemain.handleArgs(args)
+
+        self.assertEqual(e.exception.code, 1)
+
+
+    @patch("opencue.api.findJob")
+    def test_stagger_nonnumeric_increments(self, mock_findJob):
+        """Test stagger operations with increment validation """
+        mock_job = MagicMock()
+        mock_findJob.return_value = mock_job
+        
+        args = self._ns(stagger=["test_job", "1-10", "a"], force=True)
+        with self.assertRaises(SystemExit) as e:
+            cuemain.handleArgs(args)
+
+        self.assertEqual(e.exception.code, 1)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/cueman/tests/test_frame_operations.py
+++ b/cueman/tests/test_frame_operations.py
@@ -177,6 +177,7 @@ class TestFrameOperations (unittest.TestCase):
 
 
     # -------------- eatFrame range parsing and validation tests --------------
+
     @patch("opencue.api.findJob")
     def test_valid_range_inputs(self, mock_findJob):
         """Test eatFrame with valid range input"""
@@ -241,3 +242,22 @@ class TestFrameOperations (unittest.TestCase):
 
         self.assertEqual(e.exception.code, 1)
         mock_findJob.assert_called_once_with("test_job")
+
+
+    # -------------- Mark done functionality test --------------
+
+    @patch("opencue.api.findJob")
+    def test_done_fundtionality(self, mock_findJob):
+        """Test mark done functionality"""
+        mock_job = MagicMock()
+        mock_job.markdoneFrames = MagicMock()
+        mock_findJob.return_value = mock_job
+        
+        args = self._ns(done="test_job", force=True)
+        cuemain.handleArgs(args)
+
+        mock_findJob.assert_called_once_with("test_job")
+        mock_job.markdoneFrames.assert_called_once()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cueman/tests/test_frame_operations.py
+++ b/cueman/tests/test_frame_operations.py
@@ -60,6 +60,7 @@ class TestFrameOperations (unittest.TestCase):
         base.update(overrides)
         return argparse.Namespace(**base)
         
+    # -------------- Frame eat/kill/retry operations with layer and range filters tests --------------
 
     @patch("opencue.api.findJob")
     def test_eatFrames_with_valid_layer(self, mock_findJob):
@@ -107,4 +108,69 @@ class TestFrameOperations (unittest.TestCase):
 
         mock_findJob.assert_called_once_with("test_job")
         mock_job.retryFrames.assert_called_once_with(layer="render_layer", range="1-10")
+
     
+    # -------------- eatFrame state filtering tests --------------
+    
+    @patch("opencue.api.findJob")
+    def test_eatFrames_with_waiting_state_filter(self, mock_findJob):
+        """Test eatFrames with waiting state filter"""
+        mock_job = MagicMock()
+        mock_frame = MagicMock()
+        mock_job.getFrames.return_value = [mock_frame]
+        mock_job.eatFrames = MagicMock()
+        mock_findJob.return_value = mock_job
+
+        args = self._ns(eat="test_job", state=["waiting"], force=True)
+        cuemain.handleArgs(args)
+
+        mock_findJob.assert_called_once_with("test_job")
+        mock_job.eatFrames.assert_called_once_with(state=[0])
+
+
+    @patch("opencue.api.findJob")
+    def test_eatFrames_with_running_state_filter(self, mock_findJob):
+        """Test eatFrames with running state filter"""
+        mock_job = MagicMock()
+        mock_frame = MagicMock()
+        mock_job.getFrames.return_value = [mock_frame]
+        mock_job.eatFrames = MagicMock()
+        mock_findJob.return_value = mock_job
+
+        args = self._ns(eat="test_job", state=["running"], force=True)
+        cuemain.handleArgs(args)
+
+        mock_findJob.assert_called_once_with("test_job")
+        mock_job.eatFrames.assert_called_once_with(state=[2])
+
+
+    @patch("opencue.api.findJob")
+    def test_eatFrames_with_succeeded_state_filter(self, mock_findJob):
+        """Test eatFrames with succeeded state filter"""
+        mock_job = MagicMock()
+        mock_frame = MagicMock()
+        mock_job.getFrames.return_value = [mock_frame]
+        mock_job.eatFrames = MagicMock()
+        mock_findJob.return_value = mock_job
+
+        args = self._ns(eat="test_job", state=["succeeded"], force=True)
+        cuemain.handleArgs(args)
+
+        mock_findJob.assert_called_once_with("test_job")
+        mock_job.eatFrames.assert_called_once_with(state=[3])
+
+
+    @patch("opencue.api.findJob")
+    def test_eatFrames_with_dead_state_filter(self, mock_findJob):
+        """Test eatFrames with dead state filter"""
+        mock_job = MagicMock()
+        mock_frame = MagicMock()
+        mock_job.getFrames.return_value = [mock_frame]
+        mock_job.eatFrames = MagicMock()
+        mock_findJob.return_value = mock_job
+
+        args = self._ns(eat="test_job", state=["dead"], force=True)
+        cuemain.handleArgs(args)
+
+        mock_findJob.assert_called_once_with("test_job")
+        mock_job.eatFrames.assert_called_once_with(state=[5])

--- a/cueman/tests/test_frame_operations.py
+++ b/cueman/tests/test_frame_operations.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+
+#  Copyright Contributors to the OpenCue Project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+"""
+Unit tests for frame operations cueman
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+import argparse
+from cueman import main as cuemain
+
+class TestFrameOperations (unittest.TestCase):
+    """
+    Test cases for cueman frame operations
+    """
+
+    def _ns(self, **overrides):
+        """Build a minimal argparse.Namespace matching cueman.main expectations."""
+        base = {
+            "lf": None,
+            "lp": None,
+            "ll": None,
+            "info": None,
+            "pause": None,
+            "resume": None,
+            "term": None,
+            "eat": None,
+            "kill": None,
+            "retry": None,
+            "done": None,
+            "stagger": None,
+            "reorder": None,
+            "retries": None,
+            "autoeaton": None,
+            "autoeatoff": None,
+            "layer": None,
+            "range": None,
+            "state": None,
+            "page": None,
+            "limit": None,
+            "duration": None,
+            "memory": None,
+            "force": False,
+        }
+        base.update(overrides)
+        return argparse.Namespace(**base)
+        
+
+    @patch("opencue.api.findJob")
+    def test_eatFrames_with_valid_layer(self, mock_findJob):
+        """Test eatFrames with valid layer and range filters."""
+        mock_job = MagicMock()
+        mock_frame = MagicMock()
+        mock_job.getFrames.return_value = [mock_frame]
+        mock_job.eatFrames = MagicMock()
+        mock_findJob.return_value = mock_job
+
+        args = self._ns(eat="test_job", layer="render_layer", range="1-10", force=True)
+        cuemain.handleArgs(args)
+
+        mock_findJob.assert_called_once_with("test_job")
+        mock_job.eatFrames.assert_called_once_with(layer="render_layer" , range="1-10")
+        
+
+    @patch("opencue.api.findJob")
+    def test_killFrames_with_valid_layer(self, mock_findJob):
+        """Test killFrames with valid layer and range filters."""
+        mock_job = MagicMock()
+        mock_frame = MagicMock()
+        mock_job.getFrames.return_value = [mock_frame]
+        mock_job.killFrames = MagicMock()
+        mock_findJob.return_value = mock_job
+
+        args = self._ns(kill="test_job", layer="render_layer", range="1-10", force=True)
+        cuemain.handleArgs(args)
+
+        mock_findJob.assert_called_once_with("test_job")
+        mock_job.killFrames.assert_called_once_with(layer="render_layer", range="1-10")
+
+
+    @patch("opencue.api.findJob")
+    def test_retryFrames_with_valid_layer(self, mock_findJob):
+        """Test retryFrames with valid layer and range filters."""
+        mock_job = MagicMock()
+        mock_frame = MagicMock()
+        mock_job.getFrames.return_value = [mock_frame]
+        mock_job.retryFrames = MagicMock()
+        mock_findJob.return_value = mock_job
+
+        args = self._ns(retry="test_job", layer="render_layer", range="1-10", force=True)
+        cuemain.handleArgs(args)
+
+        mock_findJob.assert_called_once_with("test_job")
+        mock_job.retryFrames.assert_called_once_with(layer="render_layer", range="1-10")
+    

--- a/cueman/tests/test_frame_operations.py
+++ b/cueman/tests/test_frame_operations.py
@@ -224,7 +224,6 @@ class TestFrameOperations (unittest.TestCase):
             cuemain.handleArgs(args)
 
         self.assertEqual(e.exception.code, 1)
-        mock_findJob.assert_called_once_with("test_job")
 
 
     @patch("opencue.api.findJob")
@@ -241,7 +240,6 @@ class TestFrameOperations (unittest.TestCase):
             cuemain.handleArgs(args)
 
         self.assertEqual(e.exception.code, 1)
-        mock_findJob.assert_called_once_with("test_job")
 
 
     # -------------- Mark done functionality test --------------

--- a/cueman/tests/test_frame_operations.py
+++ b/cueman/tests/test_frame_operations.py
@@ -66,9 +66,6 @@ class TestFrameOperations (unittest.TestCase):
     def test_eatFrames_with_valid_layer(self, mock_findJob):
         """Test eatFrames with valid layer and range filters."""
         mock_job = MagicMock()
-        mock_frame = MagicMock()
-        mock_job.getFrames.return_value = [mock_frame]
-        mock_job.eatFrames = MagicMock()
         mock_findJob.return_value = mock_job
 
         args = self._ns(eat="test_job", layer="render_layer", range="1-10", force=True)
@@ -82,9 +79,6 @@ class TestFrameOperations (unittest.TestCase):
     def test_killFrames_with_valid_layer(self, mock_findJob):
         """Test killFrames with valid layer and range filters."""
         mock_job = MagicMock()
-        mock_frame = MagicMock()
-        mock_job.getFrames.return_value = [mock_frame]
-        mock_job.killFrames = MagicMock()
         mock_findJob.return_value = mock_job
 
         args = self._ns(kill="test_job", layer="render_layer", range="1-10", force=True)
@@ -98,9 +92,6 @@ class TestFrameOperations (unittest.TestCase):
     def test_retryFrames_with_valid_layer(self, mock_findJob):
         """Test retryFrames with valid layer and range filters."""
         mock_job = MagicMock()
-        mock_frame = MagicMock()
-        mock_job.getFrames.return_value = [mock_frame]
-        mock_job.retryFrames = MagicMock()
         mock_findJob.return_value = mock_job
 
         args = self._ns(retry="test_job", layer="render_layer", range="1-10", force=True)
@@ -116,9 +107,6 @@ class TestFrameOperations (unittest.TestCase):
     def test_eatFrames_with_waiting_state_filter(self, mock_findJob):
         """Test eatFrames with waiting state filter"""
         mock_job = MagicMock()
-        mock_frame = MagicMock()
-        mock_job.getFrames.return_value = [mock_frame]
-        mock_job.eatFrames = MagicMock()
         mock_findJob.return_value = mock_job
 
         args = self._ns(eat="test_job", state=["waiting"], force=True)
@@ -132,9 +120,6 @@ class TestFrameOperations (unittest.TestCase):
     def test_eatFrames_with_running_state_filter(self, mock_findJob):
         """Test eatFrames with running state filter"""
         mock_job = MagicMock()
-        mock_frame = MagicMock()
-        mock_job.getFrames.return_value = [mock_frame]
-        mock_job.eatFrames = MagicMock()
         mock_findJob.return_value = mock_job
 
         args = self._ns(eat="test_job", state=["running"], force=True)
@@ -148,9 +133,6 @@ class TestFrameOperations (unittest.TestCase):
     def test_eatFrames_with_succeeded_state_filter(self, mock_findJob):
         """Test eatFrames with succeeded state filter"""
         mock_job = MagicMock()
-        mock_frame = MagicMock()
-        mock_job.getFrames.return_value = [mock_frame]
-        mock_job.eatFrames = MagicMock()
         mock_findJob.return_value = mock_job
 
         args = self._ns(eat="test_job", state=["succeeded"], force=True)
@@ -164,9 +146,6 @@ class TestFrameOperations (unittest.TestCase):
     def test_eatFrames_with_dead_state_filter(self, mock_findJob):
         """Test eatFrames with dead state filter"""
         mock_job = MagicMock()
-        mock_frame = MagicMock()
-        mock_job.getFrames.return_value = [mock_frame]
-        mock_job.eatFrames = MagicMock()
         mock_findJob.return_value = mock_job
 
         args = self._ns(eat="test_job", state=["dead"], force=True)
@@ -182,9 +161,6 @@ class TestFrameOperations (unittest.TestCase):
     def test_valid_range_inputs(self, mock_findJob):
         """Test eatFrame with valid range input"""
         mock_job = MagicMock()
-        mock_frame = MagicMock()
-        mock_job.getFrames.return_value = [mock_frame]
-        mock_job.eatFrames = MagicMock()
         mock_findJob.return_value = mock_job
 
         args = self._ns(eat="test_job", range="1-10", force=True)
@@ -198,9 +174,6 @@ class TestFrameOperations (unittest.TestCase):
     def test_valid_single_range_inputs(self, mock_findJob):
         """Test eatFrame with single frame input"""
         mock_job = MagicMock()
-        mock_frame = MagicMock()
-        mock_job.getFrames.return_value = [mock_frame]
-        mock_job.eatFrames = MagicMock()
         mock_findJob.return_value = mock_job
 
         args = self._ns(eat="test_job", range="1", force=True)
@@ -214,9 +187,6 @@ class TestFrameOperations (unittest.TestCase):
     def test_invalid_nonnumeric_range_inputs(self, mock_findJob):
         """Test eatFrame with invalid range input (non numberic)"""
         mock_job = MagicMock()
-        mock_frame = MagicMock()
-        mock_job.getFrames.return_value = [mock_frame]
-        mock_job.eatFrames = MagicMock()
         mock_findJob.return_value = mock_job
 
         args = self._ns(eat="test_job", range="1-a", force=True)
@@ -230,9 +200,6 @@ class TestFrameOperations (unittest.TestCase):
     def test_invalid_reverse_range_inputs(self, mock_findJob):
         """Test eatFrame with invalid range inputs (reverse)"""
         mock_job = MagicMock()
-        mock_frame = MagicMock()
-        mock_job.getFrames.return_value = [mock_frame]
-        mock_job.eatFrames = MagicMock()
         mock_findJob.return_value = mock_job
 
         args = self._ns(eat="test_job", range="10-1", force=True)

--- a/cueman/tests/test_frame_operations.py
+++ b/cueman/tests/test_frame_operations.py
@@ -18,6 +18,7 @@
 """Unit tests for frame operations cueman"""
 
 #pylint: disable=invalid-name
+#pylint: disable=too-many-public-methods
 import unittest
 from unittest.mock import MagicMock, patch
 import argparse
@@ -396,7 +397,8 @@ class TestFrameOperations (unittest.TestCase):
         cuemain.handleArgs(args)
 
         mock_findJob.assert_called_once_with("test_job")
-        mock_promptYesNo.assert_called_once_with("Mark done specified frames on job test_job", False)
+        mock_promptYesNo.assert_called_once_with("Mark done specified frames on job test_job",
+                                                 False)
         mock_job.markdoneFrames.assert_called_once_with(layer="render_layer" , range="1-10")
 
 

--- a/cueman/tests/test_frame_operations.py
+++ b/cueman/tests/test_frame_operations.py
@@ -15,19 +15,16 @@
 #  limitations under the License.
 
 
-"""
-Unit tests for frame operations cueman
-"""
+"""Unit tests for frame operations cueman"""
 
+#pylint: disable=invalid-name
 import unittest
 from unittest.mock import MagicMock, patch
 import argparse
 from cueman import main as cuemain
 
 class TestFrameOperations (unittest.TestCase):
-    """
-    Test cases for cueman frame operations
-    """
+    """Test cases for cueman frame operations"""
 
     def _ns(self, **overrides):
         """Build a minimal argparse.Namespace matching cueman.main expectations."""
@@ -59,8 +56,8 @@ class TestFrameOperations (unittest.TestCase):
         }
         base.update(overrides)
         return argparse.Namespace(**base)
-        
-    # -------------- Frame eat/kill/retry operations with layer and range filters tests --------------
+
+    # ------------- Frame eat/kill/retry operations with layer and range filters tests -------------
 
     @patch("opencue.api.findJob")
     def test_eatFrames_with_valid_layer(self, mock_findJob):
@@ -73,7 +70,7 @@ class TestFrameOperations (unittest.TestCase):
 
         mock_findJob.assert_called_once_with("test_job")
         mock_job.eatFrames.assert_called_once_with(layer="render_layer" , range="1-10")
-        
+
 
     @patch("opencue.api.findJob")
     def test_killFrames_with_valid_layer(self, mock_findJob):
@@ -100,9 +97,9 @@ class TestFrameOperations (unittest.TestCase):
         mock_findJob.assert_called_once_with("test_job")
         mock_job.retryFrames.assert_called_once_with(layer="render_layer", range="1-10")
 
-    
+
     # -------------- eatFrame state filtering tests --------------
-    
+
     @patch("opencue.api.findJob")
     def test_eatFrames_with_waiting_state_filter(self, mock_findJob):
         """Test eatFrames with waiting state filter"""
@@ -169,7 +166,7 @@ class TestFrameOperations (unittest.TestCase):
         mock_findJob.assert_called_once_with("test_job")
         mock_job.eatFrames.assert_called_once_with(range="1-10")
 
-    
+
     @patch("opencue.api.findJob")
     def test_valid_single_range_inputs(self, mock_findJob):
         """Test eatFrame with single frame input"""
@@ -185,7 +182,7 @@ class TestFrameOperations (unittest.TestCase):
 
     @patch("opencue.api.findJob")
     def test_invalid_nonnumeric_range_inputs(self, mock_findJob):
-        """Test eatFrame with invalid range input (non numberic)"""
+        """Test eatFrame with invalid range input (non numeric)"""
         mock_job = MagicMock()
         mock_findJob.return_value = mock_job
 
@@ -217,7 +214,7 @@ class TestFrameOperations (unittest.TestCase):
         mock_job = MagicMock()
         mock_job.markdoneFrames = MagicMock()
         mock_findJob.return_value = mock_job
-        
+
         args = self._ns(done="test_job", force=True)
         cuemain.handleArgs(args)
 
@@ -229,10 +226,10 @@ class TestFrameOperations (unittest.TestCase):
 
     @patch("opencue.api.findJob")
     def test_stagger_increments(self, mock_findJob):
-        """Test stagger operations with increment validation """
+        """Test stagger operations with increment validation"""
         mock_job = MagicMock()
         mock_findJob.return_value = mock_job
-        
+
         args = self._ns(stagger=["test_job", "1-10", "2"], force=True)
         cuemain.handleArgs(args)
 
@@ -242,10 +239,10 @@ class TestFrameOperations (unittest.TestCase):
 
     @patch("opencue.api.findJob")
     def test_stagger_zero_increments(self, mock_findJob):
-        """Test stagger operations with increment validation """
+        """Test stagger operations with zero increment validation"""
         mock_job = MagicMock()
         mock_findJob.return_value = mock_job
-        
+
         args = self._ns(stagger=["test_job", "1-10", "0"], force=True)
         with self.assertRaises(SystemExit) as e:
             cuemain.handleArgs(args)
@@ -255,10 +252,10 @@ class TestFrameOperations (unittest.TestCase):
 
     @patch("opencue.api.findJob")
     def test_stagger_negative_increments(self, mock_findJob):
-        """Test stagger operations with increment validation """
+        """Test stagger operations with negative increment validation"""
         mock_job = MagicMock()
         mock_findJob.return_value = mock_job
-        
+
         args = self._ns(stagger=["test_job", "1-10", "-1"], force=True)
         with self.assertRaises(SystemExit) as e:
             cuemain.handleArgs(args)
@@ -268,10 +265,10 @@ class TestFrameOperations (unittest.TestCase):
 
     @patch("opencue.api.findJob")
     def test_stagger_nonnumeric_increments(self, mock_findJob):
-        """Test stagger operations with increment validation """
+        """Test stagger operations with non numeric increment validation"""
         mock_job = MagicMock()
         mock_findJob.return_value = mock_job
-        
+
         args = self._ns(stagger=["test_job", "1-10", "a"], force=True)
         with self.assertRaises(SystemExit) as e:
             cuemain.handleArgs(args)
@@ -283,10 +280,10 @@ class TestFrameOperations (unittest.TestCase):
 
     @patch("opencue.api.findJob")
     def test_reorder_first_operation(self, mock_findJob):
-        """Test reorder operation to first position """
+        """Test reorder operation to first position"""
         mock_job = MagicMock()
         mock_findJob.return_value = mock_job
-        
+
         args = self._ns(reorder=["test_job", "1-10", "FIRST"], force=True)
         cuemain.handleArgs(args)
 
@@ -296,36 +293,36 @@ class TestFrameOperations (unittest.TestCase):
 
     @patch("opencue.api.findJob")
     def test_reorder_last_operation(self, mock_findJob):
-        """Test reorder operation to last position """
+        """Test reorder operation to last position"""
         mock_job = MagicMock()
         mock_findJob.return_value = mock_job
-        
+
         args = self._ns(reorder=["test_job", "1-10", "LAST"], force=True)
         cuemain.handleArgs(args)
 
         mock_findJob.assert_called_once_with("test_job")
         mock_job.reorderFrames.assert_called_once_with("1-10", "LAST")
 
-    
+
     @patch("opencue.api.findJob")
     def test_reorder_reverse_operation(self, mock_findJob):
-        """Test reorder operation to reverse position """
+        """Test reorder operation to reverse position"""
         mock_job = MagicMock()
         mock_findJob.return_value = mock_job
-        
+
         args = self._ns(reorder=["test_job", "1-10", "REVERSE"], force=True)
         cuemain.handleArgs(args)
 
         mock_findJob.assert_called_once_with("test_job")
         mock_job.reorderFrames.assert_called_once_with("1-10", "REVERSE")
 
-    
+
     @patch("opencue.api.findJob")
     def test_reorder_invalid_operation(self, mock_findJob):
-        """Test reorder operation to invalid position """
+        """Test reorder operation to invalid position"""
         mock_job = MagicMock()
         mock_findJob.return_value = mock_job
-        
+
         args = self._ns(reorder=["test_job", "1-10", "ab"], force=True)
         with self.assertRaises(SystemExit) as e:
             cuemain.handleArgs(args)
@@ -350,6 +347,7 @@ class TestFrameOperations (unittest.TestCase):
         mock_findJob.assert_called_once_with("test_job")
         mock_promptYesNo.assert_called_once_with("Eat specified frames on job test_job", False)
         mock_job.eatFrames.assert_called_once_with(layer="render_layer" , range="1-10")
+
 
     @patch("opencue.api.findJob")
     @patch("cueadmin.util.promptYesNo")

--- a/cueman/tests/test_frame_operations.py
+++ b/cueman/tests/test_frame_operations.py
@@ -279,5 +279,58 @@ class TestFrameOperations (unittest.TestCase):
         self.assertEqual(e.exception.code, 1)
 
 
+    # -------------- Reorder operations with position valdiation test --------------
+
+    @patch("opencue.api.findJob")
+    def test_reorder_first_operation(self, mock_findJob):
+        """Test reorder operation to first position """
+        mock_job = MagicMock()
+        mock_findJob.return_value = mock_job
+        
+        args = self._ns(reorder=["test_job", "1-10", "FIRST"], force=True)
+        cuemain.handleArgs(args)
+
+        mock_findJob.assert_called_once_with("test_job")
+        mock_job.reorderFrames.assert_called_once_with("1-10", "FIRST")
+
+
+    @patch("opencue.api.findJob")
+    def test_reorder_last_operation(self, mock_findJob):
+        """Test reorder operation to last position """
+        mock_job = MagicMock()
+        mock_findJob.return_value = mock_job
+        
+        args = self._ns(reorder=["test_job", "1-10", "LAST"], force=True)
+        cuemain.handleArgs(args)
+
+        mock_findJob.assert_called_once_with("test_job")
+        mock_job.reorderFrames.assert_called_once_with("1-10", "LAST")
+
+    
+    @patch("opencue.api.findJob")
+    def test_reorder_reverse_operation(self, mock_findJob):
+        """Test reorder operation to reverse position """
+        mock_job = MagicMock()
+        mock_findJob.return_value = mock_job
+        
+        args = self._ns(reorder=["test_job", "1-10", "REVERSE"], force=True)
+        cuemain.handleArgs(args)
+
+        mock_findJob.assert_called_once_with("test_job")
+        mock_job.reorderFrames.assert_called_once_with("1-10", "REVERSE")
+
+    
+    @patch("opencue.api.findJob")
+    def test_reorder_invalid_operation(self, mock_findJob):
+        """Test reorder operation to invalid position """
+        mock_job = MagicMock()
+        mock_findJob.return_value = mock_job
+        
+        args = self._ns(reorder=["test_job", "1-10", "ab"], force=True)
+        with self.assertRaises(SystemExit) as e:
+            cuemain.handleArgs(args)
+
+        self.assertEqual(e.exception.code, 1)
+
 if __name__ == '__main__':
     unittest.main()

--- a/cueman/tests/test_frame_operations.py
+++ b/cueman/tests/test_frame_operations.py
@@ -174,3 +174,70 @@ class TestFrameOperations (unittest.TestCase):
 
         mock_findJob.assert_called_once_with("test_job")
         mock_job.eatFrames.assert_called_once_with(state=[5])
+
+
+    # -------------- eatFrame range parsing and validation tests --------------
+    @patch("opencue.api.findJob")
+    def test_valid_range_inputs(self, mock_findJob):
+        """Test eatFrame with valid range input"""
+        mock_job = MagicMock()
+        mock_frame = MagicMock()
+        mock_job.getFrames.return_value = [mock_frame]
+        mock_job.eatFrames = MagicMock()
+        mock_findJob.return_value = mock_job
+
+        args = self._ns(eat="test_job", range="1-10", force=True)
+        cuemain.handleArgs(args)
+
+        mock_findJob.assert_called_once_with("test_job")
+        mock_job.eatFrames.assert_called_once_with(range="1-10")
+
+    
+    @patch("opencue.api.findJob")
+    def test_valid_single_range_inputs(self, mock_findJob):
+        """Test eatFrame with single frame input"""
+        mock_job = MagicMock()
+        mock_frame = MagicMock()
+        mock_job.getFrames.return_value = [mock_frame]
+        mock_job.eatFrames = MagicMock()
+        mock_findJob.return_value = mock_job
+
+        args = self._ns(eat="test_job", range="1", force=True)
+        cuemain.handleArgs(args)
+
+        mock_findJob.assert_called_once_with("test_job")
+        mock_job.eatFrames.assert_called_once_with(range="1")
+
+
+    @patch("opencue.api.findJob")
+    def test_invalid_nonnumeric_range_inputs(self, mock_findJob):
+        """Test eatFrame with invalid range input (non numberic)"""
+        mock_job = MagicMock()
+        mock_frame = MagicMock()
+        mock_job.getFrames.return_value = [mock_frame]
+        mock_job.eatFrames = MagicMock()
+        mock_findJob.return_value = mock_job
+
+        args = self._ns(eat="test_job", range="1-a", force=True)
+        with self.assertRaises(SystemExit) as e:
+            cuemain.handleArgs(args)
+
+        self.assertEqual(e.exception.code, 1)
+        mock_findJob.assert_called_once_with("test_job")
+
+
+    @patch("opencue.api.findJob")
+    def test_invalid_reverse_range_inputs(self, mock_findJob):
+        """Test eatFrame with invalid range inputs (reverse)"""
+        mock_job = MagicMock()
+        mock_frame = MagicMock()
+        mock_job.getFrames.return_value = [mock_frame]
+        mock_job.eatFrames = MagicMock()
+        mock_findJob.return_value = mock_job
+
+        args = self._ns(eat="test_job", range="10-1", force=True)
+        with self.assertRaises(SystemExit) as e:
+            cuemain.handleArgs(args)
+
+        self.assertEqual(e.exception.code, 1)
+        mock_findJob.assert_called_once_with("test_job")

--- a/docs/_docs/reference/tools/cueman.md
+++ b/docs/_docs/reference/tools/cueman.md
@@ -218,6 +218,8 @@ Add delays between frame starts:
 cueman -stagger job_name 1-100 5  # Stagger by 5 frame increments
 ```
 
+**Note:** Increment must be a positive integer. Zero, negative, and non-numeric values will be rejected.
+
 #### Reorder Frames
 
 Change execution order:
@@ -227,6 +229,8 @@ cueman -reorder job_name 50-100 FIRST    # Move to front
 cueman -reorder job_name 1-49 LAST       # Move to back
 cueman -reorder job_name 1-100 REVERSE   # Reverse order
 ```
+
+**Note:** Position must be one of: `FIRST`, `LAST`, or `REVERSE`. Other values will be rejected.
 
 ## Filtering Options
 
@@ -249,6 +253,8 @@ cueman -lf job_name -range 1-100           # Continuous range
 cueman -lf job_name -range 1,3,5,7,9       # Individual frames
 cueman -lf job_name -range 1-10,20,30-40   # Mixed ranges
 ```
+
+**Validation:** Range must be numeric (single frame like `5` or range like `1-100`). For ranges, the start frame must be less than or equal to the end frame (e.g., `10-1` is invalid).
 
 ### Layer Filter
 
@@ -389,6 +395,30 @@ cueman -server cuebot.example.com:8443 -lf job_name
 
 # Enable verbose for debugging
 cueman -v -info job_name
+```
+
+**Invalid stagger increment:**
+```bash
+$ cueman -stagger job_name 1-100 0
+Error: Increment must be a positive integer.
+
+$ cueman -stagger job_name 1-100 -5
+Error: Increment must be a positive integer.
+```
+
+**Invalid reorder position:**
+```bash
+$ cueman -reorder job_name 1-50 MIDDLE
+Error: Position must be one of FIRST, LAST, or REVERSE.
+```
+
+**Invalid frame range:**
+```bash
+$ cueman -eat job_name -range 10-1
+Error: Invalid range format: 10-1
+
+$ cueman -eat job_name -range 1-a
+Error: Invalid range format: 1-a
 ```
 
 ### Getting Help

--- a/docs/_docs/tutorials/cueman-tutorial.md
+++ b/docs/_docs/tutorials/cueman-tutorial.md
@@ -225,6 +225,8 @@ cueman -stagger show_shot_lighting_v001 1-100 5
 cueman -stagger show_shot_lighting_v001 1-50 10 -layer sim_layer
 ```
 
+**Note:** The increment must be a positive integer. Values like `0`, `-5`, or `abc` will be rejected.
+
 ### Reordering Frames
 
 Control execution priority:
@@ -239,6 +241,8 @@ cueman -reorder show_shot_lighting_v001 1-49 LAST
 # Reverse frame order for debugging
 cueman -reorder show_shot_lighting_v001 1-100 REVERSE
 ```
+
+**Note:** The position must be one of `FIRST`, `LAST`, or `REVERSE`. Other values like `MIDDLE` will be rejected.
 
 ## Part 6: Real-World Scenarios
 
@@ -461,6 +465,24 @@ Error: Job 'nonexistent_job' does not exist.
 ```bash
 $ cueman -kill show_shot_001 -state SUCCEEDED
 No frames found matching criteria
+```
+
+**Invalid stagger increment:**
+```bash
+$ cueman -stagger show_shot_001 1-100 0
+Error: Increment must be a positive integer.
+```
+
+**Invalid reorder position:**
+```bash
+$ cueman -reorder show_shot_001 1-50 MIDDLE
+Error: Position must be one of FIRST, LAST, or REVERSE.
+```
+
+**Invalid frame range:**
+```bash
+$ cueman -eat show_shot_001 -range 50-10
+Error: Invalid range format: 50-10
 ```
 
 ## Summary


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/1929
- #1800 

**Summarize your change.**

Summary:

Add comprehensive unit tests for frame-specific operations and implement input validation for stagger, reorder, and frame range operations. Updated documentation to reflect new validation requirements.

Changes:

1) Unit tests (`cueman/tests/test_frame_operations.py`)

Created comprehensive test suite covering:
- Frame eat/kill/retry operations with layer and range filters
- Frame state filtering (running, waiting, dead, succeeded)
- Frame range parsing and validation
- Mark done functionality
- Stagger operations with increment validation (positive integers only)
- Reorder operations with position validation (FIRST, LAST, REVERSE)
- Confirmation prompts for destructive operations
- Error handling for invalid inputs

2) Input validation (`cueman/cueman/main.py`)

Added validation to ensure:
- Stagger increments must be positive integers (rejects 0, negative, non-numeric)
- Reorder positions must be FIRST, LAST, or REVERSE
- Frame ranges must be valid numeric formats with start < = end

3) Documentation updates

Updated documentation across multiple files:
- `docs/_docs/reference/tools/cueman.md`: Added validation notes and troubleshooting examples for invalid inputs
- `docs/_docs/tutorials/cueman-tutorial.md`: Added validation notes in Frame Manipulation section and error examples
- `cueman/cueman_tutorial.md`: Added validation notes for stagger and reorder
- `cueman/README.md`: Updated inline comments to reflect requirements

4) Test fixes

- Fixed typo in test method name: from `test_done_fundtionality` to `test_done_functionality`
- Corrected layer parameter type from string to list in 7 tests to match argparse `nargs="+"` behavior
- Updated assertions to expect list values for consistency with actual command-line argument parsing

Co-authored-by: Kathy Lee <lee.j.kathy@gmail.com>
Co-authored-by: Ramon Figueiredo <rfigueiredo@imageworks.com>