### PR TITLE
[docker/ci/docs] Introduce unified Docker Compose stack with core-only defaults, monitoring, and quick start documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,37 @@ Watch YouTube videos on the [OpenCue Playlist](https://www.youtube.com/playlist?
 
 # Quick installation and tests
 
-Read the [OpenCue sandbox documentation](https://github.com/AcademySoftwareFoundation/OpenCue/blob/master/sandbox/README.md) 
-to learn how to set up a local OpenCue environment.
+## Docker Compose
 
-- The sandbox environment offers an easy way to run a test OpenCue deployment locally, with all components running in 
+The easiest way to run OpenCue locally is using Docker Compose:
+
+```bash
+# Prerequisites
+mkdir -p /tmp/rqd/logs /tmp/rqd/shots
+
+# Start core services (db, flyway, cuebot, rqd)
+docker compose up -d
+
+# Check status
+docker compose ps
+```
+
+By default, only core services are enabled. To enable optional components (Web UI, Monitoring, Event Streaming),
+uncomment the relevant sections in `docker-compose.yml`. See the file header for detailed instructions.
+
+**Optional Components:**
+- **Web UI**: `rest-gateway`, `cueweb` - REST gateway and Web interface (CueWeb)
+- **Monitoring**: `prometheus`, `grafana`, `loki` - Metrics, dashboards, and logging
+- **Event Streaming**: `kafka`, `elasticsearch`, `kibana` - Historical data and analytics
+
+## Sandbox Environment
+
+Read the [OpenCue sandbox documentation](https://github.com/AcademySoftwareFoundation/OpenCue/blob/master/sandbox/README.md)
+to learn more about the sandbox environment.
+
+- The sandbox environment offers an easy way to run a test OpenCue deployment locally, with all components running in
 separate Docker containers or Python virtual environments.
-- It is ideal for small tests, development work, and for those new to OpenCue who want a simple setup for 
+- It is ideal for small tests, development work, and for those new to OpenCue who want a simple setup for
 experimentation and learning.
 
 To learn how to run the sandbox environment, see the [OpenCue Quick Starts documentation](https://www.opencue.io/docs/quick-starts/).

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Watch YouTube videos on the [OpenCue Playlist](https://www.youtube.com/playlist?
 
 ## Docker Compose
 
-The easiest way to run OpenCue locally is using Docker Compose:
+A local environment can be easily launched using Docker Compose:
 
 ```bash
 # Prerequisites

--- a/ci/run_integration_test.sh
+++ b/ci/run_integration_test.sh
@@ -240,8 +240,8 @@ main() {
            --build-arg OPENCUE_RQD_PACKAGE_PATH="${OPENCUE_RQD_PACKAGE_PATH}" \
            -t opencue/rqd -f rqd/Dockerfile . &>"${TEST_LOGS}/docker-build-rqd.log"
 
-    log INFO "Starting Docker compose..."
-    docker compose up &>"${DOCKER_COMPOSE_LOG}" &
+    log INFO "Starting Docker compose (core services only)..."
+    docker compose up db flyway cuebot rqd &>"${DOCKER_COMPOSE_LOG}" &
     if [[ "$(uname -s)" == "Darwin" ]]; then
         docker_timeout=$(date -v +5M +%s)
     else

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,40 @@
+# OpenCue Docker Compose Configuration
+#
+# This file contains all OpenCue services. By default, only the core services are enabled.
+# Uncomment the optional sections to enable additional functionality:
+#
+# Optional Components:
+#   - Web UI (rest-gateway, cueweb): Web-based interface for monitoring and managing OpenCue
+#   - Basic Monitoring (metrics, prometheus, grafana, loki, db-exporter): Metrics and logging
+#   - Full Monitoring (kafka, zookeeper, elasticsearch, kibana, monitoring-indexer): Event streaming and historical data
+#
+# Usage:
+#   # Start core services only (default)
+#   docker compose up -d
+#
+#   # View logs
+#   docker compose logs -f
+#
+# Prerequisites:
+#   mkdir -p /tmp/rqd/logs /tmp/rqd/shots
+#
+# Access (when enabled):
+#   - CueWeb UI: http://localhost:3000
+#   - REST Gateway: http://localhost:8448
+#   - Cuebot gRPC: localhost:8443
+#   - PostgreSQL: localhost:5432
+#   - Grafana: http://localhost:3001 (basic monitoring) or http://localhost:3002 (full monitoring)
+#   - Prometheus: http://localhost:9000 (basic) or http://localhost:9090 (full)
+#   - Kibana: http://localhost:5601
+#   - Kafka UI: http://localhost:8090
+
 services:
+  # =============================================================================
+  # CORE SERVICES (enabled by default)
+  # =============================================================================
+
+  # PostgreSQL Database
+  # Stores all OpenCue data including jobs, frames, hosts, shows, etc.
   db:
     image: postgres:15.1
     environment:
@@ -9,15 +45,28 @@ services:
       - "5432:5432"
     volumes:
       - ./sandbox/db-data:/var/lib/postgresql/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U cuebot -d cuebot"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    # Uncomment for Loki logging (requires loki service)
+    # logging:
+    #   driver: loki
+    #   options:
+    #     loki-url: http://localhost:3100/loki/api/v1/push
+    #     loki-external-labels: job=db
 
+  # Flyway Database Migration
+  # Applies database schema migrations to keep the database up to date
   flyway:
     build:
       context: ./
       dockerfile: ./sandbox/flyway.Dockerfile
-    links:
-      - db
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       - PGUSER=cuebot
       - PGPASSWORD=cuebot_password
@@ -26,6 +75,8 @@ services:
       - PGPORT=5432
     command: /opt/scripts/migrate.sh
 
+  # Cuebot Server
+  # The main OpenCue server that manages jobs, frames, and render hosts
   cuebot:
     # Use build to compile from source with latest code (recommended for development)
     build:
@@ -33,20 +84,54 @@ services:
       dockerfile: ./cuebot/Dockerfile
     # Use image for faster startup with pre-built image (uncomment to use)
     # image: opencue/cuebot
-    links:
-      - db
     ports:
       - "8443:8443"
+      # Uncomment for health/metrics endpoint access
+      # - "8080:8080"
     depends_on:
       db:
-        condition: service_started
+        condition: service_healthy
       flyway:
         condition: service_completed_successfully
+      # Uncomment if using Kafka monitoring
+      # kafka:
+      #   condition: service_healthy
     restart: always
     environment:
       - CUE_FRAME_LOG_DIR=/tmp/rqd/logs
+      # Uncomment for monitoring-full setup
+      # - CUEBOT_DB_HOST=db
+      # - CUEBOT_DB_NAME=cuebot
+      # - CUEBOT_DB_USER=cuebot
+      # - CUEBOT_DB_PASS=cuebot_password
+    # Default command (without Kafka monitoring)
     command: --datasource.cue-data-source.jdbc-url=jdbc:postgresql://db/cuebot --datasource.cue-data-source.username=cuebot --datasource.cue-data-source.password=cuebot_password
+    # Uncomment for Kafka monitoring (replace the command above)
+    # command:
+    #   - java
+    #   - -jar
+    #   - /opt/opencue/cuebot-latest.jar
+    #   - --datasource.cue-data-source.jdbc-url=jdbc:postgresql://db/cuebot
+    #   - --datasource.cue-data-source.username=cuebot
+    #   - --datasource.cue-data-source.password=cuebot_password
+    #   - --monitoring.kafka.enabled=true
+    #   - --monitoring.kafka.bootstrap.servers=kafka:29092
+    #   - --metrics.prometheus.collector=true
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/ || [ $? -eq 22 ]"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    # Uncomment for Loki logging (requires loki service)
+    # logging:
+    #   driver: loki
+    #   options:
+    #     loki-url: http://localhost:3100/loki/api/v1/push
+    #     loki-external-labels: job=cuebot
 
+  # RQD Render Queue Daemon
+  # Runs on render hosts and executes frames assigned by Cuebot
   rqd:
     image: opencue/rqd
     environment:
@@ -55,10 +140,328 @@ services:
     depends_on:
       cuebot:
         condition: service_healthy
-    links:
-      - cuebot
     ports:
       - "8444:8444"
     volumes:
       - /tmp/rqd/logs:/tmp/rqd/logs
       - /tmp/rqd/shots:/tmp/rqd/shots
+    restart: unless-stopped
+    # Uncomment for Loki logging (requires loki service)
+    # logging:
+    #   driver: loki
+    #   options:
+    #     loki-url: http://localhost:3100/loki/api/v1/push
+    #     loki-external-labels: job=rqd
+
+  # =============================================================================
+  # WEB UI SERVICES (optional)
+  # Uncomment this section to enable web-based interface
+  # =============================================================================
+
+  # REST Gateway
+  # Provides HTTP/REST API access to OpenCue (used by CueWeb)
+  rest-gateway:
+    image: opencue/rest-gateway:latest
+    build:
+      context: ./
+      dockerfile: rest_gateway/Dockerfile
+    container_name: opencue-rest-gateway
+    ports:
+      - "8448:8448"
+    environment:
+      - CUEBOT_ENDPOINT=cuebot:8443
+      - JWT_SECRET=${JWT_SECRET:-opencue-dev-jwt-secret-change-in-production}
+      - REST_PORT=8448
+      - LOG_LEVEL=info
+    depends_on:
+      cuebot:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "sh", "-c", "curl -sf http://localhost:8448/ || [ $? -eq 22 ]"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+
+  # CueWeb UI
+  # Web-based user interface for monitoring and managing OpenCue
+  cueweb:
+    image: opencue/cueweb:latest
+    build:
+      context: ./cueweb
+      dockerfile: Dockerfile
+      args:
+        # Build-time environment variables for Next.js
+        - NEXT_PUBLIC_OPENCUE_ENDPOINT=http://rest-gateway:8448
+        - NEXT_PUBLIC_URL=http://localhost:3000
+        - NEXTAUTH_URL=http://localhost:3000
+        - NEXTAUTH_SECRET=cueweb-nextauth-secret-change-in-production
+        # Authentication disabled by default for sandbox/development
+        # To enable authentication, uncomment and set providers:
+        # - NEXT_PUBLIC_AUTH_PROVIDER=github,okta,google,ldap
+        - NEXT_PUBLIC_AUTH_PROVIDER=
+        # Disable Sentry for sandbox
+        - SENTRY_ENVIRONMENT=development
+    container_name: opencue-cueweb
+    ports:
+      - "3000:3000"
+    volumes:
+      # Mount RQD logs directory so CueWeb can display frame logs
+      - /tmp/rqd/logs:/tmp/rqd/logs:ro
+    environment:
+      # Runtime environment variables
+      - NEXT_PUBLIC_OPENCUE_ENDPOINT=http://rest-gateway:8448
+      - NEXT_PUBLIC_URL=http://localhost:3000
+      - NEXT_JWT_SECRET=${JWT_SECRET:-opencue-dev-jwt-secret-change-in-production}
+      - NEXTAUTH_URL=http://localhost:3000
+      - NEXTAUTH_SECRET=cueweb-nextauth-secret-change-in-production
+      - SENTRY_ENVIRONMENT=development
+      # Authentication disabled - empty value skips auth providers
+      - NEXT_PUBLIC_AUTH_PROVIDER=
+    depends_on:
+      rest-gateway:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  # =============================================================================
+  # BASIC MONITORING SERVICES (optional)
+  # Uncomment this section for metrics, dashboards, and log aggregation
+  # =============================================================================
+
+  # PostgreSQL Exporter for Prometheus
+  db-exporter:
+    image: wrouesnel/postgres_exporter
+    container_name: opencue-db-exporter
+    environment:
+      - DATA_SOURCE_URI=db:5432/postgres?sslmode=disable
+      - DATA_SOURCE_USER=cuebot
+      - DATA_SOURCE_PASS=cuebot_password
+      - PG_EXPORTER_AUTO_DISCOVER_DATABASES=true
+    ports:
+      - "9187:9187"
+    depends_on:
+      - db
+
+  # # OpenCue Metrics Exporter
+  # # Exports OpenCue-specific metrics to Prometheus
+  # # Note: Requires building from source
+  # metrics:
+  #   restart: always
+  #   build:
+  #     context: ./
+  #     dockerfile: ./connectors/prometheus_metrics/Dockerfile
+  #   container_name: opencue-metrics
+  #   environment:
+  #     - CUEBOT_HOSTS=cuebot
+  #   depends_on:
+  #     - cuebot
+  #   ports:
+  #     - "8302:8302"
+
+  # Prometheus for metrics collection (basic monitoring)
+  prometheus:
+    image: prom/prometheus:v2.21.0
+    container_name: opencue-prometheus
+    ports:
+      - "9000:9090"
+    volumes:
+      - ./sandbox/config/prometheus:/etc/prometheus/
+      - prometheus-data:/prometheus
+    command: --web.enable-lifecycle --config.file=/etc/prometheus/prometheus.yml
+
+  # Grafana for dashboards (basic monitoring)
+  # Note: Port 3001 to avoid conflict with CueWeb
+  grafana:
+    image: grafana/grafana:7.1.1
+    container_name: opencue-grafana
+    volumes:
+      - ./sandbox/config/grafana/provisioning:/etc/grafana/provisioning
+      - ./sandbox/config/grafana/dashboards:/etc/grafana/dashboards
+    ports:
+      - "3001:3000"
+
+  # Loki for log aggregation
+  # Enable loki logging driver on other services to use
+  loki:
+    image: grafana/loki:v1.3.0
+    container_name: opencue-loki
+    volumes:
+      - ./sandbox/config/loki:/etc/config
+    entrypoint:
+      - /usr/bin/loki
+      - -config.file=/etc/config/loki.yaml
+    ports:
+      - "3100:3100"
+
+  # =============================================================================
+  # FULL MONITORING SERVICES (optional)
+  # Uncomment this section for Kafka event streaming, Elasticsearch, and advanced monitoring
+  # Note: This requires significant resources and is intended for production-like setups
+  # =============================================================================
+
+  # Zookeeper for Kafka
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.4.0
+    hostname: zookeeper
+    container_name: opencue-zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "2181"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # Kafka broker for event streaming
+  kafka:
+    image: confluentinc/cp-kafka:7.4.0
+    hostname: kafka
+    container_name: opencue-kafka
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+    ports:
+      - "9092:9092"
+      - "29092:29092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+    healthcheck:
+      test: ["CMD", "kafka-topics", "--bootstrap-server", "kafka:29092", "--list"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+
+  # Kafka UI for debugging
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: opencue-kafka-ui
+    depends_on:
+      kafka:
+        condition: service_healthy
+    ports:
+      - "8090:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: opencue
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092
+      KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
+
+  # Elasticsearch for historical data storage
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.8.0
+    container_name: opencue-elasticsearch
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cluster/health | grep -q '\"status\":\"green\"\\|\"status\":\"yellow\"'"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+
+  # Kibana for Elasticsearch visualization
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.8.0
+    container_name: opencue-kibana
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    ports:
+      - "5601:5601"
+    environment:
+      ELASTICSEARCH_HOSTS: http://elasticsearch:9200
+
+  # Prometheus for metrics collection (full monitoring version)
+  # Note: Uses different port and config than basic monitoring
+  prometheus-full:
+    image: prom/prometheus:v2.45.0
+    container_name: opencue-prometheus-full
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./sandbox/config/prometheus-monitoring.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-full-data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.enable-lifecycle'
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9090/-/healthy"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  # Grafana for dashboards (full monitoring version)
+  # Note: Port 3002 to avoid conflict with CueWeb (3000) and basic Grafana (3001)
+  grafana-full:
+    image: grafana/grafana:10.0.0
+    container_name: opencue-grafana-full
+    depends_on:
+      - prometheus-full
+    ports:
+      - "3002:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+    volumes:
+      - ./sandbox/config/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./sandbox/config/grafana/dashboards:/etc/grafana/dashboards:ro
+      - grafana-full-data:/var/lib/grafana
+
+  # Monitoring indexer - indexes OpenCue events from Kafka to Elasticsearch
+  # Note: Requires building from source (rust)
+  monitoring-indexer:
+    build:
+      context: ./rust
+      dockerfile: Dockerfile.monitoring-indexer
+    container_name: opencue-monitoring-indexer
+    depends_on:
+      kafka:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
+    environment:
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
+      - KAFKA_GROUP_ID=opencue-monitoring-indexer
+      - ELASTICSEARCH_URL=http://elasticsearch:9200
+      - ELASTICSEARCH_INDEX_PREFIX=opencue
+      - LOG_LEVEL=info
+    restart: unless-stopped
+
+# =============================================================================
+# VOLUMES
+# Uncomment volumes as needed based on which services you enable
+# =============================================================================
+
+volumes:
+  # Basic monitoring volumes
+  prometheus-data:
+
+  # Full monitoring volumes
+  prometheus-full-data:
+  grafana-full-data:
+  elasticsearch-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,6 +155,9 @@ services:
     # Default command (works without Kafka)
     command: --datasource.cue-data-source.jdbc-url=jdbc:postgresql://db/cuebot --datasource.cue-data-source.username=cuebot --datasource.cue-data-source.password=cuebot_password
     # Alternative: Enable Kafka monitoring (requires kafka service running)
+    # Note: The datasource parameters below configure the database connection and can be
+    # modified to point to an external database. Only the monitoring.kafka.* and metrics.*
+    # parameters are specific to Kafka event streaming.
     # command:
     #   - java
     #   - -jar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,12 @@
 # OpenCue Docker Compose Configuration
 #
-# This file contains all OpenCue services with everything enabled by default.
-# Comment out any services you don't need.
+# By default, only the core services are enabled (db, flyway, cuebot, rqd).
+# Uncomment the optional sections to enable additional functionality:
 #
-# Components:
-#   - Core: db, flyway, cuebot, rqd
-#   - Web UI: rest-gateway, cueweb
-#   - Monitoring: prometheus, grafana, loki, db-exporter
-#   - Event Streaming: kafka, zookeeper, elasticsearch, kibana, kafka-ui, monitoring-indexer
+# Optional Components:
+#   - Web UI (rest-gateway, cueweb): Web-based interface for monitoring and managing OpenCue
+#   - Monitoring (prometheus, grafana, loki, db-exporter): Metrics and logging
+#   - Event Streaming (kafka, zookeeper, elasticsearch, kibana, monitoring-indexer): Event streaming and historical data
 #
 # =============================================================================
 # QUICK START
@@ -22,12 +21,12 @@
 #
 # 3. Start services:
 #
-#    Option A - Start everything at once:
+#    Core only (default):
 #    docker compose up -d
 #
-#    Option B - Start in stages (recommended for debugging):
+#    Full stack (uncomment all sections first):
 #    docker compose up -d db zookeeper elasticsearch        # Stage 1: Infrastructure
-#    docker compose up -d flyway kafka                      # Stage 2: Migrations + Kafka
+#    docker compose up -d kafka                             # Stage 2: Kafka
 #    docker compose up -d cuebot                            # Stage 3: Core OpenCue
 #    docker compose up -d rqd rest-gateway cueweb           # Stage 4: RQD + Web UI
 #    docker compose up -d db-exporter prometheus grafana loki kafka-ui kibana monitoring-indexer  # Stage 5: Monitoring
@@ -65,7 +64,7 @@
 #    c) Restart cuebot: docker compose up -d cuebot
 #
 # =============================================================================
-# ACCESS ENDPOINTS
+# ACCESS ENDPOINTS (when enabled)
 # =============================================================================
 #
 #   Service          URL                              Credentials
@@ -146,10 +145,10 @@ services:
         condition: service_healthy
       flyway:
         condition: service_completed_successfully
-      # Kafka dependency is optional - cuebot works without it
-      kafka:
-        condition: service_healthy
-        required: false
+      # Uncomment if using Kafka monitoring (also uncomment kafka service below)
+      # kafka:
+      #   condition: service_healthy
+      #   required: false
     restart: always
     environment:
       - CUE_FRAME_LOG_DIR=/tmp/rqd/logs
@@ -207,276 +206,277 @@ services:
   # Uncomment this section to enable web-based interface
   # =============================================================================
 
-  # REST Gateway
-  # Provides HTTP/REST API access to OpenCue (used by CueWeb)
-  rest-gateway:
-    image: opencue/rest-gateway:latest
-    build:
-      context: ./
-      dockerfile: rest_gateway/Dockerfile
-    container_name: opencue-rest-gateway
-    ports:
-      - "8448:8448"
-    environment:
-      - CUEBOT_ENDPOINT=cuebot:8443
-      - JWT_SECRET=${JWT_SECRET:-opencue-dev-jwt-secret-change-in-production}
-      - REST_PORT=8448
-      - LOG_LEVEL=info
-    depends_on:
-      cuebot:
-        condition: service_healthy
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "sh", "-c", "curl -sf http://localhost:8448/ || [ $? -eq 22 ]"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 10s
+  # # REST Gateway
+  # # Provides HTTP/REST API access to OpenCue (used by CueWeb)
+  # rest-gateway:
+  #   image: opencue/rest-gateway:latest
+  #   build:
+  #     context: ./
+  #     dockerfile: rest_gateway/Dockerfile
+  #   container_name: opencue-rest-gateway
+  #   ports:
+  #     - "8448:8448"
+  #   environment:
+  #     - CUEBOT_ENDPOINT=cuebot:8443
+  #     - JWT_SECRET=${JWT_SECRET:-opencue-dev-jwt-secret-change-in-production}
+  #     - REST_PORT=8448
+  #     - LOG_LEVEL=info
+  #   depends_on:
+  #     cuebot:
+  #       condition: service_healthy
+  #   restart: unless-stopped
+  #   healthcheck:
+  #     test: ["CMD", "sh", "-c", "curl -sf http://localhost:8448/ || [ $? -eq 22 ]"]
+  #     interval: 30s
+  #     timeout: 10s
+  #     retries: 3
+  #     start_period: 10s
 
-  # CueWeb UI
-  # Web-based user interface for monitoring and managing OpenCue
-  cueweb:
-    image: opencue/cueweb:latest
-    build:
-      context: ./cueweb
-      dockerfile: Dockerfile
-      args:
-        # Build-time environment variables for Next.js
-        - NEXT_PUBLIC_OPENCUE_ENDPOINT=http://rest-gateway:8448
-        - NEXT_PUBLIC_URL=http://localhost:3000
-        - NEXTAUTH_URL=http://localhost:3000
-        - NEXTAUTH_SECRET=cueweb-nextauth-secret-change-in-production
-        # Authentication disabled by default for sandbox/development
-        # To enable authentication, uncomment and set providers:
-        # - NEXT_PUBLIC_AUTH_PROVIDER=github,okta,google,ldap
-        - NEXT_PUBLIC_AUTH_PROVIDER=
-        # Disable Sentry for sandbox
-        - SENTRY_ENVIRONMENT=development
-    container_name: opencue-cueweb
-    ports:
-      - "3000:3000"
-    volumes:
-      # Mount RQD logs directory so CueWeb can display frame logs
-      - /tmp/rqd/logs:/tmp/rqd/logs:ro
-    environment:
-      # Runtime environment variables
-      - NEXT_PUBLIC_OPENCUE_ENDPOINT=http://rest-gateway:8448
-      - NEXT_PUBLIC_URL=http://localhost:3000
-      - NEXT_JWT_SECRET=${JWT_SECRET:-opencue-dev-jwt-secret-change-in-production}
-      - NEXTAUTH_URL=http://localhost:3000
-      - NEXTAUTH_SECRET=cueweb-nextauth-secret-change-in-production
-      - SENTRY_ENVIRONMENT=development
-      # Authentication disabled - empty value skips auth providers
-      - NEXT_PUBLIC_AUTH_PROVIDER=
-    depends_on:
-      rest-gateway:
-        condition: service_healthy
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
+  # # CueWeb UI
+  # # Web-based user interface for monitoring and managing OpenCue
+  # cueweb:
+  #   image: opencue/cueweb:latest
+  #   build:
+  #     context: ./cueweb
+  #     dockerfile: Dockerfile
+  #     args:
+  #       # Build-time environment variables for Next.js
+  #       - NEXT_PUBLIC_OPENCUE_ENDPOINT=http://rest-gateway:8448
+  #       - NEXT_PUBLIC_URL=http://localhost:3000
+  #       - NEXTAUTH_URL=http://localhost:3000
+  #       - NEXTAUTH_SECRET=cueweb-nextauth-secret-change-in-production
+  #       # Authentication disabled by default for sandbox/development
+  #       # To enable authentication, uncomment and set providers:
+  #       # - NEXT_PUBLIC_AUTH_PROVIDER=github,okta,google,ldap
+  #       - NEXT_PUBLIC_AUTH_PROVIDER=
+  #       # Disable Sentry for sandbox
+  #       - SENTRY_ENVIRONMENT=development
+  #   container_name: opencue-cueweb
+  #   ports:
+  #     - "3000:3000"
+  #   volumes:
+  #     # Mount RQD logs directory so CueWeb can display frame logs
+  #     - /tmp/rqd/logs:/tmp/rqd/logs:ro
+  #   environment:
+  #     # Runtime environment variables
+  #     - NEXT_PUBLIC_OPENCUE_ENDPOINT=http://rest-gateway:8448
+  #     - NEXT_PUBLIC_URL=http://localhost:3000
+  #     - NEXT_JWT_SECRET=${JWT_SECRET:-opencue-dev-jwt-secret-change-in-production}
+  #     - NEXTAUTH_URL=http://localhost:3000
+  #     - NEXTAUTH_SECRET=cueweb-nextauth-secret-change-in-production
+  #     - SENTRY_ENVIRONMENT=development
+  #     # Authentication disabled - empty value skips auth providers
+  #     - NEXT_PUBLIC_AUTH_PROVIDER=
+  #   depends_on:
+  #     rest-gateway:
+  #       condition: service_healthy
+  #   restart: unless-stopped
+  #   healthcheck:
+  #     test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000"]
+  #     interval: 30s
+  #     timeout: 10s
+  #     retries: 3
+  #     start_period: 30s
 
   # =============================================================================
   # MONITORING SERVICES (optional)
   # Uncomment this section for metrics, dashboards, and log aggregation
   # =============================================================================
 
-  # PostgreSQL Exporter for Prometheus
-  db-exporter:
-    image: wrouesnel/postgres_exporter
-    container_name: opencue-db-exporter
-    environment:
-      - DATA_SOURCE_URI=db:5432/postgres?sslmode=disable
-      - DATA_SOURCE_USER=cuebot
-      - DATA_SOURCE_PASS=cuebot_password
-      - PG_EXPORTER_AUTO_DISCOVER_DATABASES=true
-    ports:
-      - "9187:9187"
-    depends_on:
-      - db
+  # # PostgreSQL Exporter for Prometheus
+  # db-exporter:
+  #   image: wrouesnel/postgres_exporter
+  #   container_name: opencue-db-exporter
+  #   environment:
+  #     - DATA_SOURCE_URI=db:5432/postgres?sslmode=disable
+  #     - DATA_SOURCE_USER=cuebot
+  #     - DATA_SOURCE_PASS=cuebot_password
+  #     - PG_EXPORTER_AUTO_DISCOVER_DATABASES=true
+  #   ports:
+  #     - "9187:9187"
+  #   depends_on:
+  #     - db
 
   # # OpenCue Metrics Exporter
   # # Exports OpenCue-specific metrics to Prometheus
   # # Note: Requires building from source
-  # metrics:
-  #   restart: always
-  #   build:
-  #     context: ./
-  #     dockerfile: ./connectors/prometheus_metrics/Dockerfile
-  #   container_name: opencue-metrics
-  #   environment:
-  #     - CUEBOT_HOSTS=cuebot
-  #   depends_on:
-  #     - cuebot
+  # # metrics:
+  # #   restart: always
+  # #   build:
+  # #     context: ./
+  # #     dockerfile: ./connectors/prometheus_metrics/Dockerfile
+  # #   container_name: opencue-metrics
+  # #   environment:
+  # #     - CUEBOT_HOSTS=cuebot
+  # #   depends_on:
+  # #     - cuebot
+  # #   ports:
+  # #     - "8302:8302"
+
+  # # Prometheus for metrics collection
+  # prometheus:
+  #   image: prom/prometheus:v2.45.0
+  #   container_name: opencue-prometheus
   #   ports:
-  #     - "8302:8302"
+  #     - "9090:9090"
+  #   volumes:
+  #     - ./sandbox/config/prometheus-monitoring.yml:/etc/prometheus/prometheus.yml:ro
+  #     - prometheus-data:/prometheus
+  #   command:
+  #     - '--config.file=/etc/prometheus/prometheus.yml'
+  #     - '--storage.tsdb.path=/prometheus'
+  #     - '--web.enable-lifecycle'
+  #   healthcheck:
+  #     test: ["CMD", "wget", "-q", "--spider", "http://localhost:9090/-/healthy"]
+  #     interval: 10s
+  #     timeout: 5s
+  #     retries: 3
 
-  # Prometheus for metrics collection
-  prometheus:
-    image: prom/prometheus:v2.45.0
-    container_name: opencue-prometheus
-    ports:
-      - "9090:9090"
-    volumes:
-      - ./sandbox/config/prometheus-monitoring.yml:/etc/prometheus/prometheus.yml:ro
-      - prometheus-data:/prometheus
-    command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-      - '--web.enable-lifecycle'
-    healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9090/-/healthy"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
+  # # Grafana for dashboards
+  # # Port 3001 to avoid conflict with CueWeb (3000)
+  # grafana:
+  #   image: grafana/grafana:10.0.0
+  #   container_name: opencue-grafana
+  #   depends_on:
+  #     - prometheus
+  #   ports:
+  #     - "3001:3000"
+  #   environment:
+  #     - GF_SECURITY_ADMIN_USER=admin
+  #     - GF_SECURITY_ADMIN_PASSWORD=admin
+  #     - GF_USERS_ALLOW_SIGN_UP=false
+  #   volumes:
+  #     - ./sandbox/config/grafana/provisioning:/etc/grafana/provisioning:ro
+  #     - ./sandbox/config/grafana/dashboards:/etc/grafana/dashboards:ro
+  #     - grafana-data:/var/lib/grafana
 
-  # Grafana for dashboards
-  # Port 3001 to avoid conflict with CueWeb (3000)
-  grafana:
-    image: grafana/grafana:10.0.0
-    container_name: opencue-grafana
-    depends_on:
-      - prometheus
-    ports:
-      - "3001:3000"
-    environment:
-      - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=admin
-      - GF_USERS_ALLOW_SIGN_UP=false
-    volumes:
-      - ./sandbox/config/grafana/provisioning:/etc/grafana/provisioning:ro
-      - ./sandbox/config/grafana/dashboards:/etc/grafana/dashboards:ro
-      - grafana-data:/var/lib/grafana
-
-  # Loki for log aggregation
-  # Enable loki logging driver on other services to use
-  loki:
-    image: grafana/loki:v1.3.0
-    container_name: opencue-loki
-    volumes:
-      - ./sandbox/config/loki:/etc/config
-    entrypoint:
-      - /usr/bin/loki
-      - -config.file=/etc/config/loki.yaml
-    ports:
-      - "3100:3100"
+  # # Loki for log aggregation
+  # # Enable loki logging driver on other services to use
+  # loki:
+  #   image: grafana/loki:v1.3.0
+  #   container_name: opencue-loki
+  #   volumes:
+  #     - ./sandbox/config/loki:/etc/config
+  #   entrypoint:
+  #     - /usr/bin/loki
+  #     - -config.file=/etc/config/loki.yaml
+  #   ports:
+  #     - "3100:3100"
 
   # =============================================================================
   # EVENT STREAMING SERVICES (optional)
   # Uncomment this section for Kafka event streaming and Elasticsearch historical data
   # Note: This requires significant resources and is intended for production-like setups
+  # Also uncomment the Kafka dependency in cuebot above and enable Kafka monitoring command
   # =============================================================================
 
-  # Zookeeper for Kafka
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.4.0
-    hostname: zookeeper
-    container_name: opencue-zookeeper
-    ports:
-      - "2181:2181"
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-    healthcheck:
-      test: ["CMD", "nc", "-z", "localhost", "2181"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
+  # # Zookeeper for Kafka
+  # zookeeper:
+  #   image: confluentinc/cp-zookeeper:7.4.0
+  #   hostname: zookeeper
+  #   container_name: opencue-zookeeper
+  #   ports:
+  #     - "2181:2181"
+  #   environment:
+  #     ZOOKEEPER_CLIENT_PORT: 2181
+  #     ZOOKEEPER_TICK_TIME: 2000
+  #   healthcheck:
+  #     test: ["CMD", "nc", "-z", "localhost", "2181"]
+  #     interval: 10s
+  #     timeout: 5s
+  #     retries: 5
 
-  # Kafka broker for event streaming
-  kafka:
-    image: confluentinc/cp-kafka:7.4.0
-    hostname: kafka
-    container_name: opencue-kafka
-    depends_on:
-      zookeeper:
-        condition: service_healthy
-    ports:
-      - "9092:9092"
-      - "29092:29092"
-    environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
-    healthcheck:
-      test: ["CMD", "kafka-topics", "--bootstrap-server", "kafka:29092", "--list"]
-      interval: 10s
-      timeout: 10s
-      retries: 5
+  # # Kafka broker for event streaming
+  # kafka:
+  #   image: confluentinc/cp-kafka:7.4.0
+  #   hostname: kafka
+  #   container_name: opencue-kafka
+  #   depends_on:
+  #     zookeeper:
+  #       condition: service_healthy
+  #   ports:
+  #     - "9092:9092"
+  #     - "29092:29092"
+  #   environment:
+  #     KAFKA_BROKER_ID: 1
+  #     KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+  #     KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+  #     KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+  #     KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+  #     KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+  #     KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+  #     KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+  #     KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+  #   healthcheck:
+  #     test: ["CMD", "kafka-topics", "--bootstrap-server", "kafka:29092", "--list"]
+  #     interval: 10s
+  #     timeout: 10s
+  #     retries: 5
 
-  # Kafka UI for debugging
-  kafka-ui:
-    image: provectuslabs/kafka-ui:latest
-    container_name: opencue-kafka-ui
-    depends_on:
-      kafka:
-        condition: service_healthy
-    ports:
-      - "8090:8080"
-    environment:
-      KAFKA_CLUSTERS_0_NAME: opencue
-      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092
-      KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
+  # # Kafka UI for debugging
+  # kafka-ui:
+  #   image: provectuslabs/kafka-ui:latest
+  #   container_name: opencue-kafka-ui
+  #   depends_on:
+  #     kafka:
+  #       condition: service_healthy
+  #   ports:
+  #     - "8090:8080"
+  #   environment:
+  #     KAFKA_CLUSTERS_0_NAME: opencue
+  #     KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092
+  #     KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
 
-  # Elasticsearch for historical data storage
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.8.0
-    container_name: opencue-elasticsearch
-    environment:
-      - discovery.type=single-node
-      - xpack.security.enabled=false
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-    ports:
-      - "9200:9200"
-      - "9300:9300"
-    volumes:
-      - elasticsearch-data:/usr/share/elasticsearch/data
-    healthcheck:
-      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cluster/health | grep -q '\"status\":\"green\"\\|\"status\":\"yellow\"'"]
-      interval: 10s
-      timeout: 10s
-      retries: 10
+  # # Elasticsearch for historical data storage
+  # elasticsearch:
+  #   image: docker.elastic.co/elasticsearch/elasticsearch:8.8.0
+  #   container_name: opencue-elasticsearch
+  #   environment:
+  #     - discovery.type=single-node
+  #     - xpack.security.enabled=false
+  #     - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+  #   ports:
+  #     - "9200:9200"
+  #     - "9300:9300"
+  #   volumes:
+  #     - elasticsearch-data:/usr/share/elasticsearch/data
+  #   healthcheck:
+  #     test: ["CMD-SHELL", "curl -s http://localhost:9200/_cluster/health | grep -q '\"status\":\"green\"\\|\"status\":\"yellow\"'"]
+  #     interval: 10s
+  #     timeout: 10s
+  #     retries: 10
 
-  # Kibana for Elasticsearch visualization
-  kibana:
-    image: docker.elastic.co/kibana/kibana:8.8.0
-    container_name: opencue-kibana
-    depends_on:
-      elasticsearch:
-        condition: service_healthy
-    ports:
-      - "5601:5601"
-    environment:
-      ELASTICSEARCH_HOSTS: http://elasticsearch:9200
+  # # Kibana for Elasticsearch visualization
+  # kibana:
+  #   image: docker.elastic.co/kibana/kibana:8.8.0
+  #   container_name: opencue-kibana
+  #   depends_on:
+  #     elasticsearch:
+  #       condition: service_healthy
+  #   ports:
+  #     - "5601:5601"
+  #   environment:
+  #     ELASTICSEARCH_HOSTS: http://elasticsearch:9200
 
-  # Monitoring indexer - indexes OpenCue events from Kafka to Elasticsearch
-  # Note: Requires building from source (rust)
-  monitoring-indexer:
-    build:
-      context: ./rust
-      dockerfile: Dockerfile.monitoring-indexer
-    container_name: opencue-monitoring-indexer
-    depends_on:
-      kafka:
-        condition: service_healthy
-      elasticsearch:
-        condition: service_healthy
-    environment:
-      - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
-      - KAFKA_GROUP_ID=opencue-monitoring-indexer
-      - ELASTICSEARCH_URL=http://elasticsearch:9200
-      - ELASTICSEARCH_INDEX_PREFIX=opencue
-      - LOG_LEVEL=info
-    restart: unless-stopped
+  # # Monitoring indexer - indexes OpenCue events from Kafka to Elasticsearch
+  # # Note: Requires building from source (rust)
+  # monitoring-indexer:
+  #   build:
+  #     context: ./rust
+  #     dockerfile: Dockerfile.monitoring-indexer
+  #   container_name: opencue-monitoring-indexer
+  #   depends_on:
+  #     kafka:
+  #       condition: service_healthy
+  #     elasticsearch:
+  #       condition: service_healthy
+  #   environment:
+  #     - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
+  #     - KAFKA_GROUP_ID=opencue-monitoring-indexer
+  #     - ELASTICSEARCH_URL=http://elasticsearch:9200
+  #     - ELASTICSEARCH_INDEX_PREFIX=opencue
+  #     - LOG_LEVEL=info
+  #   restart: unless-stopped
 
 # =============================================================================
 # VOLUMES

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -300,18 +300,18 @@ services:
   # # OpenCue Metrics Exporter
   # # Exports OpenCue-specific metrics to Prometheus
   # # Note: Requires building from source
-  # # metrics:
-  # #   restart: always
-  # #   build:
-  # #     context: ./
-  # #     dockerfile: ./connectors/prometheus_metrics/Dockerfile
-  # #   container_name: opencue-metrics
-  # #   environment:
-  # #     - CUEBOT_HOSTS=cuebot
-  # #   depends_on:
-  # #     - cuebot
-  # #   ports:
-  # #     - "8302:8302"
+  # metrics:
+  #   restart: always
+  #   build:
+  #     context: ./
+  #     dockerfile: ./connectors/prometheus_metrics/Dockerfile
+  #   container_name: opencue-metrics
+  #   environment:
+  #     - CUEBOT_HOSTS=cuebot
+  #   depends_on:
+  #     - cuebot
+  #   ports:
+  #     - "8302:8302"
 
   # # Prometheus for metrics collection
   # prometheus:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,37 +121,31 @@ services:
     # image: opencue/cuebot
     ports:
       - "8443:8443"
-      # Uncomment for health/metrics endpoint access
-      # - "8080:8080"
+      - "8080:8080"
     depends_on:
       db:
         condition: service_healthy
       flyway:
         condition: service_completed_successfully
-      # Uncomment if using Kafka monitoring
-      # kafka:
-      #   condition: service_healthy
+      kafka:
+        condition: service_healthy
     restart: always
     environment:
       - CUE_FRAME_LOG_DIR=/tmp/rqd/logs
-      # Uncomment for Kafka monitoring setup
-      # - CUEBOT_DB_HOST=db
-      # - CUEBOT_DB_NAME=cuebot
-      # - CUEBOT_DB_USER=cuebot
-      # - CUEBOT_DB_PASS=cuebot_password
-    # Default command (without Kafka monitoring)
-    command: --datasource.cue-data-source.jdbc-url=jdbc:postgresql://db/cuebot --datasource.cue-data-source.username=cuebot --datasource.cue-data-source.password=cuebot_password
-    # Uncomment for Kafka monitoring (replace the command above)
-    # command:
-    #   - java
-    #   - -jar
-    #   - /opt/opencue/cuebot-latest.jar
-    #   - --datasource.cue-data-source.jdbc-url=jdbc:postgresql://db/cuebot
-    #   - --datasource.cue-data-source.username=cuebot
-    #   - --datasource.cue-data-source.password=cuebot_password
-    #   - --monitoring.kafka.enabled=true
-    #   - --monitoring.kafka.bootstrap.servers=kafka:29092
-    #   - --metrics.prometheus.collector=true
+      - CUEBOT_DB_HOST=db
+      - CUEBOT_DB_NAME=cuebot
+      - CUEBOT_DB_USER=cuebot
+      - CUEBOT_DB_PASS=cuebot_password
+    command:
+      - java
+      - -jar
+      - /opt/opencue/cuebot-latest.jar
+      - --datasource.cue-data-source.jdbc-url=jdbc:postgresql://db/cuebot
+      - --datasource.cue-data-source.username=cuebot
+      - --datasource.cue-data-source.password=cuebot_password
+      - --monitoring.kafka.enabled=true
+      - --monitoring.kafka.bootstrap.servers=kafka:29092
+      - --metrics.prometheus.collector=true
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:8080/ || [ $? -eq 22 ]"]
       interval: 30s
@@ -307,7 +301,7 @@ services:
     ports:
       - "9090:9090"
     volumes:
-      - ./sandbox/config/prometheus:/etc/prometheus/
+      - ./sandbox/config/prometheus-monitoring.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus-data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,13 @@
 # OpenCue Docker Compose Configuration
 #
-# This file contains all OpenCue services. By default, only the core services are enabled.
-# Uncomment the optional sections to enable additional functionality:
+# This file contains all OpenCue services with everything enabled by default.
+# Comment out any services you don't need.
 #
-# Optional Components:
-#   - Web UI (rest-gateway, cueweb): Web-based interface for monitoring and managing OpenCue
-#   - Monitoring (prometheus, grafana, loki, db-exporter): Metrics and logging
-#   - Event Streaming (kafka, zookeeper, elasticsearch, kibana, monitoring-indexer): Event streaming and historical data
+# Components:
+#   - Core: db, flyway, cuebot, rqd
+#   - Web UI: rest-gateway, cueweb
+#   - Monitoring: prometheus, grafana, loki, db-exporter
+#   - Event Streaming: kafka, zookeeper, elasticsearch, kibana, kafka-ui, monitoring-indexer
 #
 # =============================================================================
 # QUICK START
@@ -39,8 +40,14 @@
 #    docker compose logs <service-name>      # Check specific service logs
 #    docker compose restart <service-name>   # Restart a specific service
 #
+# 6. CueWeb "ECONNREFUSED" or "/api/job/getjobs" errors:
+#    This happens when CueWeb has http://localhost:8448 baked in instead of
+#    http://rest-gateway:8448. Next.js NEXT_PUBLIC_* vars are embedded at build time.
+#    Fix: Rebuild the image with correct build args:
+#    docker compose build --no-cache cueweb && docker compose up -d cueweb
+#
 # =============================================================================
-# ACCESS ENDPOINTS (when enabled)
+# ACCESS ENDPOINTS
 # =============================================================================
 #
 #   Service          URL                              Credentials

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,24 @@
 #    Fix: Rebuild the image with correct build args:
 #    docker compose build --no-cache cueweb && docker compose up -d cueweb
 #
+# 7. Enable Kafka monitoring for Cuebot:
+#    In the cuebot service section:
+#    a) Uncomment port 8080:
+#       - "8080:8080"
+#    b) Comment out the simple command and uncomment the Kafka command:
+#       # command: --datasource.cue-data-source.jdbc-url=...
+#       command:
+#         - java
+#         - -jar
+#         - /opt/opencue/cuebot-latest.jar
+#         - --datasource.cue-data-source.jdbc-url=jdbc:postgresql://db/cuebot
+#         - --datasource.cue-data-source.username=cuebot
+#         - --datasource.cue-data-source.password=cuebot_password
+#         - --monitoring.kafka.enabled=true
+#         - --monitoring.kafka.bootstrap.servers=kafka:29092
+#         - --metrics.prometheus.collector=true
+#    c) Restart cuebot: docker compose up -d cuebot
+#
 # =============================================================================
 # ACCESS ENDPOINTS
 # =============================================================================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,31 +121,33 @@ services:
     # image: opencue/cuebot
     ports:
       - "8443:8443"
-      - "8080:8080"
+      # Uncomment for metrics endpoint (used with Prometheus monitoring)
+      # - "8080:8080"
     depends_on:
       db:
         condition: service_healthy
       flyway:
         condition: service_completed_successfully
+      # Kafka dependency is optional - cuebot works without it
       kafka:
         condition: service_healthy
+        required: false
     restart: always
     environment:
       - CUE_FRAME_LOG_DIR=/tmp/rqd/logs
-      - CUEBOT_DB_HOST=db
-      - CUEBOT_DB_NAME=cuebot
-      - CUEBOT_DB_USER=cuebot
-      - CUEBOT_DB_PASS=cuebot_password
-    command:
-      - java
-      - -jar
-      - /opt/opencue/cuebot-latest.jar
-      - --datasource.cue-data-source.jdbc-url=jdbc:postgresql://db/cuebot
-      - --datasource.cue-data-source.username=cuebot
-      - --datasource.cue-data-source.password=cuebot_password
-      - --monitoring.kafka.enabled=true
-      - --monitoring.kafka.bootstrap.servers=kafka:29092
-      - --metrics.prometheus.collector=true
+    # Default command (works without Kafka)
+    command: --datasource.cue-data-source.jdbc-url=jdbc:postgresql://db/cuebot --datasource.cue-data-source.username=cuebot --datasource.cue-data-source.password=cuebot_password
+    # Alternative: Enable Kafka monitoring (requires kafka service running)
+    # command:
+    #   - java
+    #   - -jar
+    #   - /opt/opencue/cuebot-latest.jar
+    #   - --datasource.cue-data-source.jdbc-url=jdbc:postgresql://db/cuebot
+    #   - --datasource.cue-data-source.username=cuebot
+    #   - --datasource.cue-data-source.password=cuebot_password
+    #   - --monitoring.kafka.enabled=true
+    #   - --monitoring.kafka.bootstrap.servers=kafka:29092
+    #   - --metrics.prometheus.collector=true
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:8080/ || [ $? -eq 22 ]"]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,28 +5,56 @@
 #
 # Optional Components:
 #   - Web UI (rest-gateway, cueweb): Web-based interface for monitoring and managing OpenCue
-#   - Basic Monitoring (metrics, prometheus, grafana, loki, db-exporter): Metrics and logging
-#   - Full Monitoring (kafka, zookeeper, elasticsearch, kibana, monitoring-indexer): Event streaming and historical data
+#   - Monitoring (prometheus, grafana, loki, db-exporter): Metrics and logging
+#   - Event Streaming (kafka, zookeeper, elasticsearch, kibana, monitoring-indexer): Event streaming and historical data
 #
-# Usage:
-#   # Start core services only (default)
-#   docker compose up -d
+# =============================================================================
+# QUICK START
+# =============================================================================
 #
-#   # View logs
-#   docker compose logs -f
+# 1. Prerequisites:
+#    mkdir -p /tmp/rqd/logs /tmp/rqd/shots
+#    docker compose down -v  # Clean up existing containers (optional)
 #
-# Prerequisites:
-#   mkdir -p /tmp/rqd/logs /tmp/rqd/shots
+# 2. Validate configuration:
+#    docker compose config
 #
-# Access (when enabled):
-#   - CueWeb UI: http://localhost:3000
-#   - REST Gateway: http://localhost:8448
-#   - Cuebot gRPC: localhost:8443
-#   - PostgreSQL: localhost:5432
-#   - Grafana: http://localhost:3001 (basic monitoring) or http://localhost:3002 (full monitoring)
-#   - Prometheus: http://localhost:9000 (basic) or http://localhost:9090 (full)
-#   - Kibana: http://localhost:5601
-#   - Kafka UI: http://localhost:8090
+# 3. Start services:
+#
+#    Option A - Start everything at once:
+#    docker compose up -d
+#
+#    Option B - Start in stages (recommended for debugging):
+#    docker compose up -d db zookeeper elasticsearch        # Stage 1: Infrastructure
+#    docker compose up -d flyway kafka                      # Stage 2: Migrations + Kafka
+#    docker compose up -d cuebot                            # Stage 3: Core OpenCue
+#    docker compose up -d rqd rest-gateway cueweb           # Stage 4: RQD + Web UI
+#    docker compose up -d db-exporter prometheus grafana loki kafka-ui kibana monitoring-indexer  # Stage 5: Monitoring
+#
+# 4. Check status:
+#    docker compose ps
+#    docker compose logs -f  # Watch logs (Ctrl+C to exit)
+#
+# 5. Troubleshoot:
+#    docker compose logs <service-name>      # Check specific service logs
+#    docker compose restart <service-name>   # Restart a specific service
+#
+# =============================================================================
+# ACCESS ENDPOINTS (when enabled)
+# =============================================================================
+#
+#   Service          URL                              Credentials
+#   -------          ---                              -----------
+#   CueWeb UI        http://localhost:3000            -
+#   REST Gateway     http://localhost:8448            -
+#   Cuebot gRPC      localhost:8443                   -
+#   PostgreSQL       localhost:5432                   cuebot / cuebot_password
+#   Grafana          http://localhost:3001            admin / admin
+#   Prometheus       http://localhost:9090            -
+#   Loki             http://localhost:3100            -
+#   Kafka UI         http://localhost:8090            -
+#   Kibana           http://localhost:5601            -
+#   Elasticsearch    http://localhost:9200            -
 
 services:
   # =============================================================================
@@ -99,7 +127,7 @@ services:
     restart: always
     environment:
       - CUE_FRAME_LOG_DIR=/tmp/rqd/logs
-      # Uncomment for monitoring-full setup
+      # Uncomment for Kafka monitoring setup
       # - CUEBOT_DB_HOST=db
       # - CUEBOT_DB_NAME=cuebot
       # - CUEBOT_DB_USER=cuebot
@@ -231,7 +259,7 @@ services:
       start_period: 30s
 
   # =============================================================================
-  # BASIC MONITORING SERVICES (optional)
+  # MONITORING SERVICES (optional)
   # Uncomment this section for metrics, dashboards, and log aggregation
   # =============================================================================
 
@@ -265,27 +293,42 @@ services:
   #   ports:
   #     - "8302:8302"
 
-  # Prometheus for metrics collection (basic monitoring)
+  # Prometheus for metrics collection
   prometheus:
-    image: prom/prometheus:v2.21.0
+    image: prom/prometheus:v2.45.0
     container_name: opencue-prometheus
     ports:
-      - "9000:9090"
+      - "9090:9090"
     volumes:
       - ./sandbox/config/prometheus:/etc/prometheus/
       - prometheus-data:/prometheus
-    command: --web.enable-lifecycle --config.file=/etc/prometheus/prometheus.yml
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.enable-lifecycle'
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9090/-/healthy"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
 
-  # Grafana for dashboards (basic monitoring)
-  # Note: Port 3001 to avoid conflict with CueWeb
+  # Grafana for dashboards
+  # Port 3001 to avoid conflict with CueWeb (3000)
   grafana:
-    image: grafana/grafana:7.1.1
+    image: grafana/grafana:10.0.0
     container_name: opencue-grafana
-    volumes:
-      - ./sandbox/config/grafana/provisioning:/etc/grafana/provisioning
-      - ./sandbox/config/grafana/dashboards:/etc/grafana/dashboards
+    depends_on:
+      - prometheus
     ports:
       - "3001:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+    volumes:
+      - ./sandbox/config/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./sandbox/config/grafana/dashboards:/etc/grafana/dashboards:ro
+      - grafana-data:/var/lib/grafana
 
   # Loki for log aggregation
   # Enable loki logging driver on other services to use
@@ -301,8 +344,8 @@ services:
       - "3100:3100"
 
   # =============================================================================
-  # FULL MONITORING SERVICES (optional)
-  # Uncomment this section for Kafka event streaming, Elasticsearch, and advanced monitoring
+  # EVENT STREAMING SERVICES (optional)
+  # Uncomment this section for Kafka event streaming and Elasticsearch historical data
   # Note: This requires significant resources and is intended for production-like setups
   # =============================================================================
 
@@ -394,44 +437,6 @@ services:
     environment:
       ELASTICSEARCH_HOSTS: http://elasticsearch:9200
 
-  # Prometheus for metrics collection (full monitoring version)
-  # Note: Uses different port and config than basic monitoring
-  prometheus-full:
-    image: prom/prometheus:v2.45.0
-    container_name: opencue-prometheus-full
-    ports:
-      - "9090:9090"
-    volumes:
-      - ./sandbox/config/prometheus-monitoring.yml:/etc/prometheus/prometheus.yml:ro
-      - prometheus-full-data:/prometheus
-    command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-      - '--web.enable-lifecycle'
-    healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9090/-/healthy"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
-
-  # Grafana for dashboards (full monitoring version)
-  # Note: Port 3002 to avoid conflict with CueWeb (3000) and basic Grafana (3001)
-  grafana-full:
-    image: grafana/grafana:10.0.0
-    container_name: opencue-grafana-full
-    depends_on:
-      - prometheus-full
-    ports:
-      - "3002:3000"
-    environment:
-      - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=admin
-      - GF_USERS_ALLOW_SIGN_UP=false
-    volumes:
-      - ./sandbox/config/grafana/provisioning:/etc/grafana/provisioning:ro
-      - ./sandbox/config/grafana/dashboards:/etc/grafana/dashboards:ro
-      - grafana-full-data:/var/lib/grafana
-
   # Monitoring indexer - indexes OpenCue events from Kafka to Elasticsearch
   # Note: Requires building from source (rust)
   monitoring-indexer:
@@ -454,14 +459,9 @@ services:
 
 # =============================================================================
 # VOLUMES
-# Uncomment volumes as needed based on which services you enable
 # =============================================================================
 
 volumes:
-  # Basic monitoring volumes
   prometheus-data:
-
-  # Full monitoring volumes
-  prometheus-full-data:
-  grafana-full-data:
+  grafana-data:
   elasticsearch-data:

--- a/rust/Dockerfile.monitoring-indexer
+++ b/rust/Dockerfile.monitoring-indexer
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /app
 
 # Copy workspace files and all crate sources
-COPY Cargo.toml Cargo.lock ./
+COPY Cargo.toml ./
 COPY crates ./crates
 
 # Build the monitoring-indexer package


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/2167

**Summarize your change.**

[docker/ci/docs] Introduce unified Docker Compose stack with core-only defaults, monitoring, and quick start documentation

Initial Docker Compose setup consolidating all sandbox definitions (full, monitoring, monitoring-full) into a single docker-compose.yml to simplify onboarding, local development, CI, and long-term maintenance.

By default, only core services are enabled to ensure fast startup and CI reliability:
- Core services (db, flyway, cuebot, rqd)

Optional components are clearly grouped and commented out by default:
- Web UI (rest-gateway, cueweb)
- Basic monitoring (prometheus, grafana, loki, metrics)
- Event streaming (kafka, elasticsearch, kibana, indexer)

Monitoring and infrastructure improvements:
- Consolidate Prometheus and Grafana into single instances
- Use Prometheus v2.45.0 on port 9090
- Use Grafana v10.0.0 on port 3001 with authentication enabled
- Remove duplicate services and unused volumes
- Rename “Full Monitoring” section to “Event Streaming”
- Enable Cuebot Kafka monitoring via metrics collector
- Expose Cuebot port 8080 for Prometheus scraping
- Add optional Cuebot dependency on Kafka
- Use prometheus-monitoring.yml to scrape Cuebot, Kafka, and Elasticsearch endpoints

CI and reliability improvements:
- Configure CI to start only core services (db, flyway, cuebot, rqd)
- Prevent CI from pulling/building all services, avoiding integration test timeouts
- Keep core services without container_name for CI compatibility
- Make Kafka dependency optional so Cuebot can start independently

Additional setup improvements:
- Fix context paths for root-level docker-compose usage
- Resolve port conflicts
- Add container names and health checks for optional services
- Remove Cargo.lock requirement from monitoring-indexer Dockerfile

The `docker-compose.yml` documentation enhancements:
- Add a comprehensive docker-compose.yml header with a quick start guide
- Include prerequisites, optional cleanup, and configuration validation steps
- Document staged vs all-at-once startup options
- Add status checks, log inspection commands, and troubleshooting tips
- Document CueWeb ECONNREFUSED troubleshooting for incorrect Next.js baked endpoints
- Add step-by-step instructions for enabling Kafka monitoring:
  - Uncomment port 8080
  - Switch to the Kafka-enabled command
  - Restart Cuebot
- Add Docker Compose quick start instructions to the README
- Document optional components and reference docker-compose.yml for advanced configuration
- Keep the existing Sandbox Environment section as an alternative setup option