### PR TITLE
[cuebot] Fix bug preventing dispatching with a single active show

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatcherDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatcherDaoJdbc.java
@@ -191,10 +191,8 @@ public class DispatcherDaoJdbc extends JdbcDaoSupport implements DispatcherDao {
     private Set<String> findDispatchJobs(DispatchHost host, int numJobs, boolean shuffleShows) {
         LinkedHashSet<String> result = new LinkedHashSet<String>();
         List<SortableShow> shows = new LinkedList<SortableShow>(getBookableShows(host));
-        // shows were sorted. If we want it in random sequence, we need to shuffle it.
+        // Shuffle shows to get them processed randomly
         if (shuffleShows) {
-            if (!shows.isEmpty())
-                shows.remove(0);
             Collections.shuffle(shows);
         }
 

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/CoreUnitDispatcherTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/CoreUnitDispatcherTests.java
@@ -131,8 +131,7 @@ public class CoreUnitDispatcherTests extends TransactionalTest {
         DispatchHost host = getHost();
 
         List<VirtualProc> procs = dispatcher.dispatchHostToAllShows(host);
-        // The first show is removed. findDispatchJobs: shows.remove(0).
-        assertEquals(0, procs.size());
+        assertEquals(1, procs.size());
     }
 
     @Test


### PR DESCRIPTION
When there's only one active show, the logic to randomize show order inadvertently removes it from the list, leading to a frozen queue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shuffle behavior so host dispatching now randomizes show order correctly when shuffle is enabled.

* **Tests**
  * Updated unit test expectations to reflect the corrected dispatch behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AcademySoftwareFoundation/OpenCue/pull/2327)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->