### PR TITLE
[cuegui] Add gRPC keepalive and automatic channel recovery

### DIFF
--- a/cuegui/cuegui/FrameMonitor.py
+++ b/cuegui/cuegui/FrameMonitor.py
@@ -30,6 +30,7 @@ from qtpy import QtWidgets
 import grpc
 
 import FileSequence
+from opencue.cuebot import Cuebot
 from opencue_proto import job_pb2
 
 import cuegui.FrameMonitorTree
@@ -165,6 +166,9 @@ class FrameMonitor(QtWidgets.QWidget):
                                                          grpc.StatusCode.UNAVAILABLE]:
                     log.warning(
                         "gRPC connection interrupted while updating frame range filter, will retry")
+                    # Record failed call and potentially reset the channel
+                    if Cuebot.recordFailedCall():
+                        log.info("Channel was reset due to connection issues")
                 else:
                     log.error("gRPC error in _frameRangeSelectionFilterUpdate: %s", e)
                 # pylint: enable=no-member
@@ -377,6 +381,9 @@ class FrameMonitor(QtWidgets.QWidget):
                                                          grpc.StatusCode.UNAVAILABLE]:
                     log.warning(
                         "gRPC connection interrupted while updating layer filter, will retry")
+                    # Record failed call and potentially reset the channel
+                    if Cuebot.recordFailedCall():
+                        log.info("Channel was reset due to connection issues")
                 else:
                     log.error("gRPC error in _filterLayersUpdate: %s", e)
                 # pylint: enable=no-member

--- a/pycue/tests/test_cuebot.py
+++ b/pycue/tests/test_cuebot.py
@@ -17,10 +17,14 @@
 """Tests for `opencue.cuebot`."""
 
 import os
+import time
 import unittest
 import mock
 
+import grpc
+
 import opencue
+from opencue import cuebot
 
 
 TESTING_CONFIG = {
@@ -70,6 +74,126 @@ class CuebotTests(unittest.TestCase):
         self.cuebot.setHostWithFacility('unknown-facility')
 
         self.assertEqual(['fake-cuebot-01'], self.cuebot.Hosts)
+
+
+class ConnectionHealthTests(unittest.TestCase):
+    """Tests for gRPC connection health tracking and recovery."""
+
+    def setUp(self):
+        """Reset connection health state before each test."""
+        opencue.Cuebot._consecutiveFailures = 0
+        opencue.Cuebot._lastSuccessfulCall = 0
+        opencue.Cuebot._channelResetInProgress = False
+
+    def tearDown(self):
+        """Reset connection health state after each test."""
+        opencue.Cuebot._consecutiveFailures = 0
+        opencue.Cuebot._lastSuccessfulCall = 0
+        opencue.Cuebot._channelResetInProgress = False
+
+    def test__keepalive_constants_defined(self):
+        """Test that keepalive constants are defined with expected values."""
+        self.assertEqual(cuebot.DEFAULT_KEEPALIVE_TIME_MS, 30000)
+        self.assertEqual(cuebot.DEFAULT_KEEPALIVE_TIMEOUT_MS, 10000)
+        self.assertTrue(cuebot.DEFAULT_KEEPALIVE_PERMIT_WITHOUT_CALLS)
+
+    def test__record_successful_call_updates_timestamp(self):
+        """Test that recordSuccessfulCall updates the last successful call timestamp."""
+        before = time.time()
+        opencue.Cuebot.recordSuccessfulCall()
+        after = time.time()
+
+        self.assertGreaterEqual(opencue.Cuebot._lastSuccessfulCall, before)
+        self.assertLessEqual(opencue.Cuebot._lastSuccessfulCall, after)
+
+    def test__record_successful_call_resets_failure_counter(self):
+        """Test that recordSuccessfulCall resets the consecutive failure counter."""
+        opencue.Cuebot._consecutiveFailures = 2
+
+        opencue.Cuebot.recordSuccessfulCall()
+
+        self.assertEqual(opencue.Cuebot._consecutiveFailures, 0)
+
+    def test__record_failed_call_increments_counter(self):
+        """Test that recordFailedCall increments the consecutive failure counter."""
+        self.assertEqual(opencue.Cuebot._consecutiveFailures, 0)
+
+        opencue.Cuebot.recordFailedCall()
+        self.assertEqual(opencue.Cuebot._consecutiveFailures, 1)
+
+        opencue.Cuebot.recordFailedCall()
+        self.assertEqual(opencue.Cuebot._consecutiveFailures, 2)
+
+    @mock.patch.object(opencue.Cuebot, 'resetChannel')
+    def test__record_failed_call_resets_channel_after_max_failures(self, mock_reset):
+        """Test that recordFailedCall triggers channel reset after max consecutive failures."""
+        # Simulate failures up to the threshold
+        for i in range(opencue.Cuebot._maxConsecutiveFailures - 1):
+            result = opencue.Cuebot.recordFailedCall()
+            self.assertFalse(result)
+            mock_reset.assert_not_called()
+
+        # The next failure should trigger a reset
+        result = opencue.Cuebot.recordFailedCall()
+        self.assertTrue(result)
+        mock_reset.assert_called_once()
+
+        # Counter should be reset after channel reset
+        self.assertEqual(opencue.Cuebot._consecutiveFailures, 0)
+
+    @mock.patch.object(opencue.Cuebot, 'resetChannel')
+    def test__record_failed_call_does_not_reset_when_already_in_progress(self, mock_reset):
+        """Test that recordFailedCall doesn't trigger reset if one is already in progress."""
+        opencue.Cuebot._channelResetInProgress = True
+        opencue.Cuebot._consecutiveFailures = opencue.Cuebot._maxConsecutiveFailures
+
+        result = opencue.Cuebot.recordFailedCall()
+
+        self.assertFalse(result)
+        mock_reset.assert_not_called()
+
+    @mock.patch.object(opencue.Cuebot, 'getStub')
+    def test__check_channel_health_returns_true_on_success(self, mock_get_stub):
+        """Test that checkChannelHealth returns True when the health check succeeds."""
+        mock_stub = mock.Mock()
+        mock_get_stub.return_value = mock_stub
+        opencue.Cuebot.RpcChannel = mock.Mock()
+
+        result = opencue.Cuebot.checkChannelHealth()
+
+        self.assertTrue(result)
+        mock_get_stub.assert_called_with('cue')
+        self.assertEqual(opencue.Cuebot._consecutiveFailures, 0)
+
+    @mock.patch.object(opencue.Cuebot, 'getStub')
+    @mock.patch.object(opencue.Cuebot, 'recordFailedCall')
+    def test__check_channel_health_returns_false_on_unavailable(
+            self, mock_record_failed, mock_get_stub):
+        """Test that checkChannelHealth returns False on UNAVAILABLE error."""
+        mock_stub = mock.Mock()
+        error = grpc.RpcError()
+        error.code = mock.Mock(return_value=grpc.StatusCode.UNAVAILABLE)
+        error.details = mock.Mock(return_value="Connection refused")
+        mock_stub.GetSystemStats.side_effect = error
+        mock_get_stub.return_value = mock_stub
+        opencue.Cuebot.RpcChannel = mock.Mock()
+
+        result = opencue.Cuebot.checkChannelHealth()
+
+        self.assertFalse(result)
+        mock_record_failed.assert_called_once()
+
+    def test__check_channel_health_returns_false_when_no_channel(self):
+        """Test that checkChannelHealth returns False when RpcChannel is None."""
+        opencue.Cuebot.RpcChannel = None
+
+        result = opencue.Cuebot.checkChannelHealth()
+
+        self.assertFalse(result)
+
+    def test__max_consecutive_failures_default(self):
+        """Test that the default max consecutive failures is set correctly."""
+        self.assertEqual(opencue.Cuebot._maxConsecutiveFailures, 3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/2139

**Summarize your change.**
Fix intermittent "Connection reset by peer" and "gRPC connection interrupted" errors that cause CueGUI to stop updating job and frame details.

Changes:
- Configure gRPC keepalive to preserve long-lived connections through load balancers and firewalls (30s ping interval, 10s timeout)
- Add channel health monitoring with automatic reconnection after 3 consecutive failures
- Integrate health tracking in FrameMonitorTree, FrameMonitor, and ThreadPool to detect and recover from stale connections

These changes prevent idle connections from being dropped by network infrastructure and ensure graceful recovery when connection issues occur.