### PR TITLE
[scheduler] Fix bug on recompute job resources logic

### DIFF
--- a/rust/crates/scheduler/src/dao/layer_dao.rs
+++ b/rust/crates/scheduler/src/dao/layer_dao.rs
@@ -178,14 +178,20 @@ WITH dispatch_frames AS (
         f.int_layer_order,
         f.int_version,
         f.ts_updated,
-        -- Accumulate the number of cores that would be consumed
+        -- Accumulate the number of cores that would be consumed across all layers of the job
         SUM(l.int_cores_min) OVER (
-            PARTITION BY l.pk_layer
-            ORDER BY f.int_dispatch_order, f.int_layer_order
+            ORDER BY l.int_dispatch_order, f.int_dispatch_order, f.int_layer_order
             ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
         ) AS aggr_job_cores,
+        -- Accumulate the number of gpus that would be consumed across all layers of the job
+        SUM(l.int_gpus_min) OVER (
+            ORDER BY l.int_dispatch_order, f.int_dispatch_order, f.int_layer_order
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS aggr_job_gpus,
         jr.int_max_cores as job_resource_core_limit,
         jr.int_cores as job_resource_consumed_cores,
+        jr.int_max_gpus as job_resource_gpu_limit,
+        jr.int_gpus as job_resource_consumed_gpus,
         -- Add row number to limit frames per layer
         ROW_NUMBER() OVER (
             PARTITION BY l.pk_layer
@@ -205,6 +211,7 @@ limited_frames AS (
     SELECT * FROM dispatch_frames
     WHERE frame_rank <= $3  -- limit frames per layer
         AND (job_resource_core_limit <= 0 OR (aggr_job_cores + job_resource_consumed_cores <= job_resource_core_limit))
+        AND (job_resource_gpu_limit <= 0 OR (aggr_job_gpus + job_resource_consumed_gpus <= job_resource_gpu_limit))
 )
 SELECT DISTINCT
     -- Layer fields

--- a/rust/crates/scheduler/src/dao/resource_accounting_dao.rs
+++ b/rust/crates/scheduler/src/dao/resource_accounting_dao.rs
@@ -84,10 +84,28 @@ WHERE lr.pk_layer = booked.pk_layer
 "#;
 
 //== Recompute Job Resource
+
+/// SQL to save original max-cores/max-gpus values before the trigger-bypass update.
+static SELECT_JOB_RESOURCE_MAX: &str = r#"
+    SELECT jr.pk_job_resource, jr.int_max_cores, jr.int_max_gpus
+    FROM job_resource jr
+    JOIN job j ON j.pk_job = jr.pk_job AND j.str_state <> 'FINISHED'
+    WHERE ($1::text[] IS NULL OR j.pk_show = ANY($1))
+"#;
+
+/// Bulk-update job_resource booked cores/gpus with trigger bypass.
+///
+/// Sets `int_max_cores = total_cores` and `int_max_gpus = total_gpus` to prevent the
+/// `verify_job_resources` trigger from raising an exception when
+/// `int_cores > int_max_cores`. The trigger fires when
+/// `NEW.int_max_cores = OLD.int_max_cores AND NEW.int_cores > OLD.int_cores`.
+/// By changing `int_max_cores` in the same UPDATE, the trigger condition is not met.
 static RECOMPUTE_JOB_RESOURCE_FROM_PROC: &str = r#"
 UPDATE job_resource jr
-SET int_cores = LEAST(COALESCE(booked.total_cores, 0), jr.int_max_cores),
-    int_gpus = LEAST(COALESCE(booked.total_gpus, 0), jr.int_max_gpus)
+SET int_cores = COALESCE(booked.total_cores, 0),
+    int_gpus = COALESCE(booked.total_gpus, 0),
+    int_max_cores = COALESCE(booked.total_cores, 0),
+    int_max_gpus = COALESCE(booked.total_gpus, 0)
 FROM (
     SELECT jr2.pk_job,
            SUM(p.int_cores_reserved)::int AS total_cores,
@@ -104,11 +122,22 @@ WHERE jr.pk_job = booked.pk_job
     OR jr.int_gpus IS DISTINCT FROM COALESCE(booked.total_gpus, 0))
 "#;
 
+/// Restore original max-cores/max-gpus values after the trigger-bypass update.
+static RESTORE_JOB_RESOURCE_MAX: &str = r#"
+    UPDATE job_resource jr
+    SET int_max_cores = restore.max_cores,
+        int_max_gpus = restore.max_gpus
+    FROM (SELECT unnest($1::text[]) AS id,
+                 unnest($2::int[]) AS max_cores,
+                 unnest($3::int[]) AS max_gpus) restore
+    WHERE jr.pk_job_resource = restore.id
+"#;
+
 //=== Recompute Folder Resources
 static RECOMPUTE_FOLDER_RESOURCE_FROM_PROC: &str = r#"
 UPDATE folder_resource fr
-SET int_cores = LEAST(COALESCE(booked.total_cores, 0), fr.int_max_cores),
-    int_gpus = LEAST(COALESCE(booked.total_gpus, 0), fr.int_max_gpus)
+SET int_cores = COALESCE(booked.total_cores, 0),
+    int_gpus = COALESCE(booked.total_gpus, 0)
 FROM (
     SELECT fr2.pk_folder,
            SUM(p.int_cores_reserved)::int AS total_cores,
@@ -278,14 +307,7 @@ impl ResourceAccountingDao {
                     .into_diagnostic()
                     .wrap_err("Failed to recompute layer resource from proc")
             },
-            async {
-                sqlx::query(RECOMPUTE_JOB_RESOURCE_FROM_PROC)
-                    .bind(bind_value)
-                    .execute(pool)
-                    .await
-                    .into_diagnostic()
-                    .wrap_err("Failed to recompute job resource from proc")
-            },
+            self.recompute_job_resource_from_proc(bind_value),
             async {
                 sqlx::query(RECOMPUTE_FOLDER_RESOURCE_FROM_PROC)
                     .bind(bind_value)
@@ -303,6 +325,72 @@ impl ResourceAccountingDao {
                     .wrap_err("Failed to recompute point from proc")
             },
         )?;
+
+        Ok(())
+    }
+
+    /// Recomputes job_resource from the proc table using a transactional trigger bypass.
+    ///
+    /// Uses a transaction with three steps:
+    /// 1. Read original max_cores/max_gpus values
+    /// 2. Bulk update cores/gpus with trigger bypass (sets max_cores/max_gpus = total to
+    ///    avoid `verify_job_resources` trigger)
+    /// 3. Restore original max_cores/max_gpus values
+    async fn recompute_job_resource_from_proc(
+        &self,
+        bind_value: Option<&[String]>,
+    ) -> std::result::Result<(), miette::Report> {
+        #[derive(sqlx::FromRow)]
+        struct MaxRow {
+            pk_job_resource: String,
+            int_max_cores: i32,
+            int_max_gpus: i32,
+        }
+
+        let mut tx = self
+            .connection_pool
+            .begin()
+            .await
+            .into_diagnostic()
+            .wrap_err("Failed to begin transaction for job resource recompute")?;
+
+        // Step 1: Save original max values
+        let max_rows: Vec<MaxRow> = sqlx::query_as(SELECT_JOB_RESOURCE_MAX)
+            .bind(bind_value)
+            .fetch_all(&mut *tx)
+            .await
+            .into_diagnostic()
+            .wrap_err("Failed to read job resource max values")?;
+
+        let ids: Vec<String> = max_rows
+            .iter()
+            .map(|r| r.pk_job_resource.clone())
+            .collect();
+        let max_cores: Vec<i32> = max_rows.iter().map(|r| r.int_max_cores).collect();
+        let max_gpus: Vec<i32> = max_rows.iter().map(|r| r.int_max_gpus).collect();
+
+        // Step 2: Bulk update cores/gpus with trigger bypass
+        sqlx::query(RECOMPUTE_JOB_RESOURCE_FROM_PROC)
+            .bind(bind_value)
+            .execute(&mut *tx)
+            .await
+            .into_diagnostic()
+            .wrap_err("Failed to recompute job resource cores/gpus from proc")?;
+
+        // Step 3: Restore original max values
+        sqlx::query(RESTORE_JOB_RESOURCE_MAX)
+            .bind(&ids)
+            .bind(&max_cores)
+            .bind(&max_gpus)
+            .execute(&mut *tx)
+            .await
+            .into_diagnostic()
+            .wrap_err("Failed to restore job resource max values")?;
+
+        tx.commit()
+            .await
+            .into_diagnostic()
+            .wrap_err("Failed to commit job resource recompute transaction")?;
 
         Ok(())
     }

--- a/rust/crates/scheduler/tests/smoke_tests.rs
+++ b/rust/crates/scheduler/tests/smoke_tests.rs
@@ -568,6 +568,34 @@ mod scheduler_smoke_test {
         layers: Vec<(&str, &str, i64, i64, i64, i64)>, // (layer_name, tag, min_cores, min_mem, min_gpus, min_gpu_mem)
         frames_by_layer: usize,
     ) -> Result<TestJob, sqlx::Error> {
+        create_job_scenario_with_limits(
+            pool,
+            show_id,
+            facility_id,
+            dept_id,
+            folder_id,
+            job_name,
+            layers,
+            frames_by_layer,
+            None, // no core limit
+            None, // no gpu limit
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn create_job_scenario_with_limits(
+        pool: &Pool<Postgres>,
+        show_id: Uuid,
+        facility_id: Uuid,
+        dept_id: Uuid,
+        folder_id: Uuid,
+        job_name: &str,
+        layers: Vec<(&str, &str, i64, i64, i64, i64)>, // (layer_name, tag, min_cores, min_mem, min_gpus, min_gpu_mem)
+        frames_by_layer: usize,
+        max_cores: Option<i64>,  // job_resource.int_max_cores (in 100x units), None = use DB default
+        max_gpus: Option<i64>,   // job_resource.int_max_gpus, None = use DB default
+    ) -> Result<TestJob, sqlx::Error> {
         let mut tx = pool.begin().await?;
         let job_id = Uuid::new_v4();
 
@@ -596,21 +624,19 @@ mod scheduler_smoke_test {
                 .fetch_one(&mut *tx)
                 .await?;
 
+        let total_waiting_frames = (layers.len() * frames_by_layer) as i64;
         if existing_job_stat == 0 {
-            let total_waiting_frames = layers.len() * 3; // 3 frames per layer
             sqlx::query(
                 "INSERT INTO job_stat (pk_job_stat, pk_job, int_waiting_count) VALUES ($1, $2, $3)",
             )
             .bind(Uuid::new_v4().to_string())
             .bind(job_id.to_string())
-            .bind(total_waiting_frames as i64)
+            .bind(total_waiting_frames)
             .execute(&mut *tx)
             .await?;
         } else {
-            // Update existing job_stat
-            let total_waiting_frames = layers.len() * 3; // 3 frames per layer
             sqlx::query("UPDATE job_stat SET int_waiting_count = $1 WHERE pk_job = $2")
-                .bind(total_waiting_frames as i64)
+                .bind(total_waiting_frames)
                 .bind(job_id.to_string())
                 .execute(&mut *tx)
                 .await?;
@@ -626,17 +652,21 @@ mod scheduler_smoke_test {
 
         if existing_job_resource == 0 {
             sqlx::query(
-                "INSERT INTO job_resource (pk_job_resource, pk_job, int_priority) VALUES ($1, $2, $3)",
+                "INSERT INTO job_resource (pk_job_resource, pk_job, int_priority, int_max_cores, int_max_gpus) VALUES ($1, $2, $3, $4, $5)",
             )
             .bind(Uuid::new_v4().to_string())
             .bind(job_id.to_string())
             .bind(1)
+            .bind(max_cores.unwrap_or(10000)) // DB default is 10000
+            .bind(max_gpus.unwrap_or(100))    // DB default is 100
             .execute(&mut *tx)
             .await?;
         } else {
             // Update existing job_resource
-            sqlx::query("UPDATE job_resource SET int_priority = $1 WHERE pk_job = $2")
+            sqlx::query("UPDATE job_resource SET int_priority = $1, int_max_cores = $2, int_max_gpus = $3 WHERE pk_job = $4")
                 .bind(1)
+                .bind(max_cores.unwrap_or(10000))
+                .bind(max_gpus.unwrap_or(100))
                 .bind(job_id.to_string())
                 .execute(&mut *tx)
                 .await?;
@@ -672,8 +702,8 @@ mod scheduler_smoke_test {
             .bind(Uuid::new_v4().to_string())
             .bind(layer_id.to_string())
             .bind(job_id.to_string())
-            .bind(3) // 3 waiting frames
-            .bind(3) // 3 total frames
+            .bind(frames_by_layer as i64)
+            .bind(frames_by_layer as i64)
             .execute(&mut *tx)
             .await?;
 
@@ -1070,6 +1100,262 @@ mod scheduler_smoke_test {
                 panic!("❌ No matching hosts integration test failed: {}", e);
             }
         }
+    }
+
+    // ============================================================
+    // Job resource limit enforcement tests
+    // ============================================================
+
+    /// Helper to set up a minimal test environment for job resource limit tests.
+    /// Returns (pool, show_id, facility_id, dept_id, folder_id, alloc_id, test_suffix).
+    async fn setup_resource_limit_test(
+        test_suffix: &str,
+    ) -> Result<(Arc<Pool<Postgres>>, Uuid, Uuid, Uuid, Uuid, Uuid, String), sqlx::Error> {
+        let pool = setup_test_database().await?;
+        let mut tx = pool.begin().await?;
+
+        let facility_id = Uuid::new_v4();
+        let dept_id = Uuid::new_v4();
+        let show_id = Uuid::new_v4();
+
+        sqlx::query("INSERT INTO facility (pk_facility, str_name) VALUES ($1, $2)")
+            .bind(facility_id.to_string())
+            .bind(format!("reslimit_facility_{}", test_suffix))
+            .execute(&mut *tx)
+            .await?;
+
+        sqlx::query("INSERT INTO dept (pk_dept, str_name) VALUES ($1, $2)")
+            .bind(dept_id.to_string())
+            .bind(format!("reslimit_dept_{}", test_suffix))
+            .execute(&mut *tx)
+            .await?;
+
+        sqlx::query("INSERT INTO show (pk_show, str_name) VALUES ($1, $2)")
+            .bind(show_id.to_string())
+            .bind(format!("reslimit_show_{}", test_suffix))
+            .execute(&mut *tx)
+            .await?;
+
+        let folder_id = create_folder(
+            &mut tx,
+            show_id,
+            dept_id,
+            &format!("reslimit_folder_{}", test_suffix),
+        )
+        .await?;
+
+        let alloc_name = format!("reslimit_alloc_{}", test_suffix);
+        let alloc_id = create_allocation(&mut tx, facility_id, &alloc_name, &alloc_name).await?;
+        create_subscription(&mut tx, alloc_id, show_id, 10000 * 100, 990000 * 100).await?;
+
+        tx.commit().await?;
+
+        let _ = OVERRIDE_CONFIG.set(create_test_config());
+
+        Ok((pool, show_id, facility_id, dept_id, folder_id, alloc_id, test_suffix.to_string()))
+    }
+
+    /// Count total frames returned across all layers from query_layers
+    fn count_dispatch_frames(layers: &[scheduler::models::DispatchLayer]) -> usize {
+        layers.iter().map(|l| l.frames.len()).sum()
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    #[serial]
+    async fn test_job_resource_core_limit_multi_layer() {
+        // Bug regression: PARTITION BY l.pk_layer caused each layer to independently
+        // accumulate cores, effectively multiplying the limit by the number of layers.
+        let (pool, show_id, facility_id, dept_id, folder_id, _alloc_id, suffix) =
+            setup_resource_limit_test("multi_layer_core").await.expect("setup failed");
+
+        // 2 layers, each with int_cores_min=1 (100 in DB units), 4 frames per layer = 8 frames total.
+        // int_max_cores=400 means at most 4 frames across the entire job.
+        let tag = format!("reslimit_tag_{}", suffix);
+        let job = create_job_scenario_with_limits(
+            &pool,
+            show_id,
+            facility_id,
+            dept_id,
+            folder_id,
+            &format!("reslimit_multi_layer_job_{}", suffix),
+            vec![
+                (&format!("reslimit_layer_a_{}", suffix), &tag, 1, 1024 * 1024, 0, 0),
+                (&format!("reslimit_layer_b_{}", suffix), &tag, 1, 1024 * 1024, 0, 0),
+            ],
+            4,             // 4 frames per layer
+            Some(400),     // int_max_cores = 400 (4 cores in 100x units)
+            None,
+        )
+        .await
+        .expect("failed to create job");
+
+        let layer_dao = scheduler::dao::LayerDao::new()
+            .await
+            .expect("failed to create LayerDao");
+
+        let layers = layer_dao
+            .query_layers(job.id, vec![tag.clone()])
+            .await
+            .expect("query_layers failed");
+
+        let total_frames = count_dispatch_frames(&layers);
+        info!("Multi-layer core limit test: got {} frames (limit=4 cores, 2 layers x 4 frames)", total_frames);
+
+        // With the fix, total frames should be at most 4 (400 cores / 100 per frame).
+        // Before the fix, each layer independently allowed 4 frames = 8 total.
+        assert!(
+            total_frames <= 4,
+            "Expected at most 4 frames but got {}. \
+             The job_resource core limit is not being enforced across layers.",
+            total_frames,
+        );
+        assert!(total_frames > 0, "Expected at least 1 frame to be dispatched");
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    #[serial]
+    async fn test_job_resource_core_limit_single_layer() {
+        let (pool, show_id, facility_id, dept_id, folder_id, _alloc_id, suffix) =
+            setup_resource_limit_test("single_layer_core").await.expect("setup failed");
+
+        // 1 layer with int_cores_min=1 (100 in DB units), 10 frames.
+        // int_max_cores=300 means at most 3 frames.
+        let tag = format!("reslimit_tag_{}", suffix);
+        let job = create_job_scenario_with_limits(
+            &pool,
+            show_id,
+            facility_id,
+            dept_id,
+            folder_id,
+            &format!("reslimit_single_layer_job_{}", suffix),
+            vec![
+                (&format!("reslimit_layer_{}", suffix), &tag, 1, 1024 * 1024, 0, 0),
+            ],
+            10,            // 10 frames
+            Some(300),     // int_max_cores = 300 (3 cores)
+            None,
+        )
+        .await
+        .expect("failed to create job");
+
+        let layer_dao = scheduler::dao::LayerDao::new()
+            .await
+            .expect("failed to create LayerDao");
+
+        let layers = layer_dao
+            .query_layers(job.id, vec![tag.clone()])
+            .await
+            .expect("query_layers failed");
+
+        let total_frames = count_dispatch_frames(&layers);
+        info!("Single-layer core limit test: got {} frames (limit=3 cores, 10 available)", total_frames);
+
+        assert!(
+            total_frames <= 3,
+            "Expected at most 3 frames but got {}. \
+             The job_resource core limit is not being enforced.",
+            total_frames,
+        );
+        assert!(total_frames > 0, "Expected at least 1 frame to be dispatched");
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    #[serial]
+    async fn test_job_resource_no_core_limit() {
+        // When int_max_cores <= 0, no limit should be applied.
+        let (pool, show_id, facility_id, dept_id, folder_id, _alloc_id, suffix) =
+            setup_resource_limit_test("no_core_limit").await.expect("setup failed");
+
+        let tag = format!("reslimit_tag_{}", suffix);
+        let job = create_job_scenario_with_limits(
+            &pool,
+            show_id,
+            facility_id,
+            dept_id,
+            folder_id,
+            &format!("reslimit_no_limit_job_{}", suffix),
+            vec![
+                (&format!("reslimit_layer_a_{}", suffix), &tag, 1, 1024 * 1024, 0, 0),
+                (&format!("reslimit_layer_b_{}", suffix), &tag, 1, 1024 * 1024, 0, 0),
+            ],
+            4,            // 4 frames per layer = 8 total
+            Some(0),      // int_max_cores = 0 means no limit
+            None,
+        )
+        .await
+        .expect("failed to create job");
+
+        let layer_dao = scheduler::dao::LayerDao::new()
+            .await
+            .expect("failed to create LayerDao");
+
+        let layers = layer_dao
+            .query_layers(job.id, vec![tag.clone()])
+            .await
+            .expect("query_layers failed");
+
+        let total_frames = count_dispatch_frames(&layers);
+        info!("No core limit test: got {} frames (no limit, 8 available)", total_frames);
+
+        // All 8 frames should be returned (subject to dispatch_frames_per_layer_limit config)
+        assert!(
+            total_frames > 4,
+            "Expected more than 4 frames when no core limit is set, but got {}",
+            total_frames,
+        );
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    #[serial]
+    async fn test_job_resource_gpu_limit_multi_layer() {
+        // Verify that GPU limits are also enforced across layers.
+        let (pool, show_id, facility_id, dept_id, folder_id, _alloc_id, suffix) =
+            setup_resource_limit_test("multi_layer_gpu").await.expect("setup failed");
+
+        // 2 layers, each with int_gpus_min=1, 4 frames per layer = 8 frames total.
+        // int_max_gpus=3 means at most 3 frames across the entire job.
+        let tag = format!("reslimit_tag_{}", suffix);
+        let job = create_job_scenario_with_limits(
+            &pool,
+            show_id,
+            facility_id,
+            dept_id,
+            folder_id,
+            &format!("reslimit_gpu_job_{}", suffix),
+            vec![
+                (&format!("reslimit_gpu_layer_a_{}", suffix), &tag, 1, 1024 * 1024, 1, 1024 * 1024),
+                (&format!("reslimit_gpu_layer_b_{}", suffix), &tag, 1, 1024 * 1024, 1, 1024 * 1024),
+            ],
+            4,             // 4 frames per layer
+            None,          // no core limit restriction
+            Some(3),       // int_max_gpus = 3
+        )
+        .await
+        .expect("failed to create job");
+
+        let layer_dao = scheduler::dao::LayerDao::new()
+            .await
+            .expect("failed to create LayerDao");
+
+        let layers = layer_dao
+            .query_layers(job.id, vec![tag.clone()])
+            .await
+            .expect("query_layers failed");
+
+        let total_frames = count_dispatch_frames(&layers);
+        info!("Multi-layer GPU limit test: got {} frames (limit=3 GPUs, 2 layers x 4 frames)", total_frames);
+
+        assert!(
+            total_frames <= 3,
+            "Expected at most 3 frames but got {}. \
+             The job_resource GPU limit is not being enforced across layers.",
+            total_frames,
+        );
+        assert!(total_frames > 0, "Expected at least 1 frame to be dispatched");
     }
 
     // #[tokio::test]

--- a/rust/crates/scheduler/tests/smoke_tests.rs
+++ b/rust/crates/scheduler/tests/smoke_tests.rs
@@ -1120,19 +1120,19 @@ mod scheduler_smoke_test {
 
         sqlx::query("INSERT INTO facility (pk_facility, str_name) VALUES ($1, $2)")
             .bind(facility_id.to_string())
-            .bind(format!("reslimit_facility_{}", test_suffix))
+            .bind(format!("integ_test_reslimit_facility_{}", test_suffix))
             .execute(&mut *tx)
             .await?;
 
         sqlx::query("INSERT INTO dept (pk_dept, str_name) VALUES ($1, $2)")
             .bind(dept_id.to_string())
-            .bind(format!("reslimit_dept_{}", test_suffix))
+            .bind(format!("integ_test_reslimit_dept_{}", test_suffix))
             .execute(&mut *tx)
             .await?;
 
         sqlx::query("INSERT INTO show (pk_show, str_name) VALUES ($1, $2)")
             .bind(show_id.to_string())
-            .bind(format!("reslimit_show_{}", test_suffix))
+            .bind(format!("integ_test_reslimit_show_{}", test_suffix))
             .execute(&mut *tx)
             .await?;
 
@@ -1140,11 +1140,11 @@ mod scheduler_smoke_test {
             &mut tx,
             show_id,
             dept_id,
-            &format!("reslimit_folder_{}", test_suffix),
+            &format!("integ_test_reslimit_folder_{}", test_suffix),
         )
         .await?;
 
-        let alloc_name = format!("reslimit_alloc_{}", test_suffix);
+        let alloc_name = format!("integ_test_reslimit_alloc_{}", test_suffix);
         let alloc_id = create_allocation(&mut tx, facility_id, &alloc_name, &alloc_name).await?;
         create_subscription(&mut tx, alloc_id, show_id, 10000 * 100, 990000 * 100).await?;
 


### PR DESCRIPTION
Bug:** `RECOMPUTE_JOB_RESOURCE_FROM_PROC` used `LEAST(total, int_max_cores)` which capped `job_resource.int_cores` at the max limit. This made CueGUI display incorrect core counts and also degraded dispatch-time enforcement (the layer DAO query uses `int_cores` to decide if more frames can be dispatched — a capped value distorts that check).

**Changes:**

1. **Job resource** — replaced `LEAST` with a 3-step transactional trigger bypass (same pattern as subscriptions):
   - `SELECT_JOB_RESOURCE_MAX` saves original `int_max_cores`/`int_max_gpus`
   - `RECOMPUTE_JOB_RESOURCE_FROM_PROC` now sets `int_max_cores = total_cores` alongside `int_cores = total_cores` (bypasses `verify_job_resources` trigger since `NEW.int_max_cores != OLD.int_max_cores`)
   - `RESTORE_JOB_RESOURCE_MAX` restores original max values via bulk `unnest` update
   - New `recompute_job_resource_from_proc()` method wraps these 3 steps in a transaction

2. **Folder resource** — removed `LEAST` from `RECOMPUTE_FOLDER_RESOURCE_FROM_PROC` (no trigger on `folder_resource`, and `LEAST(positive, -1) = -1` was actively wrong for unlimited folders)

## LLM usage disclosure
Claude Opus was used to brainstorm the solution and to help write the new queries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve job-level CPU and GPU max values during resource recomputation so scheduling decisions remain correct.
* **New Features**
  * Scheduler enforces GPU limits alongside CPU cores when selecting work and computing dispatchable frames.
* **Tests**
  * Added integration smoke tests and helpers validating multi-/single-layer dispatch, CPU/GPU limit behaviors, and no-limit scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->