### PR TITLE
[cueweb] Add human-readable age column with smart formatting

### DIFF
--- a/cueweb/app/jobs/columns.tsx
+++ b/cueweb/app/jobs/columns.tsx
@@ -108,11 +108,10 @@ export const getJobAge = (job: Job) => {
 
 export const getJobAgeInSeconds = (job: Job): number => {
   if (job?.stopTime != 0) {
-    return job.stopTime - job.startTime;
+    return Math.max(0, Math.floor(job.stopTime - job.startTime));
   }
-  const currentDate = new Date();
-  const timestampInSeconds = currentDate.getTime() / 1000;
-  return timestampInSeconds - job.startTime;
+  const nowInSeconds = Math.floor(Date.now() / 1000);
+  return Math.max(0, nowInSeconds - Math.floor(job.startTime));
 };
 
 export const getJobReadableAge = (job: Job) => {

--- a/cueweb/app/jobs/columns.tsx
+++ b/cueweb/app/jobs/columns.tsx
@@ -4,7 +4,7 @@ import { ColumnDef } from "@tanstack/react-table";
 import { Button } from "@/components/ui/button";
 import { ArrowUpDown, MoreHorizontal } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
-import { convertMemoryToString, convertUnixToHumanReadableDate, secondsToHHHMM } from "@/app/utils/layers_frames_utils";
+import { convertMemoryToString, convertUnixToHumanReadableDate, secondsToHHHMM, secondsToHumanAge } from "@/app/utils/layers_frames_utils";
 import { Status } from "@/components/ui/status";
 
 // This type is used to define the shape of our data.
@@ -103,6 +103,19 @@ export const getJobAge = (job: Job) => {
   const currentDate = new Date();
   const timestampInSeconds = currentDate.getTime() / 1000;
   return secondsToHHHMM(timestampInSeconds - job.startTime);
+};
+
+export const getJobAgeInSeconds = (job: Job): number => {
+  if (job?.stopTime != 0) {
+    return job.stopTime - job.startTime;
+  }
+  const currentDate = new Date();
+  const timestampInSeconds = currentDate.getTime() / 1000;
+  return timestampInSeconds - job.startTime;
+};
+
+export const getJobHumanAge = (job: Job) => {
+  return secondsToHumanAge(getJobAgeInSeconds(job));
 };
 
 export const columns: ColumnDef<Job>[] = [
@@ -277,6 +290,23 @@ export const columns: ColumnDef<Job>[] = [
           <ArrowUpDown className="ml-2 h-4 w-4" />
         </Button>
       );
+    },
+  },
+  {
+    id: "humanAge",
+    accessorFn: (row) => getJobHumanAge(row),
+    header: ({ column }) => {
+      return (
+        <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
+          Human Age
+          <ArrowUpDown className="ml-2 h-4 w-4" />
+        </Button>
+      );
+    },
+    sortingFn: (rowA, rowB) => {
+      const ageA = getJobAgeInSeconds(rowA.original as Job);
+      const ageB = getJobAgeInSeconds(rowB.original as Job);
+      return ageA - ageB;
     },
   },
   {

--- a/cueweb/app/jobs/columns.tsx
+++ b/cueweb/app/jobs/columns.tsx
@@ -115,7 +115,7 @@ export const getJobAgeInSeconds = (job: Job): number => {
   return timestampInSeconds - job.startTime;
 };
 
-export const getJobHumanAge = (job: Job) => {
+export const getJobReadableAge = (job: Job) => {
   return secondsToHumanAge(getJobAgeInSeconds(job));
 };
 
@@ -294,12 +294,12 @@ export const columns: ColumnDef<Job>[] = [
     },
   },
   {
-    id: "humanAge",
-    accessorFn: (row) => getJobHumanAge(row),
+    id: "readable age",
+    accessorFn: (row) => getJobReadableAge(row),
     header: ({ column }) => {
       return (
         <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
-          Human Age
+          Readable Age
           <ArrowUpDown className="ml-2 h-4 w-4" />
         </Button>
       );

--- a/cueweb/app/jobs/data-table.tsx
+++ b/cueweb/app/jobs/data-table.tsx
@@ -119,7 +119,7 @@ const initialColumnVisibility = {
   wait: false,
   eaten: false,
   age: false,
-  humanAge: false,
+  "readable age": false,
   maxRss: false,
 }
 

--- a/cueweb/app/jobs/data-table.tsx
+++ b/cueweb/app/jobs/data-table.tsx
@@ -119,6 +119,7 @@ const initialColumnVisibility = {
   wait: false,
   eaten: false,
   age: false,
+  humanAge: false,
   maxRss: false,
 }
 

--- a/cueweb/app/utils/layers_frames_utils.ts
+++ b/cueweb/app/utils/layers_frames_utils.ts
@@ -62,3 +62,24 @@ export const secondsToHHHMM = (sec: number): string => {
 
   return `${hours}:${minutes}`;
 };
+
+// Converts seconds to a human-readable age string (e.g., "2h 14m" or "3d 4h")
+export const secondsToHumanAge = (sec: number): string => {
+  if (sec < 0) {
+    return "0m";
+  }
+
+  const days = Math.floor(sec / 86400);
+  const hours = Math.floor((sec % 86400) / 3600);
+  const minutes = Math.floor((sec % 3600) / 60);
+
+  if (days > 0) {
+    return `${days}d ${hours}h`;
+  }
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+
+  return `${minutes}m`;
+};

--- a/docs/_docs/user-guides/cueweb-user-guide.md
+++ b/docs/_docs/user-guides/cueweb-user-guide.md
@@ -147,6 +147,7 @@ The dashboard consists of:
 | **Wait** | Number of frames waiting to run |
 | **MaxRss** | Maximum resident set size (peak memory usage) |
 | **Age** | Total time since job started (HHH:MM format) |
+| **Readable Age** | Same value as Age, formatted as `2h 14m` or `3d 4h` (hidden by default) |
 | **Progress** | Visual progress bar showing completion percentage |
 | **Pop-up** | Button to open job details panel |
 


### PR DESCRIPTION
## Related Issues
- #2287 

## Summarize your change.

The existing `Age` column in the jobs table displays time in HHH:MM format (e.g., `048:32`), which requires mental conversion to understand at a glance.

I added a new `Readable Age` column that shows the same datum in a more natural format:
- Jobs under a day: `2h 14m`
- Jobs over a day: `3d 4h`

The column is hidden by default and can be enabled through the column chooser dropdown, so existing workflows aren't disrupted. The header pairs with the existing `Age` column to make the relationship (same value, different format) obvious.

Implementation notes:
- New formatter `secondsToHumanAge` in `cueweb/app/utils/layers_frames_utils.ts`
- New column `readable age` in `cueweb/app/jobs/columns.tsx` with a numeric `sortingFn` so rows sort by actual elapsed seconds (not the formatted string)
- `getJobAgeInSeconds` clamps to non-negative and floors to whole seconds, so the sort key always matches what the formatter displays (addresses CodeRabbit feedback on clock-skew / fractional-second edge cases)
- Docs updated: new row in the Job Information Columns table in `docs/_docs/user-guides/cueweb-user-guide.md`

Testing:
- Formatter edge cases verified: negative values, zero, minutes-only, hours-only, multi-day jobs
- Confirmed the column appears in the chooser, is hidden by default, and sorts correctly by actual age in seconds
- Verified end-to-end in the sandbox stack (`docker compose --profile all up`)

Co-authored-by: Vishal Kumar Singh <vishal.kr.singh2021@gmail.com>
Co-authored-by: Ramon Figueiredo <rfigueiredo@imageworks.com>