### PR TITLE
[pyoutline] Add OpenJD backend for job template serialization

### DIFF
--- a/pyoutline/outline/backend/openjd.py
+++ b/pyoutline/outline/backend/openjd.py
@@ -1,0 +1,651 @@
+#  Copyright Contributors to the OpenCue Project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Open Job Description (OpenJD) backend module.
+
+Serializes a PyOutline job into an OpenJD 2023-09 Job Template (YAML).
+This backend is intended for evaluation and interoperability with the
+OpenJD ecosystem.  Jobs can be run locally via the ``openjd`` CLI, or
+submitted to render management systems that consume OpenJD templates
+such as AWS Deadline Cloud.
+
+Unlike the ``cue`` backend this module does **not** submit to a remote
+scheduler.  ``serialize()`` produces the template document and
+``launch()`` runs the job locally via the ``openjd run`` CLI
+(requires the ``openjd-cli`` package — install with
+``pip install opencue-pyoutline[openjd]``).
+
+See outline.backend.__init__.py for a description of the PyOutline backend
+system.
+
+Feature parity with the cue backend
+====================================
+
+Supported:
+
+  Job definition (maps to OpenJD template):
+  - Job name
+  - Layer → Step mapping (skip unregistered, skip children, skip empty ranges)
+  - Frame range + chunk size → parameterSpace (CHUNK[INT] task parameter)
+  - Token replacement (#IFRAME#, #FRAMESPEC#, #FRAME_START#, #FRAME_END#,
+    #FRAME_CHUNK#, #ZFRAME#, #JOB#, #LAYER#, #FRAME#)
+  - Layer-on-layer dependencies (deduplicated per target step)
+  - Host requirements: cores/threads, memory, gpus, gpu_memory, tags,
+    service, limits, os
+  - Layer env vars → stepEnvironments
+  - Job-level env vars + launcher env → jobEnvironments
+  - Job metadata (facility, show, shot, user) → job parameters
+  - timeout → onRun action timeout (seconds)
+  - Layer type Post → step with dependsOn all non-Post steps
+  - Shell, ShellScript, ShellCommand, PyEval layer types
+  - LayerPreProcess / LayerPostProcess (auto-wired as separate steps)
+
+Missing / lossy (job definition gaps):
+  - Dependency types: FrameByFrame, PreviousFrame, LayerOnSimFrame, and
+    LayerOnAny are all collapsed into a flat dependsOn.  OpenJD only models
+    step-on-step dependencies (all tasks must complete), so frame-level
+    dependency granularity is lost.  Tracked upstream:
+    https://github.com/OpenJobDescription/openjd-specifications/discussions/82
+  - timeout_llu (Last Layer Update): the maximum time a frame can go without
+    producing any output before being considered hung.  OpenJD has no
+    equivalent — its timeout is wall-clock only.
+    Created discussion https://github.com/OpenJobDescription/openjd-specifications/discussions/118
+  - Layer outputs: the cue backend (spec >= 1.15) serializes get_outputs().
+    Not yet mapped.  OpenJD PATH parameters support dataFlow but only at
+    the job level, not per-step or per-task.
+    TODO: open a discussion on openjd-specifications for step- and task-level
+    file dataflow declarations (output path registration, existence checks).
+  - Composite layers (parent-child grouping): child layers run sequentially
+    within the parent's task, not as independent steps.  Currently skipped.
+    TODO: serialize composite layers as a single step whose script runs
+    the parent and children in sequence.  Sequential actions in onRun
+    (https://github.com/OpenJobDescription/openjd-specifications/discussions/97)
+    would allow each child to have its own timeout and cancellation behavior.
+  - ShellSequence layer type (array of commands in one layer).  Sequential
+    actions in onRun would enable this:
+    https://github.com/OpenJobDescription/openjd-specifications/discussions/97
+
+Not mapped (scheduling concerns, not job definition):
+  OpenJD templates define job structure and commands, not scheduling policy.
+  These are handled by the scheduler (e.g. OpenCue's cuebot, Deadline Cloud).
+  - pause: launch job in paused state
+  - priority: job priority for dispatch ordering
+  - maxretries: max frame retry count on failure
+  - autoeat: auto-consume failed frames
+  - maxcores / maxgpus: job-level concurrency caps (max total cores/GPUs
+    the job can consume simultaneously across all running frames)
+
+Uncertain (could be either job definition or scheduling):
+  - Layer type Render/Util: informational categorization used by OpenCue's
+    filter system for bulk resource policy.  The actual resource requirements
+    are already in hostRequirements, but the categorization itself could be
+    useful metadata for a scheduler.
+  - Threadable: per-layer flag indicating whether the application can use
+    multiple cores.  Controls dynamic core scaling and bin-packing in
+    OpenCue's dispatcher.  Could be job definition (it describes the
+    application's behavior) or scheduling (it affects dispatch decisions).
+    TODO: open a discussion on openjd-specifications about task-level
+    metadata for core utilization (single-threaded vs multi-threaded) and
+    how a scheduler could use it for concurrent task placement on a host.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+import subprocess
+import tempfile
+from typing import Any, Dict, List, Optional
+
+from openjd.model import DecodeValidationError, decode_job_template, escape_format_string
+import yaml
+
+import outline
+import outline.depend
+import outline.exception
+
+logger = logging.getLogger("outline.backend.openjd")
+
+__all__ = [
+    "launch",
+    "serialize",
+    "serialize_simple",
+]
+
+SPEC_VERSION = "jobtemplate-2023-09"
+EXTENSIONS = ["TASK_CHUNKING", "EXPR"]
+
+
+# ---------------------------------------------------------------------------
+# Public backend interface (matches cue.py / local.py contract)
+# ---------------------------------------------------------------------------
+
+
+def launch(launcher, use_pycuerun=None):
+    """Launch the job locally via ``openjd run``.
+
+    Serializes the template to a temporary YAML file and invokes the
+    openjd CLI to run the full job.  Requires the ``openjd-cli`` package
+    to be installed (``pip install opencue-pyoutline[openjd]``).
+
+    The *use_pycuerun* parameter is accepted for interface compatibility
+    with other backends but has no effect — OpenJD templates always
+    contain the commands directly.
+    """
+    template_yaml = serialize(launcher)
+
+    # Write template to a temp file that persists until the run completes.
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".template.yaml",
+        prefix="openjd-",
+        delete=False,
+        encoding="utf-8",
+    )
+    try:
+        tmp.write(template_yaml)
+        tmp.close()
+
+        cmd = ["openjd", "run", tmp.name]
+
+        logger.info("Running: %s", " ".join(cmd))
+        result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+
+        if result.returncode != 0:
+            raise outline.exception.OutlineException(
+                "openjd run exited with code %d: %s" % (result.returncode, result.stderr)
+            )
+    finally:
+        try:
+            os.unlink(tmp.name)
+        except OSError:
+            pass
+
+    return template_yaml
+
+
+def serialize(launcher):
+    """Serialize the outline into an OpenJD job template YAML string."""
+    return _serialize(launcher)
+
+
+def serialize_simple(launcher):
+    """Alias - OpenJD templates don't distinguish pycuerun wrapping."""
+    return _serialize(launcher)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _frame_range_to_openjd(frame_range: str) -> str:
+    """Convert a FileSequence-style frame range into an OpenJD IntRangeExpr.
+
+    FileSequence uses ``1-10x2`` for step syntax while OpenJD uses ``1-10:2``.
+    """
+    return frame_range.replace("x", ":")
+
+
+def _build_step_dependencies(layer) -> Optional[List[Dict[str, str]]]:
+    """Return the ``dependencies`` list for a step, or *None* if empty."""
+    deps = layer.get_depends()
+    if not deps:
+        return None
+    seen = set()
+    result: List[Dict[str, str]] = []
+    for dep in deps:
+        on_name = dep.get_depend_on_layer().get_name()
+        if on_name not in seen:
+            result.append({"dependsOn": on_name})
+            seen.add(on_name)
+    return result
+
+
+def _map_os(os_name: str) -> tuple:
+    """Map an OpenCue OS string to (os_family, distro).
+
+    Returns a tuple of (family, distro) where family is one of the
+    OpenJD ``attr.worker.os.family`` values (linux, windows, macos)
+    and distro is an optional Linux distribution name for
+    ``attr.linux.distro``, or None.
+    """
+    lower = os_name.lower()
+    if lower in ("windows", "win32", "win64", "nt"):
+        return ("windows", None)
+    if lower in ("darwin", "macos"):
+        return ("macos", None)
+    if lower == "linux":
+        return ("linux", None)
+    # Distro-specific (centos7, rocky9, rhel7, etc.) → linux + distro
+    return ("linux", lower)
+
+
+def _build_host_requirements(layer, os_name: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    """Map PyOutline resource args to OpenJD ``hostRequirements``."""
+    amounts: List[Dict[str, Any]] = []
+    attributes: List[Dict[str, Any]] = []
+
+    # OS → attr.worker.os.family (and optionally attr.linux.distro)
+    if os_name:
+        family, distro = _map_os(os_name)
+        attributes.append({"name": "attr.worker.os.family", "anyOf": [family]})
+        if distro:
+            attributes.append({"name": "attr.linux.distro", "anyOf": [distro]})
+
+    # CPU cores
+    cores = None
+    if layer.is_arg_set("cores"):
+        cores = layer.get_arg("cores")
+    elif layer.is_arg_set("threads"):
+        cores = layer.get_arg("threads")
+    if cores is not None:
+        amounts.append({"name": "amount.worker.vcpu", "min": float(cores)})
+
+    # Memory — PyOutline passes memory through as an opaque string to cuebot,
+    # which parses it via convertMemoryInput:
+    #   "<number>m" → megabytes
+    #   "<number>g" → gigabytes
+    #   "<number>"  (no suffix) → gigabytes
+    # We replicate that logic here and convert to MiB for OpenJD.
+    memory = layer.get_arg("memory")
+    if memory:
+        mem_mib = _parse_memory_to_mib(str(memory))
+        amounts.append({"name": "amount.worker.memory", "min": mem_mib})
+
+    # GPUs
+    gpus = layer.get_arg("gpus")
+    if gpus:
+        amounts.append({"name": "amount.worker.gpu", "min": int(gpus)})
+    # GPU memory — same format as regular memory
+    gpu_memory = layer.get_arg("gpu_memory")
+    if gpu_memory:
+        gpu_mem_mib = _parse_memory_to_mib(str(gpu_memory))
+        amounts.append({"name": "amount.worker.gpu.memory", "min": gpu_mem_mib})
+
+    # Tags → custom attribute opencue:attr.tag
+    # Tags can be a pipe-delimited string ("render|gpu") or a list.
+    tags = layer.get_arg("tags")
+    if tags:
+        tag_list = _parse_tags(tags)
+        if tag_list:
+            attributes.append({"name": "opencue:attr.tag", "allOf": tag_list})
+
+    # Service → custom attribute opencue:attr.service
+    # Match the cue backend which takes only the first comma-separated service
+    # (see cue.py: layer.get_service().split(",")[0]).
+    # TODO: consider using the full list as anyOf values, since OpenJD's anyOf
+    # semantics ("host must have at least one") are a better fit for multiple
+    # services than discarding all but the first.
+    service = layer.get_service()
+    if service:
+        primary = service.split(",")[0].strip()
+        if primary:
+            attributes.append({"name": "opencue:attr.service", "anyOf": [primary]})
+
+    # Limits → amount.limit.<name> (min: 1)
+    # Each named limit is mapped as a consumable amount so that an
+    # OpenJD-compatible scheduler (e.g. Deadline Cloud) can enforce
+    # concurrency limits the same way OpenCue does.
+    layer_limits = layer.get_limits()
+    if layer_limits:
+        for limit_name in layer_limits:
+            amounts.append({"name": "amount.limit.%s" % limit_name, "min": 1})
+
+    if not amounts and not attributes:
+        return None
+    req: Dict[str, Any] = {}
+    if amounts:
+        req["amounts"] = amounts
+    if attributes:
+        req["attributes"] = attributes
+    return req
+
+
+def _parse_tags(tags) -> List[str]:
+    """Normalize tags from a pipe-delimited string or list into a clean list."""
+    if isinstance(tags, str):
+        return [t.strip() for t in tags.split("|") if t.strip()]
+    if isinstance(tags, (list, tuple)):
+        return [str(t).strip() for t in tags if str(t).strip()]
+    return []
+
+
+def _parse_memory_to_mib(value: str) -> int:
+    """Convert a cuebot-style memory string to MiB for OpenJD.
+
+    Follows cuebot's ``convertMemoryInput`` convention, which treats
+    MB and MiB interchangeably (no 1000→1024 conversion):
+
+      - ``"512m"``  → 512 MiB
+      - ``"4g"``    → 4096 MiB  (value × 1024)
+      - ``"4"``     → 4096 MiB  (plain number treated as GiB)
+
+    Raises:
+        LayerException: If the value cannot be parsed.
+    """
+    v = value.strip().lower()
+    try:
+        if v.endswith("m"):
+            return int(float(v[:-1]))
+        if v.endswith("g"):
+            return int(float(v[:-1]) * 1024)
+        # Plain number — cuebot treats as gigabytes.
+        return int(float(v) * 1024)
+    except (ValueError, TypeError):
+        raise outline.exception.LayerException(
+            "Invalid memory value: %r — expected a number with optional "
+            "'m' (megabytes) or 'g' (gigabytes) suffix" % value
+        )
+
+
+
+# Token replacement map for OpenCue → OpenJD.
+# All steps use CHUNK[INT], so Task.Param.Frame is a range expression.
+# min()/max() extract the first/last frame from the range.
+_TOKENS = {
+    "#FRAMESPEC#": "{{ Task.Param.Frame }}",
+    "#IFRAME#": "{{ min(Task.Param.Frame) }}",
+    "#ZFRAME#": "{{ zfill(min(Task.Param.Frame), 4) }}",
+    "#FRAME_START#": "{{ min(Task.Param.Frame) }}",
+    "#FRAME_END#": "{{ max(Task.Param.Frame) }}",
+    "#FRAME_CHUNK#": "{{ chunk_size }}",
+    "#JOB#": "{{ Job.Name }}",
+    "#LAYER#": "{{ Step.Name }}",
+    "#FRAME#": "{{ zfill(min(Task.Param.Frame), 4) }}-{{ Step.Name }}",
+}
+
+
+def _replace_tokens(value: str, token_map: dict) -> str:
+    """Replace all OpenCue command tokens in a string."""
+    for token, replacement in token_map.items():
+        value = value.replace(token, replacement)
+    return value
+
+
+def _build_cue_env_exports() -> str:
+    """Build the export lines for task-level CUE_* environment variables."""
+    return (
+        "export CUE_IFRAME={{ min(Task.Param.Frame) }}\n"
+        "export CUE_JOB={{ repr_sh(Job.Name) }}\n"
+        "export CUE_LAYER={{ repr_sh(Step.Name) }}\n"
+        "export CUE_FRAME={{ repr_sh(zfill(min(Task.Param.Frame), 4)"
+        " + '-' + Step.Name) }}\n"
+    )
+
+
+def _build_step_script(layer) -> Dict[str, Any]:
+    """Build the ``script`` block for a step.
+
+    All layer types are wrapped in a bash script that exports task-level
+    CUE_* environment variables for compatibility, then runs the actual
+    command.
+
+    Handles three layer types:
+      - ShellScript: embeds the script file, wrapper calls it.
+      - PyEval: embeds the Python code, wrapper calls ``python`` on it.
+      - Shell/ShellCommand/other: wrapper calls the command directly.
+    """
+    from outline.modules.shell import PyEval, ShellScript
+
+    env_exports = _build_cue_env_exports()
+    embedded_files: List[Dict[str, Any]] = []
+
+    # Determine the command line to put in the wrapper.
+    if isinstance(layer, ShellScript):
+        script_path = layer.get_arg("script")
+        with open(script_path, encoding="utf-8") as fp:
+            script_content = fp.read()
+        embedded_files.append(
+            {"name": "script", "type": "TEXT", "runnable": True, "data": script_content}
+        )
+        cmd_line = "{{ repr_sh(Task.File.script) }}"
+
+    elif isinstance(layer, PyEval):
+        code = layer.get_code()
+        if code is None:
+            raise outline.exception.LayerException(
+                "PyEval layer '%s' has no code — was setup() already called?" % layer.get_name()
+            )
+        embedded_files.append({"name": "script", "type": "TEXT", "data": code})
+        cmd_line = "python {{ repr_sh(Task.File.script) }}"
+
+    else:
+        # Shell/ShellCommand/other: resolve tokens in the command.
+        command_parts = layer.get_arg("command") or layer.get_arg("cmd")
+        if command_parts:
+            if isinstance(command_parts, (list, tuple)):
+                resolved = [_replace_tokens(str(part), _TOKENS) for part in command_parts]
+            else:
+                resolved = [
+                    _replace_tokens(part, _TOKENS) for part in shlex.split(str(command_parts))
+                ]
+        else:
+            raise outline.exception.LayerException(
+                "Layer '%s' has no command set" % layer.get_name()
+            )
+        cmd_line = " ".join(shlex.quote(arg) for arg in resolved)
+
+    # Build the wrapper script.
+    wrapper = "#!/bin/bash\n"
+    wrapper += env_exports
+    # 'exec' replaces the wrapper shell with the actual command process,
+    # so the session runner tracks the real PID for timeout/cancellation.
+    wrapper += f"exec {cmd_line}\n"
+
+    embedded_files.append({
+        "name": "opencue_wrapper", "type": "TEXT", "runnable": True, "data": wrapper
+    })
+
+    action: Dict[str, Any] = {"command": "{{ Task.File.opencue_wrapper }}"}
+    timeout = layer.get_arg("timeout")
+    if timeout:
+        action["timeout"] = int(timeout)
+
+    result: Dict[str, Any] = {"actions": {"onRun": action}}
+    if embedded_files:
+        result["embeddedFiles"] = embedded_files
+    return result
+
+
+def _build_environment(layer, launcher) -> List[Dict[str, Any]]:
+    """Build ``stepEnvironments`` from layer env vars and per-step CUE_* vars."""
+
+    # Start with user-defined layer env vars.
+    variables = {}
+    envs = layer.get_envs()
+    if envs:
+        variables.update({str(k): escape_format_string(str(v)) for k, v in envs.items()})
+
+    # Per-step CUE_* variables (these vary by layer).
+    variables["CUE_RANGE"] = "{{ frames }}"
+    variables["CUE_CHUNK"] = "{{ chunk_size }}"
+    variables["CUE_THREADABLE"] = "1" if layer.get_arg("threadable") else "0"
+
+    return [{"name": f"{layer.get_name()}-env", "variables": variables}]
+
+
+def _serialize(launcher) -> str:
+    """Core serialization: Outline → OpenJD 2023-09 Job Template dict → YAML."""
+    ol = launcher.get_outline()
+
+    # Collect eligible layers and partition into regular vs Post.
+    # Post layers in OpenCue run in a separate job after the main job
+    # completes.  In OpenJD we keep them in the same template and
+    # inject dependsOn entries for every non-Post step.
+    regular_layers = []
+    post_layers = []
+    for layer in ol.get_layers():
+        if not layer.get_arg("register"):
+            continue
+        if layer.get_parent():
+            continue
+        frame_range = layer.get_frame_range()
+        if not frame_range:
+            logger.info("Skipping layer %s - frame range does not intersect job range", layer)
+            continue
+        if str(layer.get_type()) == "Post":
+            post_layers.append(layer)
+        else:
+            regular_layers.append(layer)
+
+    steps: List[Dict[str, Any]] = []
+    non_post_step_names: List[str] = []
+
+    for layer in regular_layers:
+        step = _build_step(layer, launcher)
+        steps.append(step)
+        non_post_step_names.append(layer.get_name())
+
+    for layer in post_layers:
+        step = _build_step(layer, launcher, depends_on_all=non_post_step_names)
+        steps.append(step)
+
+    if not steps:
+        raise outline.exception.OutlineException(
+            "Failed to serialize job. No layers with valid frame ranges."
+        )
+
+    # Build the template dict in a human-friendly field order.
+    job_name = launcher.get_flag("basename") or ol.get_name()
+    template: Dict[str, Any] = {
+        "name": escape_format_string(job_name),
+        "specificationVersion": SPEC_VERSION,
+    }
+
+    template["extensions"] = EXTENSIONS
+
+    # Job metadata as parameters — these map OpenCue launcher flags to
+    # OpenJD job parameters so they can be overridden at submit time.
+    template["parameterDefinitions"] = [
+        {"name": "Facility", "type": "STRING", "default": launcher.get_flag("facility", "")},
+        {"name": "Show", "type": "STRING", "default": ol.get_show() or ""},
+        {"name": "Shot", "type": "STRING", "default": ol.get_shot() or ""},
+        {"name": "User", "type": "STRING", "default": launcher.get_flag("user", "")},
+    ]
+
+    # Job-level environment variables
+    job_environments: List[Dict[str, Any]] = []
+
+    # CUE_* variables that are the same for every step.
+    job_environments.append({"name": "cue-env", "variables": {
+        "CUE3": "1",
+        "CUE_SHOW": "{{ Param.Show }}",
+        "CUE_SHOT": "{{ Param.Shot }}",
+        "CUE_USER": "{{ Param.User }}",
+    }})
+
+    # User-defined job-level env vars from the outline and launcher.
+    job_envs = ol.get_env()
+    launcher_envs = launcher.get_flag("env") or []
+    variables = {}
+    if job_envs:
+        for env_k, env_v in job_envs.items():
+            # env_v is (value, pre_setshot_bool)
+            variables[env_k] = escape_format_string(env_v[0])
+    for kvp in launcher_envs:
+        k, v = kvp.split("=", 1)
+        variables[k] = escape_format_string(v)
+    if variables:
+        job_environments.append({"name": "outline-env", "variables": variables})
+
+    template["jobEnvironments"] = job_environments
+
+    template["steps"] = steps
+
+    # Validate the template using openjd-model if available.
+    _validate_template(template)
+
+    return yaml.dump(template, default_flow_style=False, sort_keys=False, Dumper=_BlockDumper)
+
+
+class _BlockDumper(yaml.SafeDumper):
+    """YAML dumper that uses block scalar style (|) for multi-line strings."""
+
+
+def _block_str_representer(dumper, data):
+    if "\n" in data:
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+
+_BlockDumper.add_representer(str, _block_str_representer)
+
+
+def _validate_template(template: Dict[str, Any]) -> None:
+    """Validate the generated template against the OpenJD model."""
+    try:
+        decode_job_template(
+            template=template,
+            supported_extensions=template.get("extensions"),
+        )
+    except DecodeValidationError as exc:
+        raise outline.exception.OutlineException(
+            "Generated OpenJD template failed validation: %s" % exc
+        )
+
+
+def _build_step(layer, launcher, depends_on_all: Optional[List[str]] = None) -> Dict[str, Any]:
+    """Build a single OpenJD step dict from a PyOutline layer."""
+    step: Dict[str, Any] = {"name": layer.get_name()}
+
+    # Dependencies — merge explicit depends with implied Post dependencies.
+    deps = _build_step_dependencies(layer)
+    if depends_on_all:
+        if deps is None:
+            deps = []
+        seen = {d["dependsOn"] for d in deps}
+        for name in depends_on_all:
+            if name not in seen:
+                deps.append({"dependsOn": name})
+                seen.add(name)
+    if deps:
+        step["dependencies"] = deps
+
+    # Step-level let bindings — define frames and chunk_size once,
+    # referenced by parameterSpace, stepEnvironments, and script.
+    chunk_size = layer.get_chunk_size()
+    openjd_range = _frame_range_to_openjd(layer.get_frame_range())
+    step["let"] = [
+        f'frames = range_expr("{openjd_range}")',
+        f"chunk_size = {chunk_size}",
+    ]
+
+    # Step environments
+    step_env = _build_environment(layer, launcher)
+    if step_env:
+        step["stepEnvironments"] = step_env
+
+    # Parameter space
+    step["parameterSpace"] = {"taskParameterDefinitions": [{
+        "name": "Frame",
+        "type": "CHUNK[INT]",
+        "range": "{{ frames }}",
+        "chunks": {
+            "defaultTaskCount": "{{ chunk_size }}",
+            "rangeConstraint": "CONTIGUOUS",
+        },
+    }]}
+
+    # Script
+    step["script"] = _build_step_script(layer)
+
+    # Host requirements
+    host_req = _build_host_requirements(layer, os_name=launcher.get_flag("os"))
+    if host_req:
+        step["hostRequirements"] = host_req
+
+    return step

--- a/pyoutline/outline/modules/shell.py
+++ b/pyoutline/outline/modules/shell.py
@@ -46,6 +46,10 @@ class PyEval(outline.layer.Layer):
 
         self.__code = code
 
+    def get_code(self):
+        """Return the embedded Python code string, or None after setup."""
+        return self.__code
+
     def _setup(self):
         with open(f"{self.get_path()}/script", "w", encoding="utf-8") as fp:
             fp.write(self.__code)

--- a/pyoutline/pyproject.toml
+++ b/pyoutline/pyproject.toml
@@ -10,7 +10,9 @@ name = "opencue_pyoutline"
 dynamic = ["version"]
 dependencies = [
     "opencue_pycue",
+    "pyyaml",
     "typing_extensions; python_version < '3.12'",  # Unpack
+    "openjd-model>=0.9,<0.10",
 ]
 requires-python = ">3.7"
 description = "PyOutline is a Python library for building and managing OpenCue job definitions. It provides an API to create outlines that describe jobs, layers, and tasks, making it easier to construct repeatable workflows for rendering pipelines."
@@ -32,8 +34,12 @@ testpaths = ["tests"] # Relative path(s) where tests are located
 python_files = ["test_*.py", "*_test.py"] # Default test file pattern
 python_functions = ["test_*"] # Default test function pattern
 
-# --- Optional Test Dependencies ---
 [project.optional-dependencies]
+# --- Optional Open Job Description Dependencies ---
+openjd = [
+    "openjd-cli>=0.4",
+]
+# --- Optional Test Dependencies ---
 test = [
     "mock==2.0.0",
     "pyfakefs==5.2.3",

--- a/pyoutline/tests/backend/test_openjd.py
+++ b/pyoutline/tests/backend/test_openjd.py
@@ -1,0 +1,580 @@
+#  Copyright Contributors to the OpenCue Project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Tests for the OpenJD backend module."""
+
+import os
+import tempfile
+import textwrap
+import unittest
+from unittest import mock
+
+import yaml
+
+import outline
+import outline.backend.openjd
+import outline.cuerun
+import outline.exception
+import outline.modules.shell
+
+TEST_USER = "test-user"
+
+# The wrapper script preamble is the same for every step.
+WRAPPER_PREAMBLE = """\
+#!/bin/bash
+export CUE_IFRAME={{ min(Task.Param.Frame) }}
+export CUE_JOB={{ repr_sh(Job.Name) }}
+export CUE_LAYER={{ repr_sh(Step.Name) }}
+export CUE_FRAME={{ repr_sh(zfill(min(Task.Param.Frame), 4) + '-' + Step.Name) }}
+"""
+
+
+def _serialize(ol):
+    """Helper: serialize an Outline and return the parsed template dict."""
+    launcher = outline.cuerun.OutlineLauncher(ol, user=TEST_USER)
+    return yaml.safe_load(outline.backend.openjd.serialize(launcher))
+
+
+def _wrapper_data(step):
+    """Extract the wrapper script content from a step dict."""
+    for ef in step["script"]["embeddedFiles"]:
+        if ef["name"] == "opencue_wrapper":
+            return ef["data"]
+    raise KeyError("No wrapper embedded file found")
+
+
+def _expected(yaml_str):
+    """Helper: parse a YAML string into a dict for comparison."""
+    return yaml.safe_load(textwrap.dedent(yaml_str))
+
+
+class SerializeBasicTest(unittest.TestCase):
+    def setUp(self):
+        outline.Outline.current = None
+
+    def test_single_layer(self):
+        ol = outline.Outline("test-job", shot="test", show="testing", user=TEST_USER)
+        ol.add_layer(
+            outline.modules.shell.Shell("render", command=["echo", "#IFRAME#"], range="1-10")
+        )
+
+        self.assertEqual(
+            _serialize(ol),
+            _expected("""
+                name: test-job
+                specificationVersion: jobtemplate-2023-09
+                extensions: [TASK_CHUNKING, EXPR]
+                parameterDefinitions:
+                  - name: Facility
+                    type: STRING
+                    default: 'local'
+                  - name: Show
+                    type: STRING
+                    default: testing
+                  - name: Shot
+                    type: STRING
+                    default: test
+                  - name: User
+                    type: STRING
+                    default: test-user
+                jobEnvironments:
+                  - name: cue-env
+                    variables:
+                      CUE3: '1'
+                      CUE_SHOW: '{{ Param.Show }}'
+                      CUE_SHOT: '{{ Param.Shot }}'
+                      CUE_USER: '{{ Param.User }}'
+                steps:
+                  - name: render
+                    let:
+                      - frames = range_expr("1-10")
+                      - chunk_size = 1
+                    stepEnvironments:
+                      - name: render-env
+                        variables:
+                          CUE_RANGE: '{{ frames }}'
+                          CUE_CHUNK: '{{ chunk_size }}'
+                          CUE_THREADABLE: '0'
+                    parameterSpace:
+                      taskParameterDefinitions:
+                        - name: Frame
+                          type: 'CHUNK[INT]'
+                          range: '{{ frames }}'
+                          chunks:
+                            defaultTaskCount: '{{ chunk_size }}'
+                            rangeConstraint: CONTIGUOUS
+                    script:
+                      actions:
+                        onRun:
+                          command: '{{ Task.File.opencue_wrapper }}'
+                      embeddedFiles:
+                        - name: opencue_wrapper
+                          type: TEXT
+                          runnable: true
+                          data: |
+                            #!/bin/bash
+                            export CUE_IFRAME={{ min(Task.Param.Frame) }}
+                            export CUE_JOB={{ repr_sh(Job.Name) }}
+                            export CUE_LAYER={{ repr_sh(Step.Name) }}
+                            export CUE_FRAME={{ repr_sh(zfill(min(Task.Param.Frame), 4) + '-' + Step.Name) }}
+                            exec echo '{{ min(Task.Param.Frame) }}'
+                    hostRequirements:
+                      attributes:
+                        - name: 'opencue:attr.service'
+                          anyOf: [shell]
+            """),
+        )
+
+
+class SerializeDependenciesTest(unittest.TestCase):
+    def setUp(self):
+        outline.Outline.current = None
+
+    def test_layer_dependency(self):
+        ol = outline.Outline("dep-job", shot="test", show="testing", user=TEST_USER)
+        l1 = outline.modules.shell.Shell("render", command=["render", "#IFRAME#"], range="1-100")
+        ol.add_layer(l1)
+        l2 = outline.modules.shell.Shell(
+            "composite", command=["comp", "#IFRAME#"], range="1-100", chunk=100
+        )
+        l2.depend_all(l1)
+        ol.add_layer(l2)
+
+        template = _serialize(ol)
+        self.assertEqual(2, len(template["steps"]))
+        self.assertNotIn("dependencies", template["steps"][0])
+        self.assertEqual([{"dependsOn": "render"}], template["steps"][1]["dependencies"])
+        # Composite step has chunk=100
+        self.assertEqual(
+            "{{ chunk_size }}",
+            template["steps"][1]["parameterSpace"]["taskParameterDefinitions"][0]["chunks"][
+                "defaultTaskCount"
+            ],
+        )
+
+
+class SerializeHostRequirementsTest(unittest.TestCase):
+    def setUp(self):
+        outline.Outline.current = None
+
+    def test_cores_and_memory(self):
+        ol = outline.Outline("resource-job", shot="test", show="testing", user=TEST_USER)
+        ol.add_layer(
+            outline.modules.shell.Shell(
+                "heavy", command=["render"], range="1-10", cores=8, memory="4g"
+            )
+        )
+
+        template = _serialize(ol)
+        self.assertEqual(
+            template["steps"][0]["hostRequirements"],
+            _expected("""
+                amounts:
+                  - name: amount.worker.vcpu
+                    min: 8.0
+                  - name: amount.worker.memory
+                    min: 4096
+                attributes:
+                  - name: 'opencue:attr.service'
+                    anyOf: [shell]
+            """),
+        )
+
+
+class SerializeEnvironmentTest(unittest.TestCase):
+    def setUp(self):
+        outline.Outline.current = None
+
+    def test_layer_env(self):
+        ol = outline.Outline("env-job", shot="test", show="testing", user=TEST_USER)
+        layer = outline.modules.shell.Shell("render", command=["render"], range="1-5")
+        layer.set_env("RENDERER", "prman")
+        layer.set_env("THREADS", "8")
+        ol.add_layer(layer)
+
+        template = _serialize(ol)
+        env_vars = template["steps"][0]["stepEnvironments"][0]["variables"]
+        # User env vars are included alongside per-step CUE_* vars
+        self.assertEqual("prman", env_vars["RENDERER"])
+        self.assertEqual("8", env_vars["THREADS"])
+        self.assertEqual("{{ frames }}", env_vars["CUE_RANGE"])
+        # Job-wide CUE_* vars are in jobEnvironments
+        job_env_vars = template["jobEnvironments"][0]["variables"]
+        self.assertEqual("1", job_env_vars["CUE3"])
+
+
+class FrameRangeConversionTest(unittest.TestCase):
+    def setUp(self):
+        outline.Outline.current = None
+
+    def test_step_syntax(self):
+        self.assertEqual("1-100:2", outline.backend.openjd._frame_range_to_openjd("1-100x2"))
+
+    def test_simple_range(self):
+        self.assertEqual("1-50", outline.backend.openjd._frame_range_to_openjd("1-50"))
+
+
+class MemoryParsingTest(unittest.TestCase):
+    def setUp(self):
+        outline.Outline.current = None
+
+    def test_megabytes_suffix(self):
+        self.assertEqual(512, outline.backend.openjd._parse_memory_to_mib("512m"))
+
+    def test_gigabytes_suffix(self):
+        self.assertEqual(4096, outline.backend.openjd._parse_memory_to_mib("4g"))
+
+    def test_plain_number_treated_as_gb(self):
+        self.assertEqual(8192, outline.backend.openjd._parse_memory_to_mib("8"))
+
+    def test_fractional_gigabytes(self):
+        self.assertEqual(1536, outline.backend.openjd._parse_memory_to_mib("1.5g"))
+
+    def test_uppercase_suffix(self):
+        self.assertEqual(512, outline.backend.openjd._parse_memory_to_mib("512M"))
+
+    def test_invalid_raises(self):
+        with self.assertRaises(outline.exception.LayerException):
+            outline.backend.openjd._parse_memory_to_mib("bogus")
+
+
+class LaunchTest(unittest.TestCase):
+    @mock.patch("outline.backend.openjd.subprocess.run")
+    def test_launch_calls_openjd_run(self, mock_run):
+        mock_run.return_value = mock.Mock(returncode=0)
+
+        ol = outline.Outline("launch-job", shot="test", show="testing", user=TEST_USER)
+        ol.add_layer(outline.modules.shell.Shell("cmd", command=["echo", "hello"], range="1-1"))
+
+        launcher = outline.cuerun.OutlineLauncher(ol, user=TEST_USER)
+        result = outline.backend.openjd.launch(launcher)
+
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        self.assertEqual(["openjd", "run"], cmd[:2])
+        self.assertTrue(cmd[2].endswith(".template.yaml"))
+
+        template = yaml.safe_load(result)
+        self.assertEqual("jobtemplate-2023-09", template["specificationVersion"])
+
+    @mock.patch("outline.backend.openjd.subprocess.run")
+    def test_launch_raises_on_failure(self, mock_run):
+        mock_run.return_value = mock.Mock(returncode=1, stderr="error output")
+
+        ol = outline.Outline("fail-job", shot="test", show="testing", user=TEST_USER)
+        ol.add_layer(outline.modules.shell.Shell("cmd", command=["false"], range="1-1"))
+
+        launcher = outline.cuerun.OutlineLauncher(ol, user=TEST_USER)
+        with self.assertRaises(outline.exception.OutlineException):
+            outline.backend.openjd.launch(launcher)
+
+
+class SerializeTimeoutTest(unittest.TestCase):
+    def setUp(self):
+        outline.Outline.current = None
+
+    def test_timeout_mapped(self):
+        ol = outline.Outline("timeout-job", shot="test", show="testing", user=TEST_USER)
+        layer = outline.modules.shell.Shell("render", command=["render"], range="1-10")
+        layer.set_arg("timeout", 3600)
+        ol.add_layer(layer)
+
+        template = _serialize(ol)
+        action = template["steps"][0]["script"]["actions"]["onRun"]
+        self.assertEqual(3600, action["timeout"])
+
+    def test_no_timeout_omitted(self):
+        ol = outline.Outline("no-timeout-job", shot="test", show="testing", user=TEST_USER)
+        ol.add_layer(outline.modules.shell.Shell("render", command=["render"], range="1-10"))
+
+        template = _serialize(ol)
+        action = template["steps"][0]["script"]["actions"]["onRun"]
+        self.assertNotIn("timeout", action)
+
+
+class SerializeTagsAndServiceTest(unittest.TestCase):
+    def setUp(self):
+        outline.Outline.current = None
+
+    def test_tags_as_string(self):
+        ol = outline.Outline("tag-job", shot="test", show="testing", user=TEST_USER)
+        ol.add_layer(
+            outline.modules.shell.Shell(
+                "render", command=["render"], range="1-10", tags="render|gpu"
+            )
+        )
+
+        self.assertEqual(
+            _serialize(ol)["steps"][0]["hostRequirements"],
+            _expected("""
+                attributes:
+                  - name: 'opencue:attr.tag'
+                    allOf: [render, gpu]
+                  - name: 'opencue:attr.service'
+                    anyOf: [shell]
+            """),
+        )
+
+    def test_service_attribute(self):
+        ol = outline.Outline("svc-job", shot="test", show="testing", user=TEST_USER)
+        layer = outline.modules.shell.Shell("render", command=["render"], range="1-10")
+        layer.set_service("prman")
+        ol.add_layer(layer)
+
+        self.assertEqual(
+            _serialize(ol)["steps"][0]["hostRequirements"],
+            _expected("""
+                attributes:
+                  - name: 'opencue:attr.service'
+                    anyOf: [prman]
+            """),
+        )
+
+    def test_tags_and_cores_combined(self):
+        ol = outline.Outline("combo-job", shot="test", show="testing", user=TEST_USER)
+        ol.add_layer(
+            outline.modules.shell.Shell(
+                "render", command=["render"], range="1-10", tags="render|gpu", cores=16
+            )
+        )
+
+        self.assertEqual(
+            _serialize(ol)["steps"][0]["hostRequirements"],
+            _expected("""
+                amounts:
+                  - name: amount.worker.vcpu
+                    min: 16.0
+                attributes:
+                  - name: 'opencue:attr.tag'
+                    allOf: [render, gpu]
+                  - name: 'opencue:attr.service'
+                    anyOf: [shell]
+            """),
+        )
+
+
+class SerializeLimitsTest(unittest.TestCase):
+    def setUp(self):
+        outline.Outline.current = None
+
+    def test_single_limit(self):
+        ol = outline.Outline("limit-job", shot="test", show="testing", user=TEST_USER)
+        layer = outline.modules.shell.Shell("render", command=["render"], range="1-10")
+        layer.set_limits(["nuke"])
+        ol.add_layer(layer)
+
+        self.assertEqual(
+            _serialize(ol)["steps"][0]["hostRequirements"],
+            _expected("""
+                amounts:
+                  - name: amount.limit.nuke
+                    min: 1
+                attributes:
+                  - name: 'opencue:attr.service'
+                    anyOf: [shell]
+            """),
+        )
+
+    def test_multiple_limits(self):
+        ol = outline.Outline("multi-limit-job", shot="test", show="testing", user=TEST_USER)
+        layer = outline.modules.shell.Shell("render", command=["render"], range="1-10")
+        layer.set_limits(["nuke", "katana"])
+        ol.add_layer(layer)
+
+        self.assertEqual(
+            _serialize(ol)["steps"][0]["hostRequirements"],
+            _expected("""
+                amounts:
+                  - name: amount.limit.nuke
+                    min: 1
+                  - name: amount.limit.katana
+                    min: 1
+                attributes:
+                  - name: 'opencue:attr.service'
+                    anyOf: [shell]
+            """),
+        )
+
+
+class SerializeChunkingTest(unittest.TestCase):
+    def setUp(self):
+        outline.Outline.current = None
+
+    def test_chunk_size_one(self):
+        ol = outline.Outline("nochunk-job", shot="test", show="testing", user=TEST_USER)
+        ol.add_layer(
+            outline.modules.shell.Shell("render", command=["render", "#IFRAME#"], range="1-100")
+        )
+
+        template = _serialize(ol)
+        param = template["steps"][0]["parameterSpace"]["taskParameterDefinitions"][0]
+        self.assertEqual("CHUNK[INT]", param["type"])
+        self.assertIn("chunk_size = 1", template["steps"][0]["let"])
+
+    def test_chunk_size_ten(self):
+        ol = outline.Outline("chunk-job", shot="test", show="testing", user=TEST_USER)
+        ol.add_layer(
+            outline.modules.shell.Shell(
+                "render", command=["render", "#IFRAME#"], range="1-100", chunk=10
+            )
+        )
+
+        template = _serialize(ol)
+        self.assertIn("chunk_size = 10", template["steps"][0]["let"])
+
+    def test_chunk_with_framespec(self):
+        """#FRAMESPEC# maps to Task.Param.Frame directly in the wrapper."""
+        ol = outline.Outline("framespec-job", shot="test", show="testing", user=TEST_USER)
+        ol.add_layer(
+            outline.modules.shell.Shell(
+                "render",
+                command=["render", "--frames", "#FRAMESPEC#"],
+                range="1-100",
+                chunk=10,
+            )
+        )
+
+        wrapper = _wrapper_data(_serialize(ol)["steps"][0])
+        self.assertIn("'{{ Task.Param.Frame }}'", wrapper)
+
+    def test_chunk_with_start_end(self):
+        """#FRAME_START# and #FRAME_END# use min()/max() in the wrapper."""
+        ol = outline.Outline("startend-job", shot="test", show="testing", user=TEST_USER)
+        ol.add_layer(
+            outline.modules.shell.Shell(
+                "render",
+                command=["render", "-start", "#FRAME_START#", "-end", "#FRAME_END#"],
+                range="1-100",
+                chunk=10,
+            )
+        )
+
+        wrapper = _wrapper_data(_serialize(ol)["steps"][0])
+        self.assertIn("'{{ min(Task.Param.Frame) }}'", wrapper)
+        self.assertIn("'{{ max(Task.Param.Frame) }}'", wrapper)
+
+
+class SerializePostLayerTest(unittest.TestCase):
+    def setUp(self):
+        outline.Outline.current = None
+
+    def test_post_depends_on_all(self):
+        ol = outline.Outline("post-job", shot="test", show="testing", user=TEST_USER)
+        ol.add_layer(
+            outline.modules.shell.Shell("render", command=["render", "#IFRAME#"], range="1-100")
+        )
+        ol.add_layer(
+            outline.modules.shell.Shell("composite", command=["comp", "#IFRAME#"], range="1-100")
+        )
+        ol.add_layer(
+            outline.modules.shell.Shell("cleanup", command=["cleanup"], range="1-1", type="Post")
+        )
+
+        template = _serialize(ol)
+        self.assertEqual(3, len(template["steps"]))
+        self.assertNotIn("dependencies", template["steps"][0])
+        self.assertNotIn("dependencies", template["steps"][1])
+
+        cleanup = template["steps"][2]
+        dep_names = {d["dependsOn"] for d in cleanup["dependencies"]}
+        self.assertEqual({"render", "composite"}, dep_names)
+
+    def test_post_merges_explicit_and_implicit_deps(self):
+        ol = outline.Outline("post-merge-job", shot="test", show="testing", user=TEST_USER)
+        r = outline.modules.shell.Shell("render", command=["render"], range="1-10")
+        ol.add_layer(r)
+        n = outline.modules.shell.Shell("notify", command=["notify"], range="1-1", type="Post")
+        n.depend_all(r)
+        ol.add_layer(n)
+
+        template = _serialize(ol)
+        self.assertEqual(template["steps"][1]["dependencies"], [{"dependsOn": "render"}])
+
+
+class SerializeShellScriptTest(unittest.TestCase):
+    def setUp(self):
+        outline.Outline.current = None
+
+    def test_shell_script_embeds_file(self):
+        ol = outline.Outline("script-job", shot="test", show="testing", user=TEST_USER)
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".sh", delete=False, encoding="utf-8"
+        ) as f:
+            f.write("#!/bin/bash\necho hello $1\n")
+            script_path = f.name
+
+        try:
+            layer = outline.modules.shell.ShellScript("run-script", script=script_path)
+            ol.add_layer(layer)
+
+            template = _serialize(ol)
+            step = template["steps"][0]
+
+            # Script file is embedded
+            script_ef = next(ef for ef in step["script"]["embeddedFiles"] if ef["name"] == "script")
+            self.assertTrue(script_ef["runnable"])
+            self.assertEqual("#!/bin/bash\necho hello $1\n", script_ef["data"])
+
+            # Wrapper calls the script via repr_sh
+            wrapper = _wrapper_data(step)
+            self.assertIn("{{ repr_sh(Task.File.script) }}", wrapper)
+            self.assertIn(WRAPPER_PREAMBLE, wrapper)
+        finally:
+            os.unlink(script_path)
+
+
+class SerializePyEvalTest(unittest.TestCase):
+    def setUp(self):
+        outline.Outline.current = None
+
+    def test_pyeval_embeds_code(self):
+        ol = outline.Outline("pyeval-job", shot="test", show="testing", user=TEST_USER)
+        code = "import os\nprint(os.getcwd())\n"
+        layer = outline.modules.shell.PyEval("run-python", code=code, range="1-1")
+        ol.add_layer(layer)
+
+        template = _serialize(ol)
+        step = template["steps"][0]
+
+        # Code is embedded without shebang, not runnable
+        script_ef = next(ef for ef in step["script"]["embeddedFiles"] if ef["name"] == "script")
+        self.assertNotIn("runnable", script_ef)
+        self.assertEqual(code, script_ef["data"])
+
+        # Wrapper calls python on the script via repr_sh
+        wrapper = _wrapper_data(step)
+        self.assertIn("python {{ repr_sh(Task.File.script) }}", wrapper)
+        self.assertIn(WRAPPER_PREAMBLE, wrapper)
+
+
+class SerializeStringCommandTest(unittest.TestCase):
+    def setUp(self):
+        outline.Outline.current = None
+
+    def test_string_command_is_split(self):
+        """A string command should be shlex.split like PyOutline does at runtime."""
+        ol = outline.Outline("str-cmd-job", shot="test", show="testing", user=TEST_USER)
+        layer = outline.modules.shell.Shell("render", range="1-10")
+        layer.set_arg("command", "render -start #IFRAME# -end #IFRAME#")
+        ol.add_layer(layer)
+
+        wrapper = _wrapper_data(_serialize(ol)["steps"][0])
+        self.assertIn("render", wrapper)
+        self.assertIn("'{{ min(Task.Param.Frame) }}'", wrapper)
+        self.assertIn(WRAPPER_PREAMBLE, wrapper)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**

https://github.com/OpenJobDescription/openjd-model-for-python/issues/137

**Summarize your change.**
Add a new PyOutline backend that serializes Outline jobs into OpenJD 2023-09 job templates. This enables running OpenCue jobs via the openjd CLI or submitting them to OpenJD-compatible schedulers like AWS Deadline Cloud. It doesn't look at the opposite of running an OpenJD job template in OpenCue. That's a separate follow-up to perform.

This PR doesn't fix the linked issue, but implementing OpenCue's pyoutline API for defining a job is a nice way to get a feel for how such an API might look in the openjd-model library, and evaluate any missing functionality in Open Job Description for supporting OpenCue jobs.

This PR depends on an in-progress RFC for the EXPR extension in Open Job Description, so it probably should stay in draft until that is merged there.

This PR was created with LLM assistance via [Kiro CLI](https://kiro.dev/cli/) and the Claude Opus 4.6 model.

The changes include:

- [ ] Serialize layers to OpenJD steps with CHUNK[INT] frame parameters
- [ ] Map OpenCue command tokens (#IFRAME#, #FRAMESPEC#, etc.) to OpenJD expressions using the EXPR extension
- [ ] Map host requirements: cores, memory, GPUs, tags, service, limits
- [ ] Map dependencies including Post layer implicit depends
- [ ] Wrap commands in bash scripts that export CUE_* environment variables
- [ ] Support Shell, ShellScript, and PyEval layer types
- [ ] Validate generated templates using openjd-model
- [ ] Launch jobs locally via openjd CLI
- [ ] Install with: pip install opencue-pyoutline[openjd]

Here's an example generated template based on [the tutorials](https://docs.opencue.io/docs/tutorials/multi-layer-jobs/#parallel-processing-with-convergence):

[parallel_pipeline.template.yaml](https://github.com/user-attachments/files/25778361/parallel_pipeline.template.yaml)
