### PR TITLE
[cuebot] Only replace username once on PostJobs

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/service/JobSpec.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/service/JobSpec.java
@@ -937,7 +937,7 @@ public class JobSpec {
 
         JobDetail job = new JobDetail();
         job.name = parent.detail.name + "_post_job_" + System.currentTimeMillis();
-        job.name = job.name.replace(user, "monitor");
+        job.name = job.name.replaceFirst(user, "monitor");
         job.state = JobState.STARTUP;
         job.isPaused = false;
         job.maxCoreUnits = 500;


### PR DESCRIPTION
When a post job is created by the JobSpec, its username is replaced by "monitor", but the logic replace all occurrences of the username, when just the first is expected to change:

``` 
Original Job: 
show_shot_user1_rest_of_the_name_for_user1

Previous Post Job name: 
show_shot_monitor_rest_of_the_name_for_monitor

New Post Job name: 
show_shot_monitor_rest_of_the_name_for_user1 
```
