### PR TITLE
[docker] Use build for Cuebot in docker-compose for development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,12 @@ services:
     command: /opt/scripts/migrate.sh
 
   cuebot:
-    image: opencue/cuebot
+    # Use build to compile from source with latest code (recommended for development)
+    build:
+      context: ./
+      dockerfile: ./cuebot/Dockerfile
+    # Use image for faster startup with pre-built image (uncomment to use)
+    # image: opencue/cuebot
     links:
       - db
     ports:

--- a/docs/_docs/concepts/command-execution.md
+++ b/docs/_docs/concepts/command-execution.md
@@ -1,6 +1,6 @@
 ---
 title: "Command Execution on the Render Farm"
-nav_order: 8
+nav_order: 14
 parent: "Concepts"
 layout: default
 date: 2025-10-02

--- a/docs/_docs/concepts/cueweb-rest-gateway.md
+++ b/docs/_docs/concepts/cueweb-rest-gateway.md
@@ -1,6 +1,6 @@
 ---
 title: "CueWeb and REST Gateway"
-nav_order: 13
+nav_order: 15
 parent: Concepts
 layout: default
 linkTitle: "CueWeb and REST Gateway"

--- a/docs/_docs/concepts/glossary.md
+++ b/docs/_docs/concepts/glossary.md
@@ -1,6 +1,6 @@
 ---
 title: "Glossary"
-nav_order: 10
+nav_order: 11
 parent: Concepts
 layout: default
 linkTitle: "Glossary"

--- a/docs/_docs/concepts/index.md
+++ b/docs/_docs/concepts/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Concepts
-nav_order: 8
+nav_order: 9
 has_children: true
 permalink: /docs/concepts
 ---

--- a/docs/_docs/concepts/nimby.md
+++ b/docs/_docs/concepts/nimby.md
@@ -1,6 +1,6 @@
 ---
 title: "NIMBY"
-nav_order: 12
+nav_order: 13
 parent: Concepts
 layout: default
 linkTitle: "NIMBY"

--- a/docs/_docs/concepts/opencue-overview.md
+++ b/docs/_docs/concepts/opencue-overview.md
@@ -1,6 +1,6 @@
 ---
 title: "OpenCue overview"
-nav_order: 9
+nav_order: 10
 parent: Concepts
 layout: default
 linkTitle: "OpenCue overview"

--- a/docs/_docs/concepts/spi-case-study.md
+++ b/docs/_docs/concepts/spi-case-study.md
@@ -1,6 +1,6 @@
 ---
 title: "OpenCue Sony Pictures Imageworks case study"
-nav_order: 14
+nav_order: 16
 parent: Concepts
 layout: default
 linkTitle: "OpenCue Sony Pictures Imageworks case study"

--- a/docs/_docs/concepts/versioning.md
+++ b/docs/_docs/concepts/versioning.md
@@ -1,6 +1,6 @@
 ---
 title: "Versioning"
-nav_order: 11
+nav_order: 12
 parent: Concepts
 layout: default
 linkTitle: "Versioning"

--- a/docs/_docs/developer-guide/contributing.md
+++ b/docs/_docs/developer-guide/contributing.md
@@ -2,7 +2,7 @@
 title: "Contributing to OpenCue"
 linkTitle: "Contributing to OpenCue"
 parent: "Developer Guide"
-nav_order: 71
+nav_order: 77
 layout: default
 date: 2020-05-04
 description: >

--- a/docs/_docs/developer-guide/cuecmd-development.md
+++ b/docs/_docs/developer-guide/cuecmd-development.md
@@ -1,6 +1,6 @@
 ---
 title: "Cuecmd Development Guide"
-nav_order: 12
+nav_order: 81
 parent: "Developer Guide"
 layout: default
 date: 2025-10-02

--- a/docs/_docs/developer-guide/cuecommander-technical-reference.md
+++ b/docs/_docs/developer-guide/cuecommander-technical-reference.md
@@ -2,7 +2,7 @@
 title: "CueCommander Technical Reference"
 layout: default
 parent: "Developer Guide"
-nav_order: 74
+nav_order: 80
 linkTitle: "CueCommander Technical Reference"
 date: 2025-01-13
 description: >

--- a/docs/_docs/developer-guide/cuenimby-development.md
+++ b/docs/_docs/developer-guide/cuenimby-development.md
@@ -1,6 +1,6 @@
 ---
 title: "CueNIMBY development guide"
-nav_order: 75
+nav_order: 82
 parent: Developer Guide
 layout: default
 linkTitle: "CueNIMBY development"

--- a/docs/_docs/developer-guide/cuetopia-technical-reference.md
+++ b/docs/_docs/developer-guide/cuetopia-technical-reference.md
@@ -2,7 +2,7 @@
 title: "Cuetopia Technical Reference"
 layout: default
 parent: "Developer Guide"
-nav_order: 73
+nav_order: 79
 linkTitle: "Cuetopia Technical Reference"
 date: 2025-01-07
 description: >

--- a/docs/_docs/developer-guide/cueweb-development.md
+++ b/docs/_docs/developer-guide/cueweb-development.md
@@ -2,7 +2,7 @@
 layout: default
 title: CueWeb Development
 parent: Developer Guide
-nav_order: 77
+nav_order: 84
 ---
 
 # CueWeb Development Guide

--- a/docs/_docs/developer-guide/index.md
+++ b/docs/_docs/developer-guide/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Developer Guide"
-nav_order: 70
+nav_order: 76
 has_children: true
 layout: default
 linkTitle: "Developer Guide"

--- a/docs/_docs/developer-guide/rest-gateway-development.md
+++ b/docs/_docs/developer-guide/rest-gateway-development.md
@@ -1,6 +1,6 @@
 ---
 title: "REST Gateway Development"
-nav_order: 76
+nav_order: 83
 parent: Developer Guide
 layout: default
 linkTitle: "Developing the OpenCue REST Gateway"

--- a/docs/_docs/developer-guide/sandbox-testing.md
+++ b/docs/_docs/developer-guide/sandbox-testing.md
@@ -1,6 +1,6 @@
 ---
 title: "Using the OpenCue Sandbox for Testing"
-nav_order: 72
+nav_order: 78
 parent: "Developer Guide"
 layout: default
 date: 2025-08-06

--- a/docs/_docs/getting-started/checking-out-the-source-code.md
+++ b/docs/_docs/getting-started/checking-out-the-source-code.md
@@ -1,6 +1,6 @@
 ---
 title: "Checking out the source code"
-nav_order: 19
+nav_order: 21
 parent: Getting Started
 layout: default
 linkTitle: "Checking out the source code"

--- a/docs/_docs/getting-started/deploying-cuebot.md
+++ b/docs/_docs/getting-started/deploying-cuebot.md
@@ -1,6 +1,6 @@
 ---
 title: "Deploying Cuebot"
-nav_order: 17
+nav_order: 19
 parent: Getting Started
 layout: default
 linkTitle: "Deploying Cuebot"

--- a/docs/_docs/getting-started/deploying-cueweb.md
+++ b/docs/_docs/getting-started/deploying-cueweb.md
@@ -2,7 +2,7 @@
 layout: default
 title: Deploying CueWeb
 parent: Getting Started
-nav_order: 25
+nav_order: 27
 ---
 
 # Deploying CueWeb

--- a/docs/_docs/getting-started/deploying-rest-gateway.md
+++ b/docs/_docs/getting-started/deploying-rest-gateway.md
@@ -1,6 +1,6 @@
 ---
 title: "Deploying OpenCue REST Gateway"
-nav_order: 24
+nav_order: 26
 parent: Getting Started
 layout: default
 linkTitle: "Deploying REST Gateway"

--- a/docs/_docs/getting-started/deploying-rqd.md
+++ b/docs/_docs/getting-started/deploying-rqd.md
@@ -1,6 +1,6 @@
 ---
 title: "Deploying RQD"
-nav_order: 18
+nav_order: 20
 parent: Getting Started
 layout: default
 linkTitle: "Deploying RQD"

--- a/docs/_docs/getting-started/index.md
+++ b/docs/_docs/getting-started/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Getting Started
-nav_order: 15
+nav_order: 17
 has_children: true
 permalink: /docs/getting-started
 ---

--- a/docs/_docs/getting-started/installing-cueadmin.md
+++ b/docs/_docs/getting-started/installing-cueadmin.md
@@ -1,6 +1,6 @@
 ---
 title: "Installing CueAdmin"
-nav_order: 21
+nav_order: 23
 parent: Getting Started
 layout: default
 linkTitle: "Installing CueAdmin"

--- a/docs/_docs/getting-started/installing-cuegui.md
+++ b/docs/_docs/getting-started/installing-cuegui.md
@@ -1,6 +1,6 @@
 ---
 title: "Installing CueGUI"
-nav_order: 22
+nav_order: 24
 parent: Getting Started
 layout: default
 linkTitle: "Installing CueGUI"

--- a/docs/_docs/getting-started/installing-cuesubmit.md
+++ b/docs/_docs/getting-started/installing-cuesubmit.md
@@ -1,6 +1,6 @@
 ---
 title: "Installing CueSubmit"
-nav_order: 22
+nav_order: 25
 parent: Getting Started
 layout: default
 linkTitle: "Installing CueSubmit"

--- a/docs/_docs/getting-started/installing-pycue-and-pyoutline.md
+++ b/docs/_docs/getting-started/installing-pycue-and-pyoutline.md
@@ -1,6 +1,6 @@
 ---
 title: "Installing PyCue and PyOutline"
-nav_order: 20
+nav_order: 22
 parent: Getting Started
 layout: default
 linkTitle: "Installing PyCue and PyOutline"

--- a/docs/_docs/getting-started/setting-up-the-database.md
+++ b/docs/_docs/getting-started/setting-up-the-database.md
@@ -1,6 +1,6 @@
 ---
 title: "Setting up the database"
-nav_order: 16
+nav_order: 18
 parent: Getting Started
 layout: default
 linkTitle: "Setting up the database"

--- a/docs/_docs/other-guides/applying-database-migrations.md
+++ b/docs/_docs/other-guides/applying-database-migrations.md
@@ -2,7 +2,7 @@
 title: "Applying database migrations"
 layout: default
 parent: Other Guides
-nav_order: 39
+nav_order: 42
 linkTitle: "Applying database migrations"
 date: 2019-08-22
 description: >

--- a/docs/_docs/other-guides/configuring-limits.md
+++ b/docs/_docs/other-guides/configuring-limits.md
@@ -2,7 +2,7 @@
 title: "Configuring limits"
 layout: default
 parent: Other Guides
-nav_order: 37
+nav_order: 40
 linkTitle: "Configuring limits"
 date: 2020-03-26
 description: >

--- a/docs/_docs/other-guides/configuring-opencue.md
+++ b/docs/_docs/other-guides/configuring-opencue.md
@@ -2,7 +2,7 @@
 title: "Configuring OpenCue"
 layout: default
 parent: Other Guides
-nav_order: 36
+nav_order: 39
 linkTitle: "Configuring OpenCue"
 date: 2023-01-26
 description: >

--- a/docs/_docs/other-guides/containerized_frames.md
+++ b/docs/_docs/other-guides/containerized_frames.md
@@ -2,7 +2,7 @@
 title: "Running RQD at Docker mode"
 layout: default
 parent: Other Guides
-nav_order: 43
+nav_order: 46
 linkTitle: "Running RQD at Docker mode"
 date: 2024-11-06
 description: >

--- a/docs/_docs/other-guides/cueweb.md
+++ b/docs/_docs/other-guides/cueweb.md
@@ -2,7 +2,7 @@
 title: "CueWeb System"
 layout: default
 parent: Other Guides
-nav_order: 46
+nav_order: 50
 linkTitle: "CueWeb system"
 date: 2025-02-04
 description: >

--- a/docs/_docs/other-guides/customizing-rqd.md
+++ b/docs/_docs/other-guides/customizing-rqd.md
@@ -2,7 +2,7 @@
 title: "Customizing RQD rendering hosts"
 layout: default
 parent: Other Guides
-nav_order: 38
+nav_order: 41
 linkTitle: "Customizing RQD rendering hosts"
 date: 2019-12-10
 description: >

--- a/docs/_docs/other-guides/deploying-rest-gateway.md
+++ b/docs/_docs/other-guides/deploying-rest-gateway.md
@@ -1,6 +1,6 @@
 ---
 title: "Deploying REST Gateway"
-nav_order: 45
+nav_order: 49
 parent: Other Guides
 layout: default
 linkTitle: "Deploying the OpenCue REST Gateway"

--- a/docs/_docs/other-guides/desktop-rendering-control.md
+++ b/docs/_docs/other-guides/desktop-rendering-control.md
@@ -1,6 +1,6 @@
 ---
 title: "Desktop rendering control"
-nav_order: 38
+nav_order: 48
 parent: Other Guides
 layout: default
 linkTitle: "Desktop rendering control"

--- a/docs/_docs/other-guides/framelogging-with-loki.md
+++ b/docs/_docs/other-guides/framelogging-with-loki.md
@@ -2,7 +2,7 @@
 title: "Configuring OpenCue with Loki for framelogs"
 layout: default
 parent: Other Guides
-nav_order: 44
+nav_order: 47
 linkTitle: "Configuring OpenCue with Loki for framelogs"
 date: 2024-11-27
 description: >

--- a/docs/_docs/other-guides/index.md
+++ b/docs/_docs/other-guides/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Other Guides
-nav_order: 35
+nav_order: 38
 has_children: true
 permalink: /docs/other-guides
 ---

--- a/docs/_docs/other-guides/monitoring-with-prometheus-loki-and-grafana.md
+++ b/docs/_docs/other-guides/monitoring-with-prometheus-loki-and-grafana.md
@@ -2,7 +2,7 @@
 title: "Monitoring with Prometheus, Loki, and Grafana"
 layout: default
 parent: Other Guides
-nav_order: 42
+nav_order: 45
 linkTitle: "Monitoring with Prometheus, Loki, and Grafana"
 date: 2021-08-01
 description: >

--- a/docs/_docs/other-guides/troubleshooting-deployment.md
+++ b/docs/_docs/other-guides/troubleshooting-deployment.md
@@ -2,7 +2,7 @@
 title: "Troubleshooting deployment"
 layout: default
 parent: Other Guides
-nav_order: 40
+nav_order: 43
 linkTitle: "Troubleshooting deployment"
 date: 2019-02-22
 description: >

--- a/docs/_docs/other-guides/troubleshooting-rendering.md
+++ b/docs/_docs/other-guides/troubleshooting-rendering.md
@@ -2,7 +2,7 @@
 title: "Troubleshooting rendering"
 layout: default
 parent: Other Guides
-nav_order: 41
+nav_order: 44
 linkTitle: "Troubleshooting rendering"
 date: 2019-02-22
 description: >

--- a/docs/_docs/quick-starts/quick-start-cuecmd.md
+++ b/docs/_docs/quick-starts/quick-start-cuecmd.md
@@ -1,6 +1,6 @@
 ---
-title: "Quick start with cuecmd"
-nav_order: 5
+title: "Cuecmd Quick Start"
+nav_order: 6
 parent: Quick Starts
 layout: default
 date: 2025-10-02

--- a/docs/_docs/quick-starts/quick-start-cuenimby.md
+++ b/docs/_docs/quick-starts/quick-start-cuenimby.md
@@ -1,6 +1,6 @@
 ---
-title: "Quick start for CueNIMBY"
-nav_order: 6
+title: "CueNIMBY Quick Start"
+nav_order: 7
 parent: Quick Starts
 layout: default
 linkTitle: "Quick start for CueNIMBY"

--- a/docs/_docs/quick-starts/quick-start-cueweb.md
+++ b/docs/_docs/quick-starts/quick-start-cueweb.md
@@ -2,7 +2,7 @@
 layout: default
 title: CueWeb Quick Start
 parent: Quick Starts
-nav_order: 7
+nav_order: 8
 ---
 
 # CueWeb Quick Start

--- a/docs/_docs/reference/CueGUI-app.md
+++ b/docs/_docs/reference/CueGUI-app.md
@@ -2,7 +2,7 @@
 title: "CueGUI app"
 layout: default
 parent: Reference
-nav_order: 48
+nav_order: 52
 linkTitle: "CueGUI app"
 date: 2019-02-22
 description: >

--- a/docs/_docs/reference/commands/cueadmin.md
+++ b/docs/_docs/reference/commands/cueadmin.md
@@ -2,7 +2,7 @@
 title: "cueadmin command"
 layout: default
 parent: Reference
-nav_order: 49
+nav_order: 53
 linkTitle: "cueadmin command"
 date: 2025-08-11
 description: >

--- a/docs/_docs/reference/commands/pycuerun.md
+++ b/docs/_docs/reference/commands/pycuerun.md
@@ -2,7 +2,7 @@
 title: "pycuerun command"
 layout: default
 parent: Reference
-nav_order: 50
+nav_order: 54
 linkTitle: "pycuerun command"
 date: 2019-05-23
 description: >

--- a/docs/_docs/reference/cuecommander-technical-reference.md
+++ b/docs/_docs/reference/cuecommander-technical-reference.md
@@ -2,7 +2,7 @@
 title: "CueCommander Technical Reference"
 layout: default
 parent: Reference
-nav_order: 52
+nav_order: 56
 linkTitle: "CueCommander Technical Reference"
 date: 2025-01-13
 description: >

--- a/docs/_docs/reference/index.md
+++ b/docs/_docs/reference/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Reference
-nav_order: 47
+nav_order: 51
 has_children: true
 permalink: /docs/reference
 ---

--- a/docs/_docs/reference/rest-api-reference.md
+++ b/docs/_docs/reference/rest-api-reference.md
@@ -2,7 +2,7 @@
 layout: default
 title: OpenCue REST API Reference
 parent: Reference
-nav_order: 57
+nav_order: 62
 ---
 
 # OpenCue REST API Reference

--- a/docs/_docs/reference/rust-rqd.md
+++ b/docs/_docs/reference/rust-rqd.md
@@ -1,6 +1,6 @@
 ---
 title: "Rust RQD"
-nav_order: 51
+nav_order: 55
 parent: Reference
 layout: default
 linkTitle: "Rust RQD"

--- a/docs/_docs/reference/tools/cueadmin.md
+++ b/docs/_docs/reference/tools/cueadmin.md
@@ -1,6 +1,6 @@
 ---
 title: "CueAdmin - CLI Administration Tool"
-nav_order: 54
+nav_order: 58
 parent: "Command Line Tools"
 grand_parent: "Reference"
 layout: default

--- a/docs/_docs/reference/tools/cuecmd.md
+++ b/docs/_docs/reference/tools/cuecmd.md
@@ -1,6 +1,6 @@
 ---
 title: "Cuecmd - Command Execution Tool"
-nav_order: 53
+nav_order: 60
 parent: "Command Line Tools"
 grand_parent: "Reference"
 layout: default

--- a/docs/_docs/reference/tools/cueman.md
+++ b/docs/_docs/reference/tools/cueman.md
@@ -1,6 +1,6 @@
 ---
 title: "Cueman - CLI Job Management Tool"
-nav_order: 55
+nav_order: 59
 parent: "Command Line Tools"
 grand_parent: "Reference"
 layout: default

--- a/docs/_docs/reference/tools/cuenimby.md
+++ b/docs/_docs/reference/tools/cuenimby.md
@@ -1,6 +1,6 @@
 ---
 title: "CueNIMBY - NIMBY CLI and System Tray Application"
-nav_order: 56
+nav_order: 61
 parent: "Command Line Tools"
 grand_parent: "Reference"
 layout: default

--- a/docs/_docs/reference/tools/index.md
+++ b/docs/_docs/reference/tools/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Command Line Tools"
-nav_order: 53
+nav_order: 57
 parent: "Reference"
 has_children: true
 layout: default

--- a/docs/_docs/tutorials/cueadmin-tutorial.md
+++ b/docs/_docs/tutorials/cueadmin-tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: "CueAdmin Tutorial"
-nav_order: 64
+nav_order: 69
 parent: "Tutorials"
 layout: default
 date: 2025-08-11

--- a/docs/_docs/tutorials/cuecmd-tutorial.md
+++ b/docs/_docs/tutorials/cuecmd-tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: "Cuecmd Tutorial"
-nav_order: 8
+nav_order: 71
 parent: Tutorials
 layout: default
 date: 2025-10-02

--- a/docs/_docs/tutorials/cueman-tutorial.md
+++ b/docs/_docs/tutorials/cueman-tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: "Cueman Tutorial"
-nav_order: 65
+nav_order: 70
 parent: "Tutorials"
 layout: default
 date: 2025-08-06

--- a/docs/_docs/tutorials/cuenimby-tutorial.md
+++ b/docs/_docs/tutorials/cuenimby-tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: "CueNIMBY tutorial"
-nav_order: 66
+nav_order: 72
 parent: Tutorials
 layout: default
 linkTitle: "CueNIMBY tutorial"

--- a/docs/_docs/tutorials/cueweb-tutorial.md
+++ b/docs/_docs/tutorials/cueweb-tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: "CueWeb Tutorial"
-nav_order: 68
+nav_order: 74
 parent: Tutorials
 layout: default
 linkTitle: "Getting Started with CueWeb"

--- a/docs/_docs/tutorials/dcc-integration.md
+++ b/docs/_docs/tutorials/dcc-integration.md
@@ -2,7 +2,7 @@
 title: "DCC Integration Tutorial"
 layout: default
 parent: Tutorials
-nav_order: 69
+nav_order: 75
 linkTitle: "DCC Integration Tutorial"
 date: 2025-01-29
 description: >

--- a/docs/_docs/tutorials/getting-started-tutorial.md
+++ b/docs/_docs/tutorials/getting-started-tutorial.md
@@ -2,7 +2,7 @@
 title: "Getting Started with OpenCue"
 layout: default
 parent: Tutorials
-nav_order: 59
+nav_order: 64
 linkTitle: "Getting Started with OpenCue"
 date: 2025-01-29
 description: >

--- a/docs/_docs/tutorials/index.md
+++ b/docs/_docs/tutorials/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Tutorials
-nav_order: 58
+nav_order: 63
 has_children: true
 permalink: /docs/tutorials
 ---

--- a/docs/_docs/tutorials/managing-jobs-frames.md
+++ b/docs/_docs/tutorials/managing-jobs-frames.md
@@ -2,7 +2,7 @@
 title: "Managing Jobs and Frames"
 layout: default
 parent: Tutorials
-nav_order: 62
+nav_order: 67
 linkTitle: "Managing Jobs and Frames"
 date: 2025-01-29
 description: >

--- a/docs/_docs/tutorials/multi-layer-jobs.md
+++ b/docs/_docs/tutorials/multi-layer-jobs.md
@@ -2,7 +2,7 @@
 title: "Creating Multi-Layer Jobs"
 layout: default
 parent: Tutorials
-nav_order: 63
+nav_order: 68
 linkTitle: "Creating Multi-Layer Jobs"
 date: 2025-01-29
 description: >

--- a/docs/_docs/tutorials/rest-api-tutorial.md
+++ b/docs/_docs/tutorials/rest-api-tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: "REST API Tutorial"
-nav_order: 67
+nav_order: 73
 parent: Tutorials
 layout: default
 linkTitle: "Getting Started with OpenCue REST API"

--- a/docs/_docs/tutorials/submitting-first-job.md
+++ b/docs/_docs/tutorials/submitting-first-job.md
@@ -2,7 +2,7 @@
 title: "Submitting Your First Job"
 layout: default
 parent: Tutorials
-nav_order: 60
+nav_order: 65
 linkTitle: "Submitting Your First Job"
 date: 2025-01-29
 description: >

--- a/docs/_docs/tutorials/using-cuegui.md
+++ b/docs/_docs/tutorials/using-cuegui.md
@@ -2,7 +2,7 @@
 title: "Using CueGUI for Job Monitoring"
 layout: default
 parent: Tutorials
-nav_order: 61
+nav_order: 66
 linkTitle: "Using CueGUI for Job Monitoring" 
 date: 2025-01-29
 description: >

--- a/docs/_docs/user-guides/adding-removing-limits.md
+++ b/docs/_docs/user-guides/adding-removing-limits.md
@@ -1,6 +1,6 @@
 ---
 title: "Adding or removing limits"
-nav_order: 27
+nav_order: 29
 parent: User Guides
 layout: default
 linkTitle: "Adding or removing limits"

--- a/docs/_docs/user-guides/cuecommander-administration-guide.md
+++ b/docs/_docs/user-guides/cuecommander-administration-guide.md
@@ -2,7 +2,7 @@
 title: "CueGUI: CueCommander Administration System"
 layout: default
 parent: User Guides
-nav_order: 31
+nav_order: 33
 linkTitle: "CueCommander Administration Guide"
 date: 2025-01-13
 description: >

--- a/docs/_docs/user-guides/cuenimby-user-guide.md
+++ b/docs/_docs/user-guides/cuenimby-user-guide.md
@@ -1,6 +1,6 @@
 ---
-title: "CueNIMBY user guide"
-nav_order: 32
+title: "CueNIMBY User Guide"
+nav_order: 35
 parent: User Guides
 layout: default
 linkTitle: "CueNIMBY user guide"

--- a/docs/_docs/user-guides/cuetopia-monitoring-guide.md
+++ b/docs/_docs/user-guides/cuetopia-monitoring-guide.md
@@ -2,7 +2,7 @@
 title: "CueGUI: Cuetopia Monitoring System"
 layout: default
 parent: User Guides
-nav_order: 30
+nav_order: 32
 linkTitle: "Cuetopia Monitoring Guide"
 date: 2025-01-07
 description: >

--- a/docs/_docs/user-guides/cueweb-user-guide.md
+++ b/docs/_docs/user-guides/cueweb-user-guide.md
@@ -2,7 +2,7 @@
 layout: default
 title: CueWeb User Guide
 parent: User Guides
-nav_order: 34
+nav_order: 37
 ---
 
 # CueWeb User Guide

--- a/docs/_docs/user-guides/index.md
+++ b/docs/_docs/user-guides/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: User Guides
-nav_order: 26
+nav_order: 28
 has_children: true
 permalink: /docs/user-guides
 ---

--- a/docs/_docs/user-guides/monitoring-jobs.md
+++ b/docs/_docs/user-guides/monitoring-jobs.md
@@ -1,6 +1,6 @@
 ---
 title: "Monitoring jobs"
-nav_order: 29
+nav_order: 31
 parent: User Guides
 layout: default
 linkTitle: "Monitoring your jobs"

--- a/docs/_docs/user-guides/submitting-jobs.md
+++ b/docs/_docs/user-guides/submitting-jobs.md
@@ -1,6 +1,6 @@
 ---
 title: "Submitting jobs"
-nav_order: 28
+nav_order: 30
 parent: User Guides
 layout: default
 linkTitle: "Submitting jobs"

--- a/docs/_docs/user-guides/using-cuecmd.md
+++ b/docs/_docs/user-guides/using-cuecmd.md
@@ -1,6 +1,6 @@
 ---
-title: "Using Cuecmd for Batch Commands"
-nav_order: 28
+title: "Cuecmd User Guide"
+nav_order: 34
 parent: "User Guides"
 layout: default
 date: 2025-10-02

--- a/docs/_docs/user-guides/using-rest-api.md
+++ b/docs/_docs/user-guides/using-rest-api.md
@@ -1,6 +1,6 @@
 ---
-title: "Using the REST API"
-nav_order: 33
+title: "Cue REST API User Guide"
+nav_order: 36
 parent: User Guides
 layout: default
 linkTitle: "Using the OpenCue REST API"


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/2031

**Summarize your change.**

[docker] Use build for Cuebot in docker-compose for development

Update docker-compose.yml to build Cuebot from source by default instead of using pre-built image. This ensures the latest code changes are included in the container.

Add comments to explain when to use:
- build: Compile from source with latest code (recommended for development)
- image: Pre-built image for faster startup (commented out)

This fixes issues where the client spec version is newer than the server DTD version when using outdated pre-built images.

See Cuebot the latest changes in:
- https://github.com/AcademySoftwareFoundation/OpenCue/pull/2001