### PR TITLE
[rest_gateway] Bump Go base image to 1.25 to fix Docker build

### DIFF
--- a/rest_gateway/Dockerfile
+++ b/rest_gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-bookworm AS build
+FROM golang:1.25-bookworm AS build
 
 # Install protobuf compiler
 RUN apt-get update && \


### PR DESCRIPTION
- grpc-gateway/v2@v2.29.0 now requires Go >= 1.25.0
- go.mod is generated at build time via `go mod tidy`
- golang Docker image defaults to GOTOOLCHAIN=local, blocking auto-upgrade
- Bump base image from golang:1.24-bookworm to golang:1.25-bookworm
