### PR TITLE
[cuebot] Rework shutdown logic to allow draining threadpools

### DIFF
--- a/cuebot/src/main/java/com/imageworks/common/spring/remoting/CueServerInterceptor.java
+++ b/cuebot/src/main/java/com/imageworks/common/spring/remoting/CueServerInterceptor.java
@@ -1,5 +1,6 @@
 package com.imageworks.common.spring.remoting;
 
+import com.imageworks.spcue.dispatcher.RqdRetryReportException;
 import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener;
 import io.grpc.Grpc;
 import io.grpc.Metadata;
@@ -27,6 +28,13 @@ public class CueServerInterceptor implements ServerInterceptor {
             public void onHalfClose() {
                 try {
                     super.onHalfClose();
+                } catch (RqdRetryReportException e) {
+                    // Map to UNAVAILABLE so RQD's RetryOnRpcErrorClientInterceptor retries
+                    // the report against the next cuebot instance.
+                    logger.warn("Cuebot shutting down — asking RQD to retry: " + e.getMessage());
+                    serverCall.close(Status.UNAVAILABLE.withCause(e)
+                            .withDescription("cuebot shutting down: " + e.getMessage()),
+                            new Metadata());
                 } catch (Exception e) {
                     logger.error("Caught an unexpected error.", e);
                     serverCall.close(Status.INTERNAL.withCause(e)

--- a/cuebot/src/main/java/com/imageworks/common/spring/remoting/CueServerInterceptor.java
+++ b/cuebot/src/main/java/com/imageworks/common/spring/remoting/CueServerInterceptor.java
@@ -31,7 +31,7 @@ public class CueServerInterceptor implements ServerInterceptor {
                 } catch (RqdRetryReportException e) {
                     // Map to UNAVAILABLE so RQD's RetryOnRpcErrorClientInterceptor retries
                     // the report against the next cuebot instance.
-                    logger.warn("Cuebot shutting down — asking RQD to retry: " + e.getMessage());
+                    logger.warn("Cuebot shutting down - asking RQD to retry: " + e.getMessage());
                     serverCall.close(Status.UNAVAILABLE.withCause(e).withDescription(
                             "cuebot shutting down: " + e.getMessage()), new Metadata());
                 } catch (Exception e) {

--- a/cuebot/src/main/java/com/imageworks/common/spring/remoting/CueServerInterceptor.java
+++ b/cuebot/src/main/java/com/imageworks/common/spring/remoting/CueServerInterceptor.java
@@ -32,9 +32,8 @@ public class CueServerInterceptor implements ServerInterceptor {
                     // Map to UNAVAILABLE so RQD's RetryOnRpcErrorClientInterceptor retries
                     // the report against the next cuebot instance.
                     logger.warn("Cuebot shutting down — asking RQD to retry: " + e.getMessage());
-                    serverCall.close(Status.UNAVAILABLE.withCause(e)
-                            .withDescription("cuebot shutting down: " + e.getMessage()),
-                            new Metadata());
+                    serverCall.close(Status.UNAVAILABLE.withCause(e).withDescription(
+                            "cuebot shutting down: " + e.getMessage()), new Metadata());
                 } catch (Exception e) {
                     logger.error("Caught an unexpected error.", e);
                     serverCall.close(Status.INTERNAL.withCause(e)

--- a/cuebot/src/main/java/com/imageworks/common/spring/remoting/GrpcServer.java
+++ b/cuebot/src/main/java/com/imageworks/common/spring/remoting/GrpcServer.java
@@ -66,7 +66,7 @@ public class GrpcServer implements ApplicationContextAware {
     }
 
     public void shutdown() {
-        if (server == null || server.isShutdown()) {
+        if (server == null || server.isTerminated()) {
             return;
         }
         logger.info("gRPC server shutting down on " + this.name + " at port " + this.port

--- a/cuebot/src/main/java/com/imageworks/common/spring/remoting/GrpcServer.java
+++ b/cuebot/src/main/java/com/imageworks/common/spring/remoting/GrpcServer.java
@@ -3,6 +3,7 @@ package com.imageworks.common.spring.remoting;
 
 import java.io.IOException;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
@@ -49,6 +50,7 @@ public class GrpcServer implements ApplicationContextAware {
     private String name;
     private int port;
     private int maxMessageBytes;
+    private long grpcShutdownGraceMs = 30000;
     private Server server;
     private ApplicationContext applicationContext;
 
@@ -64,10 +66,28 @@ public class GrpcServer implements ApplicationContextAware {
     }
 
     public void shutdown() {
-        if (!server.isShutdown()) {
-            logger.info("gRPC server shutting down on " + this.name + " at port " + this.port);
-            server.shutdown();
+        if (server == null || server.isShutdown()) {
+            return;
         }
+        logger.info("gRPC server shutting down on " + this.name + " at port " + this.port
+                + ", awaiting termination up to " + grpcShutdownGraceMs + "ms");
+        server.shutdown();
+        try {
+            if (!server.awaitTermination(grpcShutdownGraceMs, TimeUnit.MILLISECONDS)) {
+                logger.warn("gRPC server " + this.name
+                        + " did not terminate gracefully within " + grpcShutdownGraceMs
+                        + "ms; forcing shutdownNow");
+                server.shutdownNow();
+                server.awaitTermination(5, TimeUnit.SECONDS);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            server.shutdownNow();
+        }
+    }
+
+    public void setGrpcShutdownGraceMs(long grpcShutdownGraceMs) {
+        this.grpcShutdownGraceMs = grpcShutdownGraceMs;
     }
 
     public void start() throws IOException {

--- a/cuebot/src/main/java/com/imageworks/common/spring/remoting/GrpcServer.java
+++ b/cuebot/src/main/java/com/imageworks/common/spring/remoting/GrpcServer.java
@@ -4,6 +4,7 @@ package com.imageworks.common.spring.remoting;
 import java.io.IOException;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
@@ -52,6 +53,7 @@ public class GrpcServer implements ApplicationContextAware {
     private int maxMessageBytes;
     private long grpcShutdownGraceMs = 30000;
     private Server server;
+    private final AtomicBoolean shutdownStarted = new AtomicBoolean(false);
     private ApplicationContext applicationContext;
 
     public GrpcServer() {
@@ -66,7 +68,9 @@ public class GrpcServer implements ApplicationContextAware {
     }
 
     public void shutdown() {
-        if (server == null || server.isTerminated()) {
+        // Exactly-once entry: idempotent against repeated calls (e.g. Spring destroy
+        // followed by a JVM shutdown hook) without re-blocking on awaitTermination.
+        if (server == null || !shutdownStarted.compareAndSet(false, true)) {
             return;
         }
         logger.info("gRPC server shutting down on " + this.name + " at port " + this.port

--- a/cuebot/src/main/java/com/imageworks/common/spring/remoting/GrpcServer.java
+++ b/cuebot/src/main/java/com/imageworks/common/spring/remoting/GrpcServer.java
@@ -74,9 +74,8 @@ public class GrpcServer implements ApplicationContextAware {
         server.shutdown();
         try {
             if (!server.awaitTermination(grpcShutdownGraceMs, TimeUnit.MILLISECONDS)) {
-                logger.warn("gRPC server " + this.name
-                        + " did not terminate gracefully within " + grpcShutdownGraceMs
-                        + "ms; forcing shutdownNow");
+                logger.warn("gRPC server " + this.name + " did not terminate gracefully within "
+                        + grpcShutdownGraceMs + "ms; forcing shutdownNow");
                 server.shutdownNow();
                 server.awaitTermination(5, TimeUnit.SECONDS);
             }

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/BookingQueue.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/BookingQueue.java
@@ -87,6 +87,10 @@ public class BookingQueue implements QueueHealthCheck {
         healthyThreadPool.shutdown();
     }
 
+    public void setShutdownDrainMs(int shutdownDrainMs) {
+        healthyThreadPool.setShutdownDrainMs(shutdownDrainMs);
+    }
+
     public int getSize() {
         return healthyThreadPool.getQueue().size();
     }

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/BookingQueue.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/BookingQueue.java
@@ -87,7 +87,7 @@ public class BookingQueue implements QueueHealthCheck {
         healthyThreadPool.shutdown();
     }
 
-    public void setShutdownDrainMs(int shutdownDrainMs) {
+    public void setShutdownDrainMs(long shutdownDrainMs) {
         healthyThreadPool.setShutdownDrainMs(shutdownDrainMs);
     }
 

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchQueue.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchQueue.java
@@ -80,7 +80,7 @@ public class DispatchQueue implements QueueHealthCheck {
         healthyDispatchPool.shutdown();
     }
 
-    public void setShutdownDrainMs(int shutdownDrainMs) {
+    public void setShutdownDrainMs(long shutdownDrainMs) {
         healthyDispatchPool.setShutdownDrainMs(shutdownDrainMs);
     }
 

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchQueue.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchQueue.java
@@ -80,6 +80,10 @@ public class DispatchQueue implements QueueHealthCheck {
         healthyDispatchPool.shutdown();
     }
 
+    public void setShutdownDrainMs(int shutdownDrainMs) {
+        healthyDispatchPool.setShutdownDrainMs(shutdownDrainMs);
+    }
+
     public int getSize() {
         return healthyDispatchPool.getQueue().size();
     }

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HealthyThreadPool.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HealthyThreadPool.java
@@ -94,13 +94,7 @@ public class HealthyThreadPool extends ThreadPoolExecutor {
             // the work isn't lost — for FrameCompleteReports this is the dependency
             // satisfaction / job completion / event publish path.
             logger.warn(name + ": pool shutting down; running task synchronously on caller thread");
-            try {
-                r.run();
-            } catch (RuntimeException e) {
-                logger.error(name + ": synchronous fallback task failed", e);
-                throw new RqdRetryReportException(
-                        "cuebot shutting down, synchronous fallback failed", e);
-            }
+            runTaskSynchronouslyWithRetryWrap(r);
             return;
         }
         taskCache.put(r.getKey(), r);
@@ -110,7 +104,17 @@ public class HealthyThreadPool extends ThreadPoolExecutor {
             // Race with shutdown: the underlying executor was just shut down. Run
             // synchronously rather than dropping the task.
             logger.warn(name + ": rejected by pool, running synchronously", ree);
+            runTaskSynchronouslyWithRetryWrap(r);
+        }
+    }
+
+    private void runTaskSynchronouslyWithRetryWrap(Runnable r) {
+        try {
             r.run();
+        } catch (RuntimeException e) {
+            logger.error(name + ": synchronous fallback task failed", e);
+            throw new RqdRetryReportException("cuebot shutting down, synchronous fallback failed",
+                    e);
         }
     }
 

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HealthyThreadPool.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HealthyThreadPool.java
@@ -4,10 +4,11 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.util.Date;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.LinkedBlockingQueue;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -36,6 +37,7 @@ public class HealthyThreadPool extends ThreadPoolExecutor {
     private boolean wasHealthy = true;
     protected final AtomicBoolean isShutdown = new AtomicBoolean(false);
     private final int baseSleepTimeMillis;
+    private int shutdownDrainMs = 60000;
 
     /**
      * Start a thread pool
@@ -84,13 +86,32 @@ public class HealthyThreadPool extends ThreadPoolExecutor {
     }
 
     public void execute(KeyRunnable r) {
-        if (isShutdown.get()) {
-            logger.info(name + ": Task ignored, queue on hold or shutdown");
+        if (taskCache.getIfPresent(r.getKey()) != null) {
             return;
         }
-        if (taskCache.getIfPresent(r.getKey()) == null) {
-            taskCache.put(r.getKey(), r);
+        if (isShutdown.get() || super.isShutdown()) {
+            // The pool is being torn down. Run synchronously on the caller thread so
+            // the work isn't lost — for FrameCompleteReports this is the dependency
+            // satisfaction / job completion / event publish path.
+            logger.warn(name
+                    + ": pool shutting down; running task synchronously on caller thread");
+            try {
+                r.run();
+            } catch (RuntimeException e) {
+                logger.error(name + ": synchronous fallback task failed", e);
+                throw new RqdRetryReportException(
+                        "cuebot shutting down, synchronous fallback failed", e);
+            }
+            return;
+        }
+        taskCache.put(r.getKey(), r);
+        try {
             super.execute(r);
+        } catch (RejectedExecutionException ree) {
+            // Race with shutdown: the underlying executor was just shut down. Run
+            // synchronously rather than dropping the task.
+            logger.warn(name + ": rejected by pool, running synchronously", ree);
+            r.run();
         }
     }
 
@@ -199,22 +220,38 @@ public class HealthyThreadPool extends ThreadPoolExecutor {
                 || (getRejectedTaskCount() < this.poolSize / healthThreshold);
     }
 
+    public void setShutdownDrainMs(int shutdownDrainMs) {
+        this.shutdownDrainMs = shutdownDrainMs;
+    }
+
     public void shutdown() {
         if (!isShutdown.getAndSet(true)) {
             logger.info("Shutting down thread pool " + name + ", currently " + getActiveCount()
-                    + " active threads.");
+                    + " active threads, " + getQueue().size() + " queued.");
             final long startTime = System.currentTimeMillis();
-            while (this.getQueue().size() != 0 && this.getActiveCount() != 0) {
+            // Wait until BOTH the queue is empty AND no workers are still running.
+            while (this.getQueue().size() != 0 || this.getActiveCount() != 0) {
+                if (System.currentTimeMillis() - startTime > shutdownDrainMs) {
+                    logger.warn(name + ": drain timed out after " + shutdownDrainMs + "ms; "
+                            + getQueue().size() + " queued, " + getActiveCount() + " active");
+                    break;
+                }
                 try {
-                    if (System.currentTimeMillis() - startTime > 10000) {
-                        throw new InterruptedException(
-                                name + " thread pool failed to shutdown properly");
-                    }
                     Thread.sleep(250);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     break;
                 }
+            }
+            super.shutdown();
+            try {
+                if (!super.awaitTermination(5, TimeUnit.SECONDS)) {
+                    logger.warn(name + ": forcing shutdownNow after awaitTermination expired");
+                    super.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                super.shutdownNow();
             }
         }
     }

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HealthyThreadPool.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HealthyThreadPool.java
@@ -93,8 +93,7 @@ public class HealthyThreadPool extends ThreadPoolExecutor {
             // The pool is being torn down. Run synchronously on the caller thread so
             // the work isn't lost — for FrameCompleteReports this is the dependency
             // satisfaction / job completion / event publish path.
-            logger.warn(name
-                    + ": pool shutting down; running task synchronously on caller thread");
+            logger.warn(name + ": pool shutting down; running task synchronously on caller thread");
             try {
                 r.run();
             } catch (RuntimeException e) {

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HealthyThreadPool.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HealthyThreadPool.java
@@ -238,26 +238,15 @@ public class HealthyThreadPool extends ThreadPoolExecutor {
         if (!isShutdown.getAndSet(true)) {
             logger.info("Shutting down thread pool " + name + ", currently " + getActiveCount()
                     + " active threads, " + getQueue().size() + " queued.");
-            final long startTime = System.currentTimeMillis();
-            // Wait until BOTH the queue is empty AND no workers are still running.
-            while (this.getQueue().size() != 0 || this.getActiveCount() != 0) {
-                if (System.currentTimeMillis() - startTime > shutdownDrainMs) {
-                    logger.warn(name + ": drain timed out after " + shutdownDrainMs + "ms; "
-                            + getQueue().size() + " queued, " + getActiveCount() + " active");
-                    break;
-                }
-                try {
-                    Thread.sleep(250);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    break;
-                }
-            }
             super.shutdown();
             try {
-                if (!super.awaitTermination(5, TimeUnit.SECONDS)) {
-                    logger.warn(name + ": forcing shutdownNow after awaitTermination expired");
+                if (!super.awaitTermination(shutdownDrainMs, TimeUnit.MILLISECONDS)) {
+                    logger.warn(name + ": drain timed out after " + shutdownDrainMs + "ms; "
+                            + getQueue().size() + " queued, " + getActiveCount() + " active");
                     super.shutdownNow();
+                    if (!super.awaitTermination(5, TimeUnit.SECONDS)) {
+                        logger.warn(name + ": failed to terminate after shutdownNow");
+                    }
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HealthyThreadPool.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HealthyThreadPool.java
@@ -37,7 +37,7 @@ public class HealthyThreadPool extends ThreadPoolExecutor {
     private boolean wasHealthy = true;
     protected final AtomicBoolean isShutdown = new AtomicBoolean(false);
     private final int baseSleepTimeMillis;
-    private int shutdownDrainMs = 60000;
+    private long shutdownDrainMs = 60000;
 
     /**
      * Start a thread pool
@@ -102,19 +102,26 @@ public class HealthyThreadPool extends ThreadPoolExecutor {
             super.execute(r);
         } catch (RejectedExecutionException ree) {
             // Race with shutdown: the underlying executor was just shut down. Run
-            // synchronously rather than dropping the task.
+            // synchronously rather than dropping the task. afterExecute() won't fire
+            // for a rejected task, so the helper takes care of cache invalidation.
             logger.warn(name + ": rejected by pool, running synchronously", ree);
             runTaskSynchronouslyWithRetryWrap(r);
         }
     }
 
-    private void runTaskSynchronouslyWithRetryWrap(Runnable r) {
+    private void runTaskSynchronouslyWithRetryWrap(KeyRunnable r) {
+        // Mirror the async path's dedup lifecycle: register the key so a concurrent
+        // submission with the same key sees it and returns early at the top of
+        // execute(), then invalidate when the task completes (same as afterExecute).
+        taskCache.put(r.getKey(), r);
         try {
             r.run();
         } catch (RuntimeException e) {
             logger.error(name + ": synchronous fallback task failed", e);
             throw new RqdRetryReportException("cuebot shutting down, synchronous fallback failed",
                     e);
+        } finally {
+            taskCache.invalidate(r.getKey());
         }
     }
 
@@ -223,7 +230,7 @@ public class HealthyThreadPool extends ThreadPoolExecutor {
                 || (getRejectedTaskCount() < this.poolSize / healthThreshold);
     }
 
-    public void setShutdownDrainMs(int shutdownDrainMs) {
+    public void setShutdownDrainMs(long shutdownDrainMs) {
         this.shutdownDrainMs = shutdownDrainMs;
     }
 

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportQueue.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportQueue.java
@@ -36,6 +36,7 @@ public class HostReportQueue extends ThreadPoolExecutor {
     private QueueRejectCounter rejectCounter = new QueueRejectCounter();
     private AtomicBoolean isShutdown = new AtomicBoolean(false);
     private int queueCapacity;
+    private int shutdownDrainMs = 60000;
 
     private Cache<String, HostReportWrapper> hostMap =
             CacheBuilder.newBuilder().expireAfterWrite(1, TimeUnit.HOURS).build();
@@ -113,25 +114,41 @@ public class HostReportQueue extends ThreadPoolExecutor {
         return queueCapacity;
     }
 
+    public void setShutdownDrainMs(int shutdownDrainMs) {
+        this.shutdownDrainMs = shutdownDrainMs;
+    }
+
     public void shutdown() {
         if (!isShutdown.getAndSet(true)) {
             logger.info("Shutting down report pool, currently " + this.getActiveCount()
-                    + " active threads.");
+                    + " active threads, " + this.getQueue().size() + " queued.");
 
             final long startTime = System.currentTimeMillis();
-            while (this.getQueue().size() != 0 && this.getActiveCount() != 0) {
+            // Wait until BOTH the queue is empty AND no workers are still running.
+            while (this.getQueue().size() != 0 || this.getActiveCount() != 0) {
+                if (System.currentTimeMillis() - startTime > shutdownDrainMs) {
+                    logger.warn("report pool drain timed out after " + shutdownDrainMs + "ms; "
+                            + this.getQueue().size() + " queued, "
+                            + this.getActiveCount() + " active");
+                    break;
+                }
                 try {
-                    logger.info("report pool is waiting for " + this.getQueue().size()
-                            + " more units to complete");
-                    if (System.currentTimeMillis() - startTime > 10000) {
-                        throw new InterruptedException(
-                                "report thread pool failed to shutdown properly");
-                    }
                     Thread.sleep(250);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     break;
                 }
+            }
+            super.shutdown();
+            try {
+                if (!super.awaitTermination(5, TimeUnit.SECONDS)) {
+                    logger.warn(
+                            "report pool: forcing shutdownNow after awaitTermination expired");
+                    super.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                super.shutdownNow();
             }
         }
     }

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportQueue.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportQueue.java
@@ -126,28 +126,16 @@ public class HostReportQueue extends ThreadPoolExecutor {
         if (!isShutdown.getAndSet(true)) {
             logger.info("Shutting down report pool, currently " + this.getActiveCount()
                     + " active threads, " + this.getQueue().size() + " queued.");
-
-            final long startTime = System.currentTimeMillis();
-            // Wait until BOTH the queue is empty AND no workers are still running.
-            while (this.getQueue().size() != 0 || this.getActiveCount() != 0) {
-                if (System.currentTimeMillis() - startTime > shutdownDrainMs) {
+            super.shutdown();
+            try {
+                if (!super.awaitTermination(shutdownDrainMs, TimeUnit.MILLISECONDS)) {
                     logger.warn("report pool drain timed out after " + shutdownDrainMs + "ms; "
                             + this.getQueue().size() + " queued, " + this.getActiveCount()
                             + " active");
-                    break;
-                }
-                try {
-                    Thread.sleep(250);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    break;
-                }
-            }
-            super.shutdown();
-            try {
-                if (!super.awaitTermination(5, TimeUnit.SECONDS)) {
-                    logger.warn("report pool: forcing shutdownNow after awaitTermination expired");
                     super.shutdownNow();
+                    if (!super.awaitTermination(5, TimeUnit.SECONDS)) {
+                        logger.warn("report pool: failed to terminate after shutdownNow");
+                    }
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportQueue.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportQueue.java
@@ -128,8 +128,8 @@ public class HostReportQueue extends ThreadPoolExecutor {
             while (this.getQueue().size() != 0 || this.getActiveCount() != 0) {
                 if (System.currentTimeMillis() - startTime > shutdownDrainMs) {
                     logger.warn("report pool drain timed out after " + shutdownDrainMs + "ms; "
-                            + this.getQueue().size() + " queued, "
-                            + this.getActiveCount() + " active");
+                            + this.getQueue().size() + " queued, " + this.getActiveCount()
+                            + " active");
                     break;
                 }
                 try {
@@ -142,8 +142,7 @@ public class HostReportQueue extends ThreadPoolExecutor {
             super.shutdown();
             try {
                 if (!super.awaitTermination(5, TimeUnit.SECONDS)) {
-                    logger.warn(
-                            "report pool: forcing shutdownNow after awaitTermination expired");
+                    logger.warn("report pool: forcing shutdownNow after awaitTermination expired");
                     super.shutdownNow();
                 }
             } catch (InterruptedException e) {

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportQueue.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportQueue.java
@@ -36,7 +36,7 @@ public class HostReportQueue extends ThreadPoolExecutor {
     private QueueRejectCounter rejectCounter = new QueueRejectCounter();
     private AtomicBoolean isShutdown = new AtomicBoolean(false);
     private int queueCapacity;
-    private int shutdownDrainMs = 60000;
+    private long shutdownDrainMs = 60000;
 
     private Cache<String, HostReportWrapper> hostMap =
             CacheBuilder.newBuilder().expireAfterWrite(1, TimeUnit.HOURS).build();
@@ -75,6 +75,10 @@ public class HostReportQueue extends ThreadPoolExecutor {
 
     public void execute(DispatchHandleHostReport newReport) {
         if (isShutdown.get()) {
+            // HostReports should never be processed when the server is shutting down.
+            // Different from other queues, host reports are safe to be dropped and processing
+            // them could lead to an explosion of new tasks at the time when we want to drain
+            // the service.
             return;
         }
         HostReportWrapper oldWrappedReport = hostMap.getIfPresent(newReport.getKey());
@@ -114,7 +118,7 @@ public class HostReportQueue extends ThreadPoolExecutor {
         return queueCapacity;
     }
 
-    public void setShutdownDrainMs(int shutdownDrainMs) {
+    public void setShutdownDrainMs(long shutdownDrainMs) {
         this.shutdownDrainMs = shutdownDrainMs;
     }
 

--- a/cuebot/src/main/resources/conf/spring/applicationContext-grpcServer.xml
+++ b/cuebot/src/main/resources/conf/spring/applicationContext-grpcServer.xml
@@ -31,7 +31,7 @@
     <!-- depends-on forces Spring to destroy the gRPC server BEFORE these beans, so
          in-flight RPCs can finish submitting work to the queues before they shut down. -->
     <bean id="manageGrpcServer" class="com.imageworks.common.spring.remoting.GrpcServer" init-method="start" destroy-method="shutdown"
-          depends-on="frameCompleteHandler,hostReportHandler,dispatchQueue,manageQueue,bookingQueue,reportQueue,killQueue,jmsMover,kafkaEventPublisher">
+          depends-on="frameCompleteHandler,hostReportHandler,dispatchQueue,manageQueue,bookingQueue,reportQueue,killQueue">
         <constructor-arg index="0" type="java.lang.String">
             <value>cueBotGrpc</value>
         </constructor-arg>
@@ -50,4 +50,3 @@
     </bean>
 
 </beans>
-

--- a/cuebot/src/main/resources/conf/spring/applicationContext-grpcServer.xml
+++ b/cuebot/src/main/resources/conf/spring/applicationContext-grpcServer.xml
@@ -28,7 +28,10 @@
     </bean>
 
     <!--Run -->
-    <bean id="manageGrpcServer" class="com.imageworks.common.spring.remoting.GrpcServer" init-method="start" destroy-method="shutdown">
+    <!-- depends-on forces Spring to destroy the gRPC server BEFORE these beans, so
+         in-flight RPCs can finish submitting work to the queues before they shut down. -->
+    <bean id="manageGrpcServer" class="com.imageworks.common.spring.remoting.GrpcServer" init-method="start" destroy-method="shutdown"
+          depends-on="frameCompleteHandler,hostReportHandler,dispatchQueue,manageQueue,bookingQueue,reportQueue,killQueue,jmsMover,kafkaEventPublisher">
         <constructor-arg index="0" type="java.lang.String">
             <value>cueBotGrpc</value>
         </constructor-arg>
@@ -43,6 +46,7 @@
         <constructor-arg index="3" type="java.lang.Integer">
             <value>${grpc.max_message_bytes}</value>
         </constructor-arg>
+        <property name="grpcShutdownGraceMs" value="${grpc.shutdown_grace_ms}"/>
     </bean>
 
 </beans>

--- a/cuebot/src/main/resources/conf/spring/applicationContext-grpcServer.xml
+++ b/cuebot/src/main/resources/conf/spring/applicationContext-grpcServer.xml
@@ -46,7 +46,7 @@
         <constructor-arg index="3" type="java.lang.Integer">
             <value>${grpc.max_message_bytes}</value>
         </constructor-arg>
-        <property name="grpcShutdownGraceMs" value="${grpc.shutdown_grace_ms}"/>
+        <property name="grpcShutdownGraceMs" value="${grpc.shutdown_grace_ms:30000}"/>
     </bean>
 
 </beans>

--- a/cuebot/src/main/resources/conf/spring/applicationContext-service.xml
+++ b/cuebot/src/main/resources/conf/spring/applicationContext-service.xml
@@ -82,7 +82,7 @@
     <constructor-arg index="4" type="int">
       <value>${booking_queue.threadpool.max_pool_size}</value>
     </constructor-arg>
-    <property name="shutdownDrainMs" value="${healthy_threadpool.shutdown_drain_ms}"/>
+    <property name="shutdownDrainMs" value="${healthy_threadpool.shutdown_drain_ms:60000}"/>
   </bean>
 
   <bean id="dispatchQueue" class="com.imageworks.spcue.dispatcher.DispatchQueue" destroy-method="shutdown">
@@ -104,7 +104,7 @@
     <constructor-arg index="5" type="int">
       <value>${dispatch.threadpool.max_pool_size}</value>
     </constructor-arg>
-    <property name="shutdownDrainMs" value="${healthy_threadpool.shutdown_drain_ms}"/>
+    <property name="shutdownDrainMs" value="${healthy_threadpool.shutdown_drain_ms:60000}"/>
   </bean>
 
   <bean id="manageQueue" class="com.imageworks.spcue.dispatcher.DispatchQueue"   destroy-method="shutdown">
@@ -126,7 +126,7 @@
     <constructor-arg index="5" type="int">
       <value>${dispatch.threadpool.max_pool_size}</value>
     </constructor-arg>
-    <property name="shutdownDrainMs" value="${healthy_threadpool.shutdown_drain_ms}"/>
+    <property name="shutdownDrainMs" value="${healthy_threadpool.shutdown_drain_ms:60000}"/>
   </bean>
   <bean id="reportQueue" class="com.imageworks.spcue.dispatcher.HostReportQueue" destroy-method="shutdown">
     <constructor-arg index="0" type="int">
@@ -138,7 +138,7 @@
     <constructor-arg index="2" type="int">
       <value>${report_queue.queueSize}</value>
     </constructor-arg>
-    <property name="shutdownDrainMs" value="${host_report_queue.shutdown_drain_ms}"/>
+    <property name="shutdownDrainMs" value="${host_report_queue.shutdown_drain_ms:60000}"/>
   </bean>
   <bean id="killQueue" class="com.imageworks.spcue.dispatcher.HostReportQueue" destroy-method="shutdown">
     <constructor-arg index="0" type="int">
@@ -150,7 +150,7 @@
     <constructor-arg index="2" type="int">
       <value>${kill_queue.queueSize}</value>
     </constructor-arg>
-    <property name="shutdownDrainMs" value="${host_report_queue.shutdown_drain_ms}"/>
+    <property name="shutdownDrainMs" value="${host_report_queue.shutdown_drain_ms:60000}"/>
   </bean>
 
 

--- a/cuebot/src/main/resources/conf/spring/applicationContext-service.xml
+++ b/cuebot/src/main/resources/conf/spring/applicationContext-service.xml
@@ -82,6 +82,7 @@
     <constructor-arg index="4" type="int">
       <value>${booking_queue.threadpool.max_pool_size}</value>
     </constructor-arg>
+    <property name="shutdownDrainMs" value="${healthy_threadpool.shutdown_drain_ms}"/>
   </bean>
 
   <bean id="dispatchQueue" class="com.imageworks.spcue.dispatcher.DispatchQueue" destroy-method="shutdown">
@@ -103,6 +104,7 @@
     <constructor-arg index="5" type="int">
       <value>${dispatch.threadpool.max_pool_size}</value>
     </constructor-arg>
+    <property name="shutdownDrainMs" value="${healthy_threadpool.shutdown_drain_ms}"/>
   </bean>
 
   <bean id="manageQueue" class="com.imageworks.spcue.dispatcher.DispatchQueue"   destroy-method="shutdown">
@@ -124,6 +126,7 @@
     <constructor-arg index="5" type="int">
       <value>${dispatch.threadpool.max_pool_size}</value>
     </constructor-arg>
+    <property name="shutdownDrainMs" value="${healthy_threadpool.shutdown_drain_ms}"/>
   </bean>
   <bean id="reportQueue" class="com.imageworks.spcue.dispatcher.HostReportQueue" destroy-method="shutdown">
     <constructor-arg index="0" type="int">
@@ -135,6 +138,7 @@
     <constructor-arg index="2" type="int">
       <value>${report_queue.queueSize}</value>
     </constructor-arg>
+    <property name="shutdownDrainMs" value="${host_report_queue.shutdown_drain_ms}"/>
   </bean>
   <bean id="killQueue" class="com.imageworks.spcue.dispatcher.HostReportQueue" destroy-method="shutdown">
     <constructor-arg index="0" type="int">
@@ -146,6 +150,7 @@
     <constructor-arg index="2" type="int">
       <value>${kill_queue.queueSize}</value>
     </constructor-arg>
+    <property name="shutdownDrainMs" value="${host_report_queue.shutdown_drain_ms}"/>
   </bean>
 
 

--- a/cuebot/src/main/resources/opencue.properties
+++ b/cuebot/src/main/resources/opencue.properties
@@ -40,6 +40,10 @@ grpc.rqd_cache_expiration=5
 grpc.rqd_cache_concurrency=20
 # RQD Channel task deadline in seconds
 grpc.rqd_task_deadline=10
+# Time to wait for in-flight gRPC RPCs to finish during shutdown (ms).
+# Should exceed the slowest legitimate RPC so FrameCompleteReport handlers
+# can finish submitting post-frame work to the queues before they are torn down.
+grpc.shutdown_grace_ms=30000
 
 # Healthy Threadpool Executor
 booking_queue.threadpool.health_threshold=10
@@ -51,6 +55,10 @@ dispatch.threadpool.max_pool_size=8
 dispatch.threadpool.queue_capacity=2000
 healthy_threadpool.health_threshold=6
 healthy_threadpool.min_unhealthy_period_min=3
+# Time HealthyThreadPool drains queued work during shutdown (ms).
+# Should exceed grpc.shutdown_grace_ms so post-frame work submitted just before
+# the gRPC server stopped has time to complete.
+healthy_threadpool.shutdown_drain_ms=60000
 report_queue.threadPoolSizeInitial=6
 report_queue.threadPoolSizeMax=12
 # The queue size should be bigger then the expected amount of hosts
@@ -58,6 +66,8 @@ report_queue.queueSize=5000
 kill_queue.threadPoolSizeInitial=2
 kill_queue.threadPoolSizeMax=6
 kill_queue.queueSize=1000
+# Time HostReportQueue (reportQueue/killQueue) drains during shutdown (ms).
+host_report_queue.shutdown_drain_ms=60000
 
 # Turn on/off jobCompletion mailing module
 mailing.enabled=true

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HealthyThreadPoolShutdownTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HealthyThreadPoolShutdownTests.java
@@ -31,8 +31,8 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Unit tests for {@link HealthyThreadPool} shutdown behavior. No Spring context required —
- * these test the executor semantics directly.
+ * Unit tests for {@link HealthyThreadPool} shutdown behavior. No Spring context required — these
+ * test the executor semantics directly.
  */
 public class HealthyThreadPoolShutdownTests {
 

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HealthyThreadPoolShutdownTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HealthyThreadPoolShutdownTests.java
@@ -108,6 +108,47 @@ public class HealthyThreadPoolShutdownTests {
     }
 
     @Test
+    public void execute_afterShutdown_dedupsConcurrentSameKeySubmission() throws Exception {
+        // While one synchronous-fallback task is mid-execution, a second submission with
+        // the same key from another thread must be deduped (return early), not run again.
+        HealthyThreadPool pool = new HealthyThreadPool("t4", 6, 3, 100, 1, 1);
+        pool.setShutdownDrainMs(1000);
+        pool.shutdown();
+
+        AtomicInteger ran = new AtomicInteger();
+        CountDownLatch firstStarted = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+
+        Thread first = new Thread(() -> pool.execute(new KeyRunnable("dup") {
+            @Override
+            public void run() {
+                firstStarted.countDown();
+                try {
+                    release.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                ran.incrementAndGet();
+            }
+        }));
+        first.start();
+        assertTrue(firstStarted.await(2, TimeUnit.SECONDS));
+
+        // Second submission with the same key while first is still running.
+        pool.execute(new KeyRunnable("dup") {
+            @Override
+            public void run() {
+                ran.incrementAndGet();
+            }
+        });
+
+        release.countDown();
+        first.join(5000);
+
+        assertEquals("second same-key submission must be deduped", 1, ran.get());
+    }
+
+    @Test
     public void execute_afterShutdown_runsSynchronouslyOnCallerThread() {
         HealthyThreadPool pool = new HealthyThreadPool("t3", 6, 3, 100, 1, 1);
         pool.setShutdownDrainMs(1000);

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HealthyThreadPoolShutdownTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HealthyThreadPoolShutdownTests.java
@@ -1,0 +1,131 @@
+
+/*
+ * Copyright Contributors to the OpenCue Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.imageworks.spcue.test.dispatcher;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+import com.imageworks.spcue.dispatcher.HealthyThreadPool;
+import com.imageworks.spcue.dispatcher.commands.KeyRunnable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link HealthyThreadPool} shutdown behavior. No Spring context required —
+ * these test the executor semantics directly.
+ */
+public class HealthyThreadPoolShutdownTests {
+
+    @Test
+    public void shutdown_drainsRunningTask() throws InterruptedException {
+        HealthyThreadPool pool = new HealthyThreadPool("t1", 6, 3, 100, 2, 4);
+        pool.setShutdownDrainMs(5000);
+
+        AtomicInteger ran = new AtomicInteger();
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+
+        pool.execute(new KeyRunnable("k1") {
+            @Override
+            public void run() {
+                started.countDown();
+                try {
+                    release.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                ran.incrementAndGet();
+            }
+        });
+
+        assertTrue("task did not start", started.await(2, TimeUnit.SECONDS));
+
+        Thread shutdownThread = new Thread(pool::shutdown);
+        shutdownThread.start();
+        Thread.sleep(200);
+
+        // Releasing the task must let shutdown() unblock and complete.
+        release.countDown();
+        shutdownThread.join(7000);
+
+        assertEquals(1, ran.get());
+        assertTrue("pool should be terminated", pool.isTerminated());
+    }
+
+    @Test
+    public void shutdown_waitsForBusyWorkerEvenWhenQueueEmpty() throws InterruptedException {
+        // Verifies the && -> || fix: with the old buggy condition, the loop exits the
+        // moment the queue empties, before the running task finishes. With the fix,
+        // shutdown() should block until the task completes.
+        HealthyThreadPool pool = new HealthyThreadPool("t2", 6, 3, 100, 1, 1);
+        pool.setShutdownDrainMs(5000);
+
+        AtomicBoolean done = new AtomicBoolean();
+
+        pool.execute(new KeyRunnable("k1") {
+            @Override
+            public void run() {
+                try {
+                    Thread.sleep(800);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                done.set(true);
+            }
+        });
+
+        // Give the worker time to dequeue and start running.
+        Thread.sleep(150);
+
+        long t0 = System.currentTimeMillis();
+        pool.shutdown();
+        long elapsed = System.currentTimeMillis() - t0;
+
+        assertTrue("expected shutdown to block on busy worker, elapsed=" + elapsed + "ms",
+                elapsed >= 500);
+        assertTrue("task did not finish before shutdown returned", done.get());
+        assertTrue("pool should be terminated", pool.isTerminated());
+    }
+
+    @Test
+    public void execute_afterShutdown_runsSynchronouslyOnCallerThread() {
+        HealthyThreadPool pool = new HealthyThreadPool("t3", 6, 3, 100, 1, 1);
+        pool.setShutdownDrainMs(1000);
+        pool.shutdown();
+
+        AtomicInteger ran = new AtomicInteger();
+        AtomicReference<Thread> ranOn = new AtomicReference<>();
+        Thread caller = Thread.currentThread();
+
+        pool.execute(new KeyRunnable("k") {
+            @Override
+            public void run() {
+                ranOn.set(Thread.currentThread());
+                ran.incrementAndGet();
+            }
+        });
+
+        assertEquals("task must run exactly once", 1, ran.get());
+        assertSame("task must run on caller thread", caller, ranOn.get());
+    }
+}

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HostReportQueueShutdownTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HostReportQueueShutdownTests.java
@@ -29,8 +29,8 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for {@link HostReportQueue} shutdown behavior. Submits via the inherited
- * {@code ThreadPoolExecutor.execute(Runnable)} to avoid building real protobuf reports —
- * shutdown semantics depend only on the underlying executor, not the report type.
+ * {@code ThreadPoolExecutor.execute(Runnable)} to avoid building real protobuf reports — shutdown
+ * semantics depend only on the underlying executor, not the report type.
  */
 public class HostReportQueueShutdownTests {
 

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HostReportQueueShutdownTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HostReportQueueShutdownTests.java
@@ -1,0 +1,121 @@
+
+/*
+ * Copyright Contributors to the OpenCue Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.imageworks.spcue.test.dispatcher;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import com.imageworks.spcue.dispatcher.HostReportQueue;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link HostReportQueue} shutdown behavior. Submits via the inherited
+ * {@code ThreadPoolExecutor.execute(Runnable)} to avoid building real protobuf reports —
+ * shutdown semantics depend only on the underlying executor, not the report type.
+ */
+public class HostReportQueueShutdownTests {
+
+    @Test
+    public void shutdown_drainsRunningTask() throws InterruptedException {
+        HostReportQueue pool = new HostReportQueue(2, 4, 100);
+        pool.setShutdownDrainMs(5000);
+
+        AtomicInteger ran = new AtomicInteger();
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+
+        pool.execute((Runnable) () -> {
+            started.countDown();
+            try {
+                release.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            ran.incrementAndGet();
+        });
+
+        assertTrue("task did not start", started.await(2, TimeUnit.SECONDS));
+
+        Thread shutdownThread = new Thread(pool::shutdown);
+        shutdownThread.start();
+        Thread.sleep(200);
+
+        release.countDown();
+        shutdownThread.join(7000);
+
+        assertEquals(1, ran.get());
+        assertTrue("pool should be terminated", pool.isTerminated());
+    }
+
+    @Test
+    public void shutdown_waitsForBusyWorkerEvenWhenQueueEmpty() throws InterruptedException {
+        // Verifies the && -> || fix in HostReportQueue.shutdown().
+        HostReportQueue pool = new HostReportQueue(1, 1, 100);
+        pool.setShutdownDrainMs(5000);
+
+        AtomicBoolean done = new AtomicBoolean();
+
+        pool.execute((Runnable) () -> {
+            try {
+                Thread.sleep(800);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            done.set(true);
+        });
+
+        Thread.sleep(150);
+
+        long t0 = System.currentTimeMillis();
+        pool.shutdown();
+        long elapsed = System.currentTimeMillis() - t0;
+
+        assertTrue("expected shutdown to block on busy worker, elapsed=" + elapsed + "ms",
+                elapsed >= 500);
+        assertTrue("task did not finish before shutdown returned", done.get());
+        assertTrue("pool should be terminated", pool.isTerminated());
+    }
+
+    @Test
+    public void shutdown_drainsQueueBacklog() throws InterruptedException {
+        // Submit several quick tasks so some are queued; verify all complete.
+        HostReportQueue pool = new HostReportQueue(1, 1, 100);
+        pool.setShutdownDrainMs(5000);
+
+        AtomicInteger ran = new AtomicInteger();
+        for (int i = 0; i < 5; i++) {
+            pool.execute((Runnable) () -> {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                ran.incrementAndGet();
+            });
+        }
+
+        pool.shutdown();
+
+        assertEquals("all queued tasks should have run before shutdown returned", 5, ran.get());
+        assertTrue("pool should be terminated", pool.isTerminated());
+    }
+}

--- a/cuebot/src/test/resources/opencue.properties
+++ b/cuebot/src/test/resources/opencue.properties
@@ -22,6 +22,7 @@ grpc.rqd_cache_expiration=30
 grpc.rqd_cache_concurrency=20
 # RQD Channel task deadline in seconds
 grpc.rqd_task_deadline=10
+grpc.shutdown_grace_ms=30000
 
 # Set hostname/IP of the smtp host. Will be used for mailing
 smtp_host=smtp
@@ -36,6 +37,7 @@ dispatch.threadpool.max_pool_size=8
 dispatch.threadpool.queue_capacity=2000
 healthy_threadpool.health_threshold=6
 healthy_threadpool.min_unhealthy_period_min=3
+healthy_threadpool.shutdown_drain_ms=60000
 report_queue.threadPoolSizeInitial=6
 report_queue.threadPoolSizeMax=12
 # The queue size should be bigger then the expected amount of hosts
@@ -43,6 +45,7 @@ report_queue.queueSize=5000
 kill_queue.threadPoolSizeInitial=2
 kill_queue.threadPoolSizeMax=6
 kill_queue.queueSize=1000
+host_report_queue.shutdown_drain_ms=60000
 
 log.frame-log-root.default_os=/arbitraryLogDirectory
 log.frame-log-root.some_os=/arbitrarySomeOsLogDirectory


### PR DESCRIPTION
Every time cuebot restarts, some FrameCompleteReports are dismissed/ignored, causing completed jobs/layers left with pending state and dependencies unresolved.

This fix restructures the threadpool queues to allow a clean shutdown drain and forces rqd to retry requests sent during that period.


## LLM usage disclosure
What models were used? What were they used for?
Example:
Claude Opus was used for redesigning the shutdown logic and to asses the bean dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable gRPC shutdown grace time and per-queue/threadpool shutdown drain durations; shutdown ordering ensures server stops before dependent queues/handlers.

* **Bug Fixes**
  * Shutdown made idempotent with graceful wait-then-escalate behavior; thread pools deterministically drain, dedupe duplicate submissions, and fallback to synchronous execution when rejected.
  * gRPC error handling now distinguishes retry-reporting failures and closes affected calls with an unavailable status during shutdown.

* **Tests**
  * Added tests for drain/blocking semantics, deduped concurrent submissions, and post-shutdown synchronous execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->