### PR TITLE
[docs]  Move theme toggle (sun icon) into header

### DIFF
--- a/docs/_includes/header_custom.html
+++ b/docs/_includes/header_custom.html
@@ -2477,11 +2477,15 @@ document.addEventListener('DOMContentLoaded', function() {
 
 
       const auxNavList = document.querySelector('.aux-nav-list');
-      // Creat a list item to wrap teh themeButton with 
+      const auxNavList = document.querySelector('.aux-nav-list');
+      if (!auxNavList) {
+        console.warn('aux-nav-list not found, cannot add theme toggle');
+        return;
+      }
+      // Create a list item to wrap the themeButton
       const listItem = document.createElement('li');
       listItem.className = 'aux-nav-list-item';
       listItem.appendChild(themeButton);
-      // Append to aux navigation
       auxNavList.appendChild(listItem);
       updateMainThemeButton();
     }


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
Fixes #1894

**Summarize your change.**
Modified header_custom.html file to append the theme button element to aux-nav-list instead of directly to the document body. This improves visibility. 

<img width="1165" height="339" alt="Screenshot 2025-12-02 at 11 31 27 PM" src="https://github.com/user-attachments/assets/a1c99a3c-fae1-4c11-872c-0833389778c2" />


<!--
For a step-by-step list to walk you through the pull request process, see
https://www.opencue.io/contributing/.

Please add unit tests for any new code. This helps our project maintain code quality and ensure
future changes don't break anything. If you're stuck on this or not sure how to proceed, feel
free to create a Draft Pull Request and ask one of the OpenCue committers for advice.
-->

[docs] Fix theme toggle issues from header migration

- Add null check for aux-nav-list to prevent TypeError
- Remove orphaned CSS properties (top, right, align-items, gap) that had no effect without position:fixed and display:flex
- Fix typos in comments
- Update function comment to reflect new behavior


Co-authored-by: silvialpz <74107990+silvialpz@users.noreply.github.com>
Co-authored-by: Ramon Figueiredo <rfigueiredo@imageworks.com>