### PR TITLE
[docs] Fix theme toggle not displaying due to duplicate const declara…

### DIFF
--- a/docs/_includes/header_custom.html
+++ b/docs/_includes/header_custom.html
@@ -2477,7 +2477,6 @@ document.addEventListener('DOMContentLoaded', function() {
 
 
       const auxNavList = document.querySelector('.aux-nav-list');
-      const auxNavList = document.querySelector('.aux-nav-list');
       if (!auxNavList) {
         console.warn('aux-nav-list not found, cannot add theme toggle');
         return;


### PR DESCRIPTION
Minor fix. Related to PR #https://github.com/AcademySoftwareFoundation/OpenCue/pull/2090

**Link the Issue(s) this Pull Request is related to.**
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/1894

**Summarize your change.**
Remove duplicate `const auxNavList` line that was accidentally introduced in commit fa916ffd, causing a JavaScript syntax error that prevented the theme toggle button from rendering.