### PR TITLE
[cueweb/docs] Update cueweb documentation with correct healthcheck using wget instead of curl

### DIFF
--- a/docs/_docs/getting-started/deploying-cueweb.md
+++ b/docs/_docs/getting-started/deploying-cueweb.md
@@ -135,7 +135,7 @@ services:
     networks:
       - opencue
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
This fixes #2126 

**Summarize your change.**
This is a tiny patch to update the documentation with the new healthcheck based on wget.