### PR TITLE
[rqd] Add override cores, procs, memory_size and hostname

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Diego Tavares <dtavares@imageworks.com>"]
 edition = "2021"
-version = "0.1.9"
+version = "0.1.10"
 
 [workspace.dependencies]
 async-trait = "0.1"

--- a/rust/crates/rqd/src/system/linux.rs
+++ b/rust/crates/rqd/src/system/linux.rs
@@ -33,7 +33,7 @@ use opencue_proto::{
     report::{ChildrenProcStats, ProcStats, Stat},
 };
 use sysinfo::{DiskRefreshKind, Disks, MemoryRefreshKind, RefreshKind};
-use tracing::debug;
+use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use crate::{config::MachineConfig, system::reservation::ProcessorStructure};
@@ -134,20 +134,53 @@ impl LinuxSystem {
     ///
     /// sysinfo needs to have been initialized.
     pub fn init(config: &MachineConfig, cpu_initial_info: ProcessorInfoData) -> Result<Self> {
-        let identified_os = config
-            .override_real_values
-            .clone()
-            .and_then(|c| c.os)
-            .unwrap_or_else(|| {
-                Self::read_distro(&config.distro_release_path).unwrap_or("linux".to_string())
-            });
+        let overrides = config.override_real_values.clone().unwrap_or_default();
+        if config.override_real_values.is_some() {
+            info!(
+                "Applying override_real_values: cores={:?}, procs={:?}, memory_size={:?}, hostname={:?}, os={:?}, workstation_mode={:?}",
+                overrides.cores,
+                overrides.procs,
+                overrides.memory_size,
+                overrides.hostname,
+                overrides.os,
+                overrides.workstation_mode,
+            );
+        }
+
+        let identified_os = overrides.os.clone().unwrap_or_else(|| {
+            Self::read_distro(&config.distro_release_path).unwrap_or("linux".to_string())
+        });
 
         // Initialize sysinfo collector
         let sysinfo = sysinfo::System::new_with_specifics(
             RefreshKind::nothing().with_memory(MemoryRefreshKind::everything()),
         );
-        let total_memory = sysinfo.total_memory();
+        let real_total_memory = sysinfo.total_memory();
+        let total_memory = overrides
+            .memory_size
+            .map(|b| b.as_u64())
+            .unwrap_or(real_total_memory);
+        if total_memory > real_total_memory {
+            warn!(
+                "override_real_values.memory_size ({} bytes) exceeds real total memory ({} bytes); \
+                 the scheduler may dispatch frames the host cannot fit and they will OOM.",
+                total_memory, real_total_memory,
+            );
+        }
         let total_swap = sysinfo.total_swap();
+
+        let hostname = match overrides.hostname.clone() {
+            Some(h) => h,
+            None => Self::get_hostname(config.use_ip_as_hostname)?,
+        };
+        let num_sockets = overrides
+            .procs
+            .map(|p| p as u32)
+            .unwrap_or(cpu_initial_info.num_sockets);
+        let cores_per_socket = overrides
+            .cores
+            .map(|c| c as u32)
+            .unwrap_or(cpu_initial_info.cores_per_socket);
 
         // Both sysconf values return -1 if not available
         let page_size: u64 = unsafe { libc::sysconf(_SC_PAGESIZE) }
@@ -162,11 +195,11 @@ impl LinuxSystem {
         Ok(Self {
             config: config.clone(),
             static_info: MachineStaticInfo {
-                hostname: Self::get_hostname(config.use_ip_as_hostname)?,
+                hostname,
                 total_memory,
                 total_swap,
-                num_sockets: cpu_initial_info.num_sockets,
-                cores_per_socket: cpu_initial_info.cores_per_socket,
+                num_sockets,
+                cores_per_socket,
                 hyperthreading_multiplier: cpu_initial_info.hyperthreading_multiplier,
                 boot_time_secs: Self::read_boot_time(&config.proc_stat_path).unwrap_or(0),
                 tags: Self::setup_tags(config),
@@ -442,8 +475,11 @@ impl LinuxSystem {
             .unwrap_or_else(|err| err.into_inner());
         sysinfo.refresh_memory();
 
-        let available_memory = sysinfo.available_memory();
-        let total_memory = sysinfo.total_memory();
+        let real_total = sysinfo.total_memory();
+        let real_available = sysinfo.available_memory();
+        let used = real_total.saturating_sub(real_available);
+        let total_memory = self.static_info.total_memory;
+        let available_memory = total_memory.saturating_sub(used);
         debug!(
             "Memory stats: available_memory={} bytes ({:.1} GiB), total_memory={} bytes ({:.1} GiB)",
             available_memory,

--- a/rust/crates/rqd/src/system/macos.rs
+++ b/rust/crates/rqd/src/system/macos.rs
@@ -34,7 +34,7 @@ use sysinfo::{
     DiskRefreshKind, Disks, MemoryRefreshKind, Pid, ProcessRefreshKind, ProcessStatus,
     ProcessesToUpdate, RefreshKind,
 };
-use tracing::debug;
+use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use crate::{config::MachineConfig, system::reservation::ProcessorStructure};
@@ -108,29 +108,62 @@ impl MacOsSystem {
     pub fn init(config: &MachineConfig) -> Result<Self> {
         let data = Self::read_cpuinfo(&config.cpuinfo_path)?;
 
-        let identified_os = config
-            .override_real_values
-            .clone()
-            .and_then(|c| c.os)
-            .unwrap_or_else(|| {
-                Self::read_distro(&config.distro_release_path).unwrap_or("macos".to_string())
-            });
+        let overrides = config.override_real_values.clone().unwrap_or_default();
+        if config.override_real_values.is_some() {
+            info!(
+                "Applying override_real_values: cores={:?}, procs={:?}, memory_size={:?}, hostname={:?}, os={:?}, workstation_mode={:?}",
+                overrides.cores,
+                overrides.procs,
+                overrides.memory_size,
+                overrides.hostname,
+                overrides.os,
+                overrides.workstation_mode,
+            );
+        }
+
+        let identified_os = overrides.os.clone().unwrap_or_else(|| {
+            Self::read_distro(&config.distro_release_path).unwrap_or("macos".to_string())
+        });
 
         // Initialize sysinfo collector
         let sysinfo = sysinfo::System::new_with_specifics(
             RefreshKind::nothing().with_memory(MemoryRefreshKind::everything()),
         );
-        let total_memory = sysinfo.total_memory();
+        let real_total_memory = sysinfo.total_memory();
+        let total_memory = overrides
+            .memory_size
+            .map(|b| b.as_u64())
+            .unwrap_or(real_total_memory);
+        if total_memory > real_total_memory {
+            warn!(
+                "override_real_values.memory_size ({} bytes) exceeds real total memory ({} bytes); \
+                 the scheduler may dispatch frames the host cannot fit and they will OOM.",
+                total_memory, real_total_memory,
+            );
+        }
         let total_swap = sysinfo.total_swap();
+
+        let hostname = match overrides.hostname.clone() {
+            Some(h) => h,
+            None => Self::get_hostname(config.use_ip_as_hostname)?,
+        };
+        let num_sockets = overrides
+            .procs
+            .map(|p| p as u32)
+            .unwrap_or(data.num_sockets);
+        let cores_per_socket = overrides
+            .cores
+            .map(|c| c as u32)
+            .unwrap_or(data.cores_per_socket);
 
         Ok(Self {
             config: config.clone(),
             static_info: MachineStaticInfo {
-                hostname: Self::get_hostname(config.use_ip_as_hostname)?,
+                hostname,
                 total_memory,
                 total_swap,
-                num_sockets: data.num_sockets,
-                cores_per_socket: data.cores_per_socket,
+                num_sockets,
+                cores_per_socket,
                 hyperthreading_multiplier: data.hyperthreading_multiplier,
                 boot_time_secs: Self::read_boot_time(&config.proc_stat_path).unwrap_or(0),
                 tags: Self::setup_tags(config),
@@ -399,7 +432,10 @@ impl MacOsSystem {
         Ok(MachineDynamicInfo {
             // sysinfo.available_memory() would be the best way to infer available memory, but it
             // returns 0 on M macs
-            available_memory: sysinfo.total_memory() - sysinfo.used_memory(),
+            available_memory: self
+                .static_info
+                .total_memory
+                .saturating_sub(sysinfo.used_memory()),
             free_swap: sysinfo.free_swap(),
             total_temp_storage: total_space,
             free_temp_storage: available_space,

--- a/rust/crates/rqd/src/system/windows.rs
+++ b/rust/crates/rqd/src/system/windows.rs
@@ -31,7 +31,7 @@ use sysinfo::{
     DiskRefreshKind, Disks, MemoryRefreshKind, Pid, ProcessRefreshKind, ProcessStatus,
     ProcessesToUpdate, RefreshKind,
 };
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 use crate::{config::MachineConfig, system::reservation::ProcessorStructure};
 
@@ -99,27 +99,60 @@ struct SessionData {
 impl WindowsSystem {
     /// Initialize the stats collector which reads CPU and Memory information from the OS.
     pub fn init(config: &MachineConfig, cpu_initial_info: ProcessorInfoData) -> Result<Self> {
-        let identified_os = config
-            .override_real_values
-            .clone()
-            .and_then(|c| c.os)
-            .unwrap_or_else(|| "windows".to_string());
+        let overrides = config.override_real_values.clone().unwrap_or_default();
+        if config.override_real_values.is_some() {
+            info!(
+                "Applying override_real_values: cores={:?}, procs={:?}, memory_size={:?}, hostname={:?}, os={:?}, workstation_mode={:?}",
+                overrides.cores,
+                overrides.procs,
+                overrides.memory_size,
+                overrides.hostname,
+                overrides.os,
+                overrides.workstation_mode,
+            );
+        }
+
+        let identified_os = overrides.os.clone().unwrap_or_else(|| "windows".to_string());
 
         // Initialize sysinfo collector
         let sysinfo = sysinfo::System::new_with_specifics(
             RefreshKind::nothing().with_memory(MemoryRefreshKind::everything()),
         );
-        let total_memory = sysinfo.total_memory();
+        let real_total_memory = sysinfo.total_memory();
+        let total_memory = overrides
+            .memory_size
+            .map(|b| b.as_u64())
+            .unwrap_or(real_total_memory);
+        if total_memory > real_total_memory {
+            warn!(
+                "override_real_values.memory_size ({} bytes) exceeds real total memory ({} bytes); \
+                 the scheduler may dispatch frames the host cannot fit and they will OOM.",
+                total_memory, real_total_memory,
+            );
+        }
         let total_swap = sysinfo.total_swap();
+
+        let hostname = match overrides.hostname.clone() {
+            Some(h) => h,
+            None => Self::get_hostname(config.use_ip_as_hostname)?,
+        };
+        let num_sockets = overrides
+            .procs
+            .map(|p| p as u32)
+            .unwrap_or(cpu_initial_info.num_sockets);
+        let cores_per_socket = overrides
+            .cores
+            .map(|c| c as u32)
+            .unwrap_or(cpu_initial_info.cores_per_socket);
 
         Ok(Self {
             config: config.clone(),
             static_info: MachineStaticInfo {
-                hostname: Self::get_hostname(config.use_ip_as_hostname)?,
+                hostname,
                 total_memory,
                 total_swap,
-                num_sockets: cpu_initial_info.num_sockets,
-                cores_per_socket: cpu_initial_info.cores_per_socket,
+                num_sockets,
+                cores_per_socket,
                 hyperthreading_multiplier: cpu_initial_info.hyperthreading_multiplier,
                 boot_time_secs: sysinfo::System::boot_time(),
                 tags: Self::setup_tags(config),
@@ -272,8 +305,11 @@ impl WindowsSystem {
         sysinfo.refresh_memory();
 
         let hyperthreading = self.static_info.hyperthreading_multiplier.max(1);
+        let real_total = sysinfo.total_memory();
+        let real_available = sysinfo.available_memory();
+        let used = real_total.saturating_sub(real_available);
         Ok(MachineDynamicInfo {
-            available_memory: sysinfo.available_memory(),
+            available_memory: self.static_info.total_memory.saturating_sub(used),
             free_swap: sysinfo.free_swap(),
             total_temp_storage: total_space,
             free_temp_storage: available_space,


### PR DESCRIPTION
Override options were available on the config but never implemented.

## LLM usage disclosure
Claude Opus was used to implement the code changes on this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System properties (OS identification, hostname, memory, and CPU topology) can now be overridden via configuration across Linux, macOS, and Windows.
* **Bug Fixes / Reliability**
  * Memory reporting now uses overridden totals when present and avoids underflow; warnings are emitted when overrides exceed real capacity.
* **Chores**
  * Workspace package version bumped to 0.1.10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->