### PR TITLE
[cuenimby] Fix working icon description in documentation

### DIFF
--- a/cuenimby/README.md
+++ b/cuenimby/README.md
@@ -7,7 +7,7 @@ CueNIMBY is a cross-platform system tray application that provides user control 
 - **System Tray Icon with OpenCue Logo**: Visual indication of current rendering state with professional icons
   - 🔄 **Starting**: Application is initializing
   - 🟢 **Available** (`opencue-available.png`): Host is idle and ready for rendering
-  - 🔵 **Working** (`opencue-working.png`): Currently rendering frames
+  - 🔴 **Working** (`opencue-working.png`): Currently rendering frames (red dot in center)
   - 🔴 **Disabled** (`opencue-disabled.png`):
      - NIMBY locked (🔒 due to user activity)
      - Host locked (🔒 manually disabled)
@@ -251,7 +251,7 @@ All icons feature the OpenCue logo for professional appearance:
 |-----------|-------|-------|-------------|
 | `opencue-starting.png` | Starting | 🔄 | Application is initializing |
 | `opencue-available.png` | Available | 🟢 | Host is idle and ready for rendering |
-| `opencue-working.png` | Working | 🔵 | Currently rendering frames |
+| `opencue-working.png` | Working | 🔴 | Currently rendering frames (red dot in center) |
 | `opencue-disabled.png` | Disabled/Locked/Down | 🔴 | NIMBY locked, Host locked, or Host down |
 | `opencue-error.png` | Error/Unreachable | ❌ | CueBot unreachable or host not found |
 | `opencue-warning.png` | Warning/Lagging | ⚠️ | Host ping above 60 second limit |
@@ -266,7 +266,7 @@ Here are all the CueNIMBY icons with the OpenCue logo:
 | Icon | Name | Description |
 |------|------|-------------|
 | ![Available](cuenimby/icons/opencue-available.png) | `opencue-available.png` | Green icon - Host ready for rendering |
-| ![Working](cuenimby/icons/opencue-working.png) | `opencue-working.png` | Blue icon - Currently rendering |
+| ![Working](cuenimby/icons/opencue-working.png) | `opencue-working.png` | Icon with red dot in center - Currently rendering |
 | ![Disabled](cuenimby/icons/opencue-disabled.png) | `opencue-disabled.png` | Red icon - Host locked/disabled |
 | ![Error](cuenimby/icons/opencue-error.png) | `opencue-error.png` | Red X icon - Connection error |
 | ![Warning](cuenimby/icons/opencue-warning.png) | `opencue-warning.png` | Yellow icon - Warning state |

--- a/docs/_docs/concepts/nimby.md
+++ b/docs/_docs/concepts/nimby.md
@@ -97,7 +97,7 @@ Workstations can be in one of several states. CueNIMBY displays these with profe
 |-------|------|-------|-------------|
 | **STARTING** | `opencue-starting.png` | 🔄 | Application is initializing |
 | **AVAILABLE** | `opencue-available.png` | 🟢 | Host is unlocked and idle, ready to accept jobs |
-| **WORKING** | `opencue-working.png` | 🔵 | Host is unlocked and actively running frames |
+| **WORKING** | `opencue-working.png` | 🔴 | Host is unlocked and actively running frames (red dot in center) |
 | **DISABLED** | `opencue-disabled.png` | 🔴 | Host is manually locked (via CueGUI or CueNIMBY) |
 | **NIMBY_LOCKED** | `opencue-disabled.png` | 🔒 | Host is locked by NIMBY due to user activity |
 | **HOST_DOWN** | `opencue-disabled.png` | ❌ | RQD is not running on the host |
@@ -114,7 +114,7 @@ All CueNIMBY icons feature the OpenCue logo for professional appearance:
 | Icon | File | Description |
 |------|------|-------------|
 | ![Available](/assets/images/cuenimby/icons/opencue-available.png) | `opencue-available.png` | Green - Ready for rendering |
-| ![Working](/assets/images/cuenimby/icons/opencue-working.png) | `opencue-working.png` | Blue - Currently rendering |
+| ![Working](/assets/images/cuenimby/icons/opencue-working.png) | `opencue-working.png` | Icon with red dot in center - Currently rendering |
 | ![Disabled](/assets/images/cuenimby/icons/opencue-disabled.png) | `opencue-disabled.png` | Red - Locked/disabled |
 | ![Error](/assets/images/cuenimby/icons/opencue-error.png) | `opencue-error.png` | Red X - Error/unreachable |
 | ![Warning](/assets/images/cuenimby/icons/opencue-warning.png) | `opencue-warning.png` | Yellow - Warning/lagging |

--- a/docs/_docs/developer-guide/cuenimby-development.md
+++ b/docs/_docs/developer-guide/cuenimby-development.md
@@ -439,7 +439,7 @@ logging.getLogger('cuenimby.scheduler').setLevel(logging.DEBUG)
 
 **Icon files**:
 * `opencue-available.png` - Green (ready)
-* `opencue-working.png` - Blue (rendering)
+* `opencue-working.png` - Icon with red dot in center (rendering)
 * `opencue-disabled.png` - Red (locked/down)
 * `opencue-error.png` - Red with X (error/unreachable)
 * `opencue-warning.png` - Yellow (warning/lagging)
@@ -455,7 +455,7 @@ All icons are located in `cuenimby/icons/` and feature the OpenCue logo:
 | Icon | File | Description |
 |------|------|-------------|
 | ![Available](/assets/images/cuenimby/icons/opencue-available.png) | `opencue-available.png` | Green - Host ready for rendering |
-| ![Working](/assets/images/cuenimby/icons/opencue-working.png) | `opencue-working.png` | Blue - Currently rendering |
+| ![Working](/assets/images/cuenimby/icons/opencue-working.png) | `opencue-working.png` | Icon with red dot in center - Currently rendering |
 | ![Disabled](/assets/images/cuenimby/icons/opencue-disabled.png) | `opencue-disabled.png` | Red - Host locked/disabled |
 | ![Error](/assets/images/cuenimby/icons/opencue-error.png) | `opencue-error.png` | Red X - Connection error |
 | ![Warning](/assets/images/cuenimby/icons/opencue-warning.png) | `opencue-warning.png` | Yellow - Warning/lagging |

--- a/docs/_docs/other-guides/desktop-rendering-control.md
+++ b/docs/_docs/other-guides/desktop-rendering-control.md
@@ -48,7 +48,7 @@ CueNIMBY displays these states with professional icons featuring the OpenCue log
 |-------|-----------|-------|-----------|-------------|
 | **STARTING** | `opencue-starting.png` | 🔄 | N/A | Application is initializing |
 | **AVAILABLE** | `opencue-available.png` | 🟢 | Not locked | Host is idle and ready to accept jobs |
-| **WORKING** | `opencue-working.png` | 🔵 | Not locked | Host is actively running frames |
+| **WORKING** | `opencue-working.png` | 🔴 | Not locked | Host is actively running frames (red dot in center) |
 | **DISABLED** | `opencue-disabled.png` | 🔴 | Manual lock | User manually disabled rendering via CueGUI or CueNIMBY |
 | **NIMBY_LOCKED** | `opencue-disabled.png` | 🔒 | Automatic lock | RQD locked the host due to user activity (keyboard/mouse) |
 | **HOST_DOWN** | `opencue-disabled.png` | ❌ | System issue | RQD is not running on the host |
@@ -65,7 +65,7 @@ All CueNIMBY icons feature the OpenCue logo:
 | Icon | File | Description |
 |------|------|-------------|
 | ![Available](/assets/images/cuenimby/icons/opencue-available.png) | `opencue-available.png` | Green - Ready for rendering |
-| ![Working](/assets/images/cuenimby/icons/opencue-working.png) | `opencue-working.png` | Blue - Currently rendering |
+| ![Working](/assets/images/cuenimby/icons/opencue-working.png) | `opencue-working.png` | Icon with red dot in center - Currently rendering |
 | ![Disabled](/assets/images/cuenimby/icons/opencue-disabled.png) | `opencue-disabled.png` | Red - Locked/disabled |
 | ![Error](/assets/images/cuenimby/icons/opencue-error.png) | `opencue-error.png` | Red X - Error/unreachable |
 | ![Warning](/assets/images/cuenimby/icons/opencue-warning.png) | `opencue-warning.png` | Yellow - Warning/lagging |

--- a/docs/_docs/quick-starts/quick-start-cuenimby.md
+++ b/docs/_docs/quick-starts/quick-start-cuenimby.md
@@ -84,7 +84,7 @@ If you're using the OpenCue sandbox environment, CueNIMBY is automatically insta
 2. Look for the CueNIMBY icon in your system tray (professional icons with OpenCue logo):
    * 🔄 **Starting** (`opencue-starting.png`): Application is initializing
    * 🟢 **Available** (`opencue-available.png`): Host is idle and ready for rendering
-   * 🔵 **Working** (`opencue-working.png`): Currently rendering frames
+   * 🔴 **Working** (`opencue-working.png`): Currently rendering frames (red dot in center)
    * 🔴 **Disabled** (`opencue-disabled.png`): Manually locked, NIMBY locked, or host down
    * ❌ **Error** (`opencue-error.png`): CueBot unreachable or machine not found on CueBot
    * ⚠️ **Warning** (`opencue-warning.png`): Host ping above 60 second limit
@@ -104,7 +104,7 @@ If you're using the OpenCue sandbox environment, CueNIMBY is automatically insta
    | Icon | File | Description |
    |------|------|-------------|
    | ![Available](/assets/images/cuenimby/icons/opencue-available.png) | `opencue-available.png` | Green - Ready for rendering |
-   | ![Working](/assets/images/cuenimby/icons/opencue-working.png) | `opencue-working.png` | Blue - Currently rendering |
+   | ![Working](/assets/images/cuenimby/icons/opencue-working.png) | `opencue-working.png` | Icon with red dot in center - Currently rendering |
    | ![Disabled](/assets/images/cuenimby/icons/opencue-disabled.png) | `opencue-disabled.png` | Red - Locked/disabled |
    | ![Error](/assets/images/cuenimby/icons/opencue-error.png) | `opencue-error.png` | Red X - Error/unreachable |
    | ![Warning](/assets/images/cuenimby/icons/opencue-warning.png) | `opencue-warning.png` | Yellow - Warning/lagging |

--- a/docs/_docs/reference/tools/cuenimby.md
+++ b/docs/_docs/reference/tools/cuenimby.md
@@ -180,7 +180,7 @@ All icons feature the OpenCue logo for professional appearance and consistent vi
 |-----------|-------|-------|-------------|
 | `opencue-starting.png` | 🔄 | STARTING | Application is initializing |
 | `opencue-available.png` | 🟢 | AVAILABLE | Host is unlocked and idle, ready to accept jobs |
-| `opencue-working.png` | 🔵 | WORKING | Host is unlocked and actively rendering frames |
+| `opencue-working.png` | 🔴 | WORKING | Host is unlocked and actively rendering frames (red dot in center) |
 | `opencue-disabled.png` | 🔴 | DISABLED | Host is manually locked via CueGUI or CueNIMBY |
 | `opencue-disabled.png` | 🔒 | NIMBY_LOCKED | Host is locked by RQD NIMBY due to user activity |
 | `opencue-disabled.png` | ❌ | HOST_DOWN | RQD is not running on the host |
@@ -197,7 +197,7 @@ Visual representation of all CueNIMBY icons:
 | Icon | File | Description |
 |------|------|-------------|
 | ![Available](/assets/images/cuenimby/icons/opencue-available.png) | `opencue-available.png` | Green - Ready for rendering |
-| ![Working](/assets/images/cuenimby/icons/opencue-working.png) | `opencue-working.png` | Blue - Currently rendering |
+| ![Working](/assets/images/cuenimby/icons/opencue-working.png) | `opencue-working.png` | Icon with red dot in center - Currently rendering |
 | ![Disabled](/assets/images/cuenimby/icons/opencue-disabled.png) | `opencue-disabled.png` | Red - Locked/disabled |
 | ![Error](/assets/images/cuenimby/icons/opencue-error.png) | `opencue-error.png` | Red X - Error/unreachable |
 | ![Warning](/assets/images/cuenimby/icons/opencue-warning.png) | `opencue-warning.png` | Yellow - Warning/lagging |

--- a/docs/_docs/tutorials/cuenimby-tutorial.md
+++ b/docs/_docs/tutorials/cuenimby-tutorial.md
@@ -220,7 +220,7 @@ Look at the tray icon (professional icons with OpenCue logo):
 
 * 🔄 Starting (`opencue-starting.png`) = Application initializing
 * 🟢 Available (`opencue-available.png`) = Ready for rendering
-* 🔵 Working (`opencue-working.png`) = Currently rendering
+* 🔴 Working (`opencue-working.png`) = Currently rendering (red dot in center)
 * 🔴 Disabled (`opencue-disabled.png`) = Manually locked, NIMBY locked, or host down
 * ❌ Error (`opencue-error.png`) = CueBot unreachable or host not found
 * ⚠️ Warning (`opencue-warning.png`) = Host lagging (ping > 60s)
@@ -242,7 +242,7 @@ Visual representation of all CueNIMBY icons:
 | Icon | File | Description |
 |------|------|-------------|
 | ![Available](/assets/images/cuenimby/icons/opencue-available.png) | `opencue-available.png` | Green - Ready for rendering |
-| ![Working](/assets/images/cuenimby/icons/opencue-working.png) | `opencue-working.png` | Blue - Currently rendering |
+| ![Working](/assets/images/cuenimby/icons/opencue-working.png) | `opencue-working.png` | Icon with red dot in center - Currently rendering |
 | ![Disabled](/assets/images/cuenimby/icons/opencue-disabled.png) | `opencue-disabled.png` | Red - Locked/disabled |
 | ![Error](/assets/images/cuenimby/icons/opencue-error.png) | `opencue-error.png` | Red X - Error/unreachable |
 | ![Warning](/assets/images/cuenimby/icons/opencue-warning.png) | `opencue-warning.png` | Yellow - Warning/lagging |
@@ -327,7 +327,7 @@ Rendering: myshow/test
 
 ### 5.4 Watch state changes
 
-* Icon turns blue (🔵) when frame starts
+* Icon shows red dot in center (🔴) when frame starts
 * Icon turns green (🟢) when frame completes
 
 **Checkpoint**: You receive notifications when jobs start on your machine.
@@ -406,7 +406,7 @@ Right-click the tray icon and verify "Scheduler" is checked.
 * Manual toggle temporarily overrides, but scheduler resets every minute
 
 **Outside work hours:**
-* Icon should be green (🟢) if idle, or blue (🔵) if rendering
+* Icon should be green (🟢) if idle, or show red dot in center (🔴) if rendering
 
 **Checkpoint**: Scheduler automatically controls your workstation based on time.
 

--- a/docs/_docs/user-guides/cuenimby-user-guide.md
+++ b/docs/_docs/user-guides/cuenimby-user-guide.md
@@ -117,7 +117,7 @@ The CueNIMBY tray icon uses professional icons with the OpenCue logo to indicate
 |-----------|-------|-------|-------------|
 | `opencue-starting.png` | 🔄 | Starting | Application is initializing |
 | `opencue-available.png` | 🟢 | Available | Your machine is idle and ready to accept rendering jobs |
-| `opencue-working.png` | 🔵 | Working | Your machine is currently rendering a frame |
+| `opencue-working.png` | 🔴 | Working | Your machine is currently rendering a frame (red dot in center) |
 | `opencue-disabled.png` | 🔴 | Disabled | You've manually disabled rendering via CueNIMBY or CueGUI |
 | `opencue-disabled.png` | 🔒 | NIMBY Locked | RQD has locked the machine due to user activity |
 | `opencue-disabled.png` | ❌ | Host Down | RQD is not running on the host |
@@ -134,7 +134,7 @@ All CueNIMBY icons feature the OpenCue logo for professional appearance and cons
 | Icon | Name | Description |
 |------|------|-------------|
 | ![Available](/assets/images/cuenimby/icons/opencue-available.png) | `opencue-available.png` | Green icon - Host ready for rendering |
-| ![Working](/assets/images/cuenimby/icons/opencue-working.png) | `opencue-working.png` | Blue icon - Currently rendering |
+| ![Working](/assets/images/cuenimby/icons/opencue-working.png) | `opencue-working.png` | Icon with red dot in center - Currently rendering |
 | ![Disabled](/assets/images/cuenimby/icons/opencue-disabled.png) | `opencue-disabled.png` | Red icon - Host locked/disabled |
 | ![Error](/assets/images/cuenimby/icons/opencue-error.png) | `opencue-error.png` | Red X icon - Connection error |
 | ![Warning](/assets/images/cuenimby/icons/opencue-warning.png) | `opencue-warning.png` | Yellow icon - Warning state |
@@ -164,7 +164,7 @@ Right-click the CueNIMBY icon to open the menu.
 
 Controls whether your machine accepts rendering jobs.
 
-**Checked** (🟢/🔵): Machine is available for rendering
+**Checked** (🟢/🔴): Machine is available for rendering
 * Jobs can be dispatched to your machine
 * Currently running jobs continue
 


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- https://github.com/AcademySoftwareFoundation/OpenCue/pull/2061

**Summarize your change.**

Update all CueNIMBY documentation to accurately describe the working state icon as having a red dot in center rather than being blue. This better represents a "busy" state visually.

Changes made across 8 documentation files:
- 🔴 **Working** (`opencue-working.png`): Currently rendering frames (red dot in center)
- Updated emoji from 🔵 to 🔴 in state descriptions
- Changed "Blue icon" to "Icon with red dot in center" in icon galleries
- Fixed "turns blue" to "shows red dot in center" in tutorials
- Corrected "Checked (🟢/🔵)" to "Checked (🟢/🔴)" in user guide
- Added clarification "(red dot in center)" where appropriate

Updated files:
- cuenimby/README.md
- docs/_docs/concepts/nimby.md
- docs/_docs/developer-guide/cuenimby-development.md
- docs/_docs/other-guides/desktop-rendering-control.md
- docs/_docs/quick-starts/quick-start-cuenimby.md
- docs/_docs/reference/tools/cuenimby.md
- docs/_docs/tutorials/cuenimby-tutorial.md
- docs/_docs/user-guides/cuenimby-user-guide.md