### PR TITLE
[ci/rust] Upgrade CI/CD macOS runners from macos-13 to macos-14

### DIFF
--- a/.github/workflows/packaging-pipeline.yml
+++ b/.github/workflows/packaging-pipeline.yml
@@ -56,9 +56,9 @@ jobs:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-22.04
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-14
           - target: aarch64-apple-darwin
-            os: macos-13
+            os: macos-14
     runs-on: ${{ matrix.os }}
     outputs:
       rust_binaries_artifact: rust-binaries-${{ github.sha }}
@@ -86,7 +86,7 @@ jobs:
           fi
 
       - name: Install dependencies (macOS)
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-14'
         run: |
           brew install protobuf
 
@@ -108,7 +108,7 @@ jobs:
           cp rust/target/${{ matrix.target }}/release/openrqd release/openrqd-${{ env.BUILD_ID }}-${{ matrix.target }}
 
       - name: Copy binaries (macOS)
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-14'
         run: |
           cp rust/target/${{ matrix.target }}/release/openrqd release/openrqd-${{ env.BUILD_ID }}-${{ matrix.target }}
 

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -81,9 +81,9 @@ jobs:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-22.04
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-14
           - target: aarch64-apple-darwin
-            os: macos-13
+            os: macos-14
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -121,7 +121,7 @@ jobs:
           fi
 
       - name: Install dependencies (macOS)
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-14'
         run: |
           brew install protobuf
 
@@ -143,7 +143,7 @@ jobs:
           cp rust/target/${{ matrix.target }}/release/openrqd release/openrqd-${{ env.BUILD_ID }}-${{ matrix.target }}
 
       - name: Copy binaries (macOS)
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-14'
         run: |
           cp rust/target/${{ matrix.target }}/release/openrqd release/openrqd-${{ env.BUILD_ID }}-${{ matrix.target }}
 


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/2056

**Summarize your change.**
The macos-13 runner image is being deprecated by GitHub. Update the packaging and release pipelines to use macos-14 for building Rust binaries targeting macOS (x86_64 and aarch64).