### PR TITLE
[cuegui] Replace NodeGraphQtPy with NodeGraphQt

### DIFF
--- a/cuegui/cuegui/AbstractGraphWidget.py
+++ b/cuegui/cuegui/AbstractGraphWidget.py
@@ -18,8 +18,8 @@
 from qtpy import QtCore
 from qtpy import QtWidgets
 
-from NodeGraphQtPy import NodeGraph
-from NodeGraphQtPy.errors import NodeRegistrationError
+from NodeGraphQt import NodeGraph
+from NodeGraphQt.errors import NodeRegistrationError
 from cuegui.nodegraph import CueLayerNode
 from cuegui import app
 

--- a/cuegui/cuegui/nodegraph/__init__.py
+++ b/cuegui/cuegui/nodegraph/__init__.py
@@ -13,9 +13,9 @@
 #  limitations under the License.
 
 
-"""nodegraph is an OpenCue specific extension of NodeGraphQtPy
+"""nodegraph is an OpenCue specific extension of NodeGraphQt
 
-The docs for NodeGraphQtPy can be found at:
+The docs for NodeGraphQt can be found at:
 http://chantasticvfx.com/nodeGraphQt/html/nodes.html
 """
 from .nodes import CueLayerNode

--- a/cuegui/cuegui/nodegraph/nodes/__init__.py
+++ b/cuegui/cuegui/nodegraph/nodes/__init__.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 
-"""Module housing node implementations that work with NodeGraphQtPy"""
+"""Module housing node implementations that work with NodeGraphQt"""
 
 
 from .layer import CueLayerNode

--- a/cuegui/cuegui/nodegraph/nodes/base.py
+++ b/cuegui/cuegui/nodegraph/nodes/base.py
@@ -13,16 +13,16 @@
 #  limitations under the License.
 
 
-"""Base class for any cue nodes to work with NodeGraphQtPy"""
+"""Base class for any cue nodes to work with NodeGraphQt"""
 
 
 from builtins import str
-from NodeGraphQtPy import BaseNode
+from NodeGraphQt import BaseNode
 from cuegui.nodegraph.widgets.nodeWidgets import NodeProgressBar
 
 
 class CueBaseNode(BaseNode):
-    """Base class for any cue nodes to work with NodeGraphQtPy"""
+    """Base class for any cue nodes to work with NodeGraphQt"""
 
     __identifier__ = "aswf.opencue"
 

--- a/cuegui/cuegui/nodegraph/nodes/layer.py
+++ b/cuegui/cuegui/nodegraph/nodes/layer.py
@@ -13,21 +13,21 @@
 #  limitations under the License.
 
 
-"""Implementation of a Cue Layer node that works with NodeGraphQtPy"""
+"""Implementation of a Cue Layer node that works with NodeGraphQt"""
 
 
 from __future__ import division
 import os
 from qtpy import QtGui
 import opencue
-import NodeGraphQtPy.qgraphics.node_base
+import NodeGraphQt.qgraphics.node_base
 import cuegui.images
 from cuegui.Constants import RGB_FRAME_STATE
 from cuegui.nodegraph.nodes.base import CueBaseNode
 
 
 class CueLayerNode(CueBaseNode):
-    """Implementation of a Cue Layer node that works with NodeGraphQtPy"""
+    """Implementation of a Cue Layer node that works with NodeGraphQt"""
 
     __identifier__ = "aswf.opencue"
 
@@ -38,7 +38,7 @@ class CueLayerNode(CueBaseNode):
 
         self.set_name(layerRpcObject.name())
 
-        NodeGraphQtPy.qgraphics.node_base.NODE_ICON_SIZE = 30
+        NodeGraphQt.qgraphics.node_base.NODE_ICON_SIZE = 30
         services = layerRpcObject.services()
         if services:
             appService = services[0]

--- a/cuegui/cuegui/nodegraph/widgets/nodeWidgets.py
+++ b/cuegui/cuegui/nodegraph/widgets/nodeWidgets.py
@@ -15,7 +15,7 @@
 
 """Module defining custom widgets that appear on nodes in the nodegraph.
 
-The classes defined here inherit from NodeGraphQtPy base classes, therefore any
+The classes defined here inherit from NodeGraphQt base classes, therefore any
 snake_case methods defined here are overriding the base class and must remain
 snake_case to work properly.
 """
@@ -23,7 +23,7 @@ snake_case to work properly.
 
 from qtpy import QtWidgets
 from qtpy import QtCore
-from NodeGraphQtPy.widgets.node_widgets import NodeBaseWidget
+from NodeGraphQt.widgets.node_widgets import NodeBaseWidget
 
 
 class NodeProgressBar(NodeBaseWidget):
@@ -90,7 +90,7 @@ QProgressBar::chunk {
         """Get value from progress bar on node
         XXX: This property shouldn't be required as it's been superseded by get_value,
              however the progress bar doesn't update without it. Believe it may be
-             a bug in NodeGraphQtPy's `NodeObject.set_property`. We should remove this
+             a bug in NodeGraphQt's `NodeObject.set_property`. We should remove this
              once it's been resolved.
         @return: progress bar value
         @rtype:  int
@@ -102,7 +102,7 @@ QProgressBar::chunk {
         """Set value on progress bar
         XXX: This property shouldn't be required as it's been superseded by set_value,
              however the progress bar doesn't update without it. Believe it may be
-             a bug in NodeGraphQtPy's `NodeObject.set_property`. We should remove this
+             a bug in NodeGraphQt's `NodeObject.set_property`. We should remove this
              once it's been resolved.
         @param value: Value to set on progress bar
         @type  value: int

--- a/cuegui/pyproject.toml
+++ b/cuegui/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "PySide6==6.5.3;python_version=='3.11'",
     "PySide2==5.15.2.1;python_version<='3.10'",
     "QtPy==2.4.1",
-    "NodeGraphQtPy==0.6.38.6"
+    "NodeGraphQt==0.6.43"
 ]
 requires-python = ">3.7"
 description = "CueGUI is the graphical user interface for OpenCue with two main workspace views. Cuetopia provides artist-focused tools for monitoring and managing render jobs through plugins like Monitor Jobs, Job Details, Frame logs, and Job Graph. CueCommander offers administrator-focused system monitoring and host management with advanced tools for allocations, hosts, services, and resources. Together, they enable artists and administrators to track job progress and manage render farm operations."


### PR DESCRIPTION
**Summarize your change.**
This is a simple replacement of the NodeGraphQtPy fork with the original NodeGraphQt

NodeGraphQtPy was forked to support QtPy, but NodeGraphQt has since also moved to `QtPy`