### PR TITLE
[cuegui] Make job-not-found popup notification configurable, default off

### DIFF
--- a/cuegui/cuegui/Constants.py
+++ b/cuegui/cuegui/Constants.py
@@ -232,6 +232,8 @@ DISABLED_ACTION_TYPES = [action_type.strip()
 
 SEARCH_JOBS_APPEND_RESULTS = __config.get('search_jobs.append_results', True)
 
+NOTIFY_JOB_NOT_FOUND = __config.get('job_monitor.notify_job_not_found', False)
+
 TYPE_JOB = QtWidgets.QTreeWidgetItem.UserType + 1
 TYPE_LAYER = QtWidgets.QTreeWidgetItem.UserType + 2
 TYPE_FRAME = QtWidgets.QTreeWidgetItem.UserType + 3

--- a/cuegui/cuegui/JobMonitorTree.py
+++ b/cuegui/cuegui/JobMonitorTree.py
@@ -354,16 +354,18 @@ class JobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
             item = self._items[jobKey]
             self.removeItem(item)
 
-        # Add job name to pending list for batched notification
-        jobName = job.data.name if hasattr(job, 'data') else str(job)
-        self.__pendingNotFoundJobs.append(jobName)
+        # Only show notification dialog if enabled in config
+        if cuegui.Constants.NOTIFY_JOB_NOT_FOUND:
+            # Add job name to pending list for batched notification
+            jobName = job.data.name if hasattr(job, 'data') else str(job)
+            self.__pendingNotFoundJobs.append(jobName)
 
-        # Start or restart the timer to batch multiple notifications
-        if self.__notFoundTimer is None:
-            self.__notFoundTimer = QtCore.QTimer(self)
-            self.__notFoundTimer.setSingleShot(True)
-            self.__notFoundTimer.timeout.connect(self.__showBatchedJobNotFoundDialog)
-        self.__notFoundTimer.start(500)  # 500ms delay to collect multiple notifications
+            # Start or restart the timer to batch multiple notifications
+            if self.__notFoundTimer is None:
+                self.__notFoundTimer = QtCore.QTimer(self)
+                self.__notFoundTimer.setSingleShot(True)
+                self.__notFoundTimer.timeout.connect(self.__showBatchedJobNotFoundDialog)
+            self.__notFoundTimer.start(500)  # 500ms delay to collect multiple notifications
 
         # Clean up the notification tracking after a delay to allow re-notification
         # if the user adds the same job again later

--- a/cuegui/cuegui/config/cuegui.yaml
+++ b/cuegui/cuegui/config/cuegui.yaml
@@ -178,3 +178,8 @@ filter_dialog.disabled_action_types: ''
 #  - True: search result will append jobs to the current list of monitored jobs
 #  - False: repopulate the jobs table with the search result
 search_jobs.append_results: True
+
+# Whether to show a popup notification when monitored jobs are no longer available
+# (e.g., moved to historical data). Jobs are still auto-removed from the monitor list
+# regardless of this setting.
+job_monitor.notify_job_not_found: False


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/2200

**Summarize your change.**

CueGUI end-users reported the job unavailable popup was too frequent and disruptive during daily work. The notification is now opt-in via config.
- Add job_monitor.notify_job_not_found option to cuegui.yaml (default False)
- Add NOTIFY_JOB_NOT_FOUND constant in Constants.py
- Guard notification batching/dialog in JobMonitorTree behind config check
- Jobs are still silently auto-removed from the monitor list regardless