### PR TITLE
[cuegui] Revert a portion of #2370

### DIFF
--- a/cuegui/cuegui/CueJobMonitorTree.py
+++ b/cuegui/cuegui/CueJobMonitorTree.py
@@ -25,6 +25,8 @@ from builtins import map
 from collections import namedtuple
 import time
 
+import grpc
+
 from qtpy import QtCore
 from qtpy import QtGui
 from qtpy import QtWidgets
@@ -424,6 +426,9 @@ class CueJobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         updated item ideas"""
         self.currtime = time.time()
         allIds = []
+        # Return a non-None result on any failure so the success-path emit in ThreadPool still
+        # fires and _processUpdateGuarded clears _updateInFlight. Letting an exception escape
+        # would leave the guard pinned and block all future refresh ticks.
         try:
             groups = [show.getJobWhiteboard() for show in self.getShows()]
             nestedGroups = []
@@ -438,6 +443,21 @@ class CueJobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
                 # pylint: enable=no-value-for-parameter
         except opencue.exception.CueException as e:
             list(map(logger.warning, cuegui.Utils.exceptionOutput(e)))
+            return None
+        except grpc.RpcError as e:
+            # pylint: disable=no-member
+            if hasattr(e, 'code') and e.code() in (grpc.StatusCode.CANCELLED,
+                                                   grpc.StatusCode.UNAVAILABLE):
+                logger.warning("gRPC connection issue fetching job whiteboard: %s - "
+                               "UI will retry on next update", e.details())
+            else:
+                logger.error("gRPC error fetching job whiteboard: %s", e)
+            # pylint: enable=no-member
+            return None
+        # pylint: disable=broad-except
+        except Exception:
+            logger.warning("Unexpected error fetching job whiteboard; "
+                           "UI will retry on next update", exc_info=True)
             return None
 
         return [nestedGroups, allIds]

--- a/cuegui/cuegui/CueJobMonitorTree.py
+++ b/cuegui/cuegui/CueJobMonitorTree.py
@@ -426,10 +426,10 @@ class CueJobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         updated item ideas"""
         self.currtime = time.time()
         allIds = []
-        # Return a result (even if None) rather than letting exceptions escape, so the 
-        # success-path emit in ThreadPool still fires and _processUpdateGuarded clears 
-        # _updateInFlight. Letting an exception escape would leave the guard pinned and 
-        # block all future refresh ticks.
+        # Return a non-None result on any failure so the success-path emit in
+        # ThreadPool still fires and _processUpdateGuarded clears
+        # _updateInFlight. Letting an exception escape would leave the guard
+        # pinned and block all future refresh ticks.
         try:
             groups = [show.getJobWhiteboard() for show in self.getShows()]
             nestedGroups = []

--- a/cuegui/cuegui/CueJobMonitorTree.py
+++ b/cuegui/cuegui/CueJobMonitorTree.py
@@ -426,9 +426,10 @@ class CueJobMonitorTree(cuegui.AbstractTreeWidget.AbstractTreeWidget):
         updated item ideas"""
         self.currtime = time.time()
         allIds = []
-        # Return a non-None result on any failure so the success-path emit in ThreadPool still
-        # fires and _processUpdateGuarded clears _updateInFlight. Letting an exception escape
-        # would leave the guard pinned and block all future refresh ticks.
+        # Return a result (even if None) rather than letting exceptions escape, so the 
+        # success-path emit in ThreadPool still fires and _processUpdateGuarded clears 
+        # _updateInFlight. Letting an exception escape would leave the guard pinned and 
+        # block all future refresh ticks.
         try:
             groups = [show.getJobWhiteboard() for show in self.getShows()]
             nestedGroups = []

--- a/cuegui/cuegui/ThreadPool.py
+++ b/cuegui/cuegui/ThreadPool.py
@@ -206,16 +206,14 @@ class ThreadPool(QtCore.QObject):
                 if not work:
                     continue
 
-                # The callback MUST fire (with None on failure) whenever a
-                # callback was supplied. Some callers rely on the callback to
-                # clear in-flight guards; swallowing the emit on error would
-                # pin those guards forever.
-                result = None
                 try:
                     if work[3]:
                         result = work[0](*work[3])
                     else:
                         result = work[0]()
+                    if work[1]:
+                        self.workComplete.emit(work, result)
+                        del result
                 except grpc.RpcError as e:
                     # Handle gRPC errors gracefully - these are often transient
                     # pylint: disable=no-member
@@ -234,9 +232,6 @@ class ThreadPool(QtCore.QObject):
                     logger.error("RuntimeError in work processing for '%s': %s", work[2], e)
                 except Exception as e:
                     logger.error("Unexpected error processing work for '%s': %s", work[2], e)
-                finally:
-                    if work[1]:
-                        self.workComplete.emit(work, result)
 
                 logger.info("Done:' %s '", work[2])
             logger.debug("Thread Stopping")


### PR DESCRIPTION
For some unknown reason, this change was resulting on a Segmentation Fault when a combination of unrelated factors were involved. For now this PR simple reverts the previous version in an effort to avoid crashes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stopped emitting completion signals for tasks that fail, preventing failed background jobs from appearing as completed and avoiding premature cleanup of job state.
  * Improved background fetch error handling with clearer logging, distinct handling for transient RPC errors, and ensured failed fetches return safely so they are retried on the next update tick.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AcademySoftwareFoundation/OpenCue/pull/2378?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->