### PR TITLE
[cuegui] Fix CueJobMonitorTree not refreshing on property changes

### DIFF
--- a/cuegui/cuegui/CueJobMonitorTree.py
+++ b/cuegui/cuegui/CueJobMonitorTree.py
@@ -411,8 +411,9 @@ class CueJobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         try:
             current = set(self._items.keys())
             if current == set(rpcObjects[1]):
-                # Only updates if return rpcObjects doesn't equal current _items
+                # Same items exist - update their data in place
                 collapsed = self.__getCollapsed()
+                self.__processUpdateHandleNested(self.invisibleRootItem(), rpcObjects[0])
                 self.__setCollapsed(collapsed)
                 self.redraw()
             else:


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/2082

**Summarize your change.**

[cuegui] Fix CueJobMonitorTree not refreshing on property changes

When job properties (priority, progress, etc.) changed without adding or removing items, the UI would not update. The _processUpdate method was only calling redraw() when the item set was unchanged, which only triggers a visual refresh without updating the underlying item data.

Now calls __processUpdateHandleNested() to update item data before redrawing, ensuring property changes are reflected in the UI.