### PR TITLE
[cuegui] CueCommander > Monitor Hosts:  Fix Temp bar overflow on stale hosts, split "Temp Free" column in two ("Temp Free" and "Temp Free %", and increase default widths for some columns

### DIFF
--- a/cuegui/cuegui/HostMonitorTree.py
+++ b/cuegui/cuegui/HostMonitorTree.py
@@ -56,16 +56,18 @@ def _tempFreeRatio(host):
     return host.data.free_mcp / float(total)
 
 
-def _formatTempCell(host):
-    """Cell text for the Temp column: '<free> (NN%)'. When total_mcp is
-    unknown (e.g. RQD that did not initialize it), shows just the free
-    amount."""
-    free = host.data.free_mcp
+def _formatTempFreeAmount(host):
+    """Cell text for the 'Temp Free' column: free /mcp/ space (e.g. '23.5G')."""
+    return cuegui.Utils.memoryToString(host.data.free_mcp)
+
+
+def _formatTempFreePercent(host):
+    """Cell text for the 'Temp Free %' column: percent of /mcp/ free
+    (e.g. '50%'). Empty when total_mcp is unknown."""
     total = host.data.total_mcp
-    free_str = cuegui.Utils.memoryToString(free)
     if not total:
-        return free_str
-    return "%s (%d%%)" % (free_str, int(round(100.0 * free / total)))
+        return ""
+    return "%d%%" % int(round(100.0 * host.data.free_mcp / total))
 
 
 class HostMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
@@ -100,17 +102,17 @@ class HostMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                        sort=lambda host: host.data.free_memory,
                        delegate=cuegui.ItemDelegate.HostMemBarDelegate,
                        tip="The amount of used memory (red) vs available phys memory (green)")
-        self.addColumn("GPU Memory", 70, id=6,
+        self.addColumn("GPU Memory", 90, id=6,
                        data=lambda host: cuegui.Utils.memoryToString(host.data.free_gpu_memory),
                        sort=lambda host: host.data.free_gpu_memory,
                        delegate=cuegui.ItemDelegate.HostGpuBarDelegate,
                        tip="The amount of used gpu memory (red) vs available gpu memory (green)")
-        self.addColumn("Total Memory", 60, id=7,
+        self.addColumn("Total Memory", 90, id=7,
                        data=lambda host: cuegui.Utils.memoryToString(host.data.memory),
                        sort=lambda host: host.data.total_memory,
                        tip="The total amount of available memory.\n\n"
                            "Takes into consideration free memory and cached memory.")
-        self.addColumn("Idle Memory", 60, id=8,
+        self.addColumn("Idle Memory", 90, id=8,
                        data=lambda host: cuegui.Utils.memoryToString(host.data.idle_memory),
                        sort=lambda host: host.data.idle_memory,
                        tip="The amount of unreserved memory.")
@@ -120,17 +122,22 @@ class HostMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                        delegate=cuegui.ItemDelegate.HostTempBarDelegate,
                        tip="The amount of used /mcp/ space (red) vs available (green).")
         self.addColumn("Temp Free", 90, id=23,
-                       data=_formatTempCell,
+                       data=_formatTempFreeAmount,
+                       sort=lambda host: host.data.free_mcp,
+                       tip="Free /mcp/ space (e.g. '23.5G'). Sorted by absolute\n"
+                           "free amount, so 900G ranks above 400G and 1.0G.")
+        self.addColumn("Temp Free %", 100, id=24,
+                       data=_formatTempFreePercent,
                        sort=_tempFreeRatio,
-                       tip="Free /mcp/ space. The number in parentheses is the\n"
-                           "percent free; hosts have different /mcp sizes, so the\n"
-                           "percent makes it easier to compare across hosts.")
+                       tip="Percent of /mcp/ free (e.g. '50%'). Sorted by ratio,\n"
+                           "matching the adjacent 'Temp' bar. Empty when a host\n"
+                           "has not reported a total /mcp/ size.")
         self.addColumn("Cores", 60, id=10,
                        data=lambda host: "%.2f" % host.data.cores,
                        sort=lambda host: host.data.cores,
                        tip="The total number of cores.\n\n"
                            "On a frame it is the number of cores reserved.")
-        self.addColumn("Idle Cores", 60, id=11,
+        self.addColumn("Idle Cores", 70, id=11,
                        data=lambda host: "%.2f" % host.data.idle_cores,
                        sort=lambda host: host.data.idle_cores,
                        tip="The number of cores that are not reserved.")
@@ -139,20 +146,20 @@ class HostMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                        sort=lambda host: host.data.gpus,
                        tip="The total number of gpus.\n\n"
                            "On a frame it is the number of gpus reserved.")
-        self.addColumn("Idle GPUs", 50, id=13,
+        self.addColumn("Idle GPUs", 70, id=13,
                        data=lambda host: "%d" % host.data.idle_gpus,
                        sort=lambda host: host.data.idle_gpus,
                        tip="The number of gpus that are not reserved.")
-        self.addColumn("GPU Mem", 50, id=14,
+        self.addColumn("GPU Mem", 70, id=14,
                        data=lambda host: cuegui.Utils.memoryToString(host.data.gpu_memory),
                        sort=lambda host: host.data.gpu_memory,
                        tip="The total amount of reservable gpu memory.\n\n"
                            "On a frame it is the amount of gpu memory reserved.")
-        self.addColumn("Gpu Mem Idle", 50, id=15,
+        self.addColumn("GPU Mem Idle", 100, id=15,
                        data=lambda host: cuegui.Utils.memoryToString(host.data.idle_gpu_memory),
                        sort=lambda host: host.data.idle_gpu_memory,
                        tip="The amount of unreserved gpu memory.")
-        self.addColumn("Ping", 50, id=16,
+        self.addColumn("Ping", 90, id=16,
                        data=lambda host: int(time.time() - host.data.ping_time),
                        sort=lambda host: host.data.ping_time,
                        tip="The number of seconds since the cuebot last received\n"
@@ -163,11 +170,11 @@ class HostMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                        data=lambda host: cuegui.Utils.dateToMMDDHHMM(host.data.boot_time),
                        sort=lambda host: host.data.boot_time,
                        tip="The time when the host was last booted.")
-        self.addColumn("Hardware", 70, id=18,
+        self.addColumn("Hardware", 80, id=18,
                        data=lambda host: HardwareState.Name(host.data.state),
                        tip="The state of the hardware as Up or Down.\n\n"
                            "On a frame it is the amount of memory used.")
-        self.addColumn("Locked", 90, id=19,
+        self.addColumn("Locked", 110, id=19,
                        data=lambda host: LockState.Name(host.data.lock_state),
                        tip="A host can be:\n"
                            "Locked \t\t It was manually locked to prevent booking\n"
@@ -175,7 +182,7 @@ class HostMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                            "NimbyLocked \t It is a desktop machine and there is\n"
                            "\t\t someone actively using it or not enough \n"
                            "\t\t resources are available on a desktop.")
-        self.addColumn("ThreadMode", 80, id=20,
+        self.addColumn("ThreadMode", 90, id=20,
                        data=lambda host: ThreadMode.Name(host.data.thread_mode),
                        tip="A frame that runs on this host will:\n"
                            "All:  Use all cores.\n"

--- a/cuegui/cuegui/ItemDelegate.py
+++ b/cuegui/cuegui/ItemDelegate.py
@@ -77,7 +77,7 @@ class AbstractDelegate(QtWidgets.QItemDelegate):
             QtWidgets.QItemDelegate.paint(self, painter, option, index)
 
     def _paintDifferenceBar(self, painter, option, index, used, total):
-        if not total:
+        if not total or total <= 0:
             return
         painter.save()
         try:
@@ -88,8 +88,15 @@ class AbstractDelegate(QtWidgets.QItemDelegate):
             # rows are ~14-16px tall. Larger padding (e.g. 6px) consumes
             # the entire row on macOS and the bar disappears.
             rect = option.rect.adjusted(2, 2, -2, -2)
+            # Clamp used to [0, total]. Down or misreporting hosts can
+            # publish free > total (seen on DOWN hosts where /mcp (/tmp) metrics
+            # were never refreshed), which makes used negative and the
+            # free-fill rect extend past the cell - bleeding the bar's
+            # green into the columns to the left.
+            used = max(0, min(used, total))
             ratio = rect.width() / float(total)
-            length = int(ceil(ratio * (used)))
+            length = int(ceil(ratio * used))
+            painter.setClipRect(rect)
             painter.fillRect(rect,
                              self.__colorUsed)
             painter.fillRect(rect.adjusted(length, 0, 0, 0),

--- a/cuegui/cuegui/ItemDelegate.py
+++ b/cuegui/cuegui/ItemDelegate.py
@@ -88,11 +88,7 @@ class AbstractDelegate(QtWidgets.QItemDelegate):
             # rows are ~14-16px tall. Larger padding (e.g. 6px) consumes
             # the entire row on macOS and the bar disappears.
             rect = option.rect.adjusted(2, 2, -2, -2)
-            # Clamp used to [0, total]. Down or misreporting hosts can
-            # publish free > total (seen on DOWN hosts where /mcp (/tmp) metrics
-            # were never refreshed), which makes used negative and the
-            # free-fill rect extend past the cell - bleeding the bar's
-            # green into the columns to the left.
+            # Clamp used to [0, total]. Down or misreporting hosts can publish free > total
             used = max(0, min(used, total))
             ratio = rect.width() / float(total)
             length = int(ceil(ratio * used))

--- a/cuegui/tests/test_host_monitor_tree.py
+++ b/cuegui/tests/test_host_monitor_tree.py
@@ -40,20 +40,28 @@ def _makeHost(free_mcp, total_mcp):
 
 class TempCellHelpersTests(unittest.TestCase):
 
-    def test_formatIncludesPercentWhenTotalKnown(self):
+    def test_freeAmountIsHumanReadable(self):
+        host = _makeHost(free_mcp=10 * 1024 * 1024, total_mcp=20 * 1024 * 1024)
+        self.assertEqual("10.0G", cuegui.HostMonitorTree._formatTempFreeAmount(host))
+
+    def test_freeAmountRendersWhenTotalUnknown(self):
+        # Total is not required for the amount column.
+        host = _makeHost(free_mcp=5 * 1024 * 1024, total_mcp=0)
+        self.assertEqual("5.0G", cuegui.HostMonitorTree._formatTempFreeAmount(host))
+
+    def test_percentIncludesPercentSign(self):
         # 50% free.
         host = _makeHost(free_mcp=10 * 1024 * 1024, total_mcp=20 * 1024 * 1024)
-        self.assertEqual("10.0G (50%)", cuegui.HostMonitorTree._formatTempCell(host))
+        self.assertEqual("50%", cuegui.HostMonitorTree._formatTempFreePercent(host))
 
-    def test_formatRoundsPercentToNearestInteger(self):
+    def test_percentRoundsToNearestInteger(self):
         # 1/3 free -> 33%.
         host = _makeHost(free_mcp=1 * 1024 * 1024, total_mcp=3 * 1024 * 1024)
-        self.assertEqual("1.0G (33%)", cuegui.HostMonitorTree._formatTempCell(host))
+        self.assertEqual("33%", cuegui.HostMonitorTree._formatTempFreePercent(host))
 
-    def test_formatFallsBackWhenTotalUnknown(self):
+    def test_percentIsEmptyWhenTotalUnknown(self):
         host = _makeHost(free_mcp=5 * 1024 * 1024, total_mcp=0)
-        # No percent suffix when total is unknown.
-        self.assertEqual("5.0G", cuegui.HostMonitorTree._formatTempCell(host))
+        self.assertEqual("", cuegui.HostMonitorTree._formatTempFreePercent(host))
 
     def test_ratioIsFractionOfFreeOverTotal(self):
         host = _makeHost(free_mcp=25, total_mcp=100)
@@ -97,9 +105,17 @@ class HostWidgetItemTempBarDataTests(unittest.TestCase):
 
     def test_tempFreeColumnHasNoBarDelegate(self):
         # "Temp Free" sits right after "Temp" at index 9. It's a plain text
-        # column — no bar delegate, only the formatted "<free> (NN%)" text.
+        # column showing the absolute free amount (e.g. "23.5G") — no bar.
         temp_free_col_index = 9
         delegate = self.tree.itemDelegateForColumn(temp_free_col_index)
+
+        self.assertNotIsInstance(delegate, cuegui.ItemDelegate.HostTempBarDelegate)
+
+    def test_tempFreePercentColumnHasNoBarDelegate(self):
+        # "Temp Free %" sits at index 10, after "Temp Free". Plain text only
+        # ("50%"), sorted by ratio to mirror the bar at index 8.
+        temp_free_pct_col_index = 10
+        delegate = self.tree.itemDelegateForColumn(temp_free_pct_col_index)
 
         self.assertNotIsInstance(delegate, cuegui.ItemDelegate.HostTempBarDelegate)
 

--- a/docs/_docs/user-guides/cuecommander-administration-guide.md
+++ b/docs/_docs/user-guides/cuecommander-administration-guide.md
@@ -256,8 +256,9 @@ Enables real-time monitoring and management of render hosts (nodes), including t
 - **Physical**: Physical memory state
 - **GPU Memory**: GPU memory statistics
 - **Idle/Total Memory**: Memory availability
-- **Temp**: Used (red) vs available (green) `/mcp/` space, shown as a bar
-- **Temp Free**: Free `/mcp/` space with the percent free in parentheses (e.g. `99.2G (50%)`); the percent makes it easier to compare hosts with different `/mcp/` sizes
+- **Temp**: Used (red) vs available (green) `/mcp/` space, shown as a bar; sorted by percent free
+- **Temp Free**: Free `/mcp/` space as an absolute value (e.g. `23.5G`). Sorted by the numeric free amount, so `900G` ranks above `400G` and `1.0G`
+- **Temp Free %**: Percent of `/mcp/` free (e.g. `50%`). Sorted by ratio so it tracks the **Temp** bar; useful for comparing hosts with different `/mcp/` sizes
 - **Cores**: CPU core information
 - **Idle GPU/Total GPU**: GPU availability
 - **Ping**: Network responsiveness


### PR DESCRIPTION
## Related Issues
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/2314

## Summarize your change.
Bug: Down host or misreporting hosts can publish free > total (seen on DOWN hosts where /mcp metrics were never refreshed), which makes used negative and the free-fill rect extend past the cell - bleeding the bar's green into the columns to the left.

New changes:

1) Bug fix: Temp bar overflow
- `_paintDifferenceBar` computed `used = total - free`, which became negative when stale hosts published `free > total`.
- The free-fill rect was then built with `rect.adjusted(<negative>, 0, 0, 0)`, shifting its left edge beyond the cell boundary.
- Since the Temp delegate paints last in the row, its green free portion bled leftward across Idle Memory, Total Memory, GPU Memory, Physical, and Swap, causing the "green bar spanning many columns".
- Clamp `used` to `[0, total]` so misreporting hosts render as fully free (all green) without overflowing the cell.
- Add `painter.setClipRect(rect)` as a safeguard so future arithmetic issues cannot paint outside the intended cell.
- Tighten the early-return guard to also bail when `total <= 0`.

2) New improvement: "Temp Free" column split
- The combined "Temp Free" column value (e.g.: 23.5G (50%)) display made it difficult to sort by absolute free space. Sorting by percentage could rank a `1.0G / 100%` host above a `900G / 45%` host, which is counterproductive when scanning for actual available headroom.
- Replace the single Temp Free column with two: a) "Temp Free" (e.g. `"23.5G"`), sorted by "free_mcp" and b) "Temp Free %" (e.g. `"50%"`), sorted by usage ratio and left empty when "total_mcp" is unknown
- The adjacent Temp bar continues to sort by ratio for visual continuity.
- `_formatTempCell` is replaced by `_formatTempFreeAmount` and `_formatTempFreePercent`.

3) Column width tuning: Increase default widths for columns that were truncating content under production fonts:
- GPU Memory
- Total Memory
- Idle Memory
- Temp Free
- Temp Free %
- Idle Cores
- Idle GPUs
- GPU Mem
- GPU Mem Idle
- Ping
- Hardware
- Locked
- ThreadMode
- Header labels and common values now fit without clipping or hover-only visibility, making Monitor Hosts easier to scan.

4) Update tests:
- Replace `_formatTempCell` tests with dedicated helper coverage:
- Amount renders even when total is unknown
- Percentage rounds to the nearest integer
- Percentage remains empty when total is unavailable
- Add a delegate-wiring assertion for the new `Temp Free %` column at index `10`.

Docs:
- Update `cuecommander-administration-guide.md` to document all three Temp-related columns (`Temp`, `Temp Free`, `Temp Free %`) and their sorting behavior.