### PR TITLE
[cuebot] Make Satisfy depend adhere to depend config

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dao/MaintenanceDao.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/MaintenanceDao.java
@@ -71,9 +71,12 @@ public interface MaintenanceDao {
      * failures.
      *
      * @param limit maximum number of depend IDs to return
+     * @param includeEatenAsComplete when true, EATEN frames count as completion alongside
+     *        SUCCEEDED; when false, only SUCCEEDED frames satisfy dependencies (matches the
+     *        {@code depend.satisfy_only_on_frame_success} runtime behavior)
      * @return list of pk_depend values for stale active depends
      */
-    List<String> findStaleDependIds(int limit);
+    List<String> findStaleDependIds(int limit, boolean includeEatenAsComplete);
 
     /**
      * Fixes frames stuck in DEPEND state by setting int_depend_count to 0 for frames that have no

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/MaintenanceDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/MaintenanceDaoJdbc.java
@@ -95,20 +95,29 @@ public class MaintenanceDaoJdbc extends JdbcDaoSupport implements MaintenanceDao
 
     // spotless:off
     /**
-     * Finds active, non-composite depends whose depended-upon entity has already completed
-     * successfully. Composite depends (b_composite = true) are parent depends that are
-     * automatically satisfied when all their child depends are satisfied, so they should
-     * not be resolved directly.
+     * Finds active, non-composite depends whose depended-upon entity has already completed.
+     * Composite depends (b_composite = true) are parent depends that are automatically
+     * satisfied when all their child depends are satisfied, so they should not be resolved
+     * directly.
      *
-     * Section 1: Job-level depends (JOB_ON_JOB, LAYER_ON_JOB, FRAME_ON_JOB) where
-     *   every frame in the depended-upon job has SUCCEEDED or been EATEN.
+     * The set of frame states that count as completion is selected by
+     * {@code includeEatenAsComplete}: SUCCEEDED only, or SUCCEEDED+EATEN. This mirrors the
+     * runtime behavior gated by {@code depend.satisfy_only_on_frame_success} in
+     * {@code FrameCompleteHandler}.
+     *
+     * Section 1: Job-level depends (JOB_ON_JOB, LAYER_ON_JOB, FRAME_ON_JOB) where every
+     *   frame in the depended-upon job is in a completion state.
      * Section 2: Layer-level depends (JOB_ON_LAYER, LAYER_ON_LAYER, FRAME_ON_LAYER) where
-     *   every frame in the depended-upon layer has SUCCEEDED or been EATEN.
+     *   every frame in the depended-upon layer is in a completion state.
      * Section 3: Frame-level depends (JOB_ON_FRAME, LAYER_ON_FRAME, FRAME_ON_FRAME) where
-     *   the specific depended-upon frame has SUCCEEDED or been EATEN.
+     *   the specific depended-upon frame is in a completion state.
      */
-    private static final String FIND_STALE_DEPEND_IDS =
-            // Section 1: Job-level depends where all frames in the job succeeded or were eaten.
+    private static String buildFindStaleDependIdsSql(boolean includeEatenAsComplete) {
+        String completeStates = includeEatenAsComplete
+                ? "('SUCCEEDED', 'EATEN')"
+                : "('SUCCEEDED')";
+        return
+            // Section 1: Job-level depends where all frames in the job completed.
             // Pre-filter on job.str_state = 'FINISHED' leverages the i_job_str_state index to
             // skip depends on active jobs. A FINISHED job may still have DEAD frames, so we
             // also verify frame states via NOT EXISTS.
@@ -122,11 +131,11 @@ public class MaintenanceDaoJdbc extends JdbcDaoSupport implements MaintenanceDao
             + "AND NOT EXISTS ("
                 + "SELECT 1 FROM frame f "
                 + "WHERE f.pk_job = d.pk_job_depend_on "
-                + "AND f.str_state NOT IN ('SUCCEEDED', 'EATEN')) "
+                + "AND f.str_state NOT IN " + completeStates + ") "
 
             + "UNION ALL "
 
-            // Section 2: Layer-level depends where all frames in the layer succeeded or were eaten.
+            // Section 2: Layer-level depends where all frames in the layer completed.
             + "SELECT pk_depend FROM depend d "
             + "WHERE d.b_active = true "
             + "AND d.b_composite = false "
@@ -135,11 +144,11 @@ public class MaintenanceDaoJdbc extends JdbcDaoSupport implements MaintenanceDao
             + "AND NOT EXISTS ("
                 + "SELECT 1 FROM frame f "
                 + "WHERE f.pk_layer = d.pk_layer_depend_on "
-                + "AND f.str_state NOT IN ('SUCCEEDED', 'EATEN')) "
+                + "AND f.str_state NOT IN " + completeStates + ") "
 
             + "UNION ALL "
 
-            // Section 3: Frame-level depends where the specific frame succeeded or was eaten.
+            // Section 3: Frame-level depends where the specific frame completed.
             + "SELECT pk_depend FROM depend d "
             + "WHERE d.b_active = true "
             + "AND d.b_composite = false "
@@ -148,14 +157,22 @@ public class MaintenanceDaoJdbc extends JdbcDaoSupport implements MaintenanceDao
             + "AND EXISTS ("
                 + "SELECT 1 FROM frame f "
                 + "WHERE f.pk_frame = d.pk_frame_depend_on "
-                + "AND f.str_state IN ('SUCCEEDED', 'EATEN')) "
+                + "AND f.str_state IN " + completeStates + ") "
 
             + "LIMIT ?";
+    }
+
+    private static final String FIND_STALE_DEPEND_IDS_INCLUDING_EATEN =
+            buildFindStaleDependIdsSql(true);
+    private static final String FIND_STALE_DEPEND_IDS_SUCCEEDED_ONLY =
+            buildFindStaleDependIdsSql(false);
     // spotless:on
 
     @Override
-    public List<String> findStaleDependIds(int limit) {
-        return getJdbcTemplate().queryForList(FIND_STALE_DEPEND_IDS, String.class, limit);
+    public List<String> findStaleDependIds(int limit, boolean includeEatenAsComplete) {
+        String sql = includeEatenAsComplete ? FIND_STALE_DEPEND_IDS_INCLUDING_EATEN
+                : FIND_STALE_DEPEND_IDS_SUCCEEDED_ONLY;
+        return getJdbcTemplate().queryForList(sql, String.class, limit);
     }
 
     // spotless:off

--- a/cuebot/src/main/java/com/imageworks/spcue/service/MaintenanceManagerSupport.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/service/MaintenanceManagerSupport.java
@@ -272,9 +272,14 @@ public class MaintenanceManagerSupport {
         try {
             int batchSize = env.getProperty("maintenance.stuck_dependency_recovery_batch_size",
                     Integer.class, 1000);
+            // Mirror FrameCompleteHandler's runtime behavior: when this flag is true (default)
+            // EATEN frames must not satisfy dependencies, so they are excluded from the sweep.
+            boolean satisfyOnlyOnFrameSuccess =
+                    env.getProperty("depend.satisfy_only_on_frame_success", Boolean.class, true);
 
             // Phase 1: Satisfy stale active depends through normal code path
-            List<String> staleDependIds = maintenanceDao.findStaleDependIds(batchSize);
+            List<String> staleDependIds =
+                    maintenanceDao.findStaleDependIds(batchSize, !satisfyOnlyOnFrameSuccess);
             int satisfiedCount = 0;
             for (String dependId : staleDependIds) {
                 try {


### PR DESCRIPTION
The satisfy logic that runs to clean up stale depends would catch both EATEN and SUCCESS frames as a sign its dependents should be cleaned, but this behavior is only acceptable when `depend.satisfy_only_on_frame_success` is false.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `depend.satisfy_only_on_frame_success` configuration flag to control how EATEN frames are treated during dependency recovery. When enabled (default), only SUCCEEDED frames satisfy dependencies; when disabled, EATEN frames also count as completion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AcademySoftwareFoundation/OpenCue/pull/2352?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->