### PR TITLE
[cueweb/docs] Document per-job completion notifications

### DIFF
--- a/docs/_docs/developer-guide/cueweb-development.md
+++ b/docs/_docs/developer-guide/cueweb-development.md
@@ -126,6 +126,7 @@ cueweb/
 - **`FrameViewer`**: Frame log viewer component
 - **`SearchBar`**: Job search and filtering
 - **`ThemeProvider`**: Dark/light theme management
+- **`JobSubscriptionPoller`**: App-wide client provider (mounted in `app/layout.tsx`) that polls subscribed jobs every 15s. When a job reaches `FINISHED` it fires a browser notification via the Web Notifications API and marks the entry as notified. An `inFlight` ref guards against overlapping ticks, and jobs that no longer exist in Cuebot are removed from the store on the next poll.
 
 #### UI Components
 
@@ -134,6 +135,11 @@ cueweb/
 - **`Dialog`**: Modal dialog wrapper
 - **`Select`**: Dropdown selection component
 - **`Toast`**: Notification system
+- **`SubscribeBell`**: Per-row bell button in the `JobsTable` **Notify** column. Reads/writes per-job subscription state via the `useJobSubscriptions` hook (`app/utils/use_job_subscriptions.ts`), backed by `localStorage` through `app/utils/subscription_utils.ts`. Every subscribe attempt calls `requestNotificationPermission()`; the browser only displays its native permission prompt when the current state is `default` (undecided) and resolves silently with the existing decision otherwise. If the resolved permission is not `granted`, the component surfaces a toast warning and skips the subscription. The button is disabled on rows whose `jobState` is already `FINISHED` and the row has no existing subscription.
+
+##### Subscription store
+
+Subscriptions are stored as a `Record<jobId, JobSubscription>` under the `localStorage` key `cueweb:job-subscriptions`. Each entry tracks `jobId`, `jobName`, `subscribedAt`, and `notifiedAt` (null until the poller fires the notification). Mutations dispatch a `cueweb:subscriptions-changed` window event so every `useJobSubscriptions` consumer re-reads from `localStorage` &mdash; this keeps the bell, the poller, and any other consumer in sync within the same tab without prop drilling. The store getter defensively returns `{}` for missing or malformed JSON so a stale or hand-edited entry cannot crash the UI.
 
 ---
 

--- a/docs/_docs/other-guides/cueweb.md
+++ b/docs/_docs/other-guides/cueweb.md
@@ -65,6 +65,14 @@ Job actions: Unmonitor, Pause, Retry dead frames, Eat dead frames, Kill.
    - Selections combine with OR semantics; the table pages back to the first page on selection change so the filtered results are immediately visible.
    - The current selection is mirrored to the `frameStates` URL query parameter (e.g. `?frameStates=WAITING,DEAD`), making filtered views bookmarkable and shareable.
 
+14. **Per-job completion notifications:**
+   - The Jobs table includes a **Notify** column with a bell button per row. Clicking it subscribes the browser to a notification when the job reaches `FINISHED`.
+   - The bell has three visual states: outline (not subscribed), filled (subscribed/waiting), and filled with a green dot (notification has fired — click to clear).
+   - The bell is disabled on rows whose job state is already `FINISHED` when first viewed.
+   - The first subscribe of the session triggers the browser's native notification permission prompt; if permission is denied, a toast warning is shown and the subscription is not created.
+   - An app-wide background poller checks each subscribed job every 15 seconds. When a job reaches `FINISHED`, a single browser notification is fired via the Web Notifications API and the entry is marked as notified.
+   - Subscriptions are persisted in browser `localStorage` (key `cueweb:job-subscriptions`) and survive page reloads. Subscriptions to jobs that no longer exist in Cuebot are removed automatically on the next poll.
+
 ## CueWeb's user interface
 
 Upon logging in through Okta/Google/GitHub/LDAP or another authentication method configured using [NextAuth.js](https://next-auth.js.org/) (Figures 1 or 2), users are welcomed by CueWeb's main dashboard, as shown in Figure 3 (light mode) or Figure 4 (dark mode).  The CueWeb main page contains a paginated table that is populated with the OpenCue jobs. 

--- a/docs/_docs/quick-starts/quick-start-cueweb.md
+++ b/docs/_docs/quick-starts/quick-start-cueweb.md
@@ -154,6 +154,7 @@ The CueWeb interface includes:
 - **Layer Operations**: Manage job layers and dependencies
 - **Dark/Light Mode**: Toggle between themes
 - **Real-time Updates**: Automatic refresh of job status
+- **Job-finished Notifications**: Per-row bell button to subscribe to a browser notification when a job reaches `FINISHED`
 
 ---
 
@@ -179,6 +180,7 @@ The CueWeb interface includes:
 4. **Frame States**: Monitor frame progress with color-coded status
 5. **Frame State Filter Chips**: Use the chips above the frames table (`WAITING`, `RUNNING`, `SUCCEEDED`, `DEAD`, `EATEN`, `DEPEND`) — each shows a live count and toggles a filter. Multiple selections combine with OR and persist in the URL via `?frameStates=...`.
 6. **Job Progress Tooltip**: Hover the stacked progress bar in the Jobs table to see exact frame counts and percentages for each state.
+7. **Subscribe to Completion**: Click the bell in the **Notify** column of the Jobs table to receive a browser notification when the job reaches `FINISHED`. The first click prompts for browser notification permission and subscriptions persist across page reloads (stored in `localStorage`). A background poller checks each subscribed job every 15 seconds.
 
 ### Search Functionality
 

--- a/docs/_docs/reference/cueweb.md
+++ b/docs/_docs/reference/cueweb.md
@@ -158,6 +158,18 @@ The main jobs table displays rendering jobs with the following columns:
 | **Dead** | Failed frame count | Yes |
 | **Cores** | Reserved cores | Yes |
 | **Start Time** | Job start timestamp | Yes |
+| **Notify** | Per-row bell button to subscribe to a browser notification when the job reaches `FINISHED`. Three states: outline (not subscribed), filled (subscribed/waiting), filled with green dot (notification fired). Disabled on rows whose job state is already `FINISHED`. See [Job-finished notifications](#job-finished-notifications). | No |
+
+### Job-finished notifications
+
+| Behavior | Description |
+|----------|-------------|
+| **Trigger** | Click the bell in the **Notify** column. The first subscribe prompts for browser notification permission; denied permission shows a toast warning and does not create the subscription. |
+| **Polling** | An app-wide `JobSubscriptionPoller` provider polls each subscribed job's state every 15 seconds via the REST gateway. |
+| **Notification** | When a subscribed job's state becomes `FINISHED`, a single Web Notification (`<jobName>` / "Job finished") is fired and the entry is marked notified. |
+| **Persistence** | Subscriptions are stored in `localStorage` under `cueweb:job-subscriptions` and survive page reloads; cleared when the browser site data is cleared. |
+| **Auto-cleanup** | If a subscribed job no longer exists in Cuebot (the lookup returns null), the subscription is removed on the next poll. |
+| **Cross-component sync** | Mutations dispatch a `cueweb:subscriptions-changed` window event so the bell and poller stay in sync within the tab. |
 
 ### Job States
 

--- a/docs/_docs/tutorials/cueweb-tutorial.md
+++ b/docs/_docs/tutorials/cueweb-tutorial.md
@@ -84,6 +84,13 @@ The CueWeb interface consists of:
 
 4. **Inspect Per-state Progress**: Hover the progress bar in the **Progress** column to display a tooltip with the exact frame count and percentage for each state (succeeded, running, waiting, depend, dead).
 
+5. **Subscribe to Job Completion**: Click the bell in the **Notify** column to receive a browser notification when a job reaches `FINISHED`. The bell cycles through three visual states:
+   - Outline bell &rarr; not subscribed
+   - Filled bell &rarr; subscribed, waiting
+   - Filled bell with green dot &rarr; notification has fired (click to clear)
+
+   The first subscribe of the session prompts for browser notification permission. Subscriptions persist across page reloads via `localStorage` and a background poller checks each subscribed job every 15 seconds. The bell is disabled on jobs that are already `FINISHED` when first viewed.
+
 ### Understanding Job Status
 
 Jobs are color-coded for quick identification:
@@ -288,6 +295,7 @@ Customize the jobs table to show relevant information:
 ### Auto-refresh Settings
 
 * **Refresh Interval**: CueWeb uses a fixed 5-second update interval for all tables
+* **Job-finished Notifications**: Subscribe to specific jobs via the bell in the **Notify** column. A background poller checks each subscribed job every 15 seconds and fires a browser notification when the job reaches `FINISHED`. Subscriptions are stored in `localStorage` and survive page reloads.
 
 ### Monitoring Best Practices
 

--- a/docs/_docs/user-guides/cueweb-user-guide.md
+++ b/docs/_docs/user-guides/cueweb-user-guide.md
@@ -151,6 +151,7 @@ The dashboard consists of:
 | **Age** | Total time since job started (HHH:MM format) |
 | **Readable Age** | Same value as Age, formatted as `2h 14m` or `3d 4h` (hidden by default) |
 | **Progress** | Stacked progress bar with five colored segments — green (succeeded), yellow (running), light blue (waiting), purple (depend), and red (dead). Hover the bar to display a tooltip with the exact frame count and percentage for each state. |
+| **Notify** | Bell button to subscribe to a browser notification when the job reaches `FINISHED` (see [Job-finished notifications](#job-finished-notifications)) |
 | **Pop-up** | Button to open job details panel |
 
 ### Job Status Indicators
@@ -384,6 +385,23 @@ CueWeb provides automatic real-time updates:
 2. **All Tables**: Jobs, layers, and frames tables are auto-reloaded at regular intervals to display the latest data
 3. **Background Updates**: Continue updates when tab is not active
 4. **Performance Optimization**: Loading animations and virtualization optimize performance on slow connections
+
+### Job-finished notifications
+
+Each row in the jobs table has a bell button (the **Notify** column) that lets you subscribe to a browser notification when the job reaches `FINISHED`. The bell has three visual states:
+
+- **Outline bell**: not subscribed &rarr; click to subscribe
+- **Filled bell**: subscribed, waiting for `FINISHED` &rarr; click to cancel
+- **Filled bell + green dot**: notification has fired &rarr; click to clear
+
+Behavior:
+
+- The bell is disabled (faded, with tooltip) on jobs that are already `FINISHED` when first viewed; there is nothing to notify on.
+- The first time you subscribe, the browser shows its native permission prompt. If you deny permission, a toast warning is shown and the subscription is not created &mdash; re-enable browser notifications for the CueWeb origin to subscribe later.
+- A background poller checks each subscribed job every 15 seconds. When a job reaches `FINISHED` a single browser notification (`<jobName>` / "Job finished") is fired via the Web Notifications API, the bell switches to filled with a green dot, and the entry is marked as notified.
+- Notifications fire only while a CueWeb tab is open in the browser. They are delivered by the operating system, so they appear even when the CueWeb tab is in the background or another window has focus.
+- Subscriptions persist in browser `localStorage` (key `cueweb:job-subscriptions`) and survive page reloads. They are scoped to the browser and profile; clearing site data removes them.
+- If a subscribed job is deleted from Cuebot (the API returns null), the subscription is removed automatically on the next poll.
 
 ---
 


### PR DESCRIPTION
## Related Issues
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/2284

## Summarize your change.

PR #2335 added the per-job subscribe bell to the CueWeb Jobs table but shipped without doc updates. Add coverage across all cueweb doc surfaces that enumerate UI features, columns, or developer components so the feature is discoverable from every entry point.

- user-guides/cueweb-user-guide.md: Add Notify column to Job Information Columns and a Job-finished notifications subsection under Real-time Updates and Monitoring covering the three bell states, the permission prompt, the 15s poll cadence, localStorage persistence, and auto-cleanup of deleted jobs.
- developer-guide/cueweb-development.md: Register JobSubscriptionPoller under Core Components and SubscribeBell under UI Components; add a Subscription store note covering the cueweb:job-subscriptions key, the cueweb:subscriptions-changed event bus, and the defensive parser.
- reference/cueweb.md: Add Notify column to the Jobs Table and a behavior table covering trigger, polling, notification, persistence, auto-cleanup, and cross-component sync.
- quick-starts/quick-start-cueweb.md: Add Job-finished Notifications bullet to Expected Interface and step 7 to Frame Operations.
- tutorials/cueweb-tutorial.md: Add a Subscribe to Job Completion step to Viewing Your Jobs and a bullet to Auto-refresh Settings.
