### PR TITLE
[cuegui] fix max_cores bug

### DIFF
--- a/cuegui/cuegui/LayerDialog.py
+++ b/cuegui/cuegui/LayerDialog.py
@@ -329,7 +329,7 @@ class LayerPropertiesDialog(QtWidgets.QDialog):
             if self.__min_gpus.isEnabled():
                 layer.setMinGpus(self.__min_gpus.value())
             if self.__max_gpus.isEnabled():
-                layer.setMaxGpus(self.__max_cores.value())
+                layer.setMaxGpus(self.__max_gpus.value())
             if self.__gpu_mem.isEnabled():
                 layer.setMinGpuMemory(self.__gpu_mem.slider.value() * self.gpu_mem_tick_kb)
             if self.__timeout.isEnabled():


### PR DESCRIPTION
Setting the max cores is also setting the max number of gpus on LayerDialog. This PR fixes the issue.
