### PR TITLE
[docs] Remove obsolete version attribute from docker-compose.yml

### DIFF
--- a/docs/docker-compose.yml
+++ b/docs/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # Build documentation
   docs-build:


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- #1800 

**Summarize your change.**

The `version` attribute is deprecated in Docker Compose V2 and is ignored. Removing it eliminates the warning message when running docker compose commands.