### PR TITLE
[cuenimby] Fix config file open and notifications on headless render nodes

### DIFF
--- a/cuenimby/cuenimby/notifier.py
+++ b/cuenimby/cuenimby/notifier.py
@@ -29,6 +29,7 @@ class NotifierType(Enum):
     WIN10TOAST = "win10toast"
     NOTIFY2 = "notify2"
     NOTIFY_SEND = "notify-send"
+    QSYSTEMTRAY = "qsystemtray"
 
 OPENCUE_ICON = os.path.join(os.path.dirname(__file__), "icons", "opencue-icon.ico")
 
@@ -44,6 +45,7 @@ class Notifier:
         self.app_name = app_name
         self.system = platform.system()
         self.use_terminal_notifier = False
+        self._tray_icon = None  # QSystemTrayIcon fallback, set via set_tray_icon()
 
         # Try to import notification library
         try:
@@ -79,15 +81,31 @@ class Notifier:
                     # pylint: disable=import-outside-toplevel
                     import notify2
                     notify2.init(app_name)
+                    # Test that D-Bus notification service is reachable
+                    test_n = notify2.Notification("", "")
+                    test_n.show()
+                    test_n.close()
                     self.notifier = NotifierType.NOTIFY2
                     self.notify2 = notify2
-                except ImportError:
+                except Exception:
+                    logger.info("notify2 D-Bus notifications unavailable, using fallback")
                     self.notifier = NotifierType.NOTIFY_SEND
             else:
                 self.notifier = None
         except Exception as e:
             logger.error("Failed to initialize notifier: %s", e)
             self.notifier = None
+
+    def set_tray_icon(self, tray_icon) -> None:
+        """Set QSystemTrayIcon for fallback notifications.
+
+        Args:
+            tray_icon: A QSystemTrayIcon instance.
+        """
+        self._tray_icon = tray_icon
+        # If no other notifier is available, use the tray icon
+        if self.notifier is None:
+            self.notifier = NotifierType.QSYSTEMTRAY
 
     def notify(self, title: str, message: str, duration: int = 5) -> None:
         """Send a desktop notification.
@@ -150,16 +168,37 @@ class Notifier:
                 # Linux fallback
                 # pylint: disable=import-outside-toplevel
                 import subprocess
-                subprocess.run([
+                result = subprocess.run([
                     "notify-send",
                     "-t", str(duration * 1000),
                     title,
                     message
-                ], check=False)
+                ], capture_output=True, check=False)
+                if result.returncode != 0 and self._tray_icon:
+                    self._show_tray_message(title, message, duration)
+            elif self.notifier == NotifierType.QSYSTEMTRAY:
+                self._show_tray_message(title, message, duration)
             else:
                 logger.warning("No notification system available. %s: %s", title, message)
         except Exception as e:
             logger.error("Failed to send notification: %s", e)
+            # Last-resort fallback to QSystemTrayIcon
+            if self._tray_icon:
+                try:
+                    self._show_tray_message(title, message, duration)
+                except Exception:
+                    pass
+
+    def _show_tray_message(self, title: str, message: str, duration: int = 5) -> None:
+        """Show notification via QSystemTrayIcon balloon message."""
+        if self._tray_icon:
+            # pylint: disable=import-outside-toplevel
+            from qtpy import QtWidgets
+            self._tray_icon.showMessage(
+                title, message,
+                QtWidgets.QSystemTrayIcon.Information,
+                duration * 1000
+            )
 
     def notify_job_started(self, job_name: str, frame_name: str) -> None:
         """Notify when a job starts on this host.

--- a/cuenimby/cuenimby/tray.py
+++ b/cuenimby/cuenimby/tray.py
@@ -79,6 +79,7 @@ class CueNIMBYTray(QtWidgets.QSystemTrayIcon):
         # Initialize notifier
         if self.config.show_notifications:
             self.notifier = Notifier()
+            self.notifier.set_tray_icon(self)
 
         # Initialize monitor
         self.monitor = HostMonitor(
@@ -305,7 +306,35 @@ class CueNIMBYTray(QtWidgets.QSystemTrayIcon):
             elif sys.platform == "win32":  # Windows
                 os.startfile(config_path)
             else:  # Linux and others
-                subprocess.run(["xdg-open", config_path], check=True)
+                # Prefer $EDITOR/$VISUAL, then try common terminal editors
+                editor = (os.environ.get("VISUAL")
+                          or os.environ.get("EDITOR")
+                          or shutil.which("xdg-open"))
+                if editor and editor != shutil.which("xdg-open"):
+                    # Launch editor in a terminal so the user can interact
+                    terminal = shutil.which("xterm") or shutil.which("gnome-terminal")
+                    if terminal and "xterm" in terminal:
+                        subprocess.Popen([terminal, "-e", editor, config_path])
+                    elif terminal:
+                        subprocess.Popen([terminal, "--", editor, config_path])
+                    else:
+                        subprocess.Popen([editor, config_path])
+                elif shutil.which("xdg-open"):
+                    # Try xdg-open; if it fails, fall back to xterm + vi
+                    result = subprocess.run(
+                        ["xdg-open", config_path],
+                        capture_output=True, text=True, check=False
+                    )
+                    if result.returncode != 0:
+                        logger.warning("xdg-open failed (exit %d), falling back to vi",
+                                       result.returncode)
+                        term = shutil.which("xterm")
+                        if term:
+                            subprocess.Popen([term, "-e", "vi", config_path])
+                        else:
+                            raise RuntimeError("No editor or terminal found to open config")
+                else:
+                    raise RuntimeError("No editor or xdg-open found")
             logger.info("Opened config file: %s", config_path)
         except Exception as e:
             logger.error("Failed to open config file: %s", e)


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/2235

**Summarize your change.**
- Fall back to $VISUAL/$EDITOR when xdg-open fails to open config file
- Launch editor inside xterm/gnome-terminal for interactive editing
- Fall back to xterm + vi if xdg-open returns non-zero exit status
- Test notify2 D-Bus reachability at init instead of failing at runtime
- Add QSystemTrayIcon balloon message as notification fallback backend
- Wire tray icon into notifier via set_tray_icon() for last-resort popups
- Catch notify-send failures and fall back to Qt tray balloons