### PR TITLE
[scheduler] Add hardware tags to rust scheduler

### DIFF
--- a/rust/crates/scheduler/src/cluster_key.rs
+++ b/rust/crates/scheduler/src/cluster_key.rs
@@ -18,6 +18,7 @@ pub enum TagType {
     Alloc,
     HostName,
     Manual,
+    Hardware,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Hash, PartialEq, Eq)]

--- a/rust/crates/scheduler/src/host_cache/actor.rs
+++ b/rust/crates/scheduler/src/host_cache/actor.rs
@@ -376,13 +376,16 @@ impl HostCacheService {
                 show_id,
                 tag,
             })
-            // Make sure tags are evaluated in this order: MANUAL -> HOSTNAME -> ALLOC
+            // Make sure tags are evaluated in this order:
+            // MANUAL -> HOSTNAME -> HARDWARE -> ALLOC
             .sorted_by(|l, r| match (&l.tag.ttype, &r.tag.ttype) {
                 (TagType::Alloc, TagType::Alloc)
                 | (TagType::HostName, TagType::HostName)
+                | (TagType::Hardware, TagType::Hardware)
                 | (TagType::Manual, TagType::Manual) => Ordering::Equal,
                 (TagType::Manual, _) => Ordering::Less,
                 (TagType::HostName, _) => Ordering::Less,
+                (TagType::Hardware, _) => Ordering::Less,
                 (TagType::Alloc, _) => Ordering::Greater,
             })
     }


### PR DESCRIPTION
A new tag type was added by https://github.com/AcademySoftwareFoundation/OpenCue/pull/2125 and needs to be handled by the Scheduler module to account for the new type
