### PR TITLE
[CI/CD] Fix Test Documentation Build: use `python -m pip` in build_sphinx_docs.sh

### DIFF
--- a/ci/build_sphinx_docs.sh
+++ b/ci/build_sphinx_docs.sh
@@ -12,9 +12,9 @@ else
 fi
 
 # Sphinx has some additional requirements
-pip install ${PIP_OPT} -r api_docs/requirements.txt
+python -m pip install ${PIP_OPT} -r api_docs/requirements.txt
 
-pip install ${PIP_OPT} proto/ pycue/ pyoutline/ cueadmin/ cuesubmit/ cuegui/
+python -m pip install ${PIP_OPT} proto/ pycue/ pyoutline/ cueadmin/ cuesubmit/ cuegui/
 # ci/build_proto.sh
 
 # Build the docs and treat warnings as errors


### PR DESCRIPTION
## Summarize your change.

- The `aswf/ci-opencue:2023` container has no `pip` binary on PATH, so the job failed with `pip: command not found`.
- Switch both `pip install` calls to `python -m pip install`, matching `ci/run_python_tests.sh`.
