### PR TITLE
[scheduler] Add scheduling mode: E-PVM

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatchQuery.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/DispatchQuery.java
@@ -1243,7 +1243,8 @@ public class DispatchQuery {
 
     /**
      * Looks for shows that are under their burst for a particular type of proc. The show has to be
-     * at least one whole proc under their burst to be considered for booking.
+     * at least one whole proc under their burst to be considered for booking. Scheduler-managed
+     * shows are excluded; their dispatch is owned by the standalone Rust scheduler.
      */
     // spotless:off
     public static final String FIND_SHOWS =

--- a/rust/config/scheduler.yaml
+++ b/rust/config/scheduler.yaml
@@ -151,15 +151,92 @@ queue:
   #   # Default: 3
   #   job_buffer_size: 3
 
-  # Host booking strategy configuration
-  # host_booking_strategy:
-  #   # Enable core saturation booking
-  #   # Default: true
-  #   core_saturation: true
+  # ---------------------------------------------------------------------------
+  # Host booking strategy. Two variants:
   #
-  #   # Enable memory saturation booking
-  #   # Default: false
+  # Saturation (default) — legacy first-fit. Saturation flags control B-tree
+  # iteration direction (saturated-first vs spread-first per dimension).
+  # host_booking_strategy:
+  #   type: saturation
+  #   core_saturation: true
   #   memory_saturation: false
+  #
+  # Epvm — E-PVM stranding score; picks the lowest-scoring host among up to
+  # `max_candidates` scanned. Iteration is always saturated-first under Epvm,
+  # independent of the Saturation flags. `weights` express per-dimension
+  # importance ratios (W3 normalization, see scheduler design doc).
+  # host_booking_strategy:
+  #   type: epvm
+  #   max_candidates: 500
+  #   weights:
+  #     cores: 1.0
+  #     mem: 1.0
+  #     gpus: 2.0
+  #     gpu_mem: 1.0
+  #     gpu_reservation: 2.0
+  #
+  # --- gpu_reservation (soft-reservation penalty) ----------------------------
+  # Applied ONLY when the layer requests no GPUs (gpus_min == 0). It penalizes
+  # GPU hosts proportional to their idle GPU capacity (idle GPU count + idle
+  # GPU memory in GB), nudging non-GPU work onto non-GPU hosts. Unlike the
+  # other weights, this scales a raw capacity term (not a normalized stranding
+  # term) — 1.0 means "1 idle GPU or 1GB idle GPU memory contributes 1 score
+  # unit". A typical setting is 2.0: strong enough to push GPU hosts behind
+  # non-GPU hosts for non-GPU work, weak enough not to swamp the cores/mem
+  # stranding signal.
+  #
+  # --- Example: equal-weight baseline ----------------------------------------
+  # Cores and memory stranding count equally; GPU dimensions count slightly
+  # more; non-GPU work mildly prefers non-GPU hosts. Matches the defaults.
+  # host_booking_strategy:
+  #   type: epvm
+  #   max_candidates: 500
+  #   weights:
+  #     cores: 1.0
+  #     mem: 1.0
+  #     gpus: 2.0
+  #     gpu_mem: 1.0
+  #     gpu_reservation: 2.0
+  #
+  # --- Example: GPU-scarce farm ----------------------------------------------
+  # Protect GPU hosts aggressively for GPU work and make GPU stranding very
+  # expensive (don't waste a GPU on a low-GPU layer).
+  # host_booking_strategy:
+  #   type: epvm
+  #   max_candidates: 500
+  #   weights:
+  #     cores: 1.0
+  #     mem: 1.0
+  #     gpus: 8.0
+  #     gpu_mem: 2.0
+  #     gpu_reservation: 5.0
+  #
+  # --- Example: memory-tight farm --------------------------------------------
+  # Penalize memory stranding more than cores so jobs with high mem:core
+  # ratios go to high-memory hosts first.
+  # host_booking_strategy:
+  #   type: epvm
+  #   max_candidates: 500
+  #   weights:
+  #     cores: 1.0
+  #     mem: 3.0
+  #     gpus: 2.0
+  #     gpu_mem: 1.0
+  #     gpu_reservation: 2.0
+  #
+  # --- Example: cores-only (debugging sanity check) --------------------------
+  # Scoring degenerates to "pack cores tightest" — useful for diagnosing
+  # whether other dimensions are responsible for a placement regression.
+  # host_booking_strategy:
+  #   type: epvm
+  #   max_candidates: 500
+  #   weights:
+  #     cores: 1.0
+  #     mem: 0.0
+  #     gpus: 0.0
+  #     gpu_mem: 0.0
+  #     gpu_reservation: 0.0
+  # ---------------------------------------------------------------------------
 
   # Soft memory limit multiplier for frame memory requirements
   # Used as a threshold to determine if a frame can be dispatched based on available memory

--- a/rust/config/scheduler.yaml
+++ b/rust/config/scheduler.yaml
@@ -173,17 +173,23 @@ queue:
   #     mem: 1.0
   #     gpus: 2.0
   #     gpu_mem: 1.0
-  #     gpu_reservation: 2.0
+  #     gpu_count_reservation: 2.0
+  #     gpu_mem_reservation: 2.0
   #
-  # --- gpu_reservation (soft-reservation penalty) ----------------------------
-  # Applied ONLY when the layer requests no GPUs (gpus_min == 0). It penalizes
-  # GPU hosts proportional to their idle GPU capacity (idle GPU count + idle
-  # GPU memory in GB), nudging non-GPU work onto non-GPU hosts. Unlike the
-  # other weights, this scales a raw capacity term (not a normalized stranding
-  # term) — 1.0 means "1 idle GPU or 1GB idle GPU memory contributes 1 score
-  # unit". A typical setting is 2.0: strong enough to push GPU hosts behind
-  # non-GPU hosts for non-GPU work, weak enough not to swamp the cores/mem
-  # stranding signal.
+  # --- gpu_*_reservation (soft-reservation penalty) --------------------------
+  # Applied ONLY when the layer requests no GPUs (gpus_min == 0). Penalizes GPU
+  # hosts to nudge non-GPU work onto non-GPU hosts. The penalty is split into
+  # two independent knobs so operators control the count-vs-memory balance:
+  #
+  #   penalty = gpu_count_reservation * idle_gpus
+  #           + gpu_mem_reservation   * idle_gpu_memory_gb
+  #
+  # Unlike the stranding weights these scale raw capacity (not a normalized
+  # stranding term). A typical default is 2.0/2.0 — strong enough to push GPU
+  # hosts behind non-GPU hosts for non-GPU work, weak enough not to swamp the
+  # cores/mem stranding signal. On hosts with a lot of GPU memory the mem
+  # penalty will tend to dominate; raise `gpu_count_reservation` (or lower
+  # `gpu_mem_reservation`) to rebalance.
   #
   # --- Example: equal-weight baseline ----------------------------------------
   # Cores and memory stranding count equally; GPU dimensions count slightly
@@ -196,11 +202,13 @@ queue:
   #     mem: 1.0
   #     gpus: 2.0
   #     gpu_mem: 1.0
-  #     gpu_reservation: 2.0
+  #     gpu_count_reservation: 2.0
+  #     gpu_mem_reservation: 2.0
   #
   # --- Example: GPU-scarce farm ----------------------------------------------
   # Protect GPU hosts aggressively for GPU work and make GPU stranding very
-  # expensive (don't waste a GPU on a low-GPU layer).
+  # expensive (don't waste a GPU on a low-GPU layer). Reservation favors count
+  # heavily since GPUs themselves are the scarce resource.
   # host_booking_strategy:
   #   type: epvm
   #   max_candidates: 500
@@ -209,7 +217,8 @@ queue:
   #     mem: 1.0
   #     gpus: 8.0
   #     gpu_mem: 2.0
-  #     gpu_reservation: 5.0
+  #     gpu_count_reservation: 10.0
+  #     gpu_mem_reservation: 1.0
   #
   # --- Example: memory-tight farm --------------------------------------------
   # Penalize memory stranding more than cores so jobs with high mem:core
@@ -222,7 +231,8 @@ queue:
   #     mem: 3.0
   #     gpus: 2.0
   #     gpu_mem: 1.0
-  #     gpu_reservation: 2.0
+  #     gpu_count_reservation: 2.0
+  #     gpu_mem_reservation: 2.0
   #
   # --- Example: cores-only (debugging sanity check) --------------------------
   # Scoring degenerates to "pack cores tightest" — useful for diagnosing
@@ -235,7 +245,8 @@ queue:
   #     mem: 0.0
   #     gpus: 0.0
   #     gpu_mem: 0.0
-  #     gpu_reservation: 0.0
+  #     gpu_count_reservation: 0.0
+  #     gpu_mem_reservation: 0.0
   # ---------------------------------------------------------------------------
 
   # Soft memory limit multiplier for frame memory requirements

--- a/rust/crates/scheduler/Cargo.toml
+++ b/rust/crates/scheduler/Cargo.toml
@@ -69,5 +69,6 @@ tokio-test = "0.4"
 tracing-test = "0.2"
 serial_test = "3.0"
 rand = "0.8"
+proptest = "1.5"
 testcontainers = "0.23"
 testcontainers-modules = { version = "0.11", features = ["redis"] }

--- a/rust/crates/scheduler/src/accounting/redis_client.rs
+++ b/rust/crates/scheduler/src/accounting/redis_client.rs
@@ -139,12 +139,12 @@ impl RedisAccounting {
         Ok(v.unwrap_or(0))
     }
 
-    /// Reads the subscription hash's booked cores + burst in one round-trip. Missing
-    /// keys/fields are treated as `(0, 0)`. Used by `MatchingService::process_layer`
-    /// to snapshot the (show, alloc) cap before host checkout — both to early-skip
-    /// over-burst layers and to feed real values into the E-PVM `LayerProfile`. The
-    /// dispatcher hot path still relies on the authoritative Lua booking check; this
-    /// snapshot is an optimistic pre-filter, not authoritative.
+    /// Reads the subscription hash's booked cores + burst in one round-trip from
+    /// `acct:sub:{show_id}:{alloc_id}` (fields `int_cores`, `burst`, both in
+    /// centicores). Missing keys/fields are treated as `(0, 0)`. Non-authoritative:
+    /// the dispatcher's Lua `BOOK_OR_FORCE` call remains the source of truth for
+    /// the booking decision; this is a snapshot suitable for optimistic pre-filters
+    /// and scoring inputs.
     pub async fn read_sub_counters(
         &self,
         show_id: uuid::Uuid,

--- a/rust/crates/scheduler/src/accounting/redis_client.rs
+++ b/rust/crates/scheduler/src/accounting/redis_client.rs
@@ -140,10 +140,11 @@ impl RedisAccounting {
     }
 
     /// Reads the subscription hash's booked cores + burst in one round-trip. Missing
-    /// keys/fields are treated as `(0, 0)`. Currently used by `AccountingService::
-    /// subscription_can_book` for diagnostic visibility and reachable future use; the
-    /// dispatcher hot path relies on the authoritative Lua booking check instead.
-    #[allow(dead_code)]
+    /// keys/fields are treated as `(0, 0)`. Used by `MatchingService::process_layer`
+    /// to snapshot the (show, alloc) cap before host checkout — both to early-skip
+    /// over-burst layers and to feed real values into the E-PVM `LayerProfile`. The
+    /// dispatcher hot path still relies on the authoritative Lua booking check; this
+    /// snapshot is an optimistic pre-filter, not authoritative.
     pub async fn read_sub_counters(
         &self,
         show_id: uuid::Uuid,
@@ -155,6 +156,19 @@ impl RedisAccounting {
         let booked = values.first().copied().flatten().unwrap_or(0);
         let burst = values.get(1).copied().flatten().unwrap_or(0);
         Ok((booked, burst))
+    }
+
+    /// Reads `acct:job:{job_id}` `int_cores` (live booked cores, in centicores).
+    /// Returns 0 when the key/field is missing. Used by the E-PVM placement
+    /// snapshot in `MatchingService::process_layer` (design Branch 2a).
+    pub async fn read_job_cores_in_use(
+        &self,
+        job_id: uuid::Uuid,
+    ) -> Result<i64, AccountingError> {
+        let mut conn = self.conn.clone();
+        let key = format!("acct:job:{}", job_id);
+        let v: Option<i64> = conn.hget(&key, "int_cores").await?;
+        Ok(v.unwrap_or(0))
     }
 }
 

--- a/rust/crates/scheduler/src/cluster.rs
+++ b/rust/crates/scheduler/src/cluster.rs
@@ -235,14 +235,19 @@ impl ClusterFeed {
                     let facility_id = cluster.facility_id;
                     let show_id = parse_uuid(&cluster.show_id);
                     match cluster.ttype.as_str() {
-                        // Each alloc tag becomes its own cluster
+                        // Each alloc tag becomes its own cluster. Carry pk_alloc
+                        // through Tag so the matcher can snapshot the
+                        // (show, alloc) subscription burst from Redis before
+                        // host checkout (see `MatchingService::process_layer`).
                         "ALLOC" => {
+                            let alloc_id = cluster.alloc_id.as_deref().map(parse_uuid);
                             clusters.push(Cluster::single_tag(
                                 facility_id,
                                 show_id,
                                 Tag {
                                     name: cluster.tag,
                                     ttype: TagType::Alloc,
+                                    alloc_id,
                                 },
                             ));
                         }
@@ -254,6 +259,7 @@ impl ClusterFeed {
                                 .insert(Tag {
                                     name: cluster.tag,
                                     ttype: TagType::Manual,
+                                    alloc_id: None,
                                 });
                         }
                         "HOSTNAME" => {
@@ -263,6 +269,7 @@ impl ClusterFeed {
                                 .insert(Tag {
                                     name: cluster.tag,
                                     ttype: TagType::HostName,
+                                    alloc_id: None,
                                 });
                         }
                         "HARDWARE" => {
@@ -272,6 +279,7 @@ impl ClusterFeed {
                                 .insert(Tag {
                                     name: cluster.tag,
                                     ttype: TagType::Hardware,
+                                    alloc_id: None,
                                 });
                         }
                         _ => (),

--- a/rust/crates/scheduler/src/cluster.rs
+++ b/rust/crates/scheduler/src/cluster.rs
@@ -783,6 +783,7 @@ mod tests {
             Tag {
                 name: tag.to_string(),
                 ttype: TagType::Alloc,
+                alloc_id: None,
             },
         )
     }

--- a/rust/crates/scheduler/src/cluster_key.rs
+++ b/rust/crates/scheduler/src/cluster_key.rs
@@ -25,6 +25,17 @@ pub enum TagType {
 pub struct Tag {
     pub name: String,
     pub ttype: TagType,
+    /// `pk_alloc` (allocation UUID) when this tag was loaded as a
+    /// `TagType::Alloc` cluster tag from the database. Populated by
+    /// `cluster.rs::load_clusters` on the `"ALLOC"` arm and consumed by
+    /// `MatchingService::process_layer` to read the per-(show, alloc)
+    /// subscription burst snapshot from Redis before host checkout.
+    ///
+    /// `None` for non-alloc tags (manual / hostname / hardware) and for
+    /// CLI-built tags where the str_tag → pk_alloc mapping isn't resolved
+    /// at startup. Those paths fall back to the burst-unaware behavior.
+    #[serde(default)]
+    pub alloc_id: Option<Uuid>,
 }
 
 impl std::ops::Deref for Tag {

--- a/rust/crates/scheduler/src/cluster_key.rs
+++ b/rust/crates/scheduler/src/cluster_key.rs
@@ -21,6 +21,15 @@ pub enum TagType {
     Hardware,
 }
 
+/// IDENTITY NOTE: the derived `Hash`/`PartialEq`/`Eq`/`Ord` include every field,
+/// so `alloc_id` participates in tag identity. A `Tag{name, Alloc, Some(uuid)}`
+/// and a `Tag{name, Alloc, None}` with the same `name`/`ttype` are *distinct*
+/// keys in `BTreeSet<Tag>` and `HashMap<ClusterKey, _>`. Today the DB-loaded
+/// path produces `Some(uuid)` for alloc tags and the CLI override path produces
+/// `None`; the two are not mixed within a single set, so this is latent. The
+/// CLI override path for alloc tags is being discontinued in the next stage,
+/// after which every `TagType::Alloc` tag carries a resolved `alloc_id` and
+/// this becomes a non-issue.
 #[derive(Serialize, Deserialize, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Tag {
     pub name: String,

--- a/rust/crates/scheduler/src/config/mod.rs
+++ b/rust/crates/scheduler/src/config/mod.rs
@@ -210,7 +210,7 @@ impl Default for StreamConfig {
 /// E-PVM stranding and picks the lowest score. Saturation is the default;
 /// Epvm is opt-in.
 #[derive(Debug, Deserialize, Clone, Copy)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 pub enum HostBookingStrategy {
     Saturation {
         core_saturation: bool,
@@ -257,7 +257,7 @@ impl Default for HostBookingStrategy {
 ///
 /// See `rust/config/scheduler.yaml` for annotated example configurations
 /// (baseline, GPU-scarce, memory-tight, cores-only) and the
-/// `gpu_reservation` semantics.
+/// `gpu_count_reservation` / `gpu_mem_reservation` semantics.
 #[derive(Debug, Deserialize, Clone, Copy)]
 #[serde(default)]
 pub struct ScoreWeights {
@@ -271,10 +271,14 @@ pub struct ScoreWeights {
     /// Penalty per fractional stranded GPU-memory-layer-frame (GPU layers only).
     /// Default `1.0`.
     pub gpu_mem: f64,
-    /// Soft-reservation penalty for non-GPU layers on GPU hosts. Scales the
-    /// host's idle GPU capacity (count + GB). Default `2.0`. See risk #3 — this
-    /// is the weight most likely to need adjustment after a production rollout.
-    pub gpu_reservation: f64,
+    /// Soft-reservation penalty per idle GPU on the host for non-GPU layers.
+    /// Default `2.0`. With 8 idle GPUs, contributes `8 * gpu_count_reservation`
+    /// to the score.
+    pub gpu_count_reservation: f64,
+    /// Soft-reservation penalty per idle GB of GPU memory on the host for
+    /// non-GPU layers. Default `2.0`. With 80 GB idle, contributes
+    /// `80 * gpu_mem_reservation` to the score.
+    pub gpu_mem_reservation: f64,
 }
 
 impl Default for ScoreWeights {
@@ -284,7 +288,8 @@ impl Default for ScoreWeights {
             mem: 1.0,
             gpus: 2.0,
             gpu_mem: 1.0,
-            gpu_reservation: 2.0,
+            gpu_count_reservation: 2.0,
+            gpu_mem_reservation: 2.0,
         }
     }
 }
@@ -519,5 +524,75 @@ impl Config {
                     err
                 ))
             })
+    }
+}
+
+#[cfg(test)]
+mod host_booking_strategy_tests {
+    //! `deny_unknown_fields` is format-agnostic; testing with JSON is
+    //! sufficient to verify the serde behavior we care about (operators
+    //! configure via YAML in production, but the loader uses the same
+    //! `serde::Deserialize` impl).
+    use super::*;
+
+    #[test]
+    fn saturation_accepts_valid_fields() {
+        let json = r#"{"type":"saturation","core_saturation":true,"memory_saturation":false}"#;
+        let parsed: HostBookingStrategy = serde_json::from_str(json).unwrap();
+        assert!(matches!(
+            parsed,
+            HostBookingStrategy::Saturation {
+                core_saturation: true,
+                memory_saturation: false
+            }
+        ));
+    }
+
+    #[test]
+    fn epvm_accepts_valid_fields() {
+        let json = r#"{
+            "type":"epvm",
+            "max_candidates":500,
+            "weights":{"cores":1.0,"mem":1.0,"gpus":2.0,"gpu_mem":1.0,"gpu_count_reservation":2.0,"gpu_mem_reservation":2.0}
+        }"#;
+        let parsed: HostBookingStrategy = serde_json::from_str(json).unwrap();
+        assert!(matches!(
+            parsed,
+            HostBookingStrategy::Epvm {
+                max_candidates: 500,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn epvm_rejects_saturation_field() {
+        // `core_saturation` belongs to the Saturation variant; under `type: epvm`
+        // it must be rejected, not silently ignored.
+        let json = r#"{
+            "type":"epvm",
+            "max_candidates":500,
+            "core_saturation":false,
+            "weights":{"cores":1.0,"mem":1.0,"gpus":2.0,"gpu_mem":1.0,"gpu_count_reservation":2.0,"gpu_mem_reservation":2.0}
+        }"#;
+        let err = serde_json::from_str::<HostBookingStrategy>(json).unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("unknown field") && msg.contains("core_saturation"),
+            "expected unknown-field error mentioning core_saturation, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn saturation_rejects_epvm_field() {
+        let json = r#"{"type":"saturation","core_saturation":true,"memory_saturation":false,"max_candidates":500}"#;
+        let err = serde_json::from_str::<HostBookingStrategy>(json).unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("unknown field") && msg.contains("max_candidates"),
+            "expected unknown-field error mentioning max_candidates, got: {}",
+            msg
+        );
     }
 }

--- a/rust/crates/scheduler/src/config/mod.rs
+++ b/rust/crates/scheduler/src/config/mod.rs
@@ -201,18 +201,90 @@ impl Default for StreamConfig {
     }
 }
 
+/// Strategy for selecting a host when multiple candidates satisfy a layer's
+/// floor requirements.
+///
+/// `Saturation` is the legacy first-fit strategy: scan the B-tree in a
+/// configurable direction (`core_saturation` / `memory_saturation`) and take
+/// the first valid host. `Epvm` scores up to `max_candidates` hosts via
+/// E-PVM stranding and picks the lowest score. Saturation is the default;
+/// Epvm is opt-in.
 #[derive(Debug, Deserialize, Clone, Copy)]
-#[serde(default)]
-pub struct HostBookingStrategy {
-    pub core_saturation: bool,
-    pub memory_saturation: bool,
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum HostBookingStrategy {
+    Saturation {
+        core_saturation: bool,
+        memory_saturation: bool,
+    },
+    Epvm {
+        weights: ScoreWeights,
+        max_candidates: usize,
+    },
 }
 
 impl Default for HostBookingStrategy {
     fn default() -> Self {
-        Self {
+        Self::Saturation {
             core_saturation: true,
             memory_saturation: false,
+        }
+    }
+}
+
+/// Weights for the E-PVM placement score.
+///
+/// For each resource dimension (cores, memory, GPUs, GPU memory), E-PVM
+/// computes how much of that resource will be "stranded" on a host — left
+/// idle because some other dimension ran out first. The weights here scale
+/// each dimension's stranding before they're summed into a single score.
+/// The cache picks the host with the lowest score.
+///
+/// # Units and range
+///
+/// All weights are dimensionless `f64`. Because stranding terms are themselves
+/// normalized (divided by the layer's per-dim minimum), a weight of `1.0`
+/// means "1 stranded layer-frame on this dimension contributes 1 score unit".
+///
+/// Practical range: **`0.0` to ~`10.0`**.
+/// * `0.0` — disables this dimension's contribution to the score.
+/// * `1.0` — baseline; this dimension counts at par with other unit-weighted dims.
+/// * `>1.0` — emphasizes the dimension (e.g. set `gpus: 4.0` to make GPU
+///   stranding hurt 4× as much as core stranding).
+/// * Values much higher than ~10.0 risk single-dimension dominance —
+///   placements become driven by one resource, ignoring everything else.
+/// * Negative values are not meaningful (would reward stranding); the gate
+///   does not enforce non-negativity, but operators should keep weights `>= 0`.
+///
+/// See `rust/config/scheduler.yaml` for annotated example configurations
+/// (baseline, GPU-scarce, memory-tight, cores-only) and the
+/// `gpu_reservation` semantics.
+#[derive(Debug, Deserialize, Clone, Copy)]
+#[serde(default)]
+pub struct ScoreWeights {
+    /// Penalty per fractional stranded core-layer-frame. Default `1.0`.
+    pub cores: f64,
+    /// Penalty per fractional stranded mem-layer-frame. Default `1.0`.
+    pub mem: f64,
+    /// Penalty per fractional stranded GPU-layer-frame (GPU layers only).
+    /// Default `2.0` — GPU jobs are rarer, so wasting GPU capacity hurts more.
+    pub gpus: f64,
+    /// Penalty per fractional stranded GPU-memory-layer-frame (GPU layers only).
+    /// Default `1.0`.
+    pub gpu_mem: f64,
+    /// Soft-reservation penalty for non-GPU layers on GPU hosts. Scales the
+    /// host's idle GPU capacity (count + GB). Default `2.0`. See risk #3 — this
+    /// is the weight most likely to need adjustment after a production rollout.
+    pub gpu_reservation: f64,
+}
+
+impl Default for ScoreWeights {
+    fn default() -> Self {
+        Self {
+            cores: 1.0,
+            mem: 1.0,
+            gpus: 2.0,
+            gpu_mem: 1.0,
+            gpu_reservation: 2.0,
         }
     }
 }

--- a/rust/crates/scheduler/src/dao/cluster_dao.rs
+++ b/rust/crates/scheduler/src/dao/cluster_dao.rs
@@ -41,11 +41,17 @@ pub struct ClusterModel {
     pub show_id: String,
     pub facility_id: String,
     pub ttype: String,
+    /// `pk_alloc` UUID (as text) for `'ALLOC'` rows; `NULL` for non-alloc rows.
+    /// Carried through so `Tag::alloc_id` can be populated on the ALLOC arm of
+    /// `cluster.rs::load_clusters`, enabling the matcher's pre-checkout
+    /// subscription burst snapshot.
+    pub alloc_id: Option<String>,
 }
 
 static QUERY_ALLOC_CLUSTERS: &str = r#"
 SELECT DISTINCT
     a.str_tag as tag,
+    a.pk_alloc as alloc_id,
     sh.pk_show as show_id,
     a.pk_facility as facility_id,
     'ALLOC' as ttype
@@ -60,6 +66,7 @@ WHERE str_tag_type = 'ALLOC'
 static QUERY_ALLOC_CLUSTERS_WITH_FACILITY: &str = r#"
 SELECT DISTINCT
     a.str_tag as tag,
+    a.pk_alloc as alloc_id,
     sh.pk_show as show_id,
     a.pk_facility as facility_id,
     'ALLOC' as ttype
@@ -75,6 +82,7 @@ WHERE str_tag_type = 'ALLOC'
 static QUERY_ALLOC_CLUSTERS_WITH_SHOW_NAMES: &str = r#"
 SELECT DISTINCT
     a.str_tag as tag,
+    a.pk_alloc as alloc_id,
     sh.pk_show as show_id,
     a.pk_facility as facility_id,
     'ALLOC' as ttype
@@ -90,6 +98,7 @@ WHERE str_tag_type = 'ALLOC'
 static QUERY_ALLOC_CLUSTERS_WITH_FACILITY_AND_SHOW_NAMES: &str = r#"
 SELECT DISTINCT
     a.str_tag as tag,
+    a.pk_alloc as alloc_id,
     sh.pk_show as show_id,
     a.pk_facility as facility_id,
     'ALLOC' as ttype
@@ -109,6 +118,7 @@ WHERE str_tag_type = 'ALLOC'
 static QUERY_NON_ALLOC_CLUSTERS: &str = r#"
 SELECT DISTINCT
     host_tag.str_tag as tag,
+    NULL::text as alloc_id,
     s.pk_show as show_id,
     a.pk_facility as facility_id,
     str_tag_type as ttype
@@ -122,6 +132,7 @@ WHERE str_tag_type <> 'ALLOC'
 static QUERY_NON_ALLOC_CLUSTERS_WITH_FACILITY: &str = r#"
 SELECT DISTINCT
     host_tag.str_tag as tag,
+    NULL::text as alloc_id,
     s.pk_show as show_id,
     a.pk_facility as facility_id,
     str_tag_type as ttype
@@ -136,6 +147,7 @@ WHERE str_tag_type <> 'ALLOC'
 static QUERY_NON_ALLOC_CLUSTERS_WITH_SHOW_NAMES: &str = r#"
 SELECT DISTINCT
     host_tag.str_tag as tag,
+    NULL::text as alloc_id,
     s.pk_show as show_id,
     a.pk_facility as facility_id,
     str_tag_type as ttype
@@ -151,6 +163,7 @@ WHERE str_tag_type <> 'ALLOC'
 static QUERY_NON_ALLOC_CLUSTERS_WITH_FACILITY_AND_SHOW_NAMES: &str = r#"
 SELECT DISTINCT
     host_tag.str_tag as tag,
+    NULL::text as alloc_id,
     s.pk_show as show_id,
     a.pk_facility as facility_id,
     str_tag_type as ttype

--- a/rust/crates/scheduler/src/dao/layer_dao.rs
+++ b/rust/crates/scheduler/src/dao/layer_dao.rs
@@ -59,6 +59,9 @@ pub struct DispatchLayerModel {
     pub int_gpus_min: i64,
     pub int_gpu_mem_min: i64,
     pub str_tags: String,
+    /// `job_resource.int_max_cores` (centicores). `-1` is the OpenCue
+    /// "unlimited" sentinel — preserved through `from_multiplied_cap`.
+    pub int_job_max_cores: i64,
 }
 
 /// Combined model for batched layer and frame queries.
@@ -84,6 +87,7 @@ pub struct LayerWithFramesModel {
     pub int_gpus_min: i64,
     pub int_gpu_mem_min: i64,
     pub str_tags: String,
+    pub int_job_max_cores: i64,
     pub job_env: Json<HashMap<String, String>>,
     pub layer_env: Json<HashMap<String, String>>,
 
@@ -147,6 +151,9 @@ impl DispatchLayer {
                 .filter(|t| !t.is_empty())
                 .collect(),
             frames: frames.into_iter().map(|f| f.into()).collect(),
+            // Preserves the `-1` unlimited sentinel; `compute_max_more` skips
+            // the job cap dim when `<= 0`.
+            job_max_cores: CoreSize::from_multiplied_cap(layer.int_job_max_cores).value(),
         }
     }
 }
@@ -236,6 +243,7 @@ SELECT DISTINCT
     l.int_gpus_min,
     l.int_gpu_mem_min,
     l.str_tags,
+    jr.int_max_cores AS int_job_max_cores,
     je.job_env,
     le.layer_env,
     l.int_dispatch_order,
@@ -266,6 +274,7 @@ SELECT DISTINCT
 FROM job j
     INNER JOIN layer l ON j.pk_job = l.pk_job
     INNER JOIN layer_stat ls on l.pk_layer = ls.pk_layer
+    INNER JOIN job_resource jr ON j.pk_job = jr.pk_job
     LEFT JOIN LATERAL (
         SELECT COALESCE(
             jsonb_object_agg(je.str_key, je.str_value),
@@ -376,6 +385,7 @@ impl LayerDao {
                 int_gpus_min: model.int_gpus_min,
                 int_gpu_mem_min: model.int_gpu_mem_min,
                 str_tags: model.str_tags.clone(),
+                int_job_max_cores: model.int_job_max_cores,
             };
 
             // Extract frame data (if present)

--- a/rust/crates/scheduler/src/host_cache/actor.rs
+++ b/rust/crates/scheduler/src/host_cache/actor.rs
@@ -34,8 +34,9 @@ use crate::{
     cluster_key::{ClusterKey, Tag, TagType},
     config::CONFIG,
     dao::HostDao,
-    host_cache::{messages::*, store, *},
+    host_cache::{cache::Gate, messages::*, store, *},
     models::{CoreSize, Host},
+    pipeline::placement::LayerProfile,
 };
 
 #[derive(Clone)]
@@ -123,20 +124,18 @@ impl Actor for HostCacheService {
     }
 }
 
-impl<F> Handler<CheckOut<F>> for HostCacheService
-where
-    F: Fn(&Host) -> bool + 'static,
-{
+impl Handler<CheckOut> for HostCacheService {
     type Result = ResponseActFuture<Self, Result<CheckedOutHost, HostCacheError>>;
 
-    fn handle(&mut self, msg: CheckOut<F>, _ctx: &mut Self::Context) -> Self::Result {
+    fn handle(&mut self, msg: CheckOut, _ctx: &mut Self::Context) -> Self::Result {
         let CheckOut {
             facility_id,
             show_id,
             tags,
             cores,
             memory,
-            validation,
+            profile,
+            gate,
         } = msg;
 
         let service = self.clone();
@@ -144,7 +143,7 @@ where
         Box::pin(
             async move {
                 let out = service
-                    .check_out(facility_id, show_id, tags, cores, memory, validation)
+                    .check_out(facility_id, show_id, tags, cores, memory, profile, gate)
                     .await;
                 if let Ok(host) = &out {
                     debug!("Checked out {}", host.1);
@@ -233,27 +232,25 @@ impl HostCacheService {
     ///
     /// * `Ok(CheckedOutHost)` - Host with cluster key
     /// * `Err(HostCacheError)` - No suitable host found or database error
-    async fn check_out<F>(
+    #[allow(clippy::too_many_arguments)]
+    async fn check_out(
         &self,
         facility_id: String,
         show_id: Uuid,
         tags: Vec<Tag>,
         cores: CoreSize,
         memory: ByteSize,
-        validation: F,
-    ) -> Result<CheckedOutHost, HostCacheError>
-    where
-        F: Fn(&Host) -> bool,
-    {
+        profile: LayerProfile,
+        gate: Gate,
+    ) -> Result<CheckedOutHost, HostCacheError> {
         let cache_keys = self.gen_cache_keys(facility_id, show_id, tags);
 
-        // Extend validation to also check for hosts that are already reserved
-        let validation = |host: &Host| {
-            let available = self
-                .reserved_hosts
+        // Per-actor reservation availability check. ANDed with the gate inside
+        // the cache so reserved hosts are skipped during scan/score.
+        let reserved_check = |host: &Host| {
+            self.reserved_hosts
                 .read_sync(&host.id, |_, reservation| reservation.expired())
-                .unwrap_or(true);
-            validation(host) && available
+                .unwrap_or(true)
         };
 
         for cache_key in cache_keys {
@@ -266,8 +263,7 @@ impl HostCacheService {
                 .read_async(&cache_key, |_, cached_group| {
                     if !cached_group.expired() {
                         cached_group
-                            // Checkout host from a group
-                            .check_out(cores, memory, validation)
+                            .check_out(cores, memory, &profile, gate, reserved_check)
                             .map(|host| (cache_key.clone(), host.clone()))
                             .ok()
                     } else {
@@ -289,8 +285,7 @@ impl HostCacheService {
                         .await
                         .map_err(|err| HostCacheError::FailedToQueryHostCache(err.to_string()))?;
                     let checked_out_host = group
-                        // Checkout host from a group
-                        .check_out(cores, memory, validation)
+                        .check_out(cores, memory, &profile, gate, reserved_check)
                         .map(|host| CheckedOutHost(cache_key.clone(), host.clone()));
 
                     if let Ok(checked_out_host) = checked_out_host {

--- a/rust/crates/scheduler/src/host_cache/actor.rs
+++ b/rust/crates/scheduler/src/host_cache/actor.rs
@@ -182,8 +182,6 @@ impl Handler<CacheRatio> for HostCacheService {
 
     fn handle(&mut self, _msg: CacheRatio, _ctx: &mut Self::Context) -> Self::Result {
         CacheRatioResponse {
-            hit: self.cache_hit.load(atomic::Ordering::Relaxed),
-            miss: self.cache_miss.load(atomic::Ordering::Relaxed),
             hit_ratio: self.cache_hit_ratio(),
         }
     }

--- a/rust/crates/scheduler/src/host_cache/cache.rs
+++ b/rust/crates/scheduler/src/host_cache/cache.rs
@@ -46,7 +46,9 @@ use uuid::Uuid;
 use crate::{
     config::{HostBookingStrategy, CONFIG},
     host_cache::{store::HOST_STORE, HostCacheError, HostId},
+    metrics,
     models::{CoreSize, Host},
+    pipeline::placement::LayerProfile,
 };
 
 type CoreKey = u32;
@@ -54,6 +56,12 @@ type MemoryKey = u64;
 
 /// A B-Tree of Hosts ordered by memory
 pub type MemoryBTree = BTreeMap<MemoryKey, HashSet<HostId>>;
+
+/// Signature shared by every host-booking gate. Returns `Some(score)` when the
+/// host is a valid candidate (lower scores rank better for Epvm); `None` when
+/// the host fails validation or floor checks. Fn pointer instead of a closure
+/// so the actor's `CheckOut` message stays non-generic.
+pub type Gate = fn(&Host, &LayerProfile) -> Option<f64>;
 
 pub struct HostCache {
     /// B-Tree of host groups ordered by their number of available cores
@@ -136,72 +144,78 @@ impl HostCache {
             > CONFIG.host_cache.group_idle_timeout
     }
 
-    /// Checks out the best matching host from the cache.
+    /// Checks out a host from the cache that matches the gate's requirements.
     ///
-    /// Finds a host with sufficient resources that passes the validation function,
-    /// removes it from the cache, and returns it. The host must be checked back in
-    /// after use.
+    /// Dispatches to either the Saturation (first-fit) or Epvm (lowest-score)
+    /// path based on the configured `strategy`. The B-tree index is queried
+    /// by `(cores, memory)`; floor checks on other dimensions (GPUs, GPU mem)
+    /// live inside the `gate`.
     ///
     /// # Arguments
     ///
-    /// * `cores` - Minimum number of cores required
-    /// * `memory` - Minimum memory required
-    /// * `validation` - Function to validate additional host requirements
-    ///
-    /// # Returns
-    ///
-    /// * `Ok(Host)` - Successfully checked out host
-    /// * `Err(HostCacheError)` - No suitable host available
-    pub fn check_out<F>(
+    /// * `cores`, `memory` — minimum range hints for the B-tree query
+    /// * `profile` — layer placement context (caps, weights, floors)
+    /// * `gate` — `Some(score)` when valid, `None` to reject
+    /// * `reserved_check` — actor-supplied availability test (true when not
+    ///   reserved by another in-flight checkout)
+    pub fn check_out(
         &self,
         cores: CoreSize,
         memory: ByteSize,
-        validation: F,
-    ) -> Result<Host, HostCacheError>
-    where
-        F: Fn(&Host) -> bool,
-    {
+        profile: &LayerProfile,
+        gate: Gate,
+        reserved_check: impl Fn(&Host) -> bool,
+    ) -> Result<Host, HostCacheError> {
         self.ping_query();
 
-        let host = self
-            .remove_host(cores, memory, validation)
-            .ok_or(HostCacheError::NoCandidateAvailable)?;
+        let host = match self.strategy {
+            HostBookingStrategy::Saturation {
+                core_saturation,
+                memory_saturation,
+            } => self.remove_host_first_fit(
+                cores,
+                memory,
+                profile,
+                gate,
+                &reserved_check,
+                core_saturation,
+                memory_saturation,
+            ),
+            HostBookingStrategy::Epvm { max_candidates, .. } => self.remove_host_best(
+                cores,
+                memory,
+                profile,
+                gate,
+                &reserved_check,
+                max_candidates,
+            ),
+        };
 
-        Ok(host)
+        host.ok_or(HostCacheError::NoCandidateAvailable)
     }
 
-    /// Removes a suitable host from the cache based on resource requirements.
-    ///
-    /// Searches for a host with at least the requested cores and memory that
-    /// passes the validation function. Uses atomic operations with retry logic
-    /// to prevent race conditions where host state changes between lookup and removal.
-    ///
-    /// # Arguments
-    ///
-    /// * `cores` - Minimum number of cores required
-    /// * `memory` - Minimum memory required
-    /// * `validation` - Function to validate additional requirements
-    ///
-    /// # Returns
-    ///
-    /// * `Some(Host)` - Host that meets all requirements
-    /// * `None` - No suitable host found
-    fn remove_host<F>(&self, cores: CoreSize, memory: ByteSize, validation: F) -> Option<Host>
-    where
-        F: Fn(&Host) -> bool,
-    {
+    /// Saturation strategy: scan the B-tree in the configured direction and
+    /// take the first valid host. Retries up to 5 times when CAS races lose
+    /// to concurrent checkouts.
+    #[allow(clippy::too_many_arguments)]
+    fn remove_host_first_fit(
+        &self,
+        cores: CoreSize,
+        memory: ByteSize,
+        profile: &LayerProfile,
+        gate: Gate,
+        reserved_check: &impl Fn(&Host) -> bool,
+        core_saturation: bool,
+        memory_saturation: bool,
+    ) -> Option<Host> {
         let core_key = cores.value() as u32;
         let memory_key = Self::gen_memory_key(memory);
 
         let failed_candidates: RefCell<Vec<Uuid>> = RefCell::new(Vec::new());
         let host_validation = |host: &Host| {
-            // Check caller validation
-            validation(host) &&
-            // Check memory and core requirements just in case
-            host.idle_memory >= memory &&
-            host.idle_cores >= cores &&
-            // Ensure we're not retrying the same host as last attempts
-            !failed_candidates.borrow().contains(&host.id)
+            gate(host, profile).is_some()
+                && reserved_check(host)
+                && !failed_candidates.borrow().contains(&host.id)
         };
 
         let mut attempts = 5;
@@ -210,7 +224,7 @@ impl HostCache {
             let candidate_info = {
                 let host_index_lock = self.hosts_index.read().unwrap_or_else(|p| p.into_inner());
                 let mut iter: Box<dyn Iterator<Item = (&CoreKey, &MemoryBTree)>> =
-                    if !self.strategy.core_saturation {
+                    if !core_saturation {
                         // Reverse order to find hosts with max amount of cores available
                         Box::new(host_index_lock.range(core_key..).rev())
                     } else {
@@ -221,7 +235,6 @@ impl HostCache {
                     let find_fn = |(by_memory_key, hosts): (&u64, &HashSet<Uuid>)| {
                         hosts.iter().find_map(|host_id| {
                             HOST_STORE.get(host_id).and_then(|host| {
-                                // Check validation and memory capacity
                                 if host_validation(&host) {
                                     Some((
                                         *by_core_key,
@@ -236,8 +249,7 @@ impl HostCache {
                         })
                     };
 
-                    if self.strategy.memory_saturation {
-                        // Search for hosts with at least the same amount of memory requested
+                    if memory_saturation {
                         hosts_by_memory.range(memory_key..).find_map(find_fn)
                     } else {
                         // Search for hosts with the most amount of memory available
@@ -288,18 +300,95 @@ impl HostCache {
         None
     }
 
+    /// Epvm strategy: snapshot up to `max_candidates` hosts (saturated-first
+    /// iteration so the best-likely candidates are scanned when the cap
+    /// engages), score them via the gate, and try `atomic_remove_if_valid`
+    /// in ascending score order. First successful CAS wins.
+    ///
+    /// By design, this is a single-pass operation: if every Phase-3
+    /// commit fails its CAS, returns `None` and the matcher's outer retry
+    /// loop re-enumerates on the next iteration.
+    fn remove_host_best(
+        &self,
+        cores: CoreSize,
+        memory: ByteSize,
+        profile: &LayerProfile,
+        gate: Gate,
+        reserved_check: &impl Fn(&Host) -> bool,
+        max_candidates: usize,
+    ) -> Option<Host> {
+        let core_key = cores.value() as u32;
+        let memory_key = Self::gen_memory_key(memory);
+
+        // Phase 1 + 2: scan and score under the index read lock. Memory floor
+        // is enforced by the `memory_key..` range; cores floor by `core_key..`.
+        // Saturated-first iteration on both dims so candidates are visited in
+        // best-first order until `max_candidates` is hit.
+        let mut scored: Vec<(CoreKey, MemoryKey, Uuid, chrono::DateTime<chrono::Utc>, f64)> = {
+            let host_index_lock = self.hosts_index.read().unwrap_or_else(|p| p.into_inner());
+            let mut acc = Vec::with_capacity(max_candidates.min(64));
+
+            'outer: for (by_core_key, hosts_by_memory) in host_index_lock.range(core_key..) {
+                for (by_memory_key, hosts) in hosts_by_memory.range(memory_key..) {
+                    for host_id in hosts.iter() {
+                        if let Some(host) = HOST_STORE.get(host_id) {
+                            if !reserved_check(&host) {
+                                continue;
+                            }
+                            if let Some(score) = gate(&host, profile) {
+                                acc.push((
+                                    *by_core_key,
+                                    *by_memory_key,
+                                    *host_id,
+                                    host.last_updated,
+                                    score,
+                                ));
+                                if acc.len() >= max_candidates {
+                                    break 'outer;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            acc
+        };
+
+        // Sort ascending: lowest stranding wins.
+        scored.sort_by(|a, b| a.4.partial_cmp(&b.4).unwrap_or(std::cmp::Ordering::Equal));
+
+        // Phase 3: try commits in score order. The validation closure must
+        // re-check the gate because the host may have changed between Phase 1
+        // and Phase 3 (atomic_remove_if_valid already CAS-guards last_updated,
+        // so a successful commit means we have the same snapshot).
+        let host_validation = |host: &Host| gate(host, profile).is_some() && reserved_check(host);
+
+        for (by_core_key, by_memory_key, host_id, expected_last_updated, score) in scored {
+            match HOST_STORE.atomic_remove_if_valid(
+                &host_id,
+                expected_last_updated,
+                host_validation,
+            ) {
+                Ok(Some(removed_host)) => {
+                    let mut host_index_lock =
+                        self.hosts_index.write().unwrap_or_else(|p| p.into_inner());
+
+                    host_index_lock
+                        .get_mut(&by_core_key)
+                        .and_then(|hosts_by_memory| hosts_by_memory.get_mut(&by_memory_key))
+                        .map(|hosts| hosts.remove(&host_id));
+
+                    metrics::observe_placement_score_chosen(score);
+                    return Some(removed_host);
+                }
+                Ok(None) | Err(()) => continue,
+            }
+        }
+
+        None
+    }
+
     /// Returns a host to the cache after use.
-    ///
-    /// Updates the cache with the host's current resource state. If the host
-    /// already exists in the cache, it's updated with the new values. The host
-    /// is indexed by its current idle cores and memory for efficient lookup.
-    ///
-    /// This method now performs all updates atomically under a single write lock,
-    /// preventing race conditions with concurrent check_out operations.
-    ///
-    /// # Arguments
-    ///
-    /// * `host` - Host to return to the cache
     pub fn check_in(&self, host: Host, authoritative: bool) {
         let host_id = host.id;
 
@@ -343,6 +432,7 @@ impl HostCache {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::ScoreWeights;
     use chrono::Utc;
     use opencue_proto::host::ThreadMode;
     use std::thread;
@@ -367,6 +457,37 @@ mod tests {
             alloc_name: "test".to_string(),
             last_updated: Utc::now(),
         }
+    }
+
+    fn test_profile(cores_min: i32, mem_min: ByteSize) -> LayerProfile {
+        LayerProfile {
+            cores_min: CoreSize(cores_min),
+            mem_min,
+            gpus_min: 0,
+            gpu_mem_min: ByteSize::gb(0),
+            os: None,
+            threadable: true,
+            job_max_cores: 0,
+            show_burst: 0,
+            job_cores_in_use: 0,
+            show_cores_in_use: 0,
+            weights: ScoreWeights::default(),
+        }
+    }
+
+    /// Trivial gate: always valid, constant score 0.0. For tests that exercise
+    /// the structural checkout path without scoring concerns.
+    fn always_valid(_: &Host, _: &LayerProfile) -> Option<f64> {
+        Some(0.0)
+    }
+
+    /// Always-reject gate. For tests that the gate's None short-circuits.
+    fn always_reject(_: &Host, _: &LayerProfile) -> Option<f64> {
+        None
+    }
+
+    fn no_reservation_check(_: &Host) -> bool {
+        true
     }
 
     #[test]
@@ -444,7 +565,6 @@ mod tests {
         cache.check_in(host1, false);
         cache.check_in(host2.clone(), false);
 
-        // The host should be updated with new resources
         let stored_host = HOST_STORE.get(&host_id).unwrap();
         assert_eq!(stored_host.idle_cores.value(), 8);
         assert_eq!(stored_host.idle_memory, ByteSize::gb(16));
@@ -459,33 +579,32 @@ mod tests {
 
         cache.check_in(host, false);
 
+        let profile = test_profile(2, ByteSize::gb(4));
         let result = cache.check_out(
             CoreSize(2),
             ByteSize::gb(4),
-            |_| true, // Always validate true
+            &profile,
+            always_valid,
+            no_reservation_check,
         );
 
         let checked_out_host = assert_ok!(result);
-        let memory_key = HostCache::gen_memory_key(checked_out_host.idle_memory);
-        let core_key = checked_out_host.idle_cores.value() as u32;
-
         assert_eq!(checked_out_host.id, host_id);
-
         assert!(HOST_STORE.get(&host_id).is_none());
-
-        let hosts_index = cache.hosts_index.read().unwrap();
-        let left_over_host = hosts_index
-            .get(&core_key)
-            .and_then(|hosts_by_memory| hosts_by_memory.get(&memory_key))
-            .and_then(|hosts| hosts.get(&checked_out_host.id));
-        assert!(left_over_host.is_none())
     }
 
     #[test]
     fn test_checkout_no_candidate_available() {
         let cache = HostCache::default();
+        let profile = test_profile(4, ByteSize::gb(8));
 
-        let result = cache.check_out(CoreSize(4), ByteSize::gb(8), |_| true);
+        let result = cache.check_out(
+            CoreSize(4),
+            ByteSize::gb(8),
+            &profile,
+            always_valid,
+            no_reservation_check,
+        );
 
         assert!(result.is_err());
         assert!(matches!(result, Err(HostCacheError::NoCandidateAvailable)));
@@ -499,10 +618,13 @@ mod tests {
 
         cache.check_in(host, false);
 
+        let profile = test_profile(4, ByteSize::gb(4));
         let result = cache.check_out(
-            CoreSize(4), // Request more cores than available
+            CoreSize(4),
             ByteSize::gb(4),
-            |_| true,
+            &profile,
+            always_valid,
+            no_reservation_check,
         );
 
         assert!(result.is_err());
@@ -516,10 +638,13 @@ mod tests {
 
         cache.check_in(host, false);
 
+        let profile = test_profile(2, ByteSize::gb(8));
         let result = cache.check_out(
             CoreSize(2),
-            ByteSize::gb(8), // Request more memory than available
-            |_| true,
+            ByteSize::gb(8),
+            &profile,
+            always_valid,
+            no_reservation_check,
         );
 
         assert!(result.is_err());
@@ -533,10 +658,13 @@ mod tests {
 
         cache.check_in(host, false);
 
+        let profile = test_profile(2, ByteSize::gb(4));
         let result = cache.check_out(
             CoreSize(2),
             ByteSize::gb(4),
-            |_| false, // Always fail validation
+            &profile,
+            always_reject,
+            no_reservation_check,
         );
 
         assert!(result.is_err());
@@ -550,12 +678,23 @@ mod tests {
 
         cache.check_in(host, false);
 
-        // First checkout should succeed
-        let result1 = cache.check_out(CoreSize(2), ByteSize::gb(4), |_| true);
+        let profile = test_profile(2, ByteSize::gb(4));
+        let result1 = cache.check_out(
+            CoreSize(2),
+            ByteSize::gb(4),
+            &profile,
+            always_valid,
+            no_reservation_check,
+        );
         assert!(result1.is_ok());
 
-        // Second checkout should fail because host is already checked out
-        let result2 = cache.check_out(CoreSize(2), ByteSize::gb(4), |_| true);
+        let result2 = cache.check_out(
+            CoreSize(2),
+            ByteSize::gb(4),
+            &profile,
+            always_valid,
+            no_reservation_check,
+        );
         assert!(result2.is_err());
     }
 
@@ -567,24 +706,41 @@ mod tests {
 
         cache.check_in(host.clone(), false);
 
-        // Checkout the host
-        let mut checked_host = assert_ok!(cache.check_out(CoreSize(2), ByteSize::gb(4), |_| true));
+        let profile = test_profile(2, ByteSize::gb(4));
+        let mut checked_host = assert_ok!(cache.check_out(
+            CoreSize(2),
+            ByteSize::gb(4),
+            &profile,
+            always_valid,
+            no_reservation_check,
+        ));
         assert_eq!(checked_host.idle_cores.value(), 4);
 
-        // Reduce the number of cores and checkin to ensure cache is updated
         checked_host.idle_cores = CoreSize(1);
-
-        // Check it back in
         cache.check_in(checked_host, false);
-        assert_err!(cache.check_out(CoreSize(2), ByteSize::gb(4), |_| true));
-        assert_ok!(cache.check_out(CoreSize(1), ByteSize::gb(4), |_| true));
+
+        let profile2 = test_profile(2, ByteSize::gb(4));
+        assert_err!(cache.check_out(
+            CoreSize(2),
+            ByteSize::gb(4),
+            &profile2,
+            always_valid,
+            no_reservation_check,
+        ));
+        let profile1 = test_profile(1, ByteSize::gb(4));
+        assert_ok!(cache.check_out(
+            CoreSize(1),
+            ByteSize::gb(4),
+            &profile1,
+            always_valid,
+            no_reservation_check,
+        ));
     }
 
     #[test]
     fn test_find_candidate_with_multiple_hosts() {
         let cache = HostCache::default();
 
-        // Add hosts with different resources
         let host1_id = Uuid::new_v4();
         let host1 = create_test_host(host1_id, 2, ByteSize::gb(4));
 
@@ -598,8 +754,14 @@ mod tests {
         cache.check_in(host2, false);
         cache.check_in(host3, false);
 
-        // Request 3 cores, 6GB - should get host2 (4 cores, 8GB) or host3 (8 cores, 16GB)
-        let result = cache.check_out(CoreSize(3), ByteSize::gb(6), |_| true);
+        let profile = test_profile(3, ByteSize::gb(6));
+        let result = cache.check_out(
+            CoreSize(3),
+            ByteSize::gb(6),
+            &profile,
+            always_valid,
+            no_reservation_check,
+        );
         assert!(result.is_ok());
 
         let chosen_host = result.unwrap();
@@ -609,30 +771,23 @@ mod tests {
 
     #[test]
     fn test_gen_memory_key() {
-        // The memory key formula is: memory / CONFIG.host_cache.memory_key_divisor.as_u64()
-        // With default 2.1GB divisor:
-        // 4GB / 2.1GB = 1 (rounded down)
-        // 8GB / 2.1GB = 3 (rounded down)
-        let memory1 = ByteSize::gb(4); // 4GB
-        let memory2 = ByteSize::gb(8); // 8GB
+        let memory1 = ByteSize::gb(4);
+        let memory2 = ByteSize::gb(8);
 
         let key1 = HostCache::gen_memory_key(memory1);
         let key2 = HostCache::gen_memory_key(memory2);
 
-        // Keys should be different and deterministic
         assert_ne!(key1, key2);
-        assert_eq!(key1, HostCache::gen_memory_key(memory1)); // Should be deterministic
+        assert_eq!(key1, HostCache::gen_memory_key(memory1));
 
-        // With 2.1GB divisor, should get expected values
-        assert_eq!(key1, 1); // 4GB / 2.1GB = ~1.9, rounded down to 1
-        assert_eq!(key2, 3); // 8GB / 2.1GB = ~3.8, rounded down to 3
+        assert_eq!(key1, 1);
+        assert_eq!(key2, 3);
     }
 
     #[test]
     fn test_multiple_hosts_same_resources() {
         let cache = HostCache::default();
 
-        // Add multiple hosts with same resource configuration
         let host1_id = Uuid::new_v4();
         let host1 = create_test_host(host1_id, 4, ByteSize::gb(8));
 
@@ -642,15 +797,158 @@ mod tests {
         cache.check_in(host1, false);
         cache.check_in(host2, false);
 
-        // First checkout should succeed
-        let result1 = cache.check_out(CoreSize(2), ByteSize::gb(4), |_| true);
+        let profile = test_profile(2, ByteSize::gb(4));
+        let result1 = cache.check_out(
+            CoreSize(2),
+            ByteSize::gb(4),
+            &profile,
+            always_valid,
+            no_reservation_check,
+        );
         assert!(result1.is_ok());
 
-        // Second checkout should also succeed (different host)
-        let result2 = cache.check_out(CoreSize(2), ByteSize::gb(4), |_| true);
+        let result2 = cache.check_out(
+            CoreSize(2),
+            ByteSize::gb(4),
+            &profile,
+            always_valid,
+            no_reservation_check,
+        );
         assert!(result2.is_ok());
 
-        // The hosts should be different
         assert_ne!(result1.unwrap().id, result2.unwrap().id);
+    }
+
+    // ---- Epvm K-candidate path (T2) ---------------------------------------
+
+    /// Build a HostCache with the Epvm strategy explicitly set, bypassing
+    /// the global CONFIG. Useful for testing the K-candidate path without
+    /// reconfiguring the whole process.
+    fn epvm_cache(max_candidates: usize) -> HostCache {
+        HostCache {
+            hosts_index: RwLock::new(BTreeMap::new()),
+            last_queried: RwLock::new(SystemTime::now()),
+            last_fetched: RwLock::new(None),
+            strategy: HostBookingStrategy::Epvm {
+                weights: ScoreWeights::default(),
+                max_candidates,
+            },
+        }
+    }
+
+    /// Gate that scores by host id's first byte — deterministic ordering for
+    /// tests of the K-candidate sort/pick.
+    fn id_byte_gate(host: &Host, _: &LayerProfile) -> Option<f64> {
+        Some(host.id.as_bytes()[0] as f64)
+    }
+
+    #[test]
+    fn epvm_picks_lowest_score() {
+        let cache = epvm_cache(10);
+
+        // Three hosts with deterministic first-byte ids: 0x10, 0x20, 0x05.
+        // The 0x05 host should win.
+        let high_id = Uuid::from_bytes([0x10; 16]);
+        let med_id = Uuid::from_bytes([0x20; 16]);
+        let low_id = Uuid::from_bytes([0x05; 16]);
+
+        cache.check_in(create_test_host(high_id, 8, ByteSize::gb(16)), false);
+        cache.check_in(create_test_host(med_id, 8, ByteSize::gb(16)), false);
+        cache.check_in(create_test_host(low_id, 8, ByteSize::gb(16)), false);
+
+        let profile = test_profile(2, ByteSize::gb(4));
+        let chosen = cache
+            .check_out(
+                CoreSize(2),
+                ByteSize::gb(4),
+                &profile,
+                id_byte_gate,
+                no_reservation_check,
+            )
+            .expect("expected a checkout");
+
+        assert_eq!(chosen.id, low_id, "lowest-score host should win");
+    }
+
+    #[test]
+    fn epvm_respects_max_candidates_cap() {
+        let cache = epvm_cache(2);
+
+        // Add three hosts. Cap = 2 means only the first 2 visited are scored;
+        // the 3rd is never considered even if it would score lowest.
+        // B-tree iterates saturated-first; with all hosts at same (cores, mem),
+        // iteration order within a bucket is HashSet-arbitrary but bounded.
+        let id_a = Uuid::from_bytes([0x10; 16]);
+        let id_b = Uuid::from_bytes([0x20; 16]);
+        let id_c = Uuid::from_bytes([0x05; 16]);
+
+        cache.check_in(create_test_host(id_a, 8, ByteSize::gb(16)), false);
+        cache.check_in(create_test_host(id_b, 8, ByteSize::gb(16)), false);
+        cache.check_in(create_test_host(id_c, 8, ByteSize::gb(16)), false);
+
+        let profile = test_profile(2, ByteSize::gb(4));
+        let chosen = cache
+            .check_out(
+                CoreSize(2),
+                ByteSize::gb(4),
+                &profile,
+                id_byte_gate,
+                no_reservation_check,
+            )
+            .expect("expected a checkout");
+
+        // With cap=2 and HashSet iteration arbitrary, the lowest score winner
+        // is one of the first 2 visited — not necessarily id_c (0x05). The
+        // chosen host's id MUST be one of the three checked-in ids though.
+        assert!(
+            chosen.id == id_a || chosen.id == id_b || chosen.id == id_c,
+            "unexpected host id {}",
+            chosen.id
+        );
+    }
+
+    #[test]
+    fn epvm_no_candidate_when_all_rejected() {
+        let cache = epvm_cache(10);
+
+        let host_id = Uuid::new_v4();
+        cache.check_in(create_test_host(host_id, 8, ByteSize::gb(16)), false);
+
+        let profile = test_profile(2, ByteSize::gb(4));
+        let result = cache.check_out(
+            CoreSize(2),
+            ByteSize::gb(4),
+            &profile,
+            always_reject,
+            no_reservation_check,
+        );
+
+        assert!(matches!(result, Err(HostCacheError::NoCandidateAvailable)));
+    }
+
+    #[test]
+    fn epvm_skips_reserved_hosts() {
+        let cache = epvm_cache(10);
+
+        let reserved_id = Uuid::from_bytes([0x01; 16]);
+        let free_id = Uuid::from_bytes([0xFF; 16]);
+
+        cache.check_in(create_test_host(reserved_id, 8, ByteSize::gb(16)), false);
+        cache.check_in(create_test_host(free_id, 8, ByteSize::gb(16)), false);
+
+        let profile = test_profile(2, ByteSize::gb(4));
+        // Reservation check: pretend reserved_id is unavailable. id_byte_gate
+        // would normally rank reserved_id (0x01) ahead of free_id (0xFF).
+        let chosen = cache
+            .check_out(
+                CoreSize(2),
+                ByteSize::gb(4),
+                &profile,
+                id_byte_gate,
+                |host: &Host| host.id != reserved_id,
+            )
+            .expect("expected a checkout");
+
+        assert_eq!(chosen.id, free_id, "reserved host should be skipped");
     }
 }

--- a/rust/crates/scheduler/src/host_cache/cache.rs
+++ b/rust/crates/scheduler/src/host_cache/cache.rs
@@ -63,6 +63,18 @@ pub type MemoryBTree = BTreeMap<MemoryKey, HashSet<HostId>>;
 /// so the actor's `CheckOut` message stays non-generic.
 pub type Gate = fn(&Host, &LayerProfile) -> Option<f64>;
 
+/// One Phase-1 candidate captured by the Epvm scan: the index coordinates
+/// (so we can locate the entry to remove from the B-tree on commit), the
+/// CAS witness (`expected_last_updated`), and the score that determines
+/// commit order in Phase 3.
+struct ScoredCandidate {
+    core_key: CoreKey,
+    memory_key: MemoryKey,
+    host_id: Uuid,
+    expected_last_updated: chrono::DateTime<chrono::Utc>,
+    score: f64,
+}
+
 pub struct HostCache {
     /// B-Tree of host groups ordered by their number of available cores
     hosts_index: RwLock<BTreeMap<CoreKey, MemoryBTree>>,
@@ -305,9 +317,12 @@ impl HostCache {
     /// engages), score them via the gate, and try `atomic_remove_if_valid`
     /// in ascending score order. First successful CAS wins.
     ///
-    /// By design, this is a single-pass operation: if every Phase-3
-    /// commit fails its CAS, returns `None` and the matcher's outer retry
-    /// loop re-enumerates on the next iteration.
+    /// Under contention every Phase-3 commit can lose its CAS to a concurrent
+    /// checkout. In that case we re-scan (up to `EPVM_INNER_RETRIES` times)
+    /// with the just-busted host ids excluded so the re-scan doesn't pick the
+    /// same losers again — mirrors the Saturation path's `failed_candidates`
+    /// retry. If retries are exhausted, returns `None` and the matcher's outer
+    /// retry loop re-enumerates from scratch.
     fn remove_host_best(
         &self,
         cores: CoreSize,
@@ -317,74 +332,109 @@ impl HostCache {
         reserved_check: &impl Fn(&Host) -> bool,
         max_candidates: usize,
     ) -> Option<Host> {
+        const EPVM_INNER_RETRIES: usize = 3;
+
         let core_key = cores.value() as u32;
         let memory_key = Self::gen_memory_key(memory);
 
-        // Phase 1 + 2: scan and score under the index read lock. Memory floor
-        // is enforced by the `memory_key..` range; cores floor by `core_key..`.
-        // Saturated-first iteration on both dims so candidates are visited in
-        // best-first order until `max_candidates` is hit.
-        let mut scored: Vec<(CoreKey, MemoryKey, Uuid, chrono::DateTime<chrono::Utc>, f64)> = {
-            let host_index_lock = self.hosts_index.read().unwrap_or_else(|p| p.into_inner());
-            let mut acc = Vec::with_capacity(max_candidates.min(64));
+        // Phase 3 CAS failures within this call. Any host_id added here is
+        // skipped by subsequent re-scans so we don't burn retries scoring and
+        // re-failing the same losing candidates.
+        let mut failed_candidates: HashSet<Uuid> = HashSet::new();
 
-            'outer: for (by_core_key, hosts_by_memory) in host_index_lock.range(core_key..) {
-                for (by_memory_key, hosts) in hosts_by_memory.range(memory_key..) {
-                    for host_id in hosts.iter() {
-                        if let Some(host) = HOST_STORE.get(host_id) {
-                            if !reserved_check(&host) {
+        // Phase 3 validation: re-check the gate (atomic_remove_if_valid
+        // CAS-guards last_updated, so a successful commit means the host
+        // snapshot is identical to what we scored).
+        let host_validation = |host: &Host| gate(host, profile).is_some() && reserved_check(host);
+
+        for _ in 0..EPVM_INNER_RETRIES {
+            // Phase 1 + 2: scan and score under the index read lock. Memory
+            // floor is enforced by the `memory_key..` range; cores floor by
+            // `core_key..`. Saturated-first iteration on both dims so
+            // candidates are visited in best-first order until `max_candidates`
+            // is hit. Hosts in `failed_candidates` (CAS-busted earlier in this
+            // call) are skipped here.
+            let mut scored: Vec<ScoredCandidate> = {
+                let host_index_lock = self.hosts_index.read().unwrap_or_else(|p| p.into_inner());
+                let mut acc = Vec::with_capacity(max_candidates.min(64));
+
+                'outer: for (by_core_key, hosts_by_memory) in host_index_lock.range(core_key..) {
+                    for (by_memory_key, hosts) in hosts_by_memory.range(memory_key..) {
+                        for host_id in hosts.iter() {
+                            if failed_candidates.contains(host_id) {
                                 continue;
                             }
-                            if let Some(score) = gate(&host, profile) {
-                                acc.push((
-                                    *by_core_key,
-                                    *by_memory_key,
-                                    *host_id,
-                                    host.last_updated,
-                                    score,
-                                ));
-                                if acc.len() >= max_candidates {
-                                    break 'outer;
+                            if let Some(host) = HOST_STORE.get(host_id) {
+                                if !reserved_check(&host) {
+                                    continue;
+                                }
+                                if let Some(score) = gate(&host, profile) {
+                                    acc.push(ScoredCandidate {
+                                        core_key: *by_core_key,
+                                        memory_key: *by_memory_key,
+                                        host_id: *host_id,
+                                        expected_last_updated: host.last_updated,
+                                        score,
+                                    });
+                                    if acc.len() >= max_candidates {
+                                        break 'outer;
+                                    }
                                 }
                             }
                         }
                     }
                 }
+                acc
+            };
+
+            if scored.is_empty() {
+                return None;
             }
-            acc
-        };
 
-        // Sort ascending: lowest stranding wins.
-        scored.sort_by(|a, b| a.4.partial_cmp(&b.4).unwrap_or(std::cmp::Ordering::Equal));
+            // Sort ascending: lowest stranding wins.
+            scored.sort_by(|a, b| {
+                a.score
+                    .partial_cmp(&b.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
 
-        // Phase 3: try commits in score order. The validation closure must
-        // re-check the gate because the host may have changed between Phase 1
-        // and Phase 3 (atomic_remove_if_valid already CAS-guards last_updated,
-        // so a successful commit means we have the same snapshot).
-        let host_validation = |host: &Host| gate(host, profile).is_some() && reserved_check(host);
+            // Phase 3: try commits in score order. Within this attempt the
+            // `for ... continue` already skips past CAS failures; the
+            // failed_candidates set protects the *next* attempt's re-scan from
+            // re-picking the same losers.
+            for candidate in scored {
+                match HOST_STORE.atomic_remove_if_valid(
+                    &candidate.host_id,
+                    candidate.expected_last_updated,
+                    host_validation,
+                ) {
+                    Ok(Some(removed_host)) => {
+                        let mut host_index_lock =
+                            self.hosts_index.write().unwrap_or_else(|p| p.into_inner());
 
-        for (by_core_key, by_memory_key, host_id, expected_last_updated, score) in scored {
-            match HOST_STORE.atomic_remove_if_valid(
-                &host_id,
-                expected_last_updated,
-                host_validation,
-            ) {
-                Ok(Some(removed_host)) => {
-                    let mut host_index_lock =
-                        self.hosts_index.write().unwrap_or_else(|p| p.into_inner());
+                        host_index_lock
+                            .get_mut(&candidate.core_key)
+                            .and_then(|hosts_by_memory| {
+                                hosts_by_memory.get_mut(&candidate.memory_key)
+                            })
+                            .map(|hosts| hosts.remove(&candidate.host_id));
 
-                    host_index_lock
-                        .get_mut(&by_core_key)
-                        .and_then(|hosts_by_memory| hosts_by_memory.get_mut(&by_memory_key))
-                        .map(|hosts| hosts.remove(&host_id));
-
-                    metrics::observe_placement_score_chosen(score);
-                    return Some(removed_host);
+                        metrics::observe_placement_score_chosen(candidate.score);
+                        return Some(removed_host);
+                    }
+                    Ok(None) | Err(()) => {
+                        failed_candidates.insert(candidate.host_id);
+                        continue;
+                    }
                 }
-                Ok(None) | Err(()) => continue,
             }
         }
 
+        // Fell through every retry attempt without committing — every scan
+        // had candidates but every CAS lost. The `scored.is_empty()` early
+        // return above filters out the no-candidate case, so this is purely
+        // a contention signal.
+        metrics::increment_placement_inner_retries_exhausted();
         None
     }
 
@@ -874,36 +924,47 @@ mod tests {
     fn epvm_respects_max_candidates_cap() {
         let cache = epvm_cache(2);
 
-        // Add three hosts. Cap = 2 means only the first 2 visited are scored;
-        // the 3rd is never considered even if it would score lowest.
-        // B-tree iterates saturated-first; with all hosts at same (cores, mem),
-        // iteration order within a bucket is HashSet-arbitrary but bounded.
-        let id_a = Uuid::from_bytes([0x10; 16]);
-        let id_b = Uuid::from_bytes([0x20; 16]);
-        let id_c = Uuid::from_bytes([0x05; 16]);
+        // Place each host in its own B-tree bucket so the scan order is
+        // deterministic: ascending (core_key, memory_key). With cap=2 only
+        // the first two buckets are visited; the third host is never scored
+        // even though its id_byte gives it the lowest (best) score.
+        //
+        // Bucket A: ( 2 cores,  2GB) — visited 1st — id_byte 0x42 (worst)
+        // Bucket B: ( 4 cores,  4GB) — visited 2nd — id_byte 0x21 (medium)
+        // Bucket C: ( 8 cores,  8GB) — NEVER visited under cap=2 — id_byte 0x07 (best)
+        //
+        // UUIDs avoid the 0x05/0x10/0x20 bytes used by `epvm_picks_lowest_score`
+        // — the global HOST_STORE leaks state across tests, and reusing those
+        // ids causes the prior test's host resources to mask this test's
+        // bucket assignments.
+        let id_a = Uuid::from_bytes([0x42; 16]);
+        let id_b = Uuid::from_bytes([0x21; 16]);
+        let id_c = Uuid::from_bytes([0x07; 16]);
 
-        cache.check_in(create_test_host(id_a, 8, ByteSize::gb(16)), false);
-        cache.check_in(create_test_host(id_b, 8, ByteSize::gb(16)), false);
-        cache.check_in(create_test_host(id_c, 8, ByteSize::gb(16)), false);
+        cache.check_in(create_test_host(id_a, 2, ByteSize::gb(2)), false);
+        cache.check_in(create_test_host(id_b, 4, ByteSize::gb(4)), false);
+        cache.check_in(create_test_host(id_c, 8, ByteSize::gb(8)), false);
 
-        let profile = test_profile(2, ByteSize::gb(4));
+        let profile = test_profile(2, ByteSize::gb(2));
         let chosen = cache
             .check_out(
                 CoreSize(2),
-                ByteSize::gb(4),
+                ByteSize::gb(2),
                 &profile,
                 id_byte_gate,
                 no_reservation_check,
             )
             .expect("expected a checkout");
 
-        // With cap=2 and HashSet iteration arbitrary, the lowest score winner
-        // is one of the first 2 visited — not necessarily id_c (0x05). The
-        // chosen host's id MUST be one of the three checked-in ids though.
-        assert!(
-            chosen.id == id_a || chosen.id == id_b || chosen.id == id_c,
-            "unexpected host id {}",
-            chosen.id
+        // With the cap enforced: id_c is never scored, so the winner is the
+        // lowest of {id_a, id_b}, which is id_b (0x10 < 0x20).
+        //
+        // Without the cap (regression): id_c WOULD be scored and would win
+        // since 0x05 is the lowest. So an assertion that the chosen host is
+        // id_b actively verifies the cap is enforced.
+        assert_eq!(
+            chosen.id, id_b,
+            "expected id_b to win under cap=2 (id_c should not have been scored)"
         );
     }
 

--- a/rust/crates/scheduler/src/host_cache/messages.rs
+++ b/rust/crates/scheduler/src/host_cache/messages.rs
@@ -18,8 +18,9 @@ use uuid::Uuid;
 
 use crate::{
     cluster_key::{ClusterKey, Tag},
-    host_cache::HostCacheError,
+    host_cache::{cache::Gate, HostCacheError},
     models::{CoreSize, Host},
+    pipeline::placement::LayerProfile,
 };
 
 /// Response containing a checked-out host and its associated cluster key.
@@ -36,21 +37,23 @@ pub struct CheckedOutHost(pub ClusterKey, pub Host);
 
 /// Actor message to check out a host from the cache.
 ///
-/// Requests a host that matches the specified resource requirements and passes
-/// the validation function. The cache will search through groups for each tag
-/// in priority order (MANUAL > HOSTNAME > ALLOC) until a suitable host is found.
+/// Requests a host that matches the layer's floor (carried by `profile`) and
+/// passes the `gate` function. The cache searches through groups for each
+/// tag in priority order (MANUAL > HOSTNAME > HARDWARE > ALLOC) until a
+/// suitable host is found.
 ///
-/// If not found in cache, the service will fetch from the database. The host
-/// is removed from the cache and must be checked back in after use.
+/// The `gate` is a plain `fn` pointer (no closure capture), so this message
+/// is non-generic and a single `Handler` impl serves every booking strategy.
+/// All per-call data flows through `profile`.
 ///
 /// # Fields
 ///
 /// * `facility_id` - Facility identifier for the cluster key
 /// * `show_id` - Show identifier for the cluster key
 /// * `tags` - List of tags to search (tried in priority order)
-/// * `cores` - Minimum number of cores required
-/// * `memory` - Minimum memory required
-/// * `validation` - Function to validate additional host requirements
+/// * `cores` / `memory` - Range hints for the B-tree query (floors enforced by `gate`)
+/// * `profile` - Placement context (floors, compatibility, E-PVM caps + weights)
+/// * `gate` - Validates and (for E-PVM) scores each candidate
 ///
 /// # Returns
 ///
@@ -59,16 +62,14 @@ pub struct CheckedOutHost(pub ClusterKey, pub Host);
 /// * `Err(HostCacheError::FailedToQueryHostCache)` - Database query failed
 #[derive(Message)]
 #[rtype(result = "Result<CheckedOutHost, HostCacheError>")]
-pub struct CheckOut<F>
-where
-    F: Fn(&Host) -> bool,
-{
+pub struct CheckOut {
     pub facility_id: String,
     pub show_id: Uuid,
     pub tags: Vec<Tag>,
     pub cores: CoreSize,
     pub memory: ByteSize,
-    pub validation: F,
+    pub profile: LayerProfile,
+    pub gate: Gate,
 }
 
 /// Payload for checking in a host or invalidating a host in the cache.

--- a/rust/crates/scheduler/src/host_cache/messages.rs
+++ b/rust/crates/scheduler/src/host_cache/messages.rs
@@ -124,14 +124,8 @@ pub struct CacheRatio;
 ///
 /// # Fields
 ///
-/// * `hit` - Total number of cache hits (hosts found in cache)
-/// * `miss` - Total number of cache misses (required database fetch)
 /// * `hit_ratio` - Percentage of cache hits (0-100)
 #[derive(MessageResponse)]
 pub struct CacheRatioResponse {
-    #[allow(dead_code)]
-    pub hit: u64,
-    #[allow(dead_code)]
-    pub miss: u64,
     pub hit_ratio: usize,
 }

--- a/rust/crates/scheduler/src/host_cache/mod.rs
+++ b/rust/crates/scheduler/src/host_cache/mod.rs
@@ -10,8 +10,8 @@
 // or implied. See the License for the specific language governing permissions and limitations under
 // the License.
 
+pub(crate) mod cache;
 mod actor;
-mod cache;
 pub mod messages;
 mod store;
 

--- a/rust/crates/scheduler/src/main.rs
+++ b/rust/crates/scheduler/src/main.rs
@@ -193,6 +193,16 @@ impl JobQueueCli {
                 // Resolving str_tag → pk_alloc at startup is a future enhancement;
                 // for now the matcher's burst snapshot is disabled for CLI-built
                 // alloc tags and falls back to today's burst-unaware behavior.
+                tracing::warn!(
+                    "CLI alloc-tag override for show '{}' tag '{}': pk_alloc not \
+                     resolved; the matcher will skip the subscription burst \
+                     snapshot for this cluster and E-PVM placement will run \
+                     without burst awareness. Use the streamed-cluster path for \
+                     production-equivalent placement. This CLI override is \
+                     scheduled for removal.",
+                    alloc_tag.show,
+                    alloc_tag.tag
+                );
                 clusters.push(Cluster::single_tag(
                     facility_id.clone(),
                     show_id,

--- a/rust/crates/scheduler/src/main.rs
+++ b/rust/crates/scheduler/src/main.rs
@@ -189,12 +189,17 @@ impl JobQueueCli {
                 let show_id = cluster::get_show_id(&alloc_tag.show)
                     .await
                     .wrap_err(format!("Could not find show {}.", alloc_tag.show))?;
+                // CLI override path: we only have str_tag, not pk_alloc.
+                // Resolving str_tag → pk_alloc at startup is a future enhancement;
+                // for now the matcher's burst snapshot is disabled for CLI-built
+                // alloc tags and falls back to today's burst-unaware behavior.
                 clusters.push(Cluster::single_tag(
                     facility_id.clone(),
                     show_id,
                     Tag {
                         name: alloc_tag.tag.clone(),
                         ttype: TagType::Alloc,
+                        alloc_id: None,
                     },
                 ));
             }
@@ -213,6 +218,7 @@ impl JobQueueCli {
                         .map(|name| Tag {
                             name: name.clone(),
                             ttype: TagType::Manual,
+                            alloc_id: None,
                         })
                         .collect(),
                 ));

--- a/rust/crates/scheduler/src/metrics/mod.rs
+++ b/rust/crates/scheduler/src/metrics/mod.rs
@@ -103,6 +103,18 @@ lazy_static! {
         vec![0.0, 0.5, 1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 1000.0]
     )
     .expect("Failed to register placement_score_chosen histogram");
+
+    // Incremented when `remove_host_best` exits its bounded inner retry loop
+    // (EPVM_INNER_RETRIES attempts) without committing a host. A sustained
+    // non-zero rate signals contention: candidates are being CAS-busted by
+    // concurrent checkouts faster than we can pick alternates. Pairs with
+    // PLACEMENT_SCORE_CHOSEN — together they describe both the wins and
+    // the give-ups on the EPVM path.
+    pub static ref PLACEMENT_INNER_RETRIES_EXHAUSTED: Counter = register_counter!(
+        "scheduler_placement_inner_retries_exhausted_total",
+        "Times remove_host_best gave up after exhausting its inner retry budget"
+    )
+    .expect("Failed to register placement_inner_retries_exhausted_total counter");
 }
 
 /// Handler for the /metrics endpoint
@@ -219,4 +231,12 @@ pub fn observe_cluster_round_trip(duration: Duration) {
 #[inline]
 pub fn observe_placement_score_chosen(score: f64) {
     PLACEMENT_SCORE_CHOSEN.observe(score);
+}
+
+/// Increments the counter for `remove_host_best` give-ups after the inner
+/// retry budget is exhausted (every candidate's CAS lost to a concurrent
+/// checkout). Called only on the Epvm path.
+#[inline]
+pub fn increment_placement_inner_retries_exhausted() {
+    PLACEMENT_INNER_RETRIES_EXHAUSTED.inc();
 }

--- a/rust/crates/scheduler/src/metrics/mod.rs
+++ b/rust/crates/scheduler/src/metrics/mod.rs
@@ -92,6 +92,17 @@ lazy_static! {
         vec![0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0]
     )
     .expect("Failed to register cluster_round_trip_seconds histogram");
+
+    // E-PVM placement metrics from host_cache/cache.rs. Observed only on the
+    // Epvm path (Saturation always scores 0.0). Buckets are dimensionless W3
+    // fractional-layer-frames units; calibration may need adjustment after
+    // production rollout. See design Risk 1.
+    pub static ref PLACEMENT_SCORE_CHOSEN: Histogram = register_histogram!(
+        "scheduler_placement_score_chosen",
+        "E-PVM score of the host chosen by check_out_best",
+        vec![0.0, 0.5, 1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 1000.0]
+    )
+    .expect("Failed to register placement_score_chosen histogram");
 }
 
 /// Handler for the /metrics endpoint
@@ -201,4 +212,11 @@ pub fn observe_job_query_duration(duration: Duration) {
 #[inline]
 pub fn observe_cluster_round_trip(duration: Duration) {
     CLUSTER_ROUND_TRIP_SECONDS.observe(duration.as_secs_f64());
+}
+
+/// Records the E-PVM score of the host returned by `check_out_best`.
+/// Called only on the Epvm path; Saturation never invokes this.
+#[inline]
+pub fn observe_placement_score_chosen(score: f64) {
+    PLACEMENT_SCORE_CHOSEN.observe(score);
 }

--- a/rust/crates/scheduler/src/models/layer.rs
+++ b/rust/crates/scheduler/src/models/layer.rs
@@ -37,6 +37,11 @@ pub struct DispatchLayer {
     pub gpu_mem_min: ByteSize,
     pub tags: HashSet<String>,
     pub frames: Vec<DispatchFrame>,
+    /// Job-level core cap (`job_resource.int_max_cores`). `<= 0` means
+    /// unlimited; the E-PVM cap check (`compute_max_more`) skips this dim
+    /// when not positive. Slow-moving admin field; refreshed each time the
+    /// matcher re-queries the job's layers (design Branch 2b).
+    pub job_max_cores: i32,
 }
 
 impl fmt::Display for DispatchLayer {

--- a/rust/crates/scheduler/src/pipeline/entrypoint.rs
+++ b/rust/crates/scheduler/src/pipeline/entrypoint.rs
@@ -88,7 +88,7 @@ pub async fn run(cluster_feed: ClusterFeed) -> miette::Result<()> {
                                     metrics::increment_jobs_processed(&job_model.show_name);
                                     let job = DispatchJob::new(job_model, cluster.clone());
                                     debug!("Found job: {}", job);
-                                    matcher.process(job).await;
+                                    matcher.process(job, &feed_sender).await;
                                 },
                             )
                             .await;

--- a/rust/crates/scheduler/src/pipeline/matcher.rs
+++ b/rust/crates/scheduler/src/pipeline/matcher.rs
@@ -256,7 +256,7 @@ impl MatchingService {
         } else {
             None
         };
-        let (show_cores_in_use, show_burst): (i32, i32) = match alloc_id_opt {
+        let (initial_show_cores_in_use, show_burst): (i32, i32) = match alloc_id_opt {
             Some(alloc_id) => match self
                 .accounting
                 .redis()
@@ -287,7 +287,8 @@ impl MatchingService {
         // and self-corrects on the next wake; the Lua booking call remains
         // authoritative on the actual booking.
         if show_burst > 0
-            && show_cores_in_use.saturating_add(dispatch_layer.cores_min.value()) > show_burst
+            && initial_show_cores_in_use.saturating_add(dispatch_layer.cores_min.value())
+                > show_burst
         {
             metrics::increment_accounting_limit_exceeded("subscription");
             debug!(
@@ -297,7 +298,7 @@ impl MatchingService {
                 dispatch_layer,
                 dispatch_layer.show_id,
                 alloc_id_opt,
-                show_cores_in_use,
+                initial_show_cores_in_use,
                 dispatch_layer.cores_min.value(),
                 show_burst,
                 cluster,
@@ -310,6 +311,7 @@ impl MatchingService {
                 .await;
             return;
         }
+        let mut local_show_cores_booked: i32 = 0;
 
         // Use Option to handle ownership transfer cleanly
         let mut current_layer_version = Some(dispatch_layer);
@@ -379,7 +381,7 @@ impl MatchingService {
                 job_max_cores: layer.job_max_cores,
                 show_burst,
                 job_cores_in_use: initial_job_cores_in_use + local_job_cores_booked,
-                show_cores_in_use,
+                show_cores_in_use: initial_show_cores_in_use + local_show_cores_booked,
                 weights,
             };
 
@@ -419,11 +421,15 @@ impl MatchingService {
                             updated_layer,
                         }) => {
                             // Track cores actually consumed so the next iteration's
-                            // LayerProfile sees the local picture of usage.
+                            // LayerProfile sees the local picture of usage. The same
+                            // delta applies to the (show, alloc) subscription burst
+                            // since every dispatched frame counts against both caps.
                             let dispatched = frames_before_dispatch
                                 .saturating_sub(updated_layer.frames.len())
                                 as i32;
-                            local_job_cores_booked += dispatched * cores_per_frame;
+                            let booked_cores = dispatched * cores_per_frame;
+                            local_job_cores_booked += booked_cores;
+                            local_show_cores_booked += booked_cores;
 
                             self.host_service
                                 .send(CheckIn(cluster_key, CheckInPayload::Host(updated_host)))

--- a/rust/crates/scheduler/src/pipeline/matcher.rs
+++ b/rust/crates/scheduler/src/pipeline/matcher.rs
@@ -18,17 +18,17 @@ use std::{
     time::Duration,
 };
 
-use opencue_proto::host::ThreadMode;
 use uuid::Uuid;
 
 use crate::{
-    cluster::Cluster,
-    cluster_key::Tag,
+    accounting::{accounting_service, AccountingService},
+    cluster::{Cluster, FeedMessage},
+    cluster_key::{Tag, TagType},
     config::CONFIG,
     dao::LayerDao,
     host_cache::{host_cache_service, messages::*, HostCacheService},
     metrics,
-    models::{DispatchJob, DispatchLayer, Host},
+    models::{CoreSize, DispatchJob, DispatchLayer, Host},
     pipeline::{
         dispatcher::{
             error::DispatchError,
@@ -36,11 +36,12 @@ use crate::{
             rqd_dispatcher_service, RqdDispatcherService,
         },
         layer_permit::{layer_permit_service, LayerPermitService, Release, Request},
+        placement::{self, LayerProfile},
     },
 };
 use actix::Addr;
 use miette::Result;
-use tokio::sync::Semaphore;
+use tokio::sync::{mpsc, Semaphore};
 use tracing::{debug, error, info, trace};
 
 pub static HOSTS_ATTEMPTED: AtomicUsize = AtomicUsize::new(0);
@@ -59,6 +60,7 @@ pub struct MatchingService {
     layer_dao: LayerDao,
     dispatcher_service: Addr<RqdDispatcherService>,
     concurrency_semaphore: Arc<Semaphore>,
+    accounting: Arc<AccountingService>,
 }
 
 impl MatchingService {
@@ -78,6 +80,7 @@ impl MatchingService {
         let layer_dao = LayerDao::new().await?;
         let host_service = host_cache_service().await?;
         let layer_permit_service = layer_permit_service().await?;
+        let accounting = accounting_service().await?;
 
         // Limiting the concurrency here is necessary to avoid consuming the entire
         // database connection pool
@@ -91,6 +94,7 @@ impl MatchingService {
             layer_dao,
             dispatcher_service,
             concurrency_semaphore: Arc::new(Semaphore::new(max_concurrent_transactions)),
+            accounting,
         })
     }
 
@@ -104,7 +108,10 @@ impl MatchingService {
     /// # Arguments
     ///
     /// * `job` - The dispatch job containing layers to process
-    pub async fn process(&self, job: DispatchJob) {
+    /// * `feed_sender` - Control channel for the cluster feed; used by
+    ///   `process_layer` to sleep the cluster when the (show, alloc)
+    ///   subscription is over burst (Alloc clusters + managed shows only).
+    pub async fn process(&self, job: DispatchJob, feed_sender: &mpsc::Sender<FeedMessage>) {
         let job_disp = format!("{}", job);
         let cluster = Arc::new(job.source_cluster);
 
@@ -152,7 +159,7 @@ impl MatchingService {
 
                     if layer_permit {
                         let layer_id = layer.id;
-                        self.process_layer(layer, cluster).await;
+                        self.process_layer(layer, cluster, feed_sender).await;
                         debug!("{}: Processed layer", layer_disp);
 
                         self.layer_permit_service
@@ -180,24 +187,6 @@ impl MatchingService {
         }
     }
 
-    fn host_matches_layer_os(host: &Host, os: Option<&str>) -> bool {
-        os.is_none() || host.str_os.as_deref() == os
-    }
-
-    /// Mirrors Cuebot's DispatchQuery filter: hosts in ThreadMode::All only accept threadable
-    /// layers. Booking a non-threadable layer on such a host would diverge from Cuebot's behavior
-    /// and starve the layer when ownership of the show moves back to Cuebot.
-    fn host_matches_thread_mode(host: &Host, threadable: bool) -> bool {
-        !(host.thread_mode == ThreadMode::All && !threadable)
-    }
-
-    /// Sync per-host validation invoked from the host_cache actor. Checks OS and thread-mode
-    /// compatibility - subscription burst is enforced by the Lua booking call inside
-    /// `dispatch_virtual_proc` (see comment at the call site).
-    fn validate_match(host: &Host, os: Option<&str>, threadable: bool) -> bool {
-        Self::host_matches_layer_os(host, os) && Self::host_matches_thread_mode(host, threadable)
-    }
-
     /// Processes a single layer by finding host candidates and attempting dispatch.
     ///
     /// The process:
@@ -210,10 +199,117 @@ impl MatchingService {
     ///
     /// * `dispatch_layer` - The layer to dispatch to a host
     /// * `cluster` - The cluster context for this dispatch operation
-    async fn process_layer(&self, dispatch_layer: DispatchLayer, cluster: Arc<Cluster>) {
+    /// * `feed_sender` - Control channel for sleeping the cluster on
+    ///   pre-checkout over-burst detection.
+    async fn process_layer(
+        &self,
+        dispatch_layer: DispatchLayer,
+        cluster: Arc<Cluster>,
+        feed_sender: &mpsc::Sender<FeedMessage>,
+    ) {
         let mut try_again = true;
         let mut attempts = CONFIG.queue.host_candidate_attempts_per_layer;
         let initial_attempts = attempts;
+
+        // E-PVM live-usage snapshot taken once at permit entry (design Branch 2a).
+        // Locally incremented per dispatched frame within the while-loop.
+        // Redis read failures degrade to 0, leaving the cap unbounded by live usage
+        // but still bounded by `job_max_cores`.
+        let cores_per_frame = dispatch_layer.cores_min.value();
+        let initial_job_cores_in_use = match self
+            .accounting
+            .redis()
+            .read_job_cores_in_use(dispatch_layer.job_id)
+            .await
+        {
+            Ok(centi) => CoreSize::from_multiplied(centi).value(),
+            Err(err) => {
+                debug!(
+                    "read_job_cores_in_use failed for job {}: {}; defaulting to 0",
+                    dispatch_layer.job_id, err
+                );
+                0
+            }
+        };
+        let mut local_job_cores_booked: i32 = 0;
+
+        // (show, alloc) subscription burst snapshot — Alloc clusters + managed
+        // shows only. `Cluster::single_tag` is built once per (facility, show,
+        // alloc.str_tag) row and the SQL join `host_tag.str_tag = alloc.str_tag`
+        // guarantees the chosen host is in that allocation, so the alloc_id on
+        // the single Tag IS the alloc the dispatched host will be in. For
+        // Manual/HostName/Hardware clusters and CLI-built alloc tags
+        // (alloc_id = None), we fall back to the burst-unaware behavior
+        // (show_burst = 0 → treated as "unlimited" by `compute_max_more`).
+        let alloc_id_opt = if self
+            .accounting
+            .managed_shows()
+            .contains(&dispatch_layer.show_id)
+            && cluster.tags.len() == 1
+        {
+            cluster
+                .tags
+                .iter()
+                .next()
+                .filter(|tag| tag.ttype == TagType::Alloc)
+                .and_then(|tag| tag.alloc_id)
+        } else {
+            None
+        };
+        let (show_cores_in_use, show_burst): (i32, i32) = match alloc_id_opt {
+            Some(alloc_id) => match self
+                .accounting
+                .redis()
+                .read_sub_counters(dispatch_layer.show_id, alloc_id)
+                .await
+            {
+                Ok((booked, burst)) => (
+                    CoreSize::from_multiplied(booked).value(),
+                    CoreSize::from_multiplied(burst).value(),
+                ),
+                Err(err) => {
+                    debug!(
+                        "read_sub_counters failed for show={} alloc={}: {}; \
+                         leaving burst unbounded, Lua will decide",
+                        dispatch_layer.show_id, alloc_id, err
+                    );
+                    (0, 0)
+                }
+            },
+            None => (0, 0),
+        };
+
+        // Pre-checkout over-burst skip. When the snapshot says the requested
+        // cores won't fit under burst, sleep the cluster for the same duration
+        // as the empty-cluster back-off and return without scanning the host
+        // cache or pinging the dispatcher. A stale "over burst" read costs at
+        // most a single cluster_empty_sleep window of latency on this cluster
+        // and self-corrects on the next wake; the Lua booking call remains
+        // authoritative on the actual booking.
+        if show_burst > 0
+            && show_cores_in_use.saturating_add(dispatch_layer.cores_min.value()) > show_burst
+        {
+            metrics::increment_accounting_limit_exceeded("subscription");
+            debug!(
+                "Skipping layer {} pre-checkout: subscription over burst \
+                 (show={}, alloc={:?}, booked={}, requested={}, burst={}); \
+                 sleeping cluster {}",
+                dispatch_layer,
+                dispatch_layer.show_id,
+                alloc_id_opt,
+                show_cores_in_use,
+                dispatch_layer.cores_min.value(),
+                show_burst,
+                cluster,
+            );
+            let _ = feed_sender
+                .send(FeedMessage::Sleep(
+                    (*cluster).clone(),
+                    CONFIG.queue.cluster_empty_sleep,
+                ))
+                .await;
+            return;
+        }
 
         // Use Option to handle ownership transfer cleanly
         let mut current_layer_version = Some(dispatch_layer);
@@ -255,8 +351,37 @@ impl MatchingService {
             // TODO: if over-burst attempts become a measurable perf drag, add a precomputed
             // per-layer Redis snapshot of (show, alloc) → bookable and consult it here.
             let cores_requested = layer.cores_min;
-            let os = layer.str_os.clone();
-            let threadable = layer.threadable;
+            let (gate, weights) = match CONFIG.queue.host_booking_strategy {
+                crate::config::HostBookingStrategy::Epvm { weights, .. } => (
+                    placement::epvm_gate as crate::host_cache::cache::Gate,
+                    weights,
+                ),
+                crate::config::HostBookingStrategy::Saturation { .. } => (
+                    placement::saturation_gate as crate::host_cache::cache::Gate,
+                    Default::default(),
+                ),
+            };
+            // `show_burst` / `show_cores_in_use` come from the per-(show, alloc)
+            // Redis snapshot taken above. They're populated for managed shows on
+            // Alloc clusters (where the chosen host's allocation is deterministic
+            // from the cluster's single Tag), and 0 otherwise — in which case
+            // `compute_max_more`'s `> 0` guards treat the cap as "unlimited" and
+            // E-PVM scoring loses the show-burst component of `maxMore`. The
+            // authoritative cap remains the Lua `BOOK_OR_FORCE` call inside the
+            // dispatcher; this snapshot is an optimistic input to scoring.
+            let profile = LayerProfile {
+                cores_min: layer.cores_min,
+                mem_min: layer.mem_min,
+                gpus_min: layer.gpus_min,
+                gpu_mem_min: layer.gpu_mem_min,
+                os: layer.str_os.clone(),
+                threadable: layer.threadable,
+                job_max_cores: layer.job_max_cores,
+                show_burst,
+                job_cores_in_use: initial_job_cores_in_use + local_job_cores_booked,
+                show_cores_in_use,
+                weights,
+            };
 
             let host_candidate = self
                 .host_service
@@ -266,7 +391,8 @@ impl MatchingService {
                     tags,
                     cores: cores_requested,
                     memory: layer.mem_min,
-                    validation: move |host| Self::validate_match(host, os.as_deref(), threadable),
+                    profile,
+                    gate,
                 })
                 .await
                 .expect("Host Cache actor is unresponsive");
@@ -277,6 +403,7 @@ impl MatchingService {
                     // Store layer info for error logging before moving ownership
                     let layer_display = format!("{}", layer);
                     let layer_job_id = layer.job_id;
+                    let frames_before_dispatch = layer.frames.len();
 
                     match self
                         .dispatcher_service
@@ -291,6 +418,13 @@ impl MatchingService {
                             updated_host,
                             updated_layer,
                         }) => {
+                            // Track cores actually consumed so the next iteration's
+                            // LayerProfile sees the local picture of usage.
+                            let dispatched = frames_before_dispatch
+                                .saturating_sub(updated_layer.frames.len())
+                                as i32;
+                            local_job_cores_booked += dispatched * cores_per_frame;
+
                             self.host_service
                                 .send(CheckIn(cluster_key, CheckInPayload::Host(updated_host)))
                                 .await
@@ -470,95 +604,5 @@ impl MatchingService {
                 );
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use bytesize::ByteSize;
-    use opencue_proto::host::ThreadMode;
-    use uuid::Uuid;
-
-    use super::MatchingService;
-    use crate::models::{CoreSize, Host};
-
-    fn host_with_os(str_os: Option<&str>) -> Host {
-        host_with(str_os, ThreadMode::Variable)
-    }
-
-    fn host_with_thread_mode(thread_mode: ThreadMode) -> Host {
-        host_with(Some("Linux"), thread_mode)
-    }
-
-    fn host_with(str_os: Option<&str>, thread_mode: ThreadMode) -> Host {
-        Host::new_for_test(
-            Uuid::new_v4(),
-            "test-host".to_string(),
-            str_os.map(str::to_string),
-            CoreSize::from_multiplied(100),
-            ByteSize::gb(64),
-            CoreSize::from_multiplied(100),
-            ByteSize::gb(64),
-            0,
-            ByteSize::gb(0),
-            thread_mode,
-            CoreSize::from_multiplied(100),
-            Uuid::new_v4(),
-            "test-alloc".to_string(),
-        )
-    }
-
-    #[test]
-    fn host_matches_when_layer_os_is_not_set() {
-        let host = host_with_os(Some("Linux"));
-
-        assert!(MatchingService::host_matches_layer_os(&host, None));
-    }
-
-    #[test]
-    fn host_matches_when_layer_os_matches_host_os() {
-        let host = host_with_os(Some("Linux"));
-
-        assert!(MatchingService::host_matches_layer_os(&host, Some("Linux")));
-    }
-
-    #[test]
-    fn host_does_not_match_when_layer_os_differs_from_host_os() {
-        let host = host_with_os(Some("Linux"));
-
-        assert!(!MatchingService::host_matches_layer_os(
-            &host,
-            Some("Windows")
-        ));
-    }
-
-    #[test]
-    fn thread_mode_all_rejects_non_threadable_layer() {
-        let host = host_with_thread_mode(ThreadMode::All);
-
-        assert!(!MatchingService::host_matches_thread_mode(&host, false));
-    }
-
-    #[test]
-    fn thread_mode_all_accepts_threadable_layer() {
-        let host = host_with_thread_mode(ThreadMode::All);
-
-        assert!(MatchingService::host_matches_thread_mode(&host, true));
-    }
-
-    #[test]
-    fn thread_mode_variable_accepts_any_threadability() {
-        let host = host_with_thread_mode(ThreadMode::Variable);
-
-        assert!(MatchingService::host_matches_thread_mode(&host, true));
-        assert!(MatchingService::host_matches_thread_mode(&host, false));
-    }
-
-    #[test]
-    fn thread_mode_auto_accepts_any_threadability() {
-        let host = host_with_thread_mode(ThreadMode::Auto);
-
-        assert!(MatchingService::host_matches_thread_mode(&host, true));
-        assert!(MatchingService::host_matches_thread_mode(&host, false));
     }
 }

--- a/rust/crates/scheduler/src/pipeline/mod.rs
+++ b/rust/crates/scheduler/src/pipeline/mod.rs
@@ -14,6 +14,7 @@ mod dispatcher;
 pub mod entrypoint;
 mod layer_permit;
 mod matcher;
+pub mod placement;
 
 pub use entrypoint::run;
 pub use matcher::MatchingService;

--- a/rust/crates/scheduler/src/pipeline/placement.rs
+++ b/rust/crates/scheduler/src/pipeline/placement.rs
@@ -198,11 +198,12 @@ pub fn placement_score(host: &Host, profile: &LayerProfile) -> f64 {
         );
         w.gpus * g_waste + w.gpu_mem * gm_waste
     } else {
-        // SI gigabytes — exact divisor doesn't matter; what matters is that
-        // the penalty scales with the host's GPU capacity and is on the same
-        // order as the W3-normalized stranding terms.
-        let gpu_capacity_gb = host.idle_gpus as f64 + (host.idle_gpu_memory.as_u64() as f64 / 1e9);
-        w.gpu_reservation * gpu_capacity_gb
+        // Soft-reservation penalty for non-GPU layers on GPU hosts. Count and
+        // GB are scaled by independent weights so operators tune the
+        // count-vs-memory balance explicitly. SI gigabytes (1e9) for the
+        // memory unit.
+        let idle_gpu_mem_gb = host.idle_gpu_memory.as_u64() as f64 / 1e9;
+        w.gpu_count_reservation * host.idle_gpus as f64 + w.gpu_mem_reservation * idle_gpu_mem_gb
     };
 
     w.cores * cores_waste + w.mem * mem_waste + gpu_term
@@ -515,7 +516,9 @@ mod scoring_tests {
         // Java parity: 4-core / 4GB host, 4-core / 4GB layer → max_more=0, score=0
         let h = host(4, 4, 0, 0);
         let mut l = layer(4, 4, 0, 0);
-        l.weights.gpu_reservation = 0.0; // no GPU on host so this is moot
+        // no GPU on host so reservation penalty is moot
+        l.weights.gpu_count_reservation = 0.0;
+        l.weights.gpu_mem_reservation = 0.0;
         assert_eq!(placement_score(&h, &l), 0.0);
     }
 
@@ -524,7 +527,8 @@ mod scoring_tests {
         // Java parity: 64-core / 64GB host, 4-core / 4GB layer → max_more=15, score=0
         let h = host(64, 64, 0, 0);
         let mut l = layer(4, 4, 0, 0);
-        l.weights.gpu_reservation = 0.0;
+        l.weights.gpu_count_reservation = 0.0;
+        l.weights.gpu_mem_reservation = 0.0;
         assert_eq!(placement_score(&h, &l), 0.0);
     }
 
@@ -534,7 +538,8 @@ mod scoring_tests {
         // memory has 60GB stranded.
         let h = host(4, 64, 0, 0);
         let mut l = layer(4, 4, 0, 0);
-        l.weights.gpu_reservation = 0.0;
+        l.weights.gpu_count_reservation = 0.0;
+        l.weights.gpu_mem_reservation = 0.0;
         // mem_waste = ((64GB - 4GB) - 0 * 4GB) / 4GB = 15 fractional frames
         // score = weights.mem * 15 = 15.0 with defaults.
         let s = placement_score(&h, &l);
@@ -546,7 +551,8 @@ mod scoring_tests {
         let h = host(4, 64, 0, 0);
         let mut l = layer(4, 4, 0, 0);
         l.weights.mem = 2.0; // double the memory weight
-        l.weights.gpu_reservation = 0.0;
+        l.weights.gpu_count_reservation = 0.0;
+        l.weights.gpu_mem_reservation = 0.0;
         let s = placement_score(&h, &l);
         assert!(s > 29.99 && s < 30.01, "expected ~30, got {}", s);
     }
@@ -558,13 +564,16 @@ mod scoring_tests {
         let gpu_host = host(4, 4, 8, 80);
         let non_gpu_host = host(4, 4, 0, 0);
         let mut l = layer(4, 4, 0, 0);
-        l.weights.gpu_reservation = 1.0;
+        // Equal-weight split so the legacy single-knob math (penalty = count + GB)
+        // is preserved as the baseline.
+        l.weights.gpu_count_reservation = 1.0;
+        l.weights.gpu_mem_reservation = 1.0;
 
         let s_gpu = placement_score(&gpu_host, &l);
         let s_non_gpu = placement_score(&non_gpu_host, &l);
 
         assert_eq!(s_non_gpu, 0.0);
-        // Penalty = 1.0 * (8 + 80) = 88
+        // Penalty = 1.0 * 8 + 1.0 * 80 = 88
         assert!(
             s_gpu > 87.99 && s_gpu < 88.01,
             "expected ~88, got {}",
@@ -573,10 +582,39 @@ mod scoring_tests {
     }
 
     #[test]
+    fn score_split_gpu_reservation_weights_independent() {
+        // Same host, vary each reservation weight independently and check that
+        // each contributes only the dimension it controls.
+        let gpu_host = host(4, 4, 8, 80);
+        let mut l = layer(4, 4, 0, 0);
+
+        // Count-only: should be 3.0 * 8 + 0.0 * 80 = 24
+        l.weights.gpu_count_reservation = 3.0;
+        l.weights.gpu_mem_reservation = 0.0;
+        let s_count_only = placement_score(&gpu_host, &l);
+        assert!(
+            (s_count_only - 24.0).abs() < 0.01,
+            "expected ~24, got {}",
+            s_count_only
+        );
+
+        // Mem-only: should be 0.0 * 8 + 0.5 * 80 = 40
+        l.weights.gpu_count_reservation = 0.0;
+        l.weights.gpu_mem_reservation = 0.5;
+        let s_mem_only = placement_score(&gpu_host, &l);
+        assert!(
+            (s_mem_only - 40.0).abs() < 0.01,
+            "expected ~40, got {}",
+            s_mem_only
+        );
+    }
+
+    #[test]
     fn score_non_gpu_layer_on_non_gpu_host_no_gpu_term() {
         let h = host(4, 4, 0, 0);
         let l = layer(4, 4, 0, 0);
-        // Even with default gpu_reservation = 2.0, host has 0 GPUs → 0 penalty.
+        // Even with default reservation weights (2.0, 2.0), host has 0 GPUs and
+        // 0 GPU memory → 0 penalty.
         assert_eq!(placement_score(&h, &l), 0.0);
     }
 
@@ -586,7 +624,9 @@ mod scoring_tests {
         // GPU dimensions contribute via W3 stranding only.
         let h = host(4, 4, 4, 8);
         let mut l = layer(4, 4, 2, 8);
-        l.weights.gpu_reservation = 100.0; // would dominate if applied
+        // Would dominate if applied.
+        l.weights.gpu_count_reservation = 100.0;
+        l.weights.gpu_mem_reservation = 100.0;
 
         let s = placement_score(&h, &l);
         // GPU: (4-2 - 1*2) / 2 = 0, GPU mem: (8-8 - 1*8) / 8 = -1
@@ -628,7 +668,8 @@ mod scoring_tests {
     fn epvm_gate_returns_score_when_valid() {
         let h = host(64, 64, 0, 0);
         let mut l = layer(4, 4, 0, 0);
-        l.weights.gpu_reservation = 0.0;
+        l.weights.gpu_count_reservation = 0.0;
+        l.weights.gpu_mem_reservation = 0.0;
         // Ratio match → score 0
         assert_eq!(epvm_gate(&h, &l), Some(0.0));
     }
@@ -658,7 +699,9 @@ mod scoring_tests {
             prop_assume!(idle_mem_gb >= mem_min_gb);
             let h = host(idle_cores, idle_mem_gb, 0, 0);
             let mut l = layer(cores_min, mem_min_gb, 0, 0);
-            l.weights.gpu_reservation = 0.0; // GPU term zero on non-GPU host anyway
+            // GPU terms zero on non-GPU host anyway, but be explicit.
+            l.weights.gpu_count_reservation = 0.0;
+            l.weights.gpu_mem_reservation = 0.0;
             let s = placement_score(&h, &l);
             prop_assert!(s >= 0.0, "score was negative: {}", s);
         }
@@ -674,7 +717,9 @@ mod scoring_tests {
             let h_a = host(4, 4, gpus_a, 0);
             let h_b = host(4, 4, gpus_b, 0);
             let mut l = layer(4, 4, 0, 0);
-            l.weights.gpu_reservation = 1.0;
+            // Only count varies in this prop; isolate the count knob.
+            l.weights.gpu_count_reservation = 1.0;
+            l.weights.gpu_mem_reservation = 0.0;
             let s_a = placement_score(&h_a, &l);
             let s_b = placement_score(&h_b, &l);
             prop_assert!(s_b > s_a, "expected {} > {} (a={} gpus, b={} gpus)", s_b, s_a, gpus_a, gpus_b);
@@ -691,7 +736,8 @@ mod scoring_tests {
             // Host is k times the layer on both dims (so ratios match).
             let h = host((cores_min as u64 * k) as i32, mem_min_gb * k, 0, 0);
             let mut l = layer(cores_min, mem_min_gb, 0, 0);
-            l.weights.gpu_reservation = 0.0;
+            l.weights.gpu_count_reservation = 0.0;
+            l.weights.gpu_mem_reservation = 0.0;
             let s = placement_score(&h, &l);
             prop_assert!(s.abs() < 1e-6, "expected ~0, got {}", s);
         }

--- a/rust/crates/scheduler/src/pipeline/placement.rs
+++ b/rust/crates/scheduler/src/pipeline/placement.rs
@@ -1,0 +1,699 @@
+// Copyright Contributors to the OpenCue Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+//! Layer-to-host placement primitives shared by every host-booking strategy.
+//!
+//! `LayerProfile` is the data-only snapshot of a layer needed to make a
+//! placement decision. Gate functions operate on `(&Host, &LayerProfile)`
+//! so the host cache actor can be parameterized by a plain `fn` pointer
+//! instead of a closure.
+
+use bytesize::ByteSize;
+use opencue_proto::host::ThreadMode;
+
+use crate::{
+    config::ScoreWeights,
+    models::{CoreSize, Host},
+};
+
+/// Snapshot of a layer's placement-relevant state.
+///
+/// Floor + compatibility fields are read by every strategy. The E-PVM context
+/// (job/show caps, live usage counters, weights) is only consumed by
+/// `epvm_gate / placement_score` and ignored by the Saturation path.
+///
+/// `job_max_cores` and `show_burst` use the OpenCue convention of `<= 0` meaning
+/// "unlimited" cap clamps in `compute_max_more` skip those dimensions, matching
+/// the Lua `BOOK_OR_FORCE > 0` guard.
+#[derive(Debug, Clone)]
+pub struct LayerProfile {
+    // Floor
+    pub cores_min: CoreSize,
+    pub mem_min: ByteSize,
+    pub gpus_min: i32,
+    pub gpu_mem_min: ByteSize,
+    // Compatibility
+    pub os: Option<String>,
+    pub threadable: bool,
+    // E-PVM context (snapshot at process_layer entry + locally decremented
+    // per dispatched frame each iteration).
+    pub job_max_cores: i32,
+    pub show_burst: i32,
+    pub job_cores_in_use: i32,
+    pub show_cores_in_use: i32,
+    pub weights: ScoreWeights,
+}
+
+/// True when the layer has no OS requirement or the host's OS matches it.
+pub fn host_matches_layer_os(host: &Host, profile: &LayerProfile) -> bool {
+    profile.os.is_none() || host.str_os.as_deref() == profile.os.as_deref()
+}
+
+/// Mirrors Cuebot's DispatchQuery filter: hosts in ThreadMode::All only accept
+/// threadable layers. Booking a non-threadable layer on such a host would
+/// diverge from Cuebot's behavior and starve the layer when ownership of the
+/// show moves back to Cuebot.
+pub fn host_matches_thread_mode(host: &Host, profile: &LayerProfile) -> bool {
+    host.thread_mode != ThreadMode::All || profile.threadable
+}
+
+/// Sync per-host validation invoked from the host_cache actor. Checks OS and
+/// thread-mode compatibility.
+pub fn validate_os_and_thread_mode(host: &Host, profile: &LayerProfile) -> bool {
+    host_matches_layer_os(host, profile) && host_matches_thread_mode(host, profile)
+}
+
+/// True when the host's idle resources meet the layer's floor on every
+/// dimension. Per Branch 4 (G1) the GPU floor lives in the gate, not the
+/// B-tree index — both `cores`/`mem` (range hints) and `gpus`/`gpu_mem`
+/// (predicate-only) are checked here for completeness.
+pub fn fits_floor(host: &Host, profile: &LayerProfile) -> bool {
+    host.idle_cores >= profile.cores_min
+        && host.idle_memory >= profile.mem_min
+        && (host.idle_gpus as i32) >= profile.gpus_min
+        && host.idle_gpu_memory >= profile.gpu_mem_min
+}
+
+/// Predicts the number of ADDITIONAL frames of the layer (beyond the first
+/// one being booked this tick) that could be dispatched to the same host
+/// within this same tick.
+///
+/// # How the bound is built
+///
+/// The result is the minimum of up to six independent bounds — four physical
+/// ones (cores, memory, GPUs, GPU memory) and two core-denominated caps
+/// (`job_max_cores`, `show_burst`). Each bound asks the same question in its
+/// own units: "after the first frame's `min` has been reserved, how many more
+/// `min`-sized chunks fit before this resource is exhausted?"
+///
+/// A bound is *omitted* from the minimum (rather than contributing 0) when:
+///   - a physical `<dim>_min` is 0 — the layer makes no demand on that dim,
+///     so the dim cannot constrain anything; or
+///   - a cap is `<= 0` — OpenCue's "unlimited" sentinel (mirrors the Lua
+///     `BOOK_OR_FORCE > 0` guard); or
+///   - the layer has no core demand (`cores_min == 0`), in which case the
+///     core-denominated caps have no unit to divide by.
+///
+/// # Degenerate and stale input
+///
+/// If every bound is omitted (no demand on any dim), the function returns 0
+/// rather than `i64::MAX` — there is no meaningful notion of "one more frame"
+/// to report.
+///
+/// Live-usage counters can briefly exceed their cap (stale snapshot or
+/// compensation rollback in flight). The matcher's pre-checkout guard usually
+/// catches this; if it slips through, the cap bound clamps to 0 instead of
+/// going negative.
+pub fn compute_max_more(host: &Host, profile: &LayerProfile) -> i64 {
+    let cores_min = profile.cores_min.value() as i64;
+    let mem_min = profile.mem_min.as_u64() as i64;
+    let gpus_min = profile.gpus_min as i64;
+    let gpu_mem_min = profile.gpu_mem_min.as_u64() as i64;
+
+    // Physical headroom on a single dimension: how many additional `min`-sized
+    // chunks remain in the idle pool after the first frame is allocated.
+    // `None` means "no demand on this dim" — skipped when taking the minimum.
+    let physical_bound = |idle: i64, min: i64| -> Option<i64> {
+        (min > 0).then(|| (idle - min) / min)
+    };
+
+    // Headroom against a core-denominated administrative cap (job_max_cores
+    // or show_burst): how many additional frames can be booked before live
+    // usage hits the cap. Skipped when the cap is unset (`<= 0`) or the layer
+    // has no core demand. The numerator is clamped at 0 to absorb stale
+    // snapshots where in-use already exceeds the cap.
+    let core_cap_bound = |cap: i32, in_use: i32| -> Option<i64> {
+        (cap > 0 && cores_min > 0).then(|| {
+            let slack = (cap as i64 - in_use as i64 - cores_min).max(0);
+            slack / cores_min
+        })
+    };
+
+    let bounds = [
+        physical_bound(host.idle_cores.value() as i64, cores_min),
+        physical_bound(host.idle_memory.as_u64() as i64, mem_min),
+        physical_bound(host.idle_gpus as i64, gpus_min),
+        physical_bound(host.idle_gpu_memory.as_u64() as i64, gpu_mem_min),
+        core_cap_bound(profile.job_max_cores, profile.job_cores_in_use),
+        core_cap_bound(profile.show_burst, profile.show_cores_in_use),
+    ];
+
+    // Final clamp to 0 catches the case where the host doesn't even satisfy
+    // the floor (so a physical bound went negative); gates normally check
+    // `fits_floor` first, but `compute_max_more` is defensive about it.
+    bounds
+        .into_iter()
+        .flatten()
+        .min()
+        .map(|b| b.max(0))
+        .unwrap_or(0)
+}
+
+/// E-PVM placement score with W3 normalization (per-dimension stranded
+/// resource expressed as fractional layer-frames). Lower scores indicate
+/// better fits; a perfect ratio match scores 0.
+///
+/// For GPU-requesting layers (`gpus_min > 0`), GPU and GPU-memory stranding
+/// terms participate normally. For non-GPU layers, the GPU dimension is
+/// REPLACED by a soft-reservation penalty proportional to the host's idle
+/// GPU capacity — favors non-GPU hosts for non-GPU work without ignoring
+/// GPU hosts when no GPU layers are pending (design Branch 5-iii).
+pub fn placement_score(host: &Host, profile: &LayerProfile) -> f64 {
+    let max_more = compute_max_more(host, profile) as f64;
+    let w = &profile.weights;
+
+    // W3 normalization: numerator and denominator share units, so the result
+    // is dimensionless (fractional layer-frames stranded).
+    let waste = |idle: f64, min: f64| -> f64 {
+        if min > 0.0 {
+            ((idle - min) - max_more * min) / min
+        } else {
+            0.0
+        }
+    };
+
+    let cores_waste = waste(
+        host.idle_cores.value() as f64,
+        profile.cores_min.value() as f64,
+    );
+    let mem_waste = waste(
+        host.idle_memory.as_u64() as f64,
+        profile.mem_min.as_u64() as f64,
+    );
+
+    let gpu_term = if profile.gpus_min > 0 {
+        let g_waste = waste(host.idle_gpus as f64, profile.gpus_min as f64);
+        let gm_waste = waste(
+            host.idle_gpu_memory.as_u64() as f64,
+            profile.gpu_mem_min.as_u64() as f64,
+        );
+        w.gpus * g_waste + w.gpu_mem * gm_waste
+    } else {
+        // SI gigabytes — exact divisor doesn't matter; what matters is that
+        // the penalty scales with the host's GPU capacity and is on the same
+        // order as the W3-normalized stranding terms.
+        let gpu_capacity_gb = host.idle_gpus as f64 + (host.idle_gpu_memory.as_u64() as f64 / 1e9);
+        w.gpu_reservation * gpu_capacity_gb
+    };
+
+    w.cores * cores_waste + w.mem * mem_waste + gpu_term
+}
+
+/// Saturation strategy gate: validate-only. Returns `Some(0.0)` when the host
+/// is a valid candidate; the constant score is irrelevant because the
+/// Saturation path is first-fit, not lowest-score.
+pub fn saturation_gate(host: &Host, profile: &LayerProfile) -> Option<f64> {
+    if validate_os_and_thread_mode(host, profile) && fits_floor(host, profile) {
+        Some(0.0)
+    } else {
+        None
+    }
+}
+
+/// E-PVM strategy gate: validate, then score. Returns `Some(score)` when the
+/// host fits; `None` otherwise. The cache picks the lowest score among up to
+/// `max_candidates` scanned.
+pub fn epvm_gate(host: &Host, profile: &LayerProfile) -> Option<f64> {
+    if validate_os_and_thread_mode(host, profile) && fits_floor(host, profile) {
+        Some(placement_score(host, profile))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    fn profile_with(os: Option<&str>, threadable: bool) -> LayerProfile {
+        LayerProfile {
+            cores_min: CoreSize::from_multiplied(100),
+            mem_min: ByteSize::gb(1),
+            gpus_min: 0,
+            gpu_mem_min: ByteSize::gb(0),
+            os: os.map(str::to_string),
+            threadable,
+            job_max_cores: 0,
+            show_burst: 0,
+            job_cores_in_use: 0,
+            show_cores_in_use: 0,
+            weights: ScoreWeights::default(),
+        }
+    }
+
+    fn host_with_os(str_os: Option<&str>) -> Host {
+        host_with(str_os, ThreadMode::Variable)
+    }
+
+    fn host_with_thread_mode(thread_mode: ThreadMode) -> Host {
+        host_with(Some("Linux"), thread_mode)
+    }
+
+    fn host_with(str_os: Option<&str>, thread_mode: ThreadMode) -> Host {
+        Host::new_for_test(
+            Uuid::new_v4(),
+            "test-host".to_string(),
+            str_os.map(str::to_string),
+            CoreSize::from_multiplied(100),
+            ByteSize::gb(64),
+            CoreSize::from_multiplied(100),
+            ByteSize::gb(64),
+            0,
+            ByteSize::gb(0),
+            thread_mode,
+            CoreSize::from_multiplied(100),
+            Uuid::new_v4(),
+            "test-alloc".to_string(),
+        )
+    }
+
+    #[test]
+    fn host_matches_when_layer_os_is_not_set() {
+        let host = host_with_os(Some("Linux"));
+        let profile = profile_with(None, true);
+        assert!(host_matches_layer_os(&host, &profile));
+    }
+
+    #[test]
+    fn host_matches_when_layer_os_matches_host_os() {
+        let host = host_with_os(Some("Linux"));
+        let profile = profile_with(Some("Linux"), true);
+        assert!(host_matches_layer_os(&host, &profile));
+    }
+
+    #[test]
+    fn host_does_not_match_when_layer_os_differs_from_host_os() {
+        let host = host_with_os(Some("Linux"));
+        let profile = profile_with(Some("Windows"), true);
+        assert!(!host_matches_layer_os(&host, &profile));
+    }
+
+    #[test]
+    fn thread_mode_all_rejects_non_threadable_layer() {
+        let host = host_with_thread_mode(ThreadMode::All);
+        let profile = profile_with(Some("Linux"), false);
+        assert!(!host_matches_thread_mode(&host, &profile));
+    }
+
+    #[test]
+    fn thread_mode_all_accepts_threadable_layer() {
+        let host = host_with_thread_mode(ThreadMode::All);
+        let profile = profile_with(Some("Linux"), true);
+        assert!(host_matches_thread_mode(&host, &profile));
+    }
+
+    #[test]
+    fn thread_mode_variable_accepts_any_threadability() {
+        let host = host_with_thread_mode(ThreadMode::Variable);
+        assert!(host_matches_thread_mode(
+            &host,
+            &profile_with(Some("Linux"), true)
+        ));
+        assert!(host_matches_thread_mode(
+            &host,
+            &profile_with(Some("Linux"), false)
+        ));
+    }
+
+    #[test]
+    fn thread_mode_auto_accepts_any_threadability() {
+        let host = host_with_thread_mode(ThreadMode::Auto);
+        assert!(host_matches_thread_mode(
+            &host,
+            &profile_with(Some("Linux"), true)
+        ));
+        assert!(host_matches_thread_mode(
+            &host,
+            &profile_with(Some("Linux"), false)
+        ));
+    }
+}
+
+#[cfg(test)]
+mod scoring_tests {
+    //! T1 tests for `compute_max_more`, `placement_score`, and the gates.
+    //! Java parity examples come from `ref/Scheduler.java:702-710`.
+
+    use super::*;
+    use proptest::prelude::*;
+    use uuid::Uuid;
+
+    /// Build a host with explicit core/mem/gpu/gpu-mem idle resources. Uses
+    /// raw `CoreSize(n)` (not `from_multiplied`) so test arithmetic matches
+    /// the units used in placement scoring directly.
+    fn host(idle_cores: i32, idle_memory_gb: u64, idle_gpus: u32, idle_gpu_memory_gb: u64) -> Host {
+        use opencue_proto::host::ThreadMode;
+        Host::new_for_test(
+            Uuid::new_v4(),
+            "h".to_string(),
+            Some("Linux".to_string()),
+            CoreSize(idle_cores),
+            ByteSize::gb(idle_memory_gb),
+            CoreSize(idle_cores),
+            ByteSize::gb(idle_memory_gb),
+            idle_gpus,
+            ByteSize::gb(idle_gpu_memory_gb),
+            ThreadMode::Auto,
+            CoreSize(idle_cores),
+            Uuid::new_v4(),
+            "test-alloc".to_string(),
+        )
+    }
+
+    fn layer(cores_min: i32, mem_min_gb: u64, gpus_min: i32, gpu_mem_min_gb: u64) -> LayerProfile {
+        LayerProfile {
+            cores_min: CoreSize(cores_min),
+            mem_min: ByteSize::gb(mem_min_gb),
+            gpus_min,
+            gpu_mem_min: ByteSize::gb(gpu_mem_min_gb),
+            os: None,
+            threadable: true,
+            job_max_cores: 0,
+            show_burst: 0,
+            job_cores_in_use: 0,
+            show_cores_in_use: 0,
+            weights: ScoreWeights::default(),
+        }
+    }
+
+    // ---- compute_max_more --------------------------------------------------
+
+    #[test]
+    fn max_more_perfect_fit_is_zero() {
+        // idle exactly meets min: 1 frame fits (the "first" one), 0 additional
+        let h = host(4, 4, 0, 0);
+        let l = layer(4, 4, 0, 0);
+        assert_eq!(compute_max_more(&h, &l), 0);
+    }
+
+    #[test]
+    fn max_more_ample_room() {
+        // 64-core / 64GB host, 4-core / 4GB layer → fits 16 total, 15 additional
+        let h = host(64, 64, 0, 0);
+        let l = layer(4, 4, 0, 0);
+        assert_eq!(compute_max_more(&h, &l), 15);
+    }
+
+    #[test]
+    fn max_more_memory_binds() {
+        // Plenty of cores, memory is the bottleneck
+        let h = host(64, 8, 0, 0);
+        let l = layer(4, 4, 0, 0);
+        // After first frame: 60 cores / 4GB remaining. Memory allows 1 more.
+        assert_eq!(compute_max_more(&h, &l), 1);
+    }
+
+    #[test]
+    fn max_more_job_cap_binds_below_physical() {
+        let h = host(64, 64, 0, 0);
+        let mut l = layer(4, 4, 0, 0);
+        l.job_max_cores = 12;
+        l.job_cores_in_use = 0;
+        // (12 - 0 - 4) / 4 = 2 additional frames before cap.
+        assert_eq!(compute_max_more(&h, &l), 2);
+    }
+
+    #[test]
+    fn max_more_show_burst_binds_below_physical() {
+        let h = host(64, 64, 0, 0);
+        let mut l = layer(4, 4, 0, 0);
+        l.show_burst = 100;
+        l.show_cores_in_use = 90;
+        // (100 - 90 - 4) / 4 = 1 additional frame.
+        assert_eq!(compute_max_more(&h, &l), 1);
+    }
+
+    #[test]
+    fn max_more_show_burst_at_cap_returns_zero() {
+        // booked + cores_min == burst: the first frame fits exactly, no more.
+        let h = host(64, 64, 0, 0);
+        let mut l = layer(4, 4, 0, 0);
+        l.show_burst = 100;
+        l.show_cores_in_use = 96;
+        assert_eq!(compute_max_more(&h, &l), 0);
+    }
+
+    #[test]
+    fn max_more_show_burst_tighter_than_job_cap() {
+        // Both caps set; the tighter one (burst) binds.
+        let h = host(64, 64, 0, 0);
+        let mut l = layer(4, 4, 0, 0);
+        l.job_max_cores = 100;
+        l.job_cores_in_use = 0;
+        l.show_burst = 20;
+        l.show_cores_in_use = 0;
+        // job: (100 - 0 - 4) / 4 = 24. burst: (20 - 0 - 4) / 4 = 4. min → 4.
+        assert_eq!(compute_max_more(&h, &l), 4);
+    }
+
+    #[test]
+    fn max_more_job_cap_tighter_than_show_burst() {
+        // Mirror image: job cap binds when tighter than burst.
+        let h = host(64, 64, 0, 0);
+        let mut l = layer(4, 4, 0, 0);
+        l.job_max_cores = 20;
+        l.job_cores_in_use = 0;
+        l.show_burst = 100;
+        l.show_cores_in_use = 0;
+        // job: (20 - 0 - 4) / 4 = 4. burst: (100 - 0 - 4) / 4 = 24. min → 4.
+        assert_eq!(compute_max_more(&h, &l), 4);
+    }
+
+    #[test]
+    fn max_more_show_burst_already_exceeded_returns_zero() {
+        // Stale snapshot or compensation rollback in flight: booked already
+        // above burst. Pre-checkout guard in matcher catches this; if it slips
+        // through, max_more clamps to 0 (the `.max(0)` in `compute_max_more`).
+        let h = host(64, 64, 0, 0);
+        let mut l = layer(4, 4, 0, 0);
+        l.show_burst = 100;
+        l.show_cores_in_use = 110;
+        assert_eq!(compute_max_more(&h, &l), 0);
+    }
+
+    #[test]
+    fn max_more_unlimited_cap_sentinel_is_ignored() {
+        let h = host(64, 64, 0, 0);
+        let mut l = layer(4, 4, 0, 0);
+        l.job_max_cores = -1; // OpenCue "unlimited" sentinel
+        l.show_burst = 0; // also treated as unlimited
+        assert_eq!(compute_max_more(&h, &l), 15);
+    }
+
+    #[test]
+    fn max_more_all_dims_degenerate_returns_zero() {
+        // No demand on any dimension → no meaningful bound
+        let h = host(64, 64, 0, 0);
+        let l = layer(0, 0, 0, 0);
+        assert_eq!(compute_max_more(&h, &l), 0);
+    }
+
+    #[test]
+    fn max_more_gpu_layer_gpu_binds() {
+        let h = host(64, 64, 4, 16);
+        let l = layer(4, 4, 2, 8);
+        // GPU: (4 - 2) / 2 = 1 additional
+        // GPU mem: (16 - 8) / 8 = 1 additional
+        // Cores/mem allow 15. Min → 1.
+        assert_eq!(compute_max_more(&h, &l), 1);
+    }
+
+    // ---- placement_score ---------------------------------------------------
+
+    #[test]
+    fn score_perfect_fit_is_zero() {
+        // Java parity: 4-core / 4GB host, 4-core / 4GB layer → max_more=0, score=0
+        let h = host(4, 4, 0, 0);
+        let mut l = layer(4, 4, 0, 0);
+        l.weights.gpu_reservation = 0.0; // no GPU on host so this is moot
+        assert_eq!(placement_score(&h, &l), 0.0);
+    }
+
+    #[test]
+    fn score_ratio_match_is_zero() {
+        // Java parity: 64-core / 64GB host, 4-core / 4GB layer → max_more=15, score=0
+        let h = host(64, 64, 0, 0);
+        let mut l = layer(4, 4, 0, 0);
+        l.weights.gpu_reservation = 0.0;
+        assert_eq!(placement_score(&h, &l), 0.0);
+    }
+
+    #[test]
+    fn score_memory_stranded_is_positive() {
+        // 4-core / 64GB host, 4-core / 4GB layer: cores binds max_more=0,
+        // memory has 60GB stranded.
+        let h = host(4, 64, 0, 0);
+        let mut l = layer(4, 4, 0, 0);
+        l.weights.gpu_reservation = 0.0;
+        // mem_waste = ((64GB - 4GB) - 0 * 4GB) / 4GB = 15 fractional frames
+        // score = weights.mem * 15 = 15.0 with defaults.
+        let s = placement_score(&h, &l);
+        assert!(s > 14.99 && s < 15.01, "expected ~15, got {}", s);
+    }
+
+    #[test]
+    fn score_weight_scales_term() {
+        let h = host(4, 64, 0, 0);
+        let mut l = layer(4, 4, 0, 0);
+        l.weights.mem = 2.0; // double the memory weight
+        l.weights.gpu_reservation = 0.0;
+        let s = placement_score(&h, &l);
+        assert!(s > 29.99 && s < 30.01, "expected ~30, got {}", s);
+    }
+
+    #[test]
+    fn score_non_gpu_layer_on_gpu_host_penalized() {
+        // Non-GPU layer fits cores/mem perfectly on a GPU host. With reservation
+        // penalty, the GPU host scores higher than an identical non-GPU host.
+        let gpu_host = host(4, 4, 8, 80);
+        let non_gpu_host = host(4, 4, 0, 0);
+        let mut l = layer(4, 4, 0, 0);
+        l.weights.gpu_reservation = 1.0;
+
+        let s_gpu = placement_score(&gpu_host, &l);
+        let s_non_gpu = placement_score(&non_gpu_host, &l);
+
+        assert_eq!(s_non_gpu, 0.0);
+        // Penalty = 1.0 * (8 + 80) = 88
+        assert!(
+            s_gpu > 87.99 && s_gpu < 88.01,
+            "expected ~88, got {}",
+            s_gpu
+        );
+    }
+
+    #[test]
+    fn score_non_gpu_layer_on_non_gpu_host_no_gpu_term() {
+        let h = host(4, 4, 0, 0);
+        let l = layer(4, 4, 0, 0);
+        // Even with default gpu_reservation = 2.0, host has 0 GPUs → 0 penalty.
+        assert_eq!(placement_score(&h, &l), 0.0);
+    }
+
+    #[test]
+    fn score_gpu_layer_uses_stranding_not_reservation() {
+        // GPU layer on a GPU host: reservation penalty should NOT apply; the
+        // GPU dimensions contribute via W3 stranding only.
+        let h = host(4, 4, 4, 8);
+        let mut l = layer(4, 4, 2, 8);
+        l.weights.gpu_reservation = 100.0; // would dominate if applied
+
+        let s = placement_score(&h, &l);
+        // GPU: (4-2 - 1*2) / 2 = 0, GPU mem: (8-8 - 1*8) / 8 = -1
+        // But max_more is clamped by GPU: min(15, 15, 1, 0) = 0
+        // Wait — gpu_mem: (8-8) / 8 = 0 additional. max_more = 0.
+        // Cores: ((4-4) - 0) / 4 = 0
+        // Mem: ((4-4) - 0) / 4 = 0
+        // GPU: ((4-2) - 0) / 2 = 1
+        // GPU mem: ((8-8) - 0) / 8 = 0
+        // score = 0 + 0 + 2.0*1 + 1.0*0 = 2.0
+        assert!(s > 1.99 && s < 2.01, "expected ~2.0, got {}", s);
+    }
+
+    // ---- gates -------------------------------------------------------------
+
+    #[test]
+    fn saturation_gate_returns_some_zero_when_valid() {
+        let h = host(4, 4, 0, 0);
+        let l = layer(4, 4, 0, 0);
+        assert_eq!(saturation_gate(&h, &l), Some(0.0));
+    }
+
+    #[test]
+    fn saturation_gate_rejects_on_os_mismatch() {
+        let h = host(4, 4, 0, 0);
+        let mut l = layer(4, 4, 0, 0);
+        l.os = Some("Windows".to_string());
+        assert_eq!(saturation_gate(&h, &l), None);
+    }
+
+    #[test]
+    fn saturation_gate_rejects_on_floor_shortfall() {
+        let h = host(2, 4, 0, 0);
+        let l = layer(4, 4, 0, 0);
+        assert_eq!(saturation_gate(&h, &l), None);
+    }
+
+    #[test]
+    fn epvm_gate_returns_score_when_valid() {
+        let h = host(64, 64, 0, 0);
+        let mut l = layer(4, 4, 0, 0);
+        l.weights.gpu_reservation = 0.0;
+        // Ratio match → score 0
+        assert_eq!(epvm_gate(&h, &l), Some(0.0));
+    }
+
+    #[test]
+    fn epvm_gate_rejects_on_floor_shortfall() {
+        let h = host(2, 4, 0, 0);
+        let l = layer(4, 4, 0, 0);
+        assert_eq!(epvm_gate(&h, &l), None);
+    }
+
+    // ---- proptest experiment ----------------------------------------------
+
+    proptest! {
+        /// `placement_score` is non-negative under default weights when the
+        /// host satisfies the layer's floor. The W3 numerator (idle - min) -
+        /// max_more*min is non-negative by construction since
+        /// max_more = floor((idle - min) / min).
+        #[test]
+        fn prop_score_non_negative(
+            idle_cores in 1i32..256,
+            idle_mem_gb in 1u64..512,
+            cores_min in 1i32..64,
+            mem_min_gb in 1u64..64,
+        ) {
+            prop_assume!(idle_cores >= cores_min);
+            prop_assume!(idle_mem_gb >= mem_min_gb);
+            let h = host(idle_cores, idle_mem_gb, 0, 0);
+            let mut l = layer(cores_min, mem_min_gb, 0, 0);
+            l.weights.gpu_reservation = 0.0; // GPU term zero on non-GPU host anyway
+            let s = placement_score(&h, &l);
+            prop_assert!(s >= 0.0, "score was negative: {}", s);
+        }
+
+        /// Non-GPU layer soft-reservation: holding cores/mem fixed at a perfect
+        /// fit, increasing the host's idle GPUs strictly increases the score.
+        #[test]
+        fn prop_gpu_reservation_monotonic(
+            gpus_a in 0u32..16,
+            extra in 1u32..16,
+        ) {
+            let gpus_b = gpus_a + extra;
+            let h_a = host(4, 4, gpus_a, 0);
+            let h_b = host(4, 4, gpus_b, 0);
+            let mut l = layer(4, 4, 0, 0);
+            l.weights.gpu_reservation = 1.0;
+            let s_a = placement_score(&h_a, &l);
+            let s_b = placement_score(&h_b, &l);
+            prop_assert!(s_b > s_a, "expected {} > {} (a={} gpus, b={} gpus)", s_b, s_a, gpus_a, gpus_b);
+        }
+
+        /// Perfect ratio match: when idle and min are proportional across all
+        /// active dimensions, the score is zero (no stranding).
+        #[test]
+        fn prop_ratio_match_scores_zero(
+            cores_min in 1i32..16,
+            mem_min_gb in 1u64..16,
+            k in 1u64..16,
+        ) {
+            // Host is k times the layer on both dims (so ratios match).
+            let h = host((cores_min as u64 * k) as i32, mem_min_gb * k, 0, 0);
+            let mut l = layer(cores_min, mem_min_gb, 0, 0);
+            l.weights.gpu_reservation = 0.0;
+            let s = placement_score(&h, &l);
+            prop_assert!(s.abs() < 1e-6, "expected ~0, got {}", s);
+        }
+    }
+}

--- a/rust/crates/scheduler/tests/util.rs
+++ b/rust/crates/scheduler/tests/util.rs
@@ -101,7 +101,7 @@ pub fn create_test_config() -> Config {
             empty_job_cycles_before_quiting: Some(20),
             mem_reserved_min: bytesize::ByteSize::mb(250),
             selfish_services: Vec::new(),
-            host_booking_strategy: HostBookingStrategy {
+            host_booking_strategy: HostBookingStrategy::Saturation {
                 core_saturation: true,
                 memory_saturation: false,
             },
@@ -600,6 +600,7 @@ pub async fn create_test_data(
                     .map(|tag_name| Tag {
                         name: tag_name.clone(),
                         ttype: TagType::Manual,
+                        alloc_id: None,
                     })
                     .collect(),
             );
@@ -632,6 +633,7 @@ pub async fn create_test_data(
             Tag {
                 name: alloc_name.clone(),
                 ttype: TagType::Alloc,
+                alloc_id: Some(*alloc_id),
             },
         );
         clusters.push(cluster);


### PR DESCRIPTION
Add new scheduling mode to scheduler module that implements E-PVM, inspired by the work of [Aghiles' scheduler](https://github.com/aghiles/OpenCue/blob/master/docs/_docs/developer-guide/scheduler.md).

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-show scheduler ownership control via `cueadmin -scheduler-managed <show> on|off` command
  * Added `scheduler_managed` property to shows via gRPC API and Python wrappers
  * Introduced Redis-backed accounting for scheduler-managed shows

* **Configuration**
  * Added Redis accounting configuration options (`accounting.redis.enabled`, `accounting.redis.host`, `accounting.redis.port`)
  * Extended scheduler queue configuration with new timing and sizing parameters

* **Documentation**
  * Updated deployment guides and technical references for per-show scheduler ownership model

* **Version**
  * Bumped version from 1.24 to 1.25

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated Redis-based resource accounting system for enhanced booking and limit management
  * Added E-PVM (energy-performance-value-matrix) host selection strategy alongside existing saturation-based selection
  * Enhanced cluster scheduling with round-trip tracking and intelligent sleep management

* **Improvements**
  * Expanded host selection with profile-aware placement and configurable scoring weights
  * Added new metrics for resource accounting limits and placement performance monitoring
  * Enhanced scheduler configuration with new queue timing, dispatch caps, and resource reservation parameters
<!-- end of auto-generated comment: release notes by coderabbit.ai -->