### PR TITLE
[cuenimby] Make CueGUI launch command and menu label configurable

### DIFF
--- a/cuenimby/cuenimby.example.json
+++ b/cuenimby/cuenimby.example.json
@@ -5,6 +5,8 @@
   "poll_interval": 5,
   "show_notifications": true,
   "notification_duration": 5,
+  "cuegui_command": ["cuegui"],
+  "cuegui_label": "Launch CueGUI",
   "scheduler_enabled": true,
   "schedule": {
     "monday": {

--- a/cuenimby/cuenimby/config.py
+++ b/cuenimby/cuenimby/config.py
@@ -33,6 +33,8 @@ class Config:
         "poll_interval": 5,  # seconds
         "show_notifications": True,
         "notification_duration": 5,  # seconds
+        "cuegui_command": ["cuegui"],
+        "cuegui_label": "Launch CueGUI",
         "scheduler_enabled": False,
         "schedule": {
             # Example: "monday": {"start": "09:00", "end": "18:00", "state": "disabled"}
@@ -117,6 +119,16 @@ class Config:
     def scheduler_enabled(self) -> bool:
         """Check if scheduler is enabled."""
         return self.config["scheduler_enabled"]
+
+    @property
+    def cuegui_command(self) -> list:
+        """Get CueGUI launch command."""
+        return self.config.get("cuegui_command", ["cuegui"])
+
+    @property
+    def cuegui_label(self) -> str:
+        """Get CueGUI menu label."""
+        return self.config.get("cuegui_label", "Launch CueGUI")
 
     @property
     def schedule(self) -> Dict[str, Any]:

--- a/cuenimby/cuenimby/tray.py
+++ b/cuenimby/cuenimby/tray.py
@@ -228,13 +228,11 @@ class CueNIMBYTray(QtWidgets.QSystemTrayIcon):
 
     # pylint: disable=consider-using-with
     def launch_cuegui(self) -> None:
-        """Launch CueGUI application."""
+        """Launch CueGUI application using the command from config."""
         try:
-            if self._cuegui_available():
-                subprocess.Popen(["cuegui"])
-                logger.info("Launched CueGUI")
-            else:
-                raise FileNotFoundError("cuegui executable not found in PATH")
+            cmd = self.config.cuegui_command
+            subprocess.Popen(cmd)
+            logger.info("Launched CueGUI: %s", cmd)
         except Exception as e:
             logger.error("Failed to launch CueGUI: %s", e)
             if self.notifier:
@@ -245,7 +243,8 @@ class CueNIMBYTray(QtWidgets.QSystemTrayIcon):
 
     def _cuegui_available(self) -> bool:
         """Check if CueGUI is available."""
-        return shutil.which("cuegui") is not None
+        cmd = self.config.cuegui_command
+        return shutil.which(cmd[0]) is not None
 
     def _show_about(self) -> None:
         """Show about dialog using native platform dialogs."""
@@ -349,7 +348,7 @@ class CueNIMBYTray(QtWidgets.QSystemTrayIcon):
 
         self.menu.addSeparator()
 
-        self.cuegui_action = self.menu.addAction("Launch CueGUI")
+        self.cuegui_action = self.menu.addAction(self.config.cuegui_label)
         self.cuegui_action.triggered.connect(self.launch_cuegui)
         self.cuegui_action.setEnabled(self._cuegui_available())
 
@@ -383,12 +382,13 @@ class CueNIMBYTray(QtWidgets.QSystemTrayIcon):
 
         self.scheduler_action.setChecked(self._scheduler_enabled())
 
+        label = self.config.cuegui_label
         if self._cuegui_available():
             self.cuegui_action.setEnabled(True)
-            self.cuegui_action.setText("Launch CueGUI")
+            self.cuegui_action.setText(label)
         else:
             self.cuegui_action.setEnabled(False)
-            self.cuegui_action.setText("Launch CueGUI (not installed)")
+            self.cuegui_action.setText(f"{label} (not installed)")
 
     def start(self) -> None:
         """Start the tray application."""


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/2233

**Summarize your change.**

- Allow users to customize the command used to launch CueGUI and the tray menu label via cuegui_command and cuegui_label config options.