### PR TITLE
[cuebot] Add spring-boot-starter-mail into gradle dependencies

### DIFF
--- a/cuebot/build.gradle
+++ b/cuebot/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation group: 'org.jdom', name: 'jdom', version: '1.1.3'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-jdbc'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-mail'
     implementation group: 'org.springframework', name: 'spring-context-support'
     implementation group: 'org.springframework', name: 'spring-jms'
     implementation group: 'org.quartz-scheduler', name: 'quartz', version: '2.2.1', { exclude group: 'c3p0', module: 'c3p0' }


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
No issue yet reported

**Summarize your change.**
Add spring-boot-starter-mail into gradle dependencies allow cuebot EmailSupport to work as expected.
