### PR TITLE
[cuebot] Update Dockerfile to use openjdk:18-ea-18-slim-bullseye image

### DIFF
--- a/cuebot/Dockerfile
+++ b/cuebot/Dockerfile
@@ -44,7 +44,7 @@ RUN chmod +x create_rpm.sh && ./create_rpm.sh cuebot "$(cat VERSION)"
 # -----------------
 # RUN
 # -----------------
-FROM openjdk:18-slim-bullseye
+FROM openjdk:18-ea-18-slim-bullseye
 
 # Install curl for healthchecking
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Looks like the tags for openjdk has been renamed/updated.

This updates the cuebot image to use `openjdk:18-ea-18-slim-bullseye` instead of `openjdk:18-slim-bullseye`

