### PR TITLE
[cuegui] Fix AttributeError when assigning local cores from layers/frames

### DIFF
--- a/cuegui/cuegui/FrameMonitorTree.py
+++ b/cuegui/cuegui/FrameMonitorTree.py
@@ -232,6 +232,7 @@ class FrameMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         self.header().sortIndicatorChanged.connect(self.__sortByColumnSave)
 
         self.__load = None
+        self.local_plugin_saved_values = {}
         self.startTicksUpdate(20)
 
     def tick(self):

--- a/cuegui/cuegui/LayerMonitorTree.py
+++ b/cuegui/cuegui/LayerMonitorTree.py
@@ -163,6 +163,7 @@ class LayerMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
 
         self.disableUpdate = False
         self.__load = None
+        self.local_plugin_saved_values = {}
         self.startTicksUpdate(20, False, 60*60*24)
 
     # pylint: disable=attribute-defined-outside-init


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/2051

**Summarize your change.**

Users were unable to enable local rendering on frames and layers due to a missing attribute initialization. The `LocalBookingWidget` attempted to access 'local_plugin_saved_values' on the parent widget, but this attribute was only initialized in `JobMonitorTree`, not in `LayerMonitorTree` or `FrameMonitorTree`.

This caused an `AttributeError` when users tried to:
- Right-click on a layer and select "Assign Local Cores"
- Right-click on a frame and select "Assign Local Cores"
- Book local cores after successfully opening the dialog

Changes:
- Initialize `local_plugin_saved_values` dict in `LayerMonitorTree.__init__`
- Initialize `local_plugin_saved_values` dict in `FrameMonitorTree.__init__`

This ensures the `LocalBookingWidget` can properly save and restore user preferences (num_frames, num_threads, num_gpus, num_mem, num_gpu_mem) across all monitor tree types.

Fixes local rendering issues reported on affected render hosts.
