### PR TITLE
[cueweb] Host and Allocation Management: Hosts monitor page (#2292)

### DIFF
--- a/cueweb/app/__tests__/hosts/host_format_utils.test.ts
+++ b/cueweb/app/__tests__/hosts/host_format_utils.test.ts
@@ -1,0 +1,34 @@
+import { kbStringToHuman, kbStringToNumber, idleRatio } from "@/app/hosts/host_format_utils";
+
+describe("host_format_utils", () => {
+  describe("kbStringToNumber", () => {
+    it("parses a numeric KB string", () => {
+      expect(kbStringToNumber("6815744")).toBe(6815744);
+    });
+    it("returns 0 for non-numeric or empty input", () => {
+      expect(kbStringToNumber("")).toBe(0);
+      expect(kbStringToNumber("abc")).toBe(0);
+      expect(kbStringToNumber(undefined as unknown as string)).toBe(0);
+    });
+  });
+
+  describe("kbStringToHuman", () => {
+    it("formats KB strings to a human unit", () => {
+      expect(kbStringToHuman("6815744")).toBe("6.5G");
+      expect(kbStringToHuman("512")).toBe("512K");
+    });
+    it("renders a dash for non-numeric input", () => {
+      expect(kbStringToHuman("abc")).toBe("-");
+      expect(kbStringToHuman("")).toBe("-");
+    });
+  });
+
+  describe("idleRatio", () => {
+    it("returns idle / total as a 0..1 ratio", () => {
+      expect(idleRatio(4, 8)).toBe(0.5);
+    });
+    it("returns 0 when total is 0 to avoid divide-by-zero", () => {
+      expect(idleRatio(0, 0)).toBe(0);
+    });
+  });
+});

--- a/cueweb/app/hosts/columns.tsx
+++ b/cueweb/app/hosts/columns.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+/*
+ * Copyright Contributors to the OpenCue Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ColumnDef } from "@tanstack/react-table";
+import { ArrowUpDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Status } from "@/components/ui/status";
+import { Host } from "@/app/utils/get_utils";
+import { idleRatio, kbStringToHuman, kbStringToNumber } from "@/app/hosts/host_format_utils";
+
+// Shared sortable header button, matching the jobs/columns.tsx pattern.
+function sortableHeader(label: string) {
+  // eslint-disable-next-line react/display-name
+  return ({ column }: { column: any }) => (
+    <Button
+      variant="ghost"
+      size="sm"
+      className="-mx-2 h-7 px-1.5 text-xs font-medium"
+      onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+    >
+      {label}
+      <ArrowUpDown className="ml-1 h-3 w-3 opacity-60" />
+    </Button>
+  );
+}
+
+export const hostColumns: ColumnDef<Host>[] = [
+  {
+    accessorKey: "name",
+    header: sortableHeader("Name"),
+    cell: ({ row }) => <span>{row.original.name}</span>,
+  },
+  {
+    accessorKey: "state",
+    header: sortableHeader("State"),
+    cell: ({ row }) => <Status status={row.original.state} />,
+  },
+  {
+    accessorKey: "lockState",
+    id: "locked",
+    header: sortableHeader("Locked"),
+    cell: ({ row }) => <Status status={row.original.lockState} />,
+  },
+  {
+    accessorKey: "nimbyEnabled",
+    id: "nimby",
+    header: sortableHeader("NIMBY"),
+    cell: ({ row }) => <span>{row.original.nimbyEnabled ? "Yes" : "No"}</span>,
+  },
+  {
+    id: "cores",
+    header: sortableHeader("Cores (Idle/Total)"),
+    // Sort by idle ratio so "most free" sorts together regardless of host size.
+    accessorFn: (h) => idleRatio(h.idleCores, h.cores),
+    cell: ({ row }) => (
+      <span>
+        {row.original.idleCores.toFixed(2)} / {row.original.cores.toFixed(2)}
+      </span>
+    ),
+  },
+  {
+    id: "memory",
+    header: sortableHeader("Memory (Idle/Total)"),
+    // Sort by idle bytes (numeric), not the formatted string.
+    accessorFn: (h) => kbStringToNumber(h.idleMemory),
+    cell: ({ row }) => (
+      <span>
+        {kbStringToHuman(row.original.idleMemory)} / {kbStringToHuman(row.original.totalMemory)}
+      </span>
+    ),
+  },
+  {
+    id: "freeMcp",
+    header: sortableHeader("Free /mcp"),
+    accessorFn: (h) => kbStringToNumber(h.freeMcp),
+    cell: ({ row }) => <span>{kbStringToHuman(row.original.freeMcp)}</span>,
+  },
+];

--- a/cueweb/app/hosts/host_format_utils.ts
+++ b/cueweb/app/hosts/host_format_utils.ts
@@ -27,7 +27,9 @@ export function kbStringToNumber(kb: string): number {
 // Returns "-" for values that aren't a parseable positive number.
 export function kbStringToHuman(kb: string): string {
   const n = Number(kb);
-  if (!Number.isFinite(n) || kb === "" || kb === undefined || kb === null) {
+  // Number("") === 0 (finite), so guard the empty string explicitly to show
+  // "-" (no data) rather than "0K".
+  if (kb === "" || !Number.isFinite(n)) {
     return "-";
   }
   return convertMemoryToString(n, "host");

--- a/cueweb/app/hosts/host_format_utils.ts
+++ b/cueweb/app/hosts/host_format_utils.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Contributors to the OpenCue Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { convertMemoryToString } from "@/app/utils/layers_frames_utils";
+
+// The gateway returns memory / mcp sizes as KB in string form (e.g. "6815744").
+// Parse defensively: anything non-numeric becomes 0 so callers never NaN.
+export function kbStringToNumber(kb: string): number {
+  const n = Number(kb);
+  return Number.isFinite(n) ? n : 0;
+}
+
+// Human-readable size for a KB string, reusing the shared memory formatter.
+// Returns "-" for values that aren't a parseable positive number.
+export function kbStringToHuman(kb: string): string {
+  const n = Number(kb);
+  if (!Number.isFinite(n) || kb === "" || kb === undefined || kb === null) {
+    return "-";
+  }
+  return convertMemoryToString(n, "host");
+}
+
+// idle / total guarded against divide-by-zero; used as a numeric sort key.
+export function idleRatio(idle: number, total: number): number {
+  if (!total) return 0;
+  return idle / total;
+}

--- a/cueweb/app/hosts/page.tsx
+++ b/cueweb/app/hosts/page.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+/*
+ * Copyright Contributors to the OpenCue Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+import { Server } from "lucide-react";
+import { Host, getHosts } from "@/app/utils/get_utils";
+import { hostColumns } from "@/app/hosts/columns";
+import { SimpleDataTable } from "@/components/ui/simple-data-table";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const REFRESH_MS = 30000;
+
+export default function HostsPage() {
+  const [hosts, setHosts] = React.useState<Host[] | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const load = React.useCallback(async () => {
+    try {
+      const data = await getHosts();
+      setHosts(data);
+      setError(null);
+    } catch (err) {
+      // getHosts already toasts via handleError; keep any previously loaded
+      // rows on a failed poll and surface an inline message only when we have
+      // nothing to show.
+      setError(err instanceof Error ? err.message : String(err));
+      setHosts((prev) => prev ?? []);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    load();
+    const interval = setInterval(load, REFRESH_MS);
+    return () => clearInterval(interval);
+  }, [load]);
+
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-lg font-semibold">Monitor Hosts</h1>
+
+      {hosts === null ? (
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-full" />
+          <Skeleton className="h-8 w-full" />
+          <Skeleton className="h-8 w-full" />
+        </div>
+      ) : (
+        <>
+          {error && hosts.length === 0 ? (
+            <div className="mb-3 flex items-center gap-3 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm">
+              <span>Could not load hosts from Cuebot.</span>
+              <Button size="sm" variant="outline" onClick={() => load()}>
+                Retry
+              </Button>
+            </div>
+          ) : null}
+          <SimpleDataTable
+            columns={hostColumns}
+            data={hosts}
+            username=""
+            disableContextMenu
+            filterPlaceholder="Filter hosts..."
+            emptyState={
+              <EmptyState
+                icon={<Server className="h-6 w-6" aria-hidden="true" />}
+                title="No hosts registered"
+                description="No hosts have reported to Cuebot yet."
+              />
+            }
+            columnVisibilityStorageKey="cueweb.hosts.columnVisibility"
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/cueweb/app/hosts/page.tsx
+++ b/cueweb/app/hosts/page.tsx
@@ -46,10 +46,28 @@ export default function HostsPage() {
   }, []);
 
   React.useEffect(() => {
-    load();
-    const interval = setInterval(load, REFRESH_MS);
-    return () => clearInterval(interval);
-  }, [load]);
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const data = await getHosts();
+        if (!cancelled) {
+          setHosts(data);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+          setHosts((prev) => prev ?? []);
+        }
+      }
+    };
+    poll();
+    const interval = setInterval(poll, REFRESH_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
 
   return (
     <div className="p-4">

--- a/cueweb/app/utils/get_utils.ts
+++ b/cueweb/app/utils/get_utils.ts
@@ -37,8 +37,15 @@ export type JobComment = {
 export type Host = {
     id: string;
     name: string;
-    state: string;
-    lockState: string;
+    state: string;        // UP / DOWN / REPAIR ...
+    lockState: string;    // OPEN / LOCKED / NIMBY_LOCKED
+    nimbyEnabled: boolean;
+    cores: number;
+    idleCores: number;
+    memory: string;       // KB, as string from the gateway
+    idleMemory: string;   // KB, as string
+    totalMemory: string;  // KB, as string
+    freeMcp: string;      // KB, as string
     bootTime: number;
     pingTime: number;
 };

--- a/cueweb/components/ui/simple-data-table.tsx
+++ b/cueweb/components/ui/simple-data-table.tsx
@@ -88,6 +88,15 @@ interface SimpleDataTableProps<TData, TValue> {
   // Columns dropdown. Typically a section title with a row count, e.g.
   // <span>Layers [Total Count: 3]</span>.
   toolbarLeft?: React.ReactNode;
+  // When true, this table renders no row context menu (read-only tables such
+  // as the hosts page). Frames/layers callers leave it false and keep theirs.
+  disableContextMenu?: boolean;
+  // Override the substring-filter placeholder. Defaults to the frames/layers
+  // wording when omitted.
+  filterPlaceholder?: string;
+  // Override the empty-table content. Defaults to the frames/layers EmptyState
+  // when omitted.
+  emptyState?: React.ReactNode;
 }
 
 export function SimpleDataTable<TData, TValue>({
@@ -103,6 +112,9 @@ export function SimpleDataTable<TData, TValue>({
   onRowClick,
   selectedRowId,
   toolbarLeft,
+  disableContextMenu = false,
+  filterPlaceholder,
+  emptyState,
 }: SimpleDataTableProps<TData, TValue>) {
   const [sorting, setSorting] = React.useState<SortingState>([]);
 
@@ -498,8 +510,8 @@ export function SimpleDataTable<TData, TValue>({
               type="search"
               value={globalFilter}
               onChange={(e) => setGlobalFilter(e.target.value)}
-              placeholder={isFramesTable ? "Filter frames..." : "Filter layers..."}
-              aria-label={isFramesTable ? "Filter frames" : "Filter layers"}
+              placeholder={filterPlaceholder ?? (isFramesTable ? "Filter frames..." : "Filter layers...")}
+              aria-label={filterPlaceholder ?? (isFramesTable ? "Filter frames" : "Filter layers")}
               className="h-8 w-44 pl-7 pr-7 text-xs"
             />
             {globalFilter ? (
@@ -566,7 +578,7 @@ export function SimpleDataTable<TData, TValue>({
                     data-state={
                       isSelectedById || row.getIsSelected() ? "selected" : undefined
                     }
-                    onContextMenu={(e) => contextMenuHandleOpen(e, row)}
+                    onContextMenu={disableContextMenu ? undefined : (e) => contextMenuHandleOpen(e, row)}
                     onClick={
                       onRowClick
                         ? () => onRowClick(row.original as TData)
@@ -602,23 +614,25 @@ export function SimpleDataTable<TData, TValue>({
             ) : (
               <TableRow>
                 <TableCell colSpan={columns.length} className="h-32 p-0">
-                  <EmptyState
-                    icon={<Layers className="h-6 w-6" aria-hidden="true" />}
-                    title={
-                      isFramesTable
-                        ? "Layer has no frames"
-                        : isFramesLogTable
-                          ? "Frame not found"
-                          : "Job has no layers"
-                    }
-                    description={
-                      isFramesTable
-                        ? "No frames matched the current filter. Clear the frame-state chips above to see every frame."
-                        : isFramesLogTable
-                          ? "The frame referenced by this URL is no longer available in Cuebot."
-                          : "This job does not contain any layers yet."
-                    }
-                  />
+                  {emptyState ?? (
+                    <EmptyState
+                      icon={<Layers className="h-6 w-6" aria-hidden="true" />}
+                      title={
+                        isFramesTable
+                          ? "Layer has no frames"
+                          : isFramesLogTable
+                            ? "Frame not found"
+                            : "Job has no layers"
+                      }
+                      description={
+                        isFramesTable
+                          ? "No frames matched the current filter. Clear the frame-state chips above to see every frame."
+                          : isFramesLogTable
+                            ? "The frame referenced by this URL is no longer available in Cuebot."
+                            : "This job does not contain any layers yet."
+                      }
+                    />
+                  )}
                 </TableCell>
               </TableRow>
             )}
@@ -635,8 +649,9 @@ export function SimpleDataTable<TData, TValue>({
         </div>
       )}
 
-      {/* Context menus for frames and layers */}
-      {(isFramesTable || isFramesLogTable) ? (
+      {/* Context menus for frames and layers. Read-only tables (e.g. hosts)
+          opt out via disableContextMenu and render no menu. */}
+      {disableContextMenu ? null : (isFramesTable || isFramesLogTable) ? (
         <FrameContextMenu
           username={username}
           job={job}


### PR DESCRIPTION
## Related Issues

Fixes #2292

This also unblocks the sibling Host & Allocation Management issues that need a host listing surface to build on: #2296 (host tag editor), #2293 (lock/unlock), #2294 (reboot), #2295 (host detail page).

## Summarize your change.

Adds the `/hosts` route — a Monitor Hosts page for CueWeb, the web equivalent of CueGUI's CueCommander → Monitor Hosts. CueWeb previously had no hosts page (the sidebar `/hosts` link 404'd); this provides the basic sortable table the issue asks for.

**What it does:**
- New `/hosts` page that loads hosts via the existing `getHosts()` proxy and auto-refreshes every 30s.
- Sortable, filterable table with columns: Name, State, Locked, NIMBY, Cores (Idle/Total), Memory (Idle/Total), Free /mcp. Numeric columns sort by their underlying numeric value, not the formatted display string. State/Locked reuse the existing `Status` badge.
- Loading (skeletons), empty ("No hosts registered"), and error (inline message + Retry) states.

**Implementation notes:**
- `Host` type widened to include the fields the table needs (the REST gateway already returns them; memory/mcp arrive as KB-in-string, so there are small parse/format helpers with unit tests).
- The shared `SimpleDataTable` (used by jobs/layers/frames) gains **three backward-compatible optional props** so a read-only table can reuse it: `disableContextMenu` (render no row context menu), `filterPlaceholder`, and `emptyState`. All default to the existing frames/layers behavior, so current call sites are unchanged — verified by the full existing test suite still passing (48/48).

**Why idle/total (not used/total):** the issue text says "used/total", but the backend and CueGUI's Monitor Hosts both expose idle vs total, so the columns show and are labeled "(Idle/Total)" to stay faithful to the data source.

**Scope:** read-only by design. Host actions (lock/unlock, tag edit, reboot, NIMBY toggle) and server-side filtering belong to the sibling issues and are intentionally out of scope here.

**Testing:** added Jest unit tests for the formatting/sort helpers; manually verified against the local sandbox (page loads the rqd hosts, sorting and filtering work, 30s refresh, and the existing jobs/layers/frames tables are unaffected by the `SimpleDataTable` change).

## LLM usage disclosure

Claude (Opus) was used to help explore the existing CueWeb/CueGUI patterns, draft the implementation, and write the unit tests, with the changes reviewed and verified locally.
