### PR TITLE
[ci/docs] Fix permission denied error in docs pipeline

### DIFF
--- a/.github/workflows/docs-pipeline.yml
+++ b/.github/workflows/docs-pipeline.yml
@@ -145,6 +145,9 @@ jobs:
             -e JEKYLL_ENV=production \
             opencue-docs:ci \
             bundle exec jekyll build --baseurl "$BASEURL" --verbose
+
+          # Fix permissions after Docker build (Docker runs as root, so files are owned by root)
+          sudo chown -R $USER:$USER _site/
           
       - name: Create version redirect
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/1800

**Summarize your change.**
The Docker container runs as root, causing the _site directory to be owned by root. This prevented the "Create version redirect" step from creating the latest/ directory.

Add chown command after Docker build to transfer ownership back to the runner user