### PR TITLE
[cueadmin] Fix -create-sub failing with "'str' object is not callable"

### DIFF
--- a/cueadmin/cueadmin/common.py
+++ b/cueadmin/cueadmin/common.py
@@ -1378,7 +1378,7 @@ def handleArgs(args):
             % (opencue.rep(show), opencue.rep(alloc)),
             args.force,
             show.createSubscription,
-            alloc.data,
+            alloc,
             float(args.create_sub[2]),
             float(args.create_sub[3]),
         )

--- a/cueadmin/tests/integration_tests.py
+++ b/cueadmin/tests/integration_tests.py
@@ -67,8 +67,8 @@ class ShowAllocationSubscriptionWorkflowTest(unittest.TestCase):
         self.assertEqual(alloc.data.tag, TEST_TAG)
 
         # Step 3: Create subscription linking show and allocation
-        show.createSubscription(alloc.data, 100.0, 200.0)
-        show.createSubscription.assert_called_once_with(alloc.data, 100.0, 200.0)
+        show.createSubscription(alloc, 100.0, 200.0)
+        show.createSubscription.assert_called_once_with(alloc, 100.0, 200.0)
 
         # Verify state consistency: subscription should be created with correct parameters
         self.assertEqual(show.createSubscription.call_count, 1)

--- a/cueadmin/tests/test_common.py
+++ b/cueadmin/tests/test_common.py
@@ -596,7 +596,7 @@ class SubscriptionTests(unittest.TestCase):
         findShowMock.assert_called_with(TEST_SHOW)
         findAllocMock.assert_called_with(allocName)
         showMock.createSubscription.assert_called_with(
-            allocMock.data, numCores, burstCores
+            allocMock, float(numCores), float(burstCores)
         )
 
     @mock.patch("opencue.api.findShow")

--- a/cueadmin/tests/test_subscription_commands.py
+++ b/cueadmin/tests/test_subscription_commands.py
@@ -182,7 +182,7 @@ class SubscriptionCommandTests(unittest.TestCase):
         mock_find_show.assert_called_once_with(TEST_SHOW)
         mock_find_alloc.assert_called_once_with(TEST_ALLOC)
         mock_prompt.assert_called_once()
-        show.createSubscription.assert_called_once_with(alloc.data, 100.0, 200.0)
+        show.createSubscription.assert_called_once_with(alloc, 100.0, 200.0)
 
     @mock.patch('opencue.api.findAllocation')
     @mock.patch('opencue.api.findShow')
@@ -200,7 +200,7 @@ class SubscriptionCommandTests(unittest.TestCase):
 
         mock_find_show.assert_called_once_with(TEST_SHOW)
         mock_find_alloc.assert_called_once_with(TEST_ALLOC)
-        show.createSubscription.assert_called_once_with(alloc.data, 50.0, 75.0)
+        show.createSubscription.assert_called_once_with(alloc, 50.0, 75.0)
 
     @mock.patch('cueadmin.util.promptYesNo', return_value=True)
     def test_delete_sub_deletes_subscription_with_confirmation(self, mock_prompt,
@@ -466,7 +466,7 @@ class SubscriptionCommandTests(unittest.TestCase):
                                              size, burst, '-force'])
                 cueadmin.common.handleArgs(args)
 
-                show.createSubscription.assert_called_with(alloc.data, float(size), float(burst))
+                show.createSubscription.assert_called_with(alloc, float(size), float(burst))
 
     def test_resource_calculation_accuracy_comprehensive(self, getStubMock, findSubMock):
         """Comprehensive test of resource calculation accuracy for percentage burst."""

--- a/pycue/opencue/util.py
+++ b/pycue/opencue/util.py
@@ -119,7 +119,8 @@ def rep(entity):
     """rep(entity)
     Extracts a string representation of a opencue entity"""
     try:
-        return entity.name
+        name = entity.name
+        return name() if callable(name) else name
     # pylint: disable=bare-except
     except:
         return str(entity)


### PR DESCRIPTION
## Related Issues
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/2262

## Summarize your change.

Two issues prevented `cueadmin -create-sub` from working:

1. The handler passed `alloc.data` (a protobuf) to `Show.createSubscription`, but the method expects an `Allocation` wrapper and calls `allocation.id()`. On the protobuf, `data.id` is a string field, so calling it raised `'str' object is not callable`. Pass the wrapper instead.

2. `opencue.util.rep()` returned `entity.name` directly, but `name` is a method on every wrapper, so the confirm prompt rendered as `<bound method Show.name of ...>`. Call it when callable.

Subscription tests updated to assert the wrapper is passed through to `createSubscription` rather than `alloc.data`.
