### PR TITLE
[cuegui] Fix crash when closing preview dialog before images are ready

### DIFF
--- a/cuegui/cuegui/PreviewWidget.py
+++ b/cuegui/cuegui/PreviewWidget.py
@@ -145,9 +145,19 @@ class PreviewProcessorDialog(QtWidgets.QDialog):
         return name
 
     def __close(self, event):
-        """Close preview thread"""
+        """Stop the preview thread and wait for it to finish before the dialog
+        is destroyed.
+
+        Closing the dialog while the watch thread is still running would destroy
+        the QThread mid-execution, which Qt treats as a fatal error
+        ("QThread: Destroyed while thread is still running") and aborts the
+        whole application. Signalling the thread to stop and blocking until it
+        actually exits avoids that crash.
+        """
         del event
-        self.__previewThread.terminate = True
+        if self.__previewThread is not None:
+            self.__previewThread.stop()
+            self.__previewThread.wait()
 
     def __findHttpPort(self):
         """Figure out what port is being used by the tool to write previews"""
@@ -194,11 +204,17 @@ class PreviewProcessorWatchThread(QtCore.QThread):
             self.existCountChanged.emit(count, len(self.__items))
             if count == len(self.__items):
                 break
-            time.sleep(1)
             if time.time() > self.__timeout + start_time:
                 self.timeout.emit()
                 logger.warning('Timed out waiting for preview server.')
                 break
+            # Sleep in small slices so the thread reacts to stop() promptly
+            # (e.g. when the dialog is closed) instead of blocking for a full
+            # second, which would briefly freeze the GUI while it waits to exit.
+            for _ in range(10):
+                if self.terminate:
+                    break
+                time.sleep(0.1)
 
     def stop(self):
         """Stop the preview capture thread"""


### PR DESCRIPTION
## Related Issues
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/2396

## Summarize your change.

- Closing the "Waiting for preview images..." dialog before the preview images were ready crashed the app with "QThread: Destroyed while thread is still running" / Aborted.
- The close handler only set the watch thread's terminate flag without waiting for the QThread to exit, so the thread (parented to the dialog) was destroyed mid-execution, which Qt treats as a fatal error.
- Fix PreviewProcessorDialog.__close to stop the thread and wait() for it to finish before the dialog is destroyed, and guard against the thread not yet existing.
- Make PreviewProcessorWatchThread.run sleep in small slices so it reacts to stop() promptly instead of freezing the GUI for up to a second, and move the timeout check before the sleep.