### PR TITLE
[Windows] Force newline style

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.sh text eol=crlf
+*.sh text eol=lf


### PR DESCRIPTION
This is to force newline style for .sh files to Unix standard on Windows.

A user reported that the checked out bash scripts used in the flyway container had Windows newlines when checked out on Windows and caused issues with the flyway migration.