### PR TITLE
[cuegui] Add email notifications for subscription size/burst changes

### DIFF
--- a/cuegui/cuegui/Constants.py
+++ b/cuegui/cuegui/Constants.py
@@ -158,6 +158,10 @@ EMAIL_DOMAIN = __config.get('email.domain', "")
 SHOW_SUPPORT_CC_TEMPLATE = [val.strip()
                             for val
                             in __config.get('email.show_support_cc_template', '').split(',')]
+SUBSCRIPTION_CHANGE_CC_TEMPLATE = [val.strip()
+                                   for val
+                                   in __config.get('email.subscription_change_cc', '').split(',')
+                                   if val.strip()]
 
 GITHUB_CREATE_ISSUE_URL = __config.get('links.issue.create')
 URL_USERGUIDE = __config.get('links.user_guide')

--- a/cuegui/cuegui/config/cuegui.yaml
+++ b/cuegui/cuegui/config/cuegui.yaml
@@ -133,6 +133,14 @@ email.domain: 'your.domain.com'
 #  - {show} is not required and will be replaced by the job show
 #  - Multiple addresses might be provided in a comma-separated list
 email.show_support_cc_template: "{show}-support@{domain}"
+# CC list for subscription change notifications (size/burst changes)
+#  - {domain} will be replaced by email.domain
+#  - {show} will be replaced by the subscription show name
+#  - Multiple addresses might be provided in a comma-separated list
+#  - Set to empty string ("") to disable email notifications for subscription changes
+#  - Example: "{show}-admin@{domain},resource-team@{domain}"
+#  - Example: "admin@example.com,team-lead@example.com"
+email.subscription_change_cc: ""
 
 # Unix epoch timestamp. If the user last viewed the startup notice before this time, the
 # notice will be shown.


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/2045

**Summarize your change.**

Added email notifications to track subscription modifications in the CueCommander GUI. When a subscription's size or burst value is changed, an automated email is sent to configured recipients with details about the change, including:
- What was changed (size or burst)
- Old and new values
- Who made the change
- Timestamp of the change

Key features:
- Configurable CC recipients via cuegui.yaml
- Support for email templates with {show} and {domain} placeholders
- Disabled by default (set email.subscription_change_cc to enable)
- Graceful error handling - email failures don't block subscription changes

Configuration:
- New setting: email.subscription_change_cc in cuegui.yaml
- Example: "{show}-admin@{domain},resource-team@{domain}"

Files modified:
- cuegui/config/cuegui.yaml: Added email.subscription_change_cc config
- cuegui/Constants.py: Added SUBSCRIPTION_CHANGE_CC_TEMPLATE constant
- cuegui/MenuActions.py: Implemented _sendSubscriptionChangeEmail() and updated editSize() and editBurst() methods
