### PR TITLE
[cuegui] Show /mcp percent free in Monitor Hosts

### DIFF
--- a/cuegui/cuegui/HostMonitorTree.py
+++ b/cuegui/cuegui/HostMonitorTree.py
@@ -47,6 +47,27 @@ logger = cuegui.Logger.getLogger(__file__)
 COMMENT_COLUMN = 1
 
 
+def _tempFreeRatio(host):
+    """Free /mcp as a fraction of total (0.0-1.0). Falls back to free amount
+    when total_mcp is unknown so sorting still produces a sensible order."""
+    total = host.data.total_mcp
+    if not total:
+        return host.data.free_mcp
+    return host.data.free_mcp / float(total)
+
+
+def _formatTempCell(host):
+    """Cell text for the Temp column: '<free> (NN%)'. When total_mcp is
+    unknown (e.g. RQD that did not initialize it), shows just the free
+    amount."""
+    free = host.data.free_mcp
+    total = host.data.total_mcp
+    free_str = cuegui.Utils.memoryToString(free)
+    if not total:
+        return free_str
+    return "%s (%d%%)" % (free_str, int(round(100.0 * free / total)))
+
+
 class HostMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
     """Tree widget for displaying a list of hosts."""
 
@@ -93,10 +114,17 @@ class HostMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                        data=lambda host: cuegui.Utils.memoryToString(host.data.idle_memory),
                        sort=lambda host: host.data.idle_memory,
                        tip="The amount of unreserved memory.")
-        self.addColumn("Temp available", 70, id=9,
+        self.addColumn("Temp", 70, id=9,
                        data=lambda host: cuegui.Utils.memoryToString(host.data.free_mcp),
-                       sort=lambda host: host.data.free_mcp,
-                       tip="The amount of free space in /mcp/")
+                       sort=_tempFreeRatio,
+                       delegate=cuegui.ItemDelegate.HostTempBarDelegate,
+                       tip="The amount of used /mcp/ space (red) vs available (green).")
+        self.addColumn("Temp Free", 90, id=23,
+                       data=_formatTempCell,
+                       sort=_tempFreeRatio,
+                       tip="Free /mcp/ space. The number in parentheses is the\n"
+                           "percent free; hosts have different /mcp sizes, so the\n"
+                           "percent makes it easier to compare across hosts.")
         self.addColumn("Cores", 60, id=10,
                        data=lambda host: "%.2f" % host.data.cores,
                        sort=lambda host: host.data.cores,
@@ -375,5 +403,9 @@ class HostWidgetItem(cuegui.AbstractWidgetItem.AbstractWidgetItem):
             return [self.rpcObject.data.total_gpu_memory -
                     self.rpcObject.data.free_gpu_memory,
                     self.rpcObject.data.total_gpu_memory]
+
+        if role == QtCore.Qt.UserRole + 4:
+            return [self.rpcObject.data.total_mcp - self.rpcObject.data.free_mcp,
+                    self.rpcObject.data.total_mcp]
 
         return cuegui.Constants.QVARIANT_NULL

--- a/cuegui/cuegui/ItemDelegate.py
+++ b/cuegui/cuegui/ItemDelegate.py
@@ -83,7 +83,11 @@ class AbstractDelegate(QtWidgets.QItemDelegate):
         try:
             self._drawBackground(painter, option, index)
 
-            rect = option.rect.adjusted(2, 6, -2, -6)
+            # Padding (2px top/bottom) keeps the bar visible on platforms
+            # where Qt's default tree row is short — notably macOS, where
+            # rows are ~14-16px tall. Larger padding (e.g. 6px) consumes
+            # the entire row on macOS and the bar disappears.
+            rect = option.rect.adjusted(2, 2, -2, -2)
             ratio = rect.width() / float(total)
             length = int(ceil(ratio * (used)))
             painter.fillRect(rect,
@@ -375,6 +379,20 @@ class HostGpuBarDelegate(AbstractDelegate):
         if index.data(QtCore.Qt.UserRole) == cuegui.Constants.TYPE_HOST:
             self._paintDifferenceBar(painter, option, index,
                                      *index.data(QtCore.Qt.UserRole + 3))
+        else:
+            AbstractDelegate.paint(self, painter, option, index)
+
+
+class HostTempBarDelegate(AbstractDelegate):
+    """Delegate for the host temp (/mcp) field."""
+
+    def __init__(self, parent, *args):
+        AbstractDelegate.__init__(self, parent, *args)
+
+    def paint(self, painter, option, index):
+        if index.data(QtCore.Qt.UserRole) == cuegui.Constants.TYPE_HOST:
+            self._paintDifferenceBar(painter, option, index,
+                                     *index.data(QtCore.Qt.UserRole + 4))
         else:
             AbstractDelegate.paint(self, painter, option, index)
 

--- a/cuegui/tests/test_host_monitor_tree.py
+++ b/cuegui/tests/test_host_monitor_tree.py
@@ -1,0 +1,108 @@
+#  Copyright Contributors to the OpenCue Project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+"""Tests for cuegui.HostMonitorTree."""
+
+
+import unittest
+
+import mock
+import qtpy.QtCore
+import qtpy.QtWidgets
+
+import opencue.wrappers.host
+import opencue_proto.host_pb2
+
+import cuegui.HostMonitorTree
+import cuegui.ItemDelegate
+import cuegui.Style
+
+from . import test_utils
+
+
+def _makeHost(free_mcp, total_mcp):
+    return opencue.wrappers.host.Host(
+        opencue_proto.host_pb2.Host(
+            id='host-id', name='host01', free_mcp=free_mcp, total_mcp=total_mcp))
+
+
+class TempCellHelpersTests(unittest.TestCase):
+
+    def test_formatIncludesPercentWhenTotalKnown(self):
+        # 50% free.
+        host = _makeHost(free_mcp=10 * 1024 * 1024, total_mcp=20 * 1024 * 1024)
+        self.assertEqual("10.0G (50%)", cuegui.HostMonitorTree._formatTempCell(host))
+
+    def test_formatRoundsPercentToNearestInteger(self):
+        # 1/3 free -> 33%.
+        host = _makeHost(free_mcp=1 * 1024 * 1024, total_mcp=3 * 1024 * 1024)
+        self.assertEqual("1.0G (33%)", cuegui.HostMonitorTree._formatTempCell(host))
+
+    def test_formatFallsBackWhenTotalUnknown(self):
+        host = _makeHost(free_mcp=5 * 1024 * 1024, total_mcp=0)
+        # No percent suffix when total is unknown.
+        self.assertEqual("5.0G", cuegui.HostMonitorTree._formatTempCell(host))
+
+    def test_ratioIsFractionOfFreeOverTotal(self):
+        host = _makeHost(free_mcp=25, total_mcp=100)
+        self.assertAlmostEqual(0.25, cuegui.HostMonitorTree._tempFreeRatio(host))
+
+    def test_ratioFallsBackToFreeWhenTotalUnknown(self):
+        host = _makeHost(free_mcp=42, total_mcp=0)
+        # When total is unknown, sort by free amount so ordering is still
+        # somewhat sensible.
+        self.assertEqual(42, cuegui.HostMonitorTree._tempFreeRatio(host))
+
+
+@mock.patch('opencue.cuebot.Cuebot.getStub', new=mock.Mock())
+class HostWidgetItemTempBarDataTests(unittest.TestCase):
+
+    def setUp(self):
+        app = test_utils.createApplication()
+        app.settings = qtpy.QtCore.QSettings()
+        cuegui.Style.init()
+        # Kept as instance attr so the parent isn't garbage-collected mid-test.
+        self.parentWidget = qtpy.QtWidgets.QWidget()
+        self.tree = cuegui.HostMonitorTree.HostMonitorTree(self.parentWidget)
+
+    def test_userRole4ReturnsUsedAndTotal(self):
+        host = _makeHost(free_mcp=30, total_mcp=100)
+        item = cuegui.HostMonitorTree.HostWidgetItem(host, self.tree)
+
+        # Any column index is fine — the role is what selects the bar payload.
+        used, total = item.data(0, qtpy.QtCore.Qt.UserRole + 4)
+
+        self.assertEqual(70, used)
+        self.assertEqual(100, total)
+
+    def test_tempColumnIsWiredToBarDelegate(self):
+        # Column id=9 is the bar-only "Temp" column. addColumn appends in
+        # order so it lives at index 8 (zero-based).
+        temp_col_index = 8
+        delegate = self.tree.itemDelegateForColumn(temp_col_index)
+
+        self.assertIsInstance(delegate, cuegui.ItemDelegate.HostTempBarDelegate)
+
+    def test_tempFreeColumnHasNoBarDelegate(self):
+        # "Temp Free" sits right after "Temp" at index 9. It's a plain text
+        # column — no bar delegate, only the formatted "<free> (NN%)" text.
+        temp_free_col_index = 9
+        delegate = self.tree.itemDelegateForColumn(temp_free_col_index)
+
+        self.assertNotIsInstance(delegate, cuegui.ItemDelegate.HostTempBarDelegate)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/docs/_docs/user-guides/cuecommander-administration-guide.md
+++ b/docs/_docs/user-guides/cuecommander-administration-guide.md
@@ -256,7 +256,8 @@ Enables real-time monitoring and management of render hosts (nodes), including t
 - **Physical**: Physical memory state
 - **GPU Memory**: GPU memory statistics
 - **Idle/Total Memory**: Memory availability
-- **Temp Available**: Temporary disk space
+- **Temp**: Used (red) vs available (green) `/mcp/` space, shown as a bar
+- **Temp Free**: Free `/mcp/` space with the percent free in parentheses (e.g. `99.2G (50%)`); the percent makes it easier to compare hosts with different `/mcp/` sizes
 - **Cores**: CPU core information
 - **Idle GPU/Total GPU**: GPU availability
 - **Ping**: Network responsiveness


### PR DESCRIPTION
## Related Issues
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/2264

## Summarize your change.

- Replace the single "Temp available" column with two adjacent columns matching the existing Swap / Physical / GPU Memory pattern:
  * "Temp": red/green used-vs-free bar, sortable by percent free
  * "Temp Free": text "<free> (NN%)", e.g. "99.2G (50%)"

- Why two columns: /mcp sizes vary across hardware, so the absolute free amount alone makes hosts hard to compare. The percent makes the comparison obvious; the bar gives an at-a-glance visual.

- Fix a pre-existing rendering bug affecting all bar columns (Swap, Physical, GPU Memory, Temp) on macOS. `_paintDifferenceBar` shrank the bar rect by 6px top and 6px bottom; with macOS Qt's default tree row height (~14–16px), that leaves no vertical space, and the bar disappears. Tightened the padding to 2px so the bar stays visible on every platform.

 - Add unit tests for the helpers, the [used, total] data exposed to the bar delegate, and the column-to-delegate wiring.

- Update the cuecommander admin guide to describe both new columns.