### PR TITLE
[rqd] Add macOS support for temp directory stats reporting

### DIFF
--- a/rqd/rqd/rqmachine.py
+++ b/rqd/rqd/rqmachine.py
@@ -686,6 +686,11 @@ class Machine(object):
                             self.__renderHost.total_mem = int(line.split()[1])
                         elif line.startswith("SwapTotal"):
                             self.__renderHost.total_swap = int(line.split()[1])
+        elif platform.system() == 'Darwin':
+            # Reads static information for mcp
+            mcpStat = os.statvfs(self.getTempPath())
+            self.__renderHost.total_mcp = mcpStat.f_blocks * mcpStat.f_frsize // KILOBYTE
+            hyperthreadingMultiplier = 1
         else:
             hyperthreadingMultiplier = 1
 
@@ -865,6 +870,9 @@ class Machine(object):
 
         elif platform.system() == 'Darwin':
             self.updateMacMemory()
+            # Reads dynamic information for mcp
+            mcpStat = os.statvfs(self.getTempPath())
+            self.__renderHost.free_mcp = (mcpStat.f_bavail * mcpStat.f_bsize) // KILOBYTE
 
         elif platform.system() == 'Windows':
             TEMP_DEFAULT = 1048576


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/2000

**Summarize your change.**
Fixes issue where RQD on macOS doesn't report temp directory stats, causing hosts to fail in repair state due to missing storage information.

Changes:
- Add macOS code path in `__initMachineStats()` to set total_mcp using os.statvfs()
- Add macOS code path in `updateMachineStats()` to set free_mcp using os.statvfs()
- Add comprehensive unit tests for macOS temp directory functionality

The fix uses os.statvfs() on macOS (same as Linux) to read filesystem statistics for the temp directory, allowing proper reporting to cuebot.