### PR TITLE
[CICD] Cache Rust deps and add timeouts to rust-pipeline

### DIFF
--- a/.github/workflows/rust-pipeline.yml
+++ b/.github/workflows/rust-pipeline.yml
@@ -8,10 +8,17 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Incremental compilation hurts CI clean builds (extra disk I/O, larger
+  # target dirs, no benefit since each runner is ephemeral) — turn it off.
+  CARGO_INCREMENTAL: 0
+  # Be more tolerant of registry hiccups on Windows.
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
 
 jobs:
   build:
     runs-on: ubuntu-22.04
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v4
@@ -20,6 +27,11 @@ jobs:
           sudo apt-get update && sudo apt-get install -y libx11-dev protobuf-compiler libcurl4-openssl-dev
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rust-install.sh
           bash ./rust-install.sh -y
+      - name: Cache cargo deps
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+          cache-on-failure: true
       - name: Build
         run: |
           cd rust
@@ -31,6 +43,7 @@ jobs:
 
   clippy:
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4
@@ -39,6 +52,11 @@ jobs:
           sudo apt-get update && sudo apt-get install -y libx11-dev protobuf-compiler libcurl4-openssl-dev
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rust-install.sh
           bash ./rust-install.sh -y
+      - name: Cache cargo deps
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+          cache-on-failure: true
       - name: Run Clippy
         run: |
           cd rust
@@ -46,6 +64,7 @@ jobs:
 
   windows-clippy:
     runs-on: windows-latest
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v4
@@ -57,12 +76,18 @@ jobs:
         run: choco install protoc -y
       - name: Export PROTOC path
         run: echo "PROTOC=C:\ProgramData\chocolatey\bin\protoc.exe" >> $env:GITHUB_ENV
+      - name: Cache cargo deps
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+          cache-on-failure: true
       - name: Run Clippy
         working-directory: rust
-        run: cargo clippy -p rqd --verbose
+        run: cargo clippy -p rqd
 
   windows-tests:
     runs-on: windows-latest
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v4
@@ -72,6 +97,18 @@ jobs:
         run: choco install protoc -y
       - name: Export PROTOC path
         run: echo "PROTOC=C:\ProgramData\chocolatey\bin\protoc.exe" >> $env:GITHUB_ENV
+      - name: Cache cargo deps
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+          cache-on-failure: true
+      # Build tests first so we see compile-vs-run timing separately and the
+      # cache is populated even if a test later fails. `--verbose` is dropped
+      # — log volume noticeably slows Windows runners and the failure output
+      # is enough for triage.
+      - name: Build tests
+        working-directory: rust
+        run: cargo test -p rqd --no-run
       - name: Run tests
         working-directory: rust
-        run: cargo test -p rqd --verbose
+        run: cargo test -p rqd


### PR DESCRIPTION
The windows-tests job was timing out because every PR rebuilt all of rqd's transitive deps from scratch on a slow Windows runner, with no job timeout (default 6h).

.github/workflows/rust-pipeline.yml:
- Add Swatinem/rust-cache@v2 to all four jobs so target/ and the registry are reused across runs (typically 5-10x faster on Windows after the first build).
- Add timeout-minutes per job (30-60 min) so stalled runs fail fast.
- Set CARGO_INCREMENTAL=0 (no upside on ephemeral CI, hurts clean builds) plus CARGO_NET_RETRY / RUSTUP_MAX_RETRIES = 10 for Windows registry flakiness.
- Split windows-tests into `cargo test -p rqd --no-run` then `cargo test -p rqd` so compile-vs-run timing is obvious and the cache lands even when a test fails.
- Drop `--verbose` from the Windows jobs . Log volume noticeably slows Windows runners.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to improve build reliability and performance through enhanced caching mechanisms and retry configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AcademySoftwareFoundation/OpenCue/pull/2321)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->