### PR TITLE
[scheduler] Handle threadable frames similar to cuebot

### DIFF
--- a/rust/crates/scheduler/src/pipeline/dispatcher/actor.rs
+++ b/rust/crates/scheduler/src/pipeline/dispatcher/actor.rs
@@ -885,7 +885,8 @@ impl RqdDispatcherService {
                 }
                 cores
             }
-            (ThreadMode::All, false) => cores_requested,
+            // (ThreadMode::All, false) is rejected upstream in MatchingService::validate_match
+            // to mirror Cuebot's DispatchQuery filter, so it cannot reach this match.
             // Limit Variable booking to at least 2 cores
             (ThreadMode::Variable, true) if cores_requested.value() <= 2 => CoreSize(2),
             (ThreadMode::Auto, true) | (ThreadMode::Variable, true) => {
@@ -1414,22 +1415,6 @@ mod tests {
         let result =
             RqdDispatcherService::calculate_core_reservation(&host, &frame, memory_threshold);
         assert_eq!(result, CoreSize(1)); // Non-threadable frames are clamped to 1 core
-    }
-
-    #[tokio::test]
-    async fn test_calculate_core_reservation_not_threadable_thread_mode_all() {
-        let mut host = create_test_host();
-        host.thread_mode = ThreadMode::All;
-        host.idle_cores = CoreSize(6);
-
-        let mut frame = create_test_dispatch_frame();
-        frame.threadable = false;
-
-        let memory_threshold = ByteSize::mib(500);
-
-        let result =
-            RqdDispatcherService::calculate_core_reservation(&host, &frame, memory_threshold);
-        assert_eq!(result, CoreSize(1)); // Non-threadable frames are clamped to 1 core even in All mode
     }
 
     #[tokio::test]

--- a/rust/crates/scheduler/src/pipeline/matcher.rs
+++ b/rust/crates/scheduler/src/pipeline/matcher.rs
@@ -18,6 +18,7 @@ use std::{
     time::Duration,
 };
 
+use opencue_proto::host::ThreadMode;
 use uuid::Uuid;
 
 use crate::{
@@ -189,6 +190,13 @@ impl MatchingService {
         os.is_none() || host.str_os.as_deref() == os
     }
 
+    /// Mirrors Cuebot's DispatchQuery filter: hosts in ThreadMode::All only accept threadable
+    /// layers. Booking a non-threadable layer on such a host would diverge from Cuebot's behavior
+    /// and starve the layer when ownership of the show moves back to Cuebot.
+    fn host_matches_thread_mode(host: &Host, threadable: bool) -> bool {
+        !(host.thread_mode == ThreadMode::All && !threadable)
+    }
+
     /// Validates whether a host is suitable for a specific layer.
     ///
     /// Subscriptions: Check whether this hosts' subscription can book at least one frame
@@ -206,11 +214,16 @@ impl MatchingService {
         _layer_id: &Uuid,
         show_id: &Uuid,
         cores_requested: CoreSize,
+        threadable: bool,
         resource_accounting_service: &ResourceAccountingService,
         os: Option<&str>,
     ) -> bool {
         // Check OS compatibility
         if !Self::host_matches_layer_os(host, os) {
+            return false;
+        }
+
+        if !Self::host_matches_thread_mode(host, threadable) {
             return false;
         }
 
@@ -280,6 +293,7 @@ impl MatchingService {
             let layer_id = layer.id;
             let show_id = layer.show_id;
             let cores_requested = layer.cores_min;
+            let threadable = layer.threadable;
             let resource_accounting_service = self.resource_accounting_service.clone();
             let os = layer.str_os.clone();
 
@@ -297,6 +311,7 @@ impl MatchingService {
                             &layer_id,
                             &show_id,
                             cores_requested,
+                            threadable,
                             &resource_accounting_service,
                             os.as_deref(),
                         )
@@ -517,6 +532,14 @@ mod tests {
     use crate::models::{CoreSize, Host};
 
     fn host_with_os(str_os: Option<&str>) -> Host {
+        host_with(str_os, ThreadMode::Variable)
+    }
+
+    fn host_with_thread_mode(thread_mode: ThreadMode) -> Host {
+        host_with(Some("Linux"), thread_mode)
+    }
+
+    fn host_with(str_os: Option<&str>, thread_mode: ThreadMode) -> Host {
         Host::new_for_test(
             Uuid::new_v4(),
             "test-host".to_string(),
@@ -527,7 +550,7 @@ mod tests {
             ByteSize::gb(64),
             0,
             ByteSize::gb(0),
-            ThreadMode::Variable,
+            thread_mode,
             CoreSize::from_multiplied(100),
             Uuid::new_v4(),
             "test-alloc".to_string(),
@@ -556,5 +579,35 @@ mod tests {
             &host,
             Some("Windows")
         ));
+    }
+
+    #[test]
+    fn thread_mode_all_rejects_non_threadable_layer() {
+        let host = host_with_thread_mode(ThreadMode::All);
+
+        assert!(!MatchingService::host_matches_thread_mode(&host, false));
+    }
+
+    #[test]
+    fn thread_mode_all_accepts_threadable_layer() {
+        let host = host_with_thread_mode(ThreadMode::All);
+
+        assert!(MatchingService::host_matches_thread_mode(&host, true));
+    }
+
+    #[test]
+    fn thread_mode_variable_accepts_any_threadability() {
+        let host = host_with_thread_mode(ThreadMode::Variable);
+
+        assert!(MatchingService::host_matches_thread_mode(&host, true));
+        assert!(MatchingService::host_matches_thread_mode(&host, false));
+    }
+
+    #[test]
+    fn thread_mode_auto_accepts_any_threadability() {
+        let host = host_with_thread_mode(ThreadMode::Auto);
+
+        assert!(MatchingService::host_matches_thread_mode(&host, true));
+        assert!(MatchingService::host_matches_thread_mode(&host, false));
     }
 }


### PR DESCRIPTION
The scheduler was inadvertently booking non-threadable jobs on threadable machines. Going against cuebot's behavior. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined thread-mode validation logic in the scheduler's core reservation and host matching systems.
  * Removed redundant code paths and consolidated validation logic.

* **Tests**
  * Enhanced test coverage for thread-mode compatibility validation across different thread-mode configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AcademySoftwareFoundation/OpenCue/pull/2328)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->