### PR TITLE
[rust-rqd] Report correct temp storage when temp_path is a symlink

### DIFF
--- a/rust/crates/rqd/Cargo.toml
+++ b/rust/crates/rqd/Cargo.toml
@@ -66,7 +66,7 @@ lazy_static = "1.5"
 ureq = { version = "3.1.0", features = ["json"] }
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.29", features = ["process", "signal", "reboot", "hostname"] }
+nix = { version = "0.29", features = ["process", "signal", "reboot", "hostname", "fs"] }
 users = "0.11"
 
 [target.'cfg(not(windows))'.dependencies]

--- a/rust/crates/rqd/src/config/mod.rs
+++ b/rust/crates/rqd/src/config/mod.rs
@@ -381,6 +381,18 @@ impl Config {
                 ))
             })?;
         }
+        // Ensure machine temp path exists. read_temp_storage calls statvfs
+        // directly on this path, which fails with ENOENT if missing; frame
+        // launch also uses temp_path as its working dir.
+        let temp_path = Path::new(&self.machine.temp_path);
+        if !temp_path.exists() {
+            fs::create_dir_all(temp_path).map_err(|err| {
+                RqdConfigError::InvalidPath(format!(
+                    "Failed to create machine temp dir at {:?}: {err}",
+                    temp_path
+                ))
+            })?;
+        }
         Ok(())
     }
 }

--- a/rust/crates/rqd/src/config/mod.rs
+++ b/rust/crates/rqd/src/config/mod.rs
@@ -383,15 +383,22 @@ impl Config {
         }
         // Ensure machine temp path exists. read_temp_storage calls statvfs
         // directly on this path, which fails with ENOENT if missing; frame
-        // launch also uses temp_path as its working dir.
+        // launch also uses temp_path as its working dir. create_dir_all is
+        // a no-op when the directory already exists, so the only path it
+        // surfaces an error for is the genuinely-broken case (parent missing,
+        // permission denied, etc.).
         let temp_path = Path::new(&self.machine.temp_path);
-        if !temp_path.exists() {
-            fs::create_dir_all(temp_path).map_err(|err| {
-                RqdConfigError::InvalidPath(format!(
-                    "Failed to create machine temp dir at {:?}: {err}",
-                    temp_path
-                ))
-            })?;
+        fs::create_dir_all(temp_path).map_err(|err| {
+            RqdConfigError::InvalidPath(format!(
+                "Failed to create machine temp dir at {:?}: {err}",
+                temp_path
+            ))
+        })?;
+        if !temp_path.is_dir() {
+            return Err(RqdConfigError::InvalidPath(format!(
+                "Machine temp path is not a directory: {:?}",
+                temp_path
+            )));
         }
         Ok(())
     }

--- a/rust/crates/rqd/src/main.rs
+++ b/rust/crates/rqd/src/main.rs
@@ -38,6 +38,10 @@ fn main() -> miette::Result<()> {
 }
 
 async fn async_main() -> miette::Result<()> {
+    // Ensure provisioned paths (snapshots, machine temp) exist before any
+    // subsystem touches them.
+    CONFIG.setup()?;
+
     let log_level =
         tracing::Level::from_str(CONFIG.logging.level.as_str()).expect("Invalid log level");
     let log_builder = tracing_subscriber::fmt()

--- a/rust/crates/rqd/src/system/linux.rs
+++ b/rust/crates/rqd/src/system/linux.rs
@@ -540,7 +540,7 @@ impl LinuxSystem {
                 format!("statvfs failed for temp path {}", self.config.temp_path)
             })?;
         let total_space = stat.blocks() as u64 * stat.fragment_size() as u64;
-        let available_space = stat.blocks_available() as u64 * stat.block_size() as u64;
+        let available_space = stat.blocks_available() as u64 * stat.fragment_size() as u64;
         Ok((total_space, available_space))
     }
 

--- a/rust/crates/rqd/src/system/linux.rs
+++ b/rust/crates/rqd/src/system/linux.rs
@@ -32,7 +32,7 @@ use opencue_proto::{
     host::HardwareState,
     report::{ChildrenProcStats, ProcStats, Stat},
 };
-use sysinfo::{DiskRefreshKind, Disks, MemoryRefreshKind, RefreshKind};
+use sysinfo::{MemoryRefreshKind, RefreshKind};
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
@@ -522,32 +522,26 @@ impl LinuxSystem {
         load_val.ok_or(miette!("Couldn't find load average"))
     }
 
-    /// Reads storage information from the temporary mount point and extracts
+    /// Reads storage information for the configured temp path and extracts
     /// the total space and available space.
+    ///
+    /// Uses `statvfs` directly so the path is followed through symlinks and
+    /// stats the actual underlying filesystem. The previous `sysinfo`-based
+    /// mount-list lookup misreported any host where `temp_path` was a symlink,
+    /// because the prefix match could fall back to the root filesystem.
     ///
     /// # Returns
     ///
     /// A `Result` containing a tuple of total space and available space in bytes.
     fn read_temp_storage(&self) -> Result<(u64, u64)> {
-        let mut diskinfo =
-            Disks::new_with_refreshed_list_specifics(DiskRefreshKind::nothing().with_storage());
-        let tmp_disk = diskinfo.list_mut().iter_mut().find(|disk| {
-            self.config.temp_path.starts_with(
-                disk.mount_point()
-                    .to_str()
-                    .unwrap_or("invalid_path_will_never_match"),
-            )
-        });
-        match tmp_disk {
-            Some(disk) => {
-                disk.refresh_specifics(DiskRefreshKind::everything());
-                Ok((disk.total_space(), disk.available_space()))
-            }
-            None => Err(miette!(
-                "Could not locate disk for temp path {}",
-                self.config.temp_path
-            )),
-        }
+        let stat = nix::sys::statvfs::statvfs(self.config.temp_path.as_str())
+            .into_diagnostic()
+            .wrap_err_with(|| {
+                format!("statvfs failed for temp path {}", self.config.temp_path)
+            })?;
+        let total_space = stat.blocks() as u64 * stat.fragment_size() as u64;
+        let available_space = stat.blocks_available() as u64 * stat.block_size() as u64;
+        Ok((total_space, available_space))
     }
 
     fn refresh_procs_cache(&self) -> Result<()> {

--- a/rust/crates/rqd/src/system/macos.rs
+++ b/rust/crates/rqd/src/system/macos.rs
@@ -485,7 +485,7 @@ impl MacOsSystem {
                 format!("statvfs failed for temp path {}", self.config.temp_path)
             })?;
         let total_space = stat.blocks() as u64 * stat.fragment_size() as u64;
-        let available_space = stat.blocks_available() as u64 * stat.block_size() as u64;
+        let available_space = stat.blocks_available() as u64 * stat.fragment_size() as u64;
         Ok((total_space, available_space))
     }
 

--- a/rust/crates/rqd/src/system/macos.rs
+++ b/rust/crates/rqd/src/system/macos.rs
@@ -31,8 +31,7 @@ use opencue_proto::{
     report::{ChildrenProcStats, ProcStats, Stat},
 };
 use sysinfo::{
-    DiskRefreshKind, Disks, MemoryRefreshKind, Pid, ProcessRefreshKind, ProcessStatus,
-    ProcessesToUpdate, RefreshKind,
+    MemoryRefreshKind, Pid, ProcessRefreshKind, ProcessStatus, ProcessesToUpdate, RefreshKind,
 };
 use tracing::{debug, info, warn};
 use uuid::Uuid;
@@ -468,32 +467,26 @@ impl MacOsSystem {
         load_val.ok_or(miette!("Couldn't find load average"))
     }
 
-    /// Reads storage information from the temporary mount point and extracts
+    /// Reads storage information for the configured temp path and extracts
     /// the total space and available space.
+    ///
+    /// Uses `statvfs` directly so the path is followed through symlinks and
+    /// stats the actual underlying filesystem. The previous `sysinfo`-based
+    /// mount-list lookup misreported any host where `temp_path` was a symlink,
+    /// because the prefix match could fall back to the root filesystem.
     ///
     /// # Returns
     ///
     /// A `Result` containing a tuple of total space and available space in bytes.
     fn read_temp_storage(&self) -> Result<(u64, u64)> {
-        let mut diskinfo =
-            Disks::new_with_refreshed_list_specifics(DiskRefreshKind::nothing().with_storage());
-        let tmp_disk = diskinfo.list_mut().iter_mut().find(|disk| {
-            self.config.temp_path.starts_with(
-                disk.mount_point()
-                    .to_str()
-                    .unwrap_or("invalid_path_will_never_match"),
-            )
-        });
-        match tmp_disk {
-            Some(disk) => {
-                disk.refresh_specifics(DiskRefreshKind::everything());
-                Ok((disk.total_space(), disk.available_space()))
-            }
-            None => Err(miette!(
-                "Could not locate disk for temp path {}",
-                self.config.temp_path
-            )),
-        }
+        let stat = nix::sys::statvfs::statvfs(self.config.temp_path.as_str())
+            .into_diagnostic()
+            .wrap_err_with(|| {
+                format!("statvfs failed for temp path {}", self.config.temp_path)
+            })?;
+        let total_space = stat.blocks() as u64 * stat.fragment_size() as u64;
+        let available_space = stat.blocks_available() as u64 * stat.block_size() as u64;
+        Ok((total_space, available_space))
     }
 
     /// Refresh the cache of children procs.

--- a/rust/crates/rqd/src/system/windows.rs
+++ b/rust/crates/rqd/src/system/windows.rs
@@ -317,18 +317,39 @@ impl WindowsSystem {
         })
     }
 
-    /// Reads storage information from the temporary mount point and extracts
+    /// Reads storage information for the configured temp path and extracts
     /// the total space and available space.
+    ///
+    /// Resolves the temp path through junctions/symlinks first so the lookup
+    /// hits the real underlying volume, and picks the longest matching mount
+    /// point so a deeper mount wins over the root drive.
     fn read_temp_storage(&self) -> Result<(u64, u64)> {
         let temp_path = std::path::Path::new(&self.config.temp_path);
+        let canonical = std::fs::canonicalize(temp_path)
+            .into_diagnostic()
+            .wrap_err_with(|| {
+                format!("Could not canonicalize temp path {}", self.config.temp_path)
+            })?;
+        // canonicalize returns a verbatim path (\\?\...) on Windows; strip
+        // that prefix so the result matches drive-letter mount points like
+        // "C:\" reported by sysinfo, since Path::starts_with is component-based.
+        let canonical_str = canonical.to_string_lossy().into_owned();
+        let stripped = canonical_str
+            .strip_prefix(r"\\?\")
+            .unwrap_or(&canonical_str);
+        let resolved = std::path::PathBuf::from(stripped);
         let mut diskinfo =
             Disks::new_with_refreshed_list_specifics(DiskRefreshKind::nothing().with_storage());
-        let tmp_disk = diskinfo
-            .list_mut()
-            .iter_mut()
-            .find(|disk| temp_path.starts_with(disk.mount_point()));
-        match tmp_disk {
-            Some(disk) => {
+        let idx = diskinfo
+            .list()
+            .iter()
+            .enumerate()
+            .filter(|(_, disk)| resolved.starts_with(disk.mount_point()))
+            .max_by_key(|(_, disk)| disk.mount_point().as_os_str().len())
+            .map(|(i, _)| i);
+        match idx {
+            Some(i) => {
+                let disk = &mut diskinfo.list_mut()[i];
                 disk.refresh_specifics(DiskRefreshKind::everything());
                 Ok((disk.total_space(), disk.available_space()))
             }

--- a/rust/crates/rqd/src/system/windows.rs
+++ b/rust/crates/rqd/src/system/windows.rs
@@ -330,14 +330,21 @@ impl WindowsSystem {
             .wrap_err_with(|| {
                 format!("Could not canonicalize temp path {}", self.config.temp_path)
             })?;
-        // canonicalize returns a verbatim path (\\?\...) on Windows; strip
-        // that prefix so the result matches drive-letter mount points like
-        // "C:\" reported by sysinfo, since Path::starts_with is component-based.
+        // canonicalize returns a verbatim path on Windows; convert it back to
+        // a normal form so the result matches the mount points reported by
+        // sysinfo (Path::starts_with is component-based, so "\\?\C:" won't
+        // match "C:"). Two cases: \\?\UNC\server\share\... → \\server\share\...,
+        // and \\?\C:\... → C:\....
         let canonical_str = canonical.to_string_lossy().into_owned();
-        let stripped = canonical_str
-            .strip_prefix(r"\\?\")
-            .unwrap_or(&canonical_str);
-        let resolved = std::path::PathBuf::from(stripped);
+        let resolved = if let Some(unc) = canonical_str.strip_prefix(r"\\?\UNC\") {
+            std::path::PathBuf::from(format!(r"\\{unc}"))
+        } else {
+            std::path::PathBuf::from(
+                canonical_str
+                    .strip_prefix(r"\\?\")
+                    .unwrap_or(&canonical_str),
+            )
+        };
         let mut diskinfo =
             Disks::new_with_refreshed_list_specifics(DiskRefreshKind::nothing().with_storage());
         let idx = diskinfo

--- a/rust/crates/rqd/tests/rqd_integration_tests.rs
+++ b/rust/crates/rqd/tests/rqd_integration_tests.rs
@@ -370,6 +370,13 @@ fn setup_test_env(monitor_interval: &str, worker_threads: u32) -> TestEnv {
     let config_path = temp_dir.path().join("test_config.yaml");
     let (rqd_port, cuebot_port) = get_two_free_ports();
 
+    // The yaml config below points machine.temp_path / runner.temp_path at
+    // <temp_dir>/tmp and runner.snapshots_path at <temp_dir>/snapshots. These
+    // must exist before openrqd starts: machine stats collection uses statvfs
+    // on temp_path, which fails with ENOENT if the directory is missing.
+    std::fs::create_dir_all(temp_dir.path().join("tmp")).unwrap();
+    std::fs::create_dir_all(temp_dir.path().join("snapshots")).unwrap();
+
     let test_config = make_test_config(&temp_dir, rqd_port, cuebot_port, monitor_interval, worker_threads);
     std::fs::write(&config_path, test_config).unwrap();
 

--- a/rust/crates/rqd/tests/rqd_integration_tests.rs
+++ b/rust/crates/rqd/tests/rqd_integration_tests.rs
@@ -370,13 +370,6 @@ fn setup_test_env(monitor_interval: &str, worker_threads: u32) -> TestEnv {
     let config_path = temp_dir.path().join("test_config.yaml");
     let (rqd_port, cuebot_port) = get_two_free_ports();
 
-    // The yaml config below points machine.temp_path / runner.temp_path at
-    // <temp_dir>/tmp and runner.snapshots_path at <temp_dir>/snapshots. These
-    // must exist before openrqd starts: machine stats collection uses statvfs
-    // on temp_path, which fails with ENOENT if the directory is missing.
-    std::fs::create_dir_all(temp_dir.path().join("tmp")).unwrap();
-    std::fs::create_dir_all(temp_dir.path().join("snapshots")).unwrap();
-
     let test_config = make_test_config(&temp_dir, rqd_port, cuebot_port, monitor_interval, worker_threads);
     std::fs::write(&config_path, test_config).unwrap();
 


### PR DESCRIPTION
## Related Issues
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/2266

## Summarize your change.

Cross-platform fix for incorrect "Temp Free" reporting in CueGUI on hosts where the configured temp_path is a symlink (e.g. /mcp -> /storage/mcp).

Linux / macOS:
- Replace the sysinfo mount-list lookup in read_temp_storage with a direct nix::sys::statvfs::statvfs(temp_path) call, matching the Python RQD (os.statvfs(getTempPath())). The kernel follows the symlink and stats the underlying filesystem, so it works regardless of whether temp_path is a symlink, a bind mount, or a real mount.
- Fix POSIX units: multiply blocks_available() by fragment_size() (not block_size()) for available_space, matching the total_space calculation. Per POSIX statvfs(3), both f_blocks and f_bavail are counted in f_frsize units, not f_bsize. The two only differ on filesystems like some NFS mounts.
- Add the "fs" feature to the nix dependency for statvfs.

Windows:
- nix is cfg(unix)-only, so apply an equivalent fix using sysinfo: canonicalize temp_path first to follow junctions/symlinks, strip the \\?\ verbatim prefix that canonicalize prepends so the result matches drive-letter mount points (Path::starts_with is component-based), handle the \\?\UNC\server\share\... case by rewriting to \\server\share\..., and pick the longest matching mount point instead of the first to fix the latent prefix-fallback bug.

Config / startup:
- Extend Config::setup() to provision machine.temp_path alongside the existing runner.snapshots_path, and assert it's a directory after create_dir_all. statvfs on Unix and canonicalize on Windows both fail with ENOENT if temp_path doesn't exist; frame launch also uses it as the working dir. Fail fast at startup with a clear error if the path is a file or unreachable.
- Wire CONFIG.setup() into main.rs early in async_main. Previously setup() was only invoked from test helpers, so production startup never provisioned snapshots_path or temp_path.

Visible symptom this fixes: in CueCommander the "Temp Free" column clustered around the root partition size on affected hosts instead of reflecting real scratch free space, breaking the mental model of the column and potentially misleading scheduling decisions that depend on host_stat.int_mcp_*.

All existing rqd unit and integration tests continue to pass on Linux/macOS. The Windows path is cfg(target_os = "windows")-gated and needs validation on a Windows host before it can be considered verified.