### PR TITLE
[docs] Revert uri gem to 1.0.3 in Gemfile.lock

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -170,7 +170,7 @@ GEM
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.6.0)
-    uri (1.0.4)
+    uri (1.0.3)
     webrick (1.9.1)
 
 PLATFORMS


### PR DESCRIPTION
Reverts a transient Bundler lockfile update that bumped uri from 1.0.3 to 1.0.4. 
- The docs Docker build runs Bundler in a local/deployment-style setup and does not fetch new gems, causing the build to fail when the lockfile references an uncached gem version.

Related to: 
- https://github.com/AcademySoftwareFoundation/OpenCue/pull/2135