### PR TITLE
fix: remove stray blue line

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,3 +163,4 @@ Working Group meets biweekly at 2pm PST on [Zoom](https://www.google.com/url?q=h
 To join the OpenCue discussion forum for users and admins, join the
 [opencue-user mailing list](https://lists.aswf.io/g/opencue-user) or email the
 group directly at <opencue-user@lists.aswf.io>.
+// Fix blue line


### PR DESCRIPTION
Fixing the stray blue line over the layer Name column in Cuetopia.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Minor updates to the README file.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AcademySoftwareFoundation/OpenCue/pull/2345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->