### PR TITLE
[cuegui] Fix LLU and Last Line columns not populating on large jobs

### DIFF
--- a/cuegui/cuegui/FrameMonitorTree.py
+++ b/cuegui/cuegui/FrameMonitorTree.py
@@ -735,9 +735,9 @@ class FrameLogDataBuffer(object):
                 self.__queue.clear()
                 self.__currentJob = jobKey
 
-            # Cache will be managed by time-based expiration (maxCacheTime)
-            # and job-switching detection. Removed aggressive cache clearing
-            # that was causing LLU and Last Line data loss on large jobs.
+            # Prevent unbounded queue growth when threadpool is saturated
+            if len(self.__queue) > self.maxQueue:
+                self.__queue.clear()
 
             frameKey = cuegui.Utils.getObjectKey(frame)
             if frameKey in self.__cache:


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/2043

**Summarize your change.**

The LLU (Last Log Update) and Last Line columns were not populating reliably for jobs with many running frames (>500) due to aggressive cache clearing in FrameLogDataBuffer.

The cache was being completely cleared whenever the local queue length exceeded the ThreadPool queue length, which occurred frequently when the ThreadPool dropped tasks due to queue saturation. This caused LLU and Last Line data to be wiped out before it could be displayed.

Removed the problematic cache-clearing logic and rely on existing cache management mechanisms:
- Time-based expiration (maxCacheTime = 5 seconds)
- Job-switching detection (clears cache when changing jobs)
- Individual cache entry updates

This restores the monitoring functionality administrators or Production Services and Resources Team (PSRs) depend on for tracking frame progress, especially on large jobs.