### PR TITLE
Fix PyOutline package name typo in installation docs

### DIFF
--- a/docs/_docs/getting-started/installing-pycue-and-pyoutline.md
+++ b/docs/_docs/getting-started/installing-pycue-and-pyoutline.md
@@ -68,7 +68,7 @@ pip install opencue-pycue
 Then follow the same steps to install PyOutline:
 
 ```shell
-pip install opencue-pyotline
+pip install opencue-pyoutline
 ```
 
 ### Option 2: Installing from source


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Fixes https://github.com/AcademySoftwareFoundation/OpenCue/issues/2065

**Summarize your change.**
This PR fixes a typo in the PyOutline installation documentation where the package name was misspelled as `opencue-pyotline` instead of `opencue-pyoutline`.

**Changes made:**
- Changed `opencue-pyotline` to `opencue-pyoutline` in `/docs/_docs/getting-started/installing-pycue-and-pyoutline.md`

**Why this change is needed:**
The current documentation shows an incorrect command that results in a package not found error when users try to install PyOutline. This prevents users from successfully setting up OpenCue components.

**Testing performed:**
- Verified that `pip install opencue-pyoutline` works correctly
- Confirmed that `pip install opencue-pyotline` produces the expected package not found error
- The change is a straightforward documentation correction with no functional code changes