### PR TITLE
[scheduler] Make b_scheduler_managed the single source of truth

### DIFF
--- a/docs/_docs/developer-guide/scheduler.md
+++ b/docs/_docs/developer-guide/scheduler.md
@@ -764,28 +764,20 @@ scheduler_host_cache_hits_total
 
 ### Cluster Configuration
 
-**Allocation Tags**:
+**Show selection** is driven solely by the `show.b_scheduler_managed` boolean DB column
+(toggled with `cueadmin -scheduler-managed <show> on|off`). The scheduler automatically
+loads *all* clusters — allocation, manual-tag, hostname-tag, and hardware host-tag — for
+every show where `b_scheduler_managed = true`. There is no per-show, per-allocation, or
+per-tag selection in the config; a show is wholly scheduler-managed or wholly
+Cuebot-managed.
+
+**Facility**:
 ```yaml
 scheduler:
-  alloc_tags:
-    - show: myshow
-      tag: general
+  facility: spi
 ```
 
-Loads one cluster per entry: `(facility_id, show_id, "general")`
-
-**Manual Tags**:
-```yaml
-scheduler:
-  manual_tags:
-    - urgent
-    - desktop
-    - workstation
-```
-
-Chunks into groups (default: 100 tags per cluster):
-- Cluster 1: `(facility_id, [urgent, desktop, workstation])`
-- If more than 100 tags, splits into multiple clusters
+Optionally scopes the instance to one facility's scheduler-managed clusters.
 
 **Ignore Tags**:
 ```yaml
@@ -794,7 +786,22 @@ scheduler:
     - deprecated_tag
 ```
 
-Filters out specified tags from all cluster types before processing.
+Filters out specified tags from all loaded clusters before processing.
+
+**Cluster Reload Interval**:
+```yaml
+queue:
+  cluster_reload_interval: 120s
+```
+
+Interval between full reloads of the cluster set from the DB. The scheduler periodically
+rebuilds the set of clusters from all currently-managed shows and swaps the live set only
+when it actually changed, so flipping `b_scheduler_managed` (and host-tag / subscription
+changes) is picked up without a restart. Default: 120s.
+
+The manual-tag and hostname-tag chunk sizes (`queue.manual_tags_chunk_size`,
+`queue.hostname_tags_chunk_size`) control how DB-loaded host-tags are grouped into
+clusters (see [Cluster System](#1-cluster-system)).
 
 ### Performance Tuning
 
@@ -904,24 +911,28 @@ The matching Cuebot side requires `accounting.redis.enabled=true` and the same
 
 ### Current Architecture (v1.0)
 
-The scheduler supports distributed operation via manual cluster assignment:
+The scheduler supports distributed operation by scoping each instance to a facility with
+`--facility`. Show ownership is selected by the per-show `b_scheduler_managed` flag, and
+each instance automatically loads all clusters (allocation, manual, hostname, and
+hardware host-tags) for every scheduler-managed show in its facility:
 
 **Instance 1**:
 ```bash
-cue-scheduler --alloc_tags=show1:general,show1:priority
+cue-scheduler --facility spi
 ```
 
 **Instance 2**:
 ```bash
-cue-scheduler --alloc_tags=show2:general,show2:priority
+cue-scheduler --facility lax
 ```
 
-**Instance 3**:
-```bash
-cue-scheduler --manual_tags=urgent,desktop
-```
+There is no hand-listing of tags or clusters. To move work onto (or off) the scheduler,
+toggle the show with `cueadmin -scheduler-managed <show> on|off`; the change is picked up
+on the next cluster reload (`queue.cluster_reload_interval`, default 120s) with no
+restart.
 
-**Critical**: Ensure no cluster overlap between instances to prevent race conditions.
+**Critical**: When running multiple instances, scope them to non-overlapping facilities
+to prevent two instances from owning the same clusters.
 
 ### Coordination Mechanisms
 

--- a/docs/_docs/getting-started/deploying-scheduler.md
+++ b/docs/_docs/getting-started/deploying-scheduler.md
@@ -47,7 +47,7 @@ The scheduler is organized around **clusters**, which represent unique combinati
 - **Manual Tag Clusters**: Groups of manual tags (chunk size configurable)
 - **Hostname Tag Clusters**: Groups of hostname tags (chunk size configurable)
 
-Each scheduler instance processes one or more clusters in a round-robin fashion. In distributed deployments, different instances handle different clusters to share the workload.
+Each scheduler instance processes one or more clusters in a round-robin fashion. The cluster set is built automatically from every show with `b_scheduler_managed = true`, optionally scoped to one facility via `--facility`. In distributed deployments, different instances are scoped to different facilities to share the workload.
 
 ## Before You Begin
 
@@ -105,23 +105,18 @@ queue:
   dispatch_frames_per_layer_limit: 20
   manual_tags_chunk_size: 100
   hostname_tags_chunk_size: 300
+  cluster_reload_interval: 120s   # How often to reload the managed-show cluster set from the DB
 
 scheduler:
   # Optional: Filter to a specific facility
   # facility: spi
   
-  # Process these allocation clusters (show:tag format)
-  alloc_tags:
-    - show: myshow
-      tag: general
-    - show: anothershow
-      tag: priority
-  
-  # Process these manual tags
-  manual_tags:
-    - urgent
-    - desktop
+  # Optional: Tags to exclude from all loaded clusters
+  # ignore_tags:
+  #   - deprecated_tag
 ```
+
+The scheduler automatically loads every cluster (allocation, manual, hostname, and hardware host-tags) for all shows where `b_scheduler_managed = true`. There is no per-show or per-tag selection in the config; ownership is driven solely by the `show.b_scheduler_managed` DB column (see [Configuring Cuebot Exclusion List](#configuring-cuebot-exclusion-list)).
 
 #### 3. Run the Scheduler Container
 
@@ -200,8 +195,7 @@ OPENCUE_SCHEDULER_CONFIG=/path/to/scheduler.yaml cue-scheduler
 # Or use command-line overrides
 cue-scheduler \
   --facility spi \
-  --alloc_tags=show1:general,show2:priority \
-  --manual_tags=urgent,desktop
+  --ignore_tags=deprecated,old
 ```
 
 ### Option 4: Build from Source
@@ -240,7 +234,7 @@ The binary will be at `target/release/cue-scheduler`.
 #### 3. Run
 
 ```bash
-target/release/cue-scheduler --facility spi --alloc_tags=show:general
+target/release/cue-scheduler --facility spi
 ```
 
 ## Configuring Cuebot Exclusion List
@@ -260,36 +254,37 @@ Cuebot supports two exclusion mechanisms:
    Mark a show as managed by the standalone scheduler. Cuebot then skips that show in
    dispatch and the standalone scheduler dispatches its frames. Toggle with `cueadmin`:
    ```bash
-   cueadmin -show myshow -setSchedulerManaged true
-   cueadmin -show myshow -setSchedulerManaged false
+   cueadmin -scheduler-managed myshow on
+   cueadmin -scheduler-managed myshow off
    ```
 
-   Granularity is **per show**, not per show:allocation. If you need to scope dispatch
-   to a subset of a show's allocations, configure that on the scheduler side via
-   `alloc_tags` / `manual_tags`.
+   This is the **sole** onboarding mechanism. Granularity is **whole-show**: when a show
+   is scheduler-managed, the scheduler automatically loads *all* of its clusters
+   (every allocation, manual, hostname, and hardware host-tag), so there is nothing else
+   to configure per show or per allocation. The set of managed shows is reloaded from the
+   DB periodically (`queue.cluster_reload_interval`, default 120s), so flipping the flag
+   takes effect without restarting the scheduler.
 
 ### Migration Strategy
 
 We recommend a **gradual migration** approach:
 
-#### Phase 1: Test with One Cluster
+#### Phase 1: Test with One Show
 
-1. **Deploy scheduler** covering **every** allocation of the pilot show. Because
-   `show.b_scheduler_managed` is a whole-show toggle (`cueadmin -setSchedulerManaged`,
-   see [Per-show Scheduler Ownership](#understanding-exclusion-configuration)), the
-   scheduler's `alloc_tags` must list all of `testshow`'s allocations before you flip
-   it — otherwise Cuebot stops dispatching the show while the scheduler ignores any
-   allocation it isn't configured for. If `testshow` only uses the `test` allocation:
+1. **Deploy scheduler** (optionally scoped to a facility):
    ```bash
-   cue-scheduler --facility spi --alloc_tags=testshow:test
+   cue-scheduler --facility spi
    ```
-   If it spans more, list them all (for example `--alloc_tags=testshow:test,testshow:general`).
+   You do not list the show's allocations or tags anywhere — the scheduler covers all
+   of a managed show's clusters automatically.
 
-2. **Hand the show to the scheduler** (only after the scheduler covers the show's full
-   allocation set):
+2. **Hand the show to the scheduler**:
    ```bash
-   cueadmin -show testshow -setSchedulerManaged true
+   cueadmin -scheduler-managed testshow on
    ```
+   The scheduler picks up all of `testshow`'s clusters (allocation, manual, hostname,
+   and hardware host-tags) within `queue.cluster_reload_interval` (default 120s), with
+   no restart required.
 
 3. **Monitor both systems**:
    - Watch scheduler metrics at `http://scheduler-host:9090/metrics`
@@ -298,22 +293,14 @@ We recommend a **gradual migration** approach:
 
 #### Phase 2: Expand Coverage
 
-1. **Add more allocations** to scheduler:
-   ```yaml
-   scheduler:
-     alloc_tags:
-       - show: testshow
-         tag: test
-       - show: mainshow
-         tag: general
-       - show: mainshow
-         tag: priority
-   ```
+**Mark each additional show as scheduler-managed**:
+```bash
+cueadmin -scheduler-managed mainshow on
+```
 
-2. **Mark each additional show as scheduler-managed**:
-   ```bash
-   cueadmin -show mainshow -setSchedulerManaged true
-   ```
+No scheduler-side configuration change is needed: the scheduler reloads the managed-show
+set from the DB every `cluster_reload_interval` and automatically picks up all of the
+newly managed show's clusters.
 
 #### Phase 3: Full Migration (Optional)
 
@@ -327,10 +314,14 @@ At this point, all dispatching is handled by the scheduler.
 
 ### Notes on Granularity
 
-- Marking a show as scheduler-managed applies to the whole show across all allocations.
-- Manual tags and hostname tags are configured on the scheduler side (`manual_tags`);
-  they are not show-scoped.
-- To return a show to Cuebot dispatch, run `cueadmin -show myshow -setSchedulerManaged false`.
+- Marking a show as scheduler-managed applies to the whole show across all of its
+  clusters (allocation, manual, hostname, and hardware host-tags). There is no per-show,
+  per-allocation, or per-tag selection — a show is wholly scheduler-managed or wholly
+  Cuebot-managed.
+- The scheduler reloads the managed-show set from the DB every
+  `queue.cluster_reload_interval` (default 120s), so toggling a show — or changing its
+  host-tags / subscriptions — is picked up without a restart.
+- To return a show to Cuebot dispatch, run `cueadmin -scheduler-managed myshow off`.
 
 ## Configuration Reference
 
@@ -348,24 +339,16 @@ database:
 
 ### Scheduler Cluster Selection
 
+The scheduler automatically loads all clusters for every show where
+`b_scheduler_managed = true` (toggled with `cueadmin -scheduler-managed <show> on|off`).
+The only scheduler-side knobs are an optional facility scope and a tag-exclusion list:
+
 ```yaml
 scheduler:
   # Optional: Filter clusters to a specific facility
   facility: spi
-  
-  # Allocation clusters to process (show:tag format)
-  alloc_tags:
-    - show: myshow
-      tag: general
-    - show: myshow
-      tag: priority
-  
-  # Manual tags to process (not tied to allocations)
-  manual_tags:
-    - urgent
-    - desktop
-  
-  # Tags to ignore (exclude from all cluster types)
+
+  # Optional: Tags to ignore (exclude from all loaded clusters)
   ignore_tags:
     - deprecated_tag
     - old_allocation
@@ -380,6 +363,7 @@ queue:
   dispatch_frames_per_layer_limit: 20       # Max frames per layer per cycle
   manual_tags_chunk_size: 100               # Manual tags per cluster
   hostname_tags_chunk_size: 300             # Hostname tags per cluster
+  cluster_reload_interval: 120s             # How often to reload the managed-show cluster set from the DB
   host_candidate_attemps_per_layer: 10      # Host matching retries
   job_back_off_duration: 300s               # Backoff after failures
   
@@ -405,8 +389,6 @@ CLI arguments override YAML configuration:
 ```bash
 cue-scheduler \
   --facility spi \
-  --alloc_tags=show1:general,show2:priority \
-  --manual_tags=urgent,desktop \
   --ignore_tags=deprecated,old
 ```
 
@@ -541,7 +523,7 @@ Future releases will include automatic cluster distribution for true multi-insta
 
 **Check**:
 1. Database connectivity: `psql -h dbhost -U cuebot -d cuebot -c "SELECT 1"`
-2. Cluster configuration: Ensure `alloc_tags` matches show/allocation in database
+2. Show ownership: Verify the show has `b_scheduler_managed = true` (`cueadmin -scheduler-managed <show> on`) and that its hosts/allocations carry the expected tags in the database
 3. Cuebot exclusion: Verify Cuebot isn't still booking the same clusters
 4. RQD connectivity: Ensure scheduler can reach RQD gRPC port (8444)
 
@@ -570,9 +552,9 @@ Future releases will include automatic cluster distribution for true multi-insta
 
 ### Version 1.0 Constraints
 
-- **Manual cluster assignment**: You must specify which clusters each instance handles
-- **No automatic distribution**: Cluster workload isn't automatically balanced across instances
-- **Single instance recommended**: While multi-instance is supported, it requires careful manual configuration
+- **Facility-scoped distribution**: Multi-instance deployments are split by facility (`--facility`); there is no finer-grained per-cluster assignment
+- **No automatic distribution**: Cluster workload isn't automatically balanced across instances within a facility
+- **Single instance recommended**: While multi-instance is supported, it requires careful facility scoping to avoid overlap
 
 ### Future Enhancements
 

--- a/docs/news/2025-12-12-distributed-scheduler-release.md
+++ b/docs/news/2025-12-12-distributed-scheduler-release.md
@@ -98,8 +98,8 @@ Two complementary mechanisms:
 > those shows will resume being booked by Cuebot.
 
 **Migration Strategy**:
-1. Deploy the Scheduler with specific `--alloc_tags` and `--manual_tags`.
-2. Mark each show the Scheduler should own with `cueadmin -scheduler-managed <show> on`.
+1. Deploy the Scheduler (optionally scoped to a facility with `--facility`).
+2. Mark each show the Scheduler should own with `cueadmin -scheduler-managed <show> on`; the Scheduler then auto-loads all of that show's clusters.
 3. Monitor both systems to verify no overlap.
 4. Gradually migrate more shows to the Scheduler.
 5. Eventually disable Cuebot booking entirely with `dispatcher.turn_off_booking=true`.
@@ -117,7 +117,7 @@ Early testing shows significant improvements:
 
 ### Current Version (v1.0)
 
-- **Manual Cluster Distribution**: Operators must manually specify which clusters each scheduler instance handles via `--alloc_tags` and `--manual_tags`
+- **Facility-Scoped Distribution**: Scheduler instances are scoped by `--facility`; show ownership is the per-show `b_scheduler_managed` flag (`cueadmin -scheduler-managed <show> on|off`). Each instance auto-loads all clusters for the scheduler-managed shows in its facility and reloads that set periodically, so no per-cluster configuration or restart is needed.
 - **Single Instance Recommended**: While multi-instance deployment is supported, cluster assignment is static and requires careful configuration
 
 ### Future Development

--- a/rust/README.md
+++ b/rust/README.md
@@ -89,12 +89,16 @@ env OPENCUE_SCHEDULER_CONFIG=/PATH-TO-OPENCUE/OpenCue/rust/config/scheduler.yaml
 Or specify scheduling parameters via command-line arguments:
 
 ```bash
-target/release/cue-scheduler --facility <facility> --alloc_tags=<show:tag> --manual_tags=<tag>
+target/release/cue-scheduler --facility <facility>
 ```
 
 **Notes:**
 - Configuration is loaded from `config/scheduler.yaml` or the path specified by `OPENCUE_SCHEDULER_CONFIG`
 - Command-line arguments override configuration file values
+- Which shows the scheduler owns is controlled by the `show.b_scheduler_managed`
+  database column (`cueadmin -scheduler-managed <show> on|off`), not by flags. The
+  scheduler auto-loads every cluster for scheduler-managed shows and refreshes
+  that set periodically, so toggling a show takes effect without a restart.
 - The scheduler can be run in dry-run mode for testing (set `rqd.dry_run_mode: true` in config)
 
 2. Run the scheduler using Docker:

--- a/rust/config/scheduler.yaml
+++ b/rust/config/scheduler.yaml
@@ -102,6 +102,13 @@ queue:
   # Default: 30s
   # cluster_empty_sleep: 30s
 
+  # Interval between full reloads of the cluster set from the database. The feed
+  # re-runs the cluster query each tick so show.b_scheduler_managed flips (and
+  # host-tag/subscription changes) are picked up without a restart. The live set
+  # is only swapped when it actually changed.
+  # Default: 120s
+  # cluster_reload_interval: 120s
+
   # Chunk size for processing manual tags
   # Default: 50
   # manual_tags_chunk_size: 50
@@ -213,37 +220,18 @@ host_cache:
 # =============================================================================
 # SCHEDULER CONFIGURATION
 # =============================================================================
+# Which shows the scheduler owns is NOT configured here. It is driven entirely by
+# the show.b_scheduler_managed database column (toggle it per show with
+# `cueadmin -scheduler-managed <show> on|off`). The scheduler automatically loads
+# every cluster (allocation, manual, hostname, and hardware host-tags) for shows
+# where b_scheduler_managed = true, and refreshes that set periodically - see
+# queue.cluster_reload_interval - so toggling a show takes effect without a
+# restart.
 scheduler:
-  # Optional facility code to run on (can be overridden with --facility flag)
-  # This optional is a no-op for entire_shows and manual_tags
+  # Optional facility code to run on (can be overridden with --facility flag).
+  # Scopes this instance to one facility's scheduler-managed clusters.
   # Default: None
   # facility: eat
-
-  # List of show names to be fully scheduled (can be overridden with --entire_show flag)
-  # Default: []
-  # entire_shows:
-  #   - show1
-  #   - show2
-
-  # List of allocation tags in show:tag format (can be overridden with --alloc_tags flag)
-  # Default: []
-  # alloc_tags:
-  #   - show: show1
-  #     tag: general
-  #   - show: show2
-  #     tag: priority
-
-  # List of manual tags not associated with an allocation, scoped by show
-  # (can be overridden with --manual_tags flag, eg. show1:tag1,tag2,tag3)
-  # Default: []
-  # manual_tags:
-  #   - show: show1
-  #     tags:
-  #       - tag1
-  #       - tag2
-  #   - show: show2
-  #     tags:
-  #       - tag3
 
   # List of tags to ignore when loading clusters (can be overridden with --ignore_tags flag)
   # These tags will be filtered out from all cluster types (manual, hostname, and alloc)

--- a/rust/crates/scheduler/src/cluster.rs
+++ b/rust/crates/scheduler/src/cluster.rs
@@ -11,7 +11,7 @@
 // the License.
 
 use std::{
-    collections::{BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     ops::ControlFlow,
     panic::AssertUnwindSafe,
     sync::{
@@ -25,7 +25,7 @@ use futures::{FutureExt, StreamExt};
 use itertools::Itertools;
 use miette::{IntoDiagnostic, Result};
 use serde::{Deserialize, Serialize};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Notify};
 use tracing::{debug, error, warn};
 use uuid::Uuid;
 
@@ -75,12 +75,38 @@ impl Cluster {
     }
 }
 
+/// Inputs retained by a DB-backed [`ClusterFeed`] so it can periodically reload
+/// its cluster set. Absent on feeds built from an explicit list (tests), which
+/// never reload.
+#[derive(Debug, Clone)]
+struct ReloadCtx {
+    facility_id: Option<String>,
+    ignore_tags: Vec<String>,
+}
+
+/// Interval the producer idles for when the cluster set is currently empty
+/// (e.g. every show was flipped to Cuebot-managed). The reload loop will
+/// repopulate the set; this is just how often the producer re-checks.
+const EMPTY_FEED_POLL_INTERVAL: Duration = Duration::from_secs(5);
+
 #[derive(Debug)]
 pub struct ClusterFeed {
     pub clusters: Arc<RwLock<Vec<Cluster>>>,
     current_index: Arc<AtomicUsize>,
     stop_flag: Arc<AtomicBool>,
+    /// Pinged alongside `stop_flag` so the reload loop can break its
+    /// `interval.tick()` immediately on shutdown instead of waiting up to
+    /// `cluster_reload_interval`.
+    stop_notify: Arc<Notify>,
     sleep_map: Arc<Mutex<HashMap<Cluster, SystemTime>>>,
+    /// Tracks the last emission time per active cluster for the round-trip
+    /// histogram. Owned by the feed so `apply_reload_inner` can prune entries
+    /// for clusters that no longer exist; the producer/receiver tasks share
+    /// clones of this `Arc`.
+    last_sent_map: Arc<Mutex<HashMap<Cluster, Instant>>>,
+    /// `Some` for DB-backed feeds (enables periodic reload), `None` for feeds
+    /// built from an explicit cluster list.
+    reload: Option<ReloadCtx>,
 }
 
 /// Control messages for the cluster feed stream.
@@ -109,16 +135,12 @@ pub enum FeedMessage {
 /// ```ignore
 /// let feed = ClusterFeed::facility(facility_id)
 ///     .with_ignore_tags(ignore_tags)
-///     .with_clusters(clusters)
-///     .with_entire_shows(shows)
 ///     .build()
 ///     .await?;
 /// ```
 pub struct ClusterFeedBuilder {
     facility_id: Option<String>,
     ignore_tags: Vec<String>,
-    clusters: Vec<Cluster>,
-    entire_shows: Vec<String>,
 }
 
 impl ClusterFeedBuilder {
@@ -128,45 +150,27 @@ impl ClusterFeedBuilder {
         self
     }
 
-    /// Provides an explicit list of clusters instead of loading from the database.
-    pub fn with_clusters(mut self, clusters: Vec<Cluster>) -> Self {
-        self.clusters = clusters;
-        self
-    }
-
-    /// Specifies show names whose frames should be scheduled in their entirety.
-    pub fn with_entire_shows(mut self, shows: Vec<String>) -> Self {
-        self.entire_shows = shows;
-        self
-    }
-
     /// Builds the [`ClusterFeed`].
     ///
-    /// If explicit clusters were provided via [`with_clusters`](Self::with_clusters), they are
-    /// used directly (filtered by ignore tags). Otherwise all clusters are loaded from the
-    /// database, filtered to the configured facility and ignore tags.
+    /// Loads every cluster for shows where `b_scheduler_managed = true` from the
+    /// database, filtered to the configured facility and ignore tags. The returned
+    /// feed retains its facility/ignore-tags so [`ClusterFeed::start_reload_loop`]
+    /// can refresh the set without a restart.
     pub async fn build(self) -> Result<ClusterFeed> {
-        let clusters = if self.clusters.is_empty() && self.entire_shows.is_empty() {
-            let all = ClusterFeed::load_clusters(self.facility_id, &self.ignore_tags, None).await?;
-            ClusterFeed::filter_clusters(all, &self.ignore_tags)
-        } else {
-            let mut clusters: HashSet<Cluster> = self.clusters.into_iter().collect();
-            if !self.entire_shows.is_empty() {
-                let show_clusters = ClusterFeed::load_clusters(
-                    self.facility_id,
-                    &self.ignore_tags,
-                    Some(self.entire_shows),
-                )
-                .await?;
-                clusters.extend(show_clusters);
-            }
-            ClusterFeed::filter_clusters(clusters.into_iter().collect(), &self.ignore_tags)
-        };
+        let loaded =
+            ClusterFeed::load_clusters(self.facility_id.clone(), &self.ignore_tags).await?;
+        let clusters = ClusterFeed::filter_clusters(loaded, &self.ignore_tags);
         Ok(ClusterFeed {
             clusters: Arc::new(RwLock::new(clusters)),
             current_index: Arc::new(AtomicUsize::new(0)),
             stop_flag: Arc::new(AtomicBool::new(false)),
+            stop_notify: Arc::new(Notify::new()),
             sleep_map: Arc::new(Mutex::new(HashMap::new())),
+            last_sent_map: Arc::new(Mutex::new(HashMap::new())),
+            reload: Some(ReloadCtx {
+                facility_id: self.facility_id,
+                ignore_tags: self.ignore_tags,
+            }),
         })
     }
 }
@@ -177,8 +181,6 @@ impl ClusterFeed {
         ClusterFeedBuilder {
             facility_id: Some(facility_id),
             ignore_tags: Vec::new(),
-            clusters: Vec::new(),
-            entire_shows: Vec::new(),
         }
     }
 
@@ -187,16 +189,35 @@ impl ClusterFeed {
         ClusterFeedBuilder {
             facility_id: None,
             ignore_tags: Vec::new(),
-            clusters: Vec::new(),
-            entire_shows: Vec::new(),
         }
     }
 
-    /// Loads all clusters from the database and organizes them by tag type.
+    /// Creates a feed from an explicit list of clusters, bypassing the database.
+    ///
+    /// Intended for tests: the resulting feed is static (`reload = None`) and
+    /// will not refresh from the DB.
+    // Only used by the lib's test consumers (integration + unit tests); the
+    // `cue-scheduler` binary crate never calls it.
+    #[allow(dead_code)]
+    pub fn load_from_clusters(clusters: Vec<Cluster>, ignore_tags: &[String]) -> ClusterFeed {
+        let clusters = ClusterFeed::filter_clusters(clusters, ignore_tags);
+        ClusterFeed {
+            clusters: Arc::new(RwLock::new(clusters)),
+            current_index: Arc::new(AtomicUsize::new(0)),
+            stop_flag: Arc::new(AtomicBool::new(false)),
+            stop_notify: Arc::new(Notify::new()),
+            sleep_map: Arc::new(Mutex::new(HashMap::new())),
+            last_sent_map: Arc::new(Mutex::new(HashMap::new())),
+            reload: None,
+        }
+    }
+
+    /// Loads all clusters for scheduler-managed shows and organizes them by tag type.
     ///
     /// Loads allocation clusters (one per facility+show+tag), and chunks manual/hostname tags
-    /// into groups based on configured chunk sizes. In a distributed system, this should be
-    /// scheduled and coordinated across nodes.
+    /// into groups based on configured chunk sizes. Only shows where
+    /// `b_scheduler_managed = true` are included (enforced in SQL). In a distributed
+    /// system, this should be scheduled and coordinated across nodes.
     ///
     /// # Arguments
     ///
@@ -205,23 +226,27 @@ impl ClusterFeed {
     ///
     /// # Returns
     ///
-    /// * `Ok(ClusterFeed)` - Successfully loaded cluster feed
+    /// * `Ok(Vec<Cluster>)` - Successfully loaded clusters
     /// * `Err(miette::Error)` - Failed to load clusters from database
     pub async fn load_clusters(
         facility_id: Option<String>,
         ignore_tags: &[String],
-        shows_filter: Option<Vec<String>>,
     ) -> Result<Vec<Cluster>> {
         let cluster_dao = ClusterDao::new().await?;
 
         // Fetch clusters for alloc and non_alloc tags
         let mut clusters_stream = cluster_dao
-            .fetch_alloc_clusters(facility_id.clone(), shows_filter.clone())
-            .chain(cluster_dao.fetch_non_alloc_clusters(facility_id, shows_filter));
+            .fetch_alloc_clusters(facility_id.clone())
+            .chain(cluster_dao.fetch_non_alloc_clusters(facility_id));
         let mut clusters = Vec::new();
-        let mut manual_tags: HashMap<(Uuid, String), HashSet<Tag>> = HashMap::new();
-        let mut hardware_tags: HashMap<(Uuid, String), HashSet<Tag>> = HashMap::new();
-        let mut hostname_tags: HashMap<(Uuid, String), HashSet<Tag>> = HashMap::new();
+        // BTreeMap/BTreeSet are deliberate: their iteration order is
+        // deterministic, so chunking produces a stable set of Cluster instances
+        // for the same DB state. With HashMap/HashSet's randomized iteration,
+        // the change-gate in apply_reload_inner would see "changed" on every
+        // reload and pointlessly swap the set.
+        let mut manual_tags: BTreeMap<(Uuid, String), BTreeSet<Tag>> = BTreeMap::new();
+        let mut hardware_tags: BTreeMap<(Uuid, String), BTreeSet<Tag>> = BTreeMap::new();
+        let mut hostname_tags: BTreeMap<(Uuid, String), BTreeSet<Tag>> = BTreeMap::new();
 
         // Collect all tags
         while let Some(record) = clusters_stream.next().await {
@@ -324,16 +349,16 @@ impl ClusterFeed {
         Ok(clusters)
     }
 
-    /// Creates a ClusterFeed from a predefined list of clusters for testing.
+    /// Removes ignored tags from each cluster, dropping clusters left empty.
     ///
     /// # Arguments
     ///
-    /// * `clusters` - List of clusters to iterate over
-    /// * `ignore_tags` - List of tag names to ignore when loading clusters
+    /// * `clusters` - Clusters to filter
+    /// * `ignore_tags` - List of tag names to strip from every cluster
     ///
     /// # Returns
     ///
-    /// * `ClusterFeed` - Feed configured to run once through the provided clusters
+    /// * `Vec<Cluster>` - Clusters with ignored tags removed
     pub fn filter_clusters(clusters: Vec<Cluster>, ignore_tags: &[String]) -> Vec<Cluster> {
         if ignore_tags.is_empty() {
             return clusters;
@@ -349,6 +374,150 @@ impl ClusterFeed {
                 }
             })
             .collect()
+    }
+
+    /// Replaces the live cluster set with `new_clusters` if it differs from the
+    /// current set, returning whether a swap happened.
+    ///
+    /// The comparison is set-based (order-insensitive), since `load_clusters`
+    /// produces clusters in nondeterministic Vec order. On an actual change the
+    /// whole set is swapped and the round-robin index is reset. Sleep and
+    /// last-sent entries for clusters that no longer exist are dropped;
+    /// survivors keep their backoff state and round-trip baseline, which are
+    /// unrelated to topology changes.
+    // The reload loop calls `apply_reload_inner` directly; this wrapper exists
+    // for unit tests, so the `cue-scheduler` binary crate never calls it.
+    #[allow(dead_code)]
+    pub fn apply_reload(&self, new_clusters: Vec<Cluster>) -> bool {
+        Self::apply_reload_inner(
+            &self.clusters,
+            &self.current_index,
+            &self.sleep_map,
+            &self.last_sent_map,
+            new_clusters,
+        )
+    }
+
+    /// Shared swap logic, operating on the feed's `Arc`-held state so the reload
+    /// loop (which can't hold `&self`) and [`apply_reload`](Self::apply_reload)
+    /// can both use it.
+    fn apply_reload_inner(
+        clusters: &Arc<RwLock<Vec<Cluster>>>,
+        current_index: &Arc<AtomicUsize>,
+        sleep_map: &Arc<Mutex<HashMap<Cluster, SystemTime>>>,
+        last_sent_map: &Arc<Mutex<HashMap<Cluster, Instant>>>,
+        new_clusters: Vec<Cluster>,
+    ) -> bool {
+        // Change-gate: only the expensive swap/disruption happens on a real change.
+        let changed = {
+            let current = clusters.read().unwrap_or_else(|p| p.into_inner());
+            let current_set: HashSet<&Cluster> = current.iter().collect();
+            let new_set: HashSet<&Cluster> = new_clusters.iter().collect();
+            current_set != new_set
+        };
+        if !changed {
+            return false;
+        }
+
+        {
+            // Drop sleep / last-sent entries for clusters that no longer exist;
+            // preserve survivors' backoff state and round-trip baseline.
+            let new_set: HashSet<&Cluster> = new_clusters.iter().collect();
+            {
+                let mut sleep = sleep_map.lock().unwrap_or_else(|p| p.into_inner());
+                sleep.retain(|k, _| new_set.contains(k));
+            }
+            {
+                let mut last_sent = last_sent_map.lock().unwrap_or_else(|p| p.into_inner());
+                last_sent.retain(|k, _| new_set.contains(k));
+            }
+        }
+
+        let new_len = new_clusters.len();
+        {
+            // Reset the index under the same write lock that swaps the Vec. The
+            // producer reads `current_index` inside the `clusters` read lock, so
+            // this serializes the swap and prevents an out-of-bounds index.
+            let mut current = clusters.write().unwrap_or_else(|p| p.into_inner());
+            *current = new_clusters;
+            current_index.store(0, Ordering::Relaxed);
+        }
+        debug!("Cluster set reloaded: {} clusters", new_len);
+        true
+    }
+
+    /// Spawns a background task that periodically reloads the cluster set from
+    /// the database, picking up `b_scheduler_managed` flips and host-tag /
+    /// subscription churn without a restart.
+    ///
+    /// No-op for feeds built from an explicit cluster list (`reload = None`).
+    /// Mirrors `ManagedShowsCache::start_refresh_loop`: skip-first-tick,
+    /// per-iteration `catch_unwind`, and keep the current set on DB error. The
+    /// loop exits when the feed's stop flag is set.
+    pub fn start_reload_loop(&self) {
+        let Some(reload) = self.reload.clone() else {
+            return;
+        };
+        let clusters = self.clusters.clone();
+        let current_index = self.current_index.clone();
+        let sleep_map = self.sleep_map.clone();
+        let last_sent_map = self.last_sent_map.clone();
+        let stop_flag = self.stop_flag.clone();
+        let stop_notify = self.stop_notify.clone();
+
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(CONFIG.queue.cluster_reload_interval);
+            // Skip the immediate first tick - build() already loaded on startup.
+            // Still race the notify so an immediate Stop doesn't block on a full
+            // interval before exit.
+            tokio::select! {
+                _ = interval.tick() => {}
+                _ = stop_notify.notified() => {
+                    debug!("Cluster reload loop stopping (feed stopped).");
+                    return;
+                }
+            }
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {}
+                    _ = stop_notify.notified() => {
+                        debug!("Cluster reload loop stopping (feed stopped).");
+                        break;
+                    }
+                }
+                if stop_flag.load(Ordering::Relaxed) {
+                    debug!("Cluster reload loop stopping (feed stopped).");
+                    break;
+                }
+                let result = AssertUnwindSafe(async {
+                    match ClusterFeed::load_clusters(
+                        reload.facility_id.clone(),
+                        &reload.ignore_tags,
+                    )
+                    .await
+                    {
+                        Ok(loaded) => {
+                            let filtered =
+                                ClusterFeed::filter_clusters(loaded, &reload.ignore_tags);
+                            Self::apply_reload_inner(
+                                &clusters,
+                                &current_index,
+                                &sleep_map,
+                                &last_sent_map,
+                                filtered,
+                            );
+                        }
+                        // Keep the current set on a transient failure - never wipe.
+                        Err(err) => warn!("Failed to reload clusters: {err}"),
+                    }
+                })
+                .catch_unwind()
+                .await;
+                if let Err(e) = result {
+                    error!("Cluster reload iteration panicked: {:?}", e);
+                }
+            }
+        });
     }
 
     /// Streams clusters to a channel receiver with backpressure control.
@@ -380,11 +549,12 @@ impl ClusterFeed {
         let stop_flag = self.stop_flag.clone();
         let sleep_map = self.sleep_map.clone();
 
-        // Tracks the last emission time per active cluster, for round-trip histogram.
-        // Entries are dropped when a cluster is put to sleep so wake-up doesn't produce
-        // a spurious sample covering the sleep duration.
-        let last_sent_map: Arc<Mutex<HashMap<Cluster, Instant>>> =
-            Arc::new(Mutex::new(HashMap::new()));
+        // Tracks the last emission time per active cluster, for round-trip
+        // histogram. Entries are dropped when a cluster is put to sleep so
+        // wake-up doesn't produce a spurious sample covering the sleep
+        // duration, and `apply_reload_inner` prunes entries for clusters
+        // that no longer exist.
+        let last_sent_map = self.last_sent_map.clone();
         let last_sent_map_producer = last_sent_map.clone();
 
         // Stream clusters on the caller channel
@@ -401,19 +571,30 @@ impl ClusterFeed {
                         return ControlFlow::Break(());
                     }
 
-                    let (item, cluster_size, completed_round) = {
+                    let snapshot = {
                         let clusters = feed.read().unwrap_or_else(|poisoned| poisoned.into_inner());
                         if clusters.is_empty() {
-                            return ControlFlow::Break(());
+                            None
+                        } else {
+                            // Clamp defensively: a concurrent reload may have shrunk the
+                            // Vec since the index was last stored.
+                            let current_index =
+                                current_index_atomic.load(Ordering::Relaxed) % clusters.len();
+                            let item = clusters[current_index].clone();
+                            let next_index = (current_index + 1) % clusters.len();
+                            let completed_round = next_index == 0; // Detect wrap-around
+                            current_index_atomic.store(next_index, Ordering::Relaxed);
+
+                            Some((item, clusters.len(), completed_round))
                         }
+                    };
 
-                        let current_index = current_index_atomic.load(Ordering::Relaxed);
-                        let item = clusters[current_index].clone();
-                        let next_index = (current_index + 1) % clusters.len();
-                        let completed_round = next_index == 0; // Detect wrap-around
-                        current_index_atomic.store(next_index, Ordering::Relaxed);
-
-                        (item, clusters.len(), completed_round)
+                    // An empty set is transient with hot reload (e.g. every show
+                    // was flipped to Cuebot-managed). Idle and re-check rather than
+                    // terminating; the reload loop will repopulate.
+                    let Some((item, cluster_size, completed_round)) = snapshot else {
+                        tokio::time::sleep(EMPTY_FEED_POLL_INTERVAL).await;
+                        return ControlFlow::Continue(());
                     };
 
                     // Skip cluster if it is marked as sleeping
@@ -503,6 +684,7 @@ impl ClusterFeed {
 
         // Process messages on the receiving end
         let stop_flag_recv = self.stop_flag.clone();
+        let stop_notify_recv = self.stop_notify.clone();
         let sleep_map = self.sleep_map.clone();
         let last_sent_map_receiver = last_sent_map.clone();
         tokio::spawn(async move {
@@ -538,6 +720,10 @@ impl ClusterFeed {
                         }
                         FeedMessage::Stop() => {
                             stop_flag_recv.store(true, Ordering::Relaxed);
+                            // notify_one() stores a permit if nobody's parked
+                            // yet, so the reload loop sees the wake even if it
+                            // was mid-body when Stop arrived.
+                            stop_notify_recv.notify_one();
                             ControlFlow::Break(())
                         }
                     }
@@ -578,17 +764,96 @@ pub async fn get_facility_id(facility_name: &str) -> Result<String> {
         .into_diagnostic()
 }
 
-/// Looks up a show ID by show name.
-///
-/// # Arguments
-///
-/// * `show_name` - The name of the show
-///
-/// # Returns
-///
-/// * `Ok(Uuid)` - The show ID
-/// * `Err(miette::Error)` - If show not found or database error
-pub async fn get_show_id(show_name: &str) -> Result<Uuid> {
-    let cluster_dao = ClusterDao::new().await?;
-    cluster_dao.get_show_id(show_name).await.into_diagnostic()
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cluster(tag: &str) -> Cluster {
+        Cluster::single_tag(
+            "facility".to_string(),
+            Uuid::nil(),
+            Tag {
+                name: tag.to_string(),
+                ttype: TagType::Alloc,
+            },
+        )
+    }
+
+    fn cluster_names(feed: &ClusterFeed) -> Vec<String> {
+        let clusters = feed.clusters.read().unwrap();
+        let mut names: Vec<String> = clusters
+            .iter()
+            .flat_map(|c| c.tags.iter().map(|t| t.name.clone()))
+            .collect();
+        names.sort();
+        names
+    }
+
+    /// A genuinely different set is swapped in; the index resets, sleep and
+    /// last-sent entries for survivors are preserved, and entries for removed
+    /// clusters are dropped.
+    #[test]
+    fn apply_reload_swaps_on_change() {
+        let feed = ClusterFeed::load_from_clusters(vec![cluster("a"), cluster("b")], &[]);
+        // Simulate an advanced round-robin position and two sleeping clusters
+        // with last-sent baselines, one of which will survive the swap and one
+        // that will be removed.
+        feed.current_index.store(5, Ordering::Relaxed);
+        let now = SystemTime::now();
+        feed.sleep_map.lock().unwrap().insert(cluster("a"), now);
+        feed.sleep_map.lock().unwrap().insert(cluster("b"), now);
+        let baseline = Instant::now();
+        feed.last_sent_map
+            .lock()
+            .unwrap()
+            .insert(cluster("a"), baseline);
+        feed.last_sent_map
+            .lock()
+            .unwrap()
+            .insert(cluster("b"), baseline);
+
+        // "a" survives, "b" is removed, "c" is new.
+        let changed = feed.apply_reload(vec![cluster("a"), cluster("c")]);
+
+        assert!(changed);
+        assert_eq!(cluster_names(&feed), vec!["a".to_string(), "c".to_string()]);
+        assert_eq!(feed.current_index.load(Ordering::Relaxed), 0);
+        let sleep = feed.sleep_map.lock().unwrap();
+        assert_eq!(sleep.len(), 1);
+        assert!(sleep.contains_key(&cluster("a")));
+        let last_sent = feed.last_sent_map.lock().unwrap();
+        assert_eq!(last_sent.len(), 1);
+        assert!(last_sent.contains_key(&cluster("a")));
+    }
+
+    /// The same members in a different order are not a change: no swap, and
+    /// the existing index / sleep state is left untouched.
+    #[test]
+    fn apply_reload_is_noop_when_unchanged_ignoring_order() {
+        let feed = ClusterFeed::load_from_clusters(vec![cluster("a"), cluster("b")], &[]);
+        feed.current_index.store(1, Ordering::Relaxed);
+        feed.sleep_map
+            .lock()
+            .unwrap()
+            .insert(cluster("a"), SystemTime::now());
+
+        let changed = feed.apply_reload(vec![cluster("b"), cluster("a")]);
+
+        assert!(!changed);
+        assert_eq!(feed.current_index.load(Ordering::Relaxed), 1);
+        assert_eq!(feed.sleep_map.lock().unwrap().len(), 1);
+    }
+
+    /// Reloading to an empty set is a valid change (every show un-managed):
+    /// the feed goes empty without panicking; the producer idles on it.
+    #[test]
+    fn apply_reload_to_empty_set() {
+        let feed = ClusterFeed::load_from_clusters(vec![cluster("a")], &[]);
+
+        let changed = feed.apply_reload(vec![]);
+
+        assert!(changed);
+        assert!(feed.clusters.read().unwrap().is_empty());
+        assert_eq!(feed.current_index.load(Ordering::Relaxed), 0);
+    }
 }

--- a/rust/crates/scheduler/src/config/mod.rs
+++ b/rust/crates/scheduler/src/config/mod.rs
@@ -18,7 +18,7 @@ use config::{Config as ConfigBase, Environment, File};
 use lazy_static::lazy_static;
 use once_cell::sync::OnceCell;
 use serde::Deserialize;
-use std::{collections::HashSet, env, fs, path::PathBuf, time::Duration};
+use std::{env, fs, path::PathBuf, time::Duration};
 
 static DEFAULT_CONFIG_FILE: &str = "~/.local/share/scheduler.yaml";
 
@@ -140,6 +140,12 @@ pub struct QueueConfig {
     /// Larger values reduce empty-pass query load on the database.
     #[serde(with = "humantime_serde")]
     pub cluster_empty_sleep: Duration,
+    /// Interval between full reloads of the cluster set from the database. The
+    /// feed re-runs the cluster query each tick so `show.b_scheduler_managed`
+    /// flips (and host-tag/subscription churn) are picked up without a restart.
+    /// The reload only swaps the live set when it actually changed.
+    #[serde(with = "humantime_serde")]
+    pub cluster_reload_interval: Duration,
     pub stream: StreamConfig,
     /// Maximum number of jobs returned per cluster pass. Caps the per-pass
     /// dispatch cost so a big-show cluster doesn't iterate thousands of jobs
@@ -169,6 +175,7 @@ impl Default for QueueConfig {
             memory_stranded_threshold: ByteSize::gib(2),
             job_back_off_duration: Duration::from_secs(300),
             cluster_empty_sleep: Duration::from_secs(30),
+            cluster_reload_interval: Duration::from_secs(120),
             stream: StreamConfig::default(),
             max_jobs_per_cluster_pass: 20,
             manual_tags_chunk_size: 50,
@@ -309,36 +316,7 @@ impl Default for HostCacheConfig {
 #[serde(default)]
 pub struct SchedulerConfig {
     pub facility: Option<String>,
-    pub entire_shows: Vec<String>,
-    pub alloc_tags: Vec<AllocTag>,
-    pub manual_tags: Vec<ManualTags>,
     pub ignore_tags: Vec<String>,
-}
-
-impl SchedulerConfig {
-    pub fn show_names(&self) -> Option<Vec<String>> {
-        let mut show_names: HashSet<String> = HashSet::from_iter(self.entire_shows.iter().cloned());
-        for tag in &self.alloc_tags {
-            show_names.insert(tag.show.clone());
-        }
-        if show_names.is_empty() {
-            None
-        } else {
-            Some(show_names.into_iter().collect())
-        }
-    }
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct AllocTag {
-    pub show: String,
-    pub tag: String,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct ManualTags {
-    pub show: String,
-    pub tags: Vec<String>,
 }
 
 //===Config Loader===

--- a/rust/crates/scheduler/src/dao/cluster_dao.rs
+++ b/rust/crates/scheduler/src/dao/cluster_dao.rs
@@ -16,9 +16,7 @@ use futures::Stream;
 use miette::{IntoDiagnostic, Result};
 use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Postgres};
-use uuid::Uuid;
-
-use crate::{dao::helpers::parse_uuid, pgpool::connection_pool};
+use crate::pgpool::connection_pool;
 
 /// Data Access Object for host operations in the job dispatch system.
 ///
@@ -43,6 +41,8 @@ pub struct ClusterModel {
     pub ttype: String,
 }
 
+// Only shows flagged `b_scheduler_managed = true` are owned by the scheduler;
+// every cluster query is scoped to those shows. Cuebot owns the rest.
 static QUERY_ALLOC_CLUSTERS: &str = r#"
 SELECT DISTINCT
     a.str_tag as tag,
@@ -55,6 +55,7 @@ FROM host_tag
     JOIN show sh ON sub.pk_show = sh.pk_show
 WHERE str_tag_type = 'ALLOC'
     AND sh.b_active = true
+    AND sh.b_scheduler_managed = true
 "#;
 
 static QUERY_ALLOC_CLUSTERS_WITH_FACILITY: &str = r#"
@@ -69,38 +70,8 @@ FROM host_tag
     JOIN show sh ON sub.pk_show = sh.pk_show
 WHERE str_tag_type = 'ALLOC'
     AND sh.b_active = true
+    AND sh.b_scheduler_managed = true
     AND a.pk_facility = $1
-"#;
-
-static QUERY_ALLOC_CLUSTERS_WITH_SHOW_NAMES: &str = r#"
-SELECT DISTINCT
-    a.str_tag as tag,
-    sh.pk_show as show_id,
-    a.pk_facility as facility_id,
-    'ALLOC' as ttype
-FROM host_tag
-    JOIN alloc a ON a.str_tag = host_tag.str_tag
-    JOIN subscription sub ON sub.pk_alloc = a.pk_alloc
-    JOIN show sh ON sub.pk_show = sh.pk_show
-WHERE str_tag_type = 'ALLOC'
-    AND sh.str_name = ANY($1)
-    AND sh.b_active = true
-"#;
-
-static QUERY_ALLOC_CLUSTERS_WITH_FACILITY_AND_SHOW_NAMES: &str = r#"
-SELECT DISTINCT
-    a.str_tag as tag,
-    sh.pk_show as show_id,
-    a.pk_facility as facility_id,
-    'ALLOC' as ttype
-FROM host_tag
-    JOIN alloc a ON a.str_tag = host_tag.str_tag
-    JOIN subscription sub ON sub.pk_alloc = a.pk_alloc
-    JOIN show sh ON sub.pk_show = sh.pk_show
-WHERE str_tag_type = 'ALLOC'
-    AND sh.b_active = true
-    AND a.pk_facility = $1
-    AND sh.str_name = ANY($2)
 "#;
 
 // As this query is not filtered by show, each show+subscription will
@@ -116,7 +87,9 @@ FROM host_tag
 JOIN host h on h.pk_host = host_tag.pk_host
 JOIN alloc a ON a.pk_alloc = h.pk_alloc
 JOIN subscription s ON a.pk_alloc = s.pk_alloc
+JOIN show sh ON sh.pk_show = s.pk_show
 WHERE str_tag_type <> 'ALLOC'
+    AND sh.b_scheduler_managed = true
 "#;
 
 static QUERY_NON_ALLOC_CLUSTERS_WITH_FACILITY: &str = r#"
@@ -129,50 +102,15 @@ FROM host_tag
 JOIN host h on h.pk_host = host_tag.pk_host
 JOIN alloc a ON a.pk_alloc = h.pk_alloc
 JOIN subscription s ON a.pk_alloc = s.pk_alloc
-WHERE str_tag_type <> 'ALLOC'
-    AND a.pk_facility = $1
-"#;
-
-static QUERY_NON_ALLOC_CLUSTERS_WITH_SHOW_NAMES: &str = r#"
-SELECT DISTINCT
-    host_tag.str_tag as tag,
-    s.pk_show as show_id,
-    a.pk_facility as facility_id,
-    str_tag_type as ttype
-FROM host_tag
-JOIN host h on h.pk_host = host_tag.pk_host
-JOIN alloc a ON a.pk_alloc = h.pk_alloc
-JOIN subscription s ON a.pk_alloc = s.pk_alloc
 JOIN show sh ON sh.pk_show = s.pk_show
 WHERE str_tag_type <> 'ALLOC'
-    AND sh.str_name = ANY($1)
-"#;
-
-static QUERY_NON_ALLOC_CLUSTERS_WITH_FACILITY_AND_SHOW_NAMES: &str = r#"
-SELECT DISTINCT
-    host_tag.str_tag as tag,
-    s.pk_show as show_id,
-    a.pk_facility as facility_id,
-    str_tag_type as ttype
-FROM host_tag
-JOIN host h on h.pk_host = host_tag.pk_host
-JOIN alloc a ON a.pk_alloc = h.pk_alloc
-JOIN subscription s ON a.pk_alloc = s.pk_alloc
-JOIN show sh ON sh.pk_show = s.pk_show
-WHERE str_tag_type <> 'ALLOC'
+    AND sh.b_scheduler_managed = true
     AND a.pk_facility = $1
-    AND sh.str_name = ANY($2)
 "#;
 
 static QUERY_FACILITY_ID: &str = r#"
 SELECT pk_facility
 FROM facility
-WHERE str_name = $1
-"#;
-
-static QUERY_SHOW_ID: &str = r#"
-SELECT pk_show
-FROM show
 WHERE str_name = $1
 "#;
 
@@ -192,15 +130,14 @@ impl ClusterDao {
         })
     }
 
-    /// Fetches all allocation-based clusters from the database.
+    /// Fetches all allocation-based clusters for scheduler-managed shows.
     ///
     /// Returns clusters defined by facility, show, and allocation tag combinations.
-    /// Only includes active shows with host tags.
+    /// Only includes active shows where `b_scheduler_managed = true`.
     ///
     /// # Arguments
     ///
     /// * `facility_id` - Optional facility ID to filter clusters to a specific facility
-    /// * `shows_filter` - Optional list of show names to filter clusters
     ///
     /// # Returns
     ///
@@ -208,43 +145,29 @@ impl ClusterDao {
     pub fn fetch_alloc_clusters(
         &self,
         facility_id: Option<String>,
-        shows_filter: Option<Vec<String>>,
-    ) -> std::pin::Pin<Box<dyn Stream<Item = Result<ClusterModel, sqlx::Error>> + '_>> {
-        match (facility_id, shows_filter) {
-            (Some(fid), Some(show_names)) => Box::pin(
-                sqlx::query_as::<_, ClusterModel>(
-                    QUERY_ALLOC_CLUSTERS_WITH_FACILITY_AND_SHOW_NAMES,
-                )
-                .bind(fid)
-                .bind(show_names)
-                .fetch(&*self.connection_pool),
-            ),
-            (Some(fid), None) => Box::pin(
+    ) -> std::pin::Pin<Box<dyn Stream<Item = Result<ClusterModel, sqlx::Error>> + Send + '_>> {
+        match facility_id {
+            Some(fid) => Box::pin(
                 sqlx::query_as::<_, ClusterModel>(QUERY_ALLOC_CLUSTERS_WITH_FACILITY)
                     .bind(fid)
                     .fetch(&*self.connection_pool),
             ),
-            (None, Some(show_names)) => Box::pin(
-                sqlx::query_as::<_, ClusterModel>(QUERY_ALLOC_CLUSTERS_WITH_SHOW_NAMES)
-                    .bind(show_names)
-                    .fetch(&*self.connection_pool),
-            ),
-            (None, None) => Box::pin(
+            None => Box::pin(
                 sqlx::query_as::<_, ClusterModel>(QUERY_ALLOC_CLUSTERS)
                     .fetch(&*self.connection_pool),
             ),
         }
     }
 
-    /// Fetches all non-allocation clusters (MANUAL and HOSTNAME tags).
+    /// Fetches all non-allocation clusters (MANUAL, HOSTNAME, HARDWARE tags) for
+    /// scheduler-managed shows.
     ///
-    /// Returns clusters defined by manual or hostname-based tags
-    /// tied to their specific facility/show.
+    /// Returns clusters defined by non-allocation host tags tied to their
+    /// specific facility/show, scoped to shows where `b_scheduler_managed = true`.
     ///
     /// # Arguments
     ///
     /// * `facility_id` - Optional facility ID to filter clusters to a specific facility
-    /// * `shows_filter` - Optional list of show names to filter clusters
     ///
     /// # Returns
     ///
@@ -252,28 +175,14 @@ impl ClusterDao {
     pub fn fetch_non_alloc_clusters(
         &self,
         facility_id: Option<String>,
-        shows_filter: Option<Vec<String>>,
-    ) -> std::pin::Pin<Box<dyn Stream<Item = Result<ClusterModel, sqlx::Error>> + '_>> {
-        match (facility_id, shows_filter) {
-            (Some(fid), Some(show_names)) => Box::pin(
-                sqlx::query_as::<_, ClusterModel>(
-                    QUERY_NON_ALLOC_CLUSTERS_WITH_FACILITY_AND_SHOW_NAMES,
-                )
-                .bind(fid)
-                .bind(show_names)
-                .fetch(&*self.connection_pool),
-            ),
-            (Some(fid), None) => Box::pin(
+    ) -> std::pin::Pin<Box<dyn Stream<Item = Result<ClusterModel, sqlx::Error>> + Send + '_>> {
+        match facility_id {
+            Some(fid) => Box::pin(
                 sqlx::query_as::<_, ClusterModel>(QUERY_NON_ALLOC_CLUSTERS_WITH_FACILITY)
                     .bind(fid)
                     .fetch(&*self.connection_pool),
             ),
-            (None, Some(show_names)) => Box::pin(
-                sqlx::query_as::<_, ClusterModel>(QUERY_NON_ALLOC_CLUSTERS_WITH_SHOW_NAMES)
-                    .bind(show_names)
-                    .fetch(&*self.connection_pool),
-            ),
-            (None, None) => Box::pin(
+            None => Box::pin(
                 sqlx::query_as::<_, ClusterModel>(QUERY_NON_ALLOC_CLUSTERS)
                     .fetch(&*self.connection_pool),
             ),
@@ -296,23 +205,5 @@ impl ClusterDao {
             .fetch_one(&*self.connection_pool)
             .await?;
         Ok(row.0)
-    }
-
-    /// Looks up a show ID by show name.
-    ///
-    /// # Arguments
-    ///
-    /// * `show_name` - The name of the show
-    ///
-    /// # Returns
-    ///
-    /// * `Ok(Uuid)` - The show ID
-    /// * `Err(sqlx::Error)` - If show not found or database error
-    pub async fn get_show_id(&self, show_name: &str) -> Result<Uuid, sqlx::Error> {
-        let row: (String,) = sqlx::query_as(QUERY_SHOW_ID)
-            .bind(show_name)
-            .fetch_one(&*self.connection_pool)
-            .await?;
-        Ok(parse_uuid(&row.0))
     }
 }

--- a/rust/crates/scheduler/src/dao/cluster_dao.rs
+++ b/rust/crates/scheduler/src/dao/cluster_dao.rs
@@ -89,6 +89,7 @@ JOIN alloc a ON a.pk_alloc = h.pk_alloc
 JOIN subscription s ON a.pk_alloc = s.pk_alloc
 JOIN show sh ON sh.pk_show = s.pk_show
 WHERE str_tag_type <> 'ALLOC'
+    AND sh.b_active = true
     AND sh.b_scheduler_managed = true
 "#;
 
@@ -104,6 +105,7 @@ JOIN alloc a ON a.pk_alloc = h.pk_alloc
 JOIN subscription s ON a.pk_alloc = s.pk_alloc
 JOIN show sh ON sh.pk_show = s.pk_show
 WHERE str_tag_type <> 'ALLOC'
+    AND sh.b_active = true
     AND sh.b_scheduler_managed = true
     AND a.pk_facility = $1
 "#;

--- a/rust/crates/scheduler/src/main.rs
+++ b/rust/crates/scheduler/src/main.rs
@@ -10,9 +10,7 @@
 // or implied. See the License for the specific language governing permissions and limitations under
 // the License.
 
-use std::str::FromStr;
-
-use miette::{miette, Context, IntoDiagnostic};
+use miette::{Context, IntoDiagnostic};
 use structopt::StructOpt;
 #[cfg(unix)]
 use tokio::signal::unix::{signal, SignalKind};
@@ -20,12 +18,7 @@ use tracing_rolling_file::{RollingConditionBase, RollingFileAppenderBase};
 use tracing_subscriber::{layer::SubscriberExt, reload};
 use tracing_subscriber::{EnvFilter, Registry};
 
-use crate::config::{AllocTag, ManualTags};
-use crate::{
-    cluster::{Cluster, ClusterFeed},
-    cluster_key::{Tag, TagType},
-    config::CONFIG,
-};
+use crate::{cluster::ClusterFeed, config::CONFIG};
 
 mod accounting;
 mod cluster;
@@ -38,7 +31,7 @@ mod models;
 mod pgpool;
 mod pipeline;
 
-// scheduler --facility eat --alloc_tags=show:tag,show:tag,show:tag --manual_tags=tag1,tag2
+// scheduler --facility eat
 #[derive(StructOpt, Debug)]
 pub struct JobQueueCli {
     #[structopt(long, short = "f", long_help = "Facility code to run on")]
@@ -46,58 +39,10 @@ pub struct JobQueueCli {
 
     #[structopt(
         long,
-        short = "s",
-        long_help = "A list of show names to be scheduled entirely."
-    )]
-    entire_shows: Vec<String>,
-
-    #[structopt(
-        long,
-        short = "a",
-        long_help = "A list of show:tag entries associated to an allocation. (eg. show1:general)."
-    )]
-    alloc_tags: Vec<ColonSeparatedList>,
-
-    #[structopt(
-        long,
-        short = "t",
-        long_help = "A list of show and tags not associated with an allocation. (eg. show1:tag1,tag2,tag3)"
-    )]
-    manual_tags: Vec<ColonSeparatedList>,
-
-    #[structopt(
-        long,
         short = "i",
         long_help = "A list of tags to ignore when loading clusters."
     )]
     ignore_tags: Vec<String>,
-}
-
-#[derive(Debug, Clone)]
-pub struct ColonSeparatedList(pub String, pub String);
-
-impl FromStr for ColonSeparatedList {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts: Vec<&str> = s.split(":").map(|v| v.trim()).collect();
-        if parts.len() != 2 {
-            return Err(format!("Invalid format: expected 'show:tag', got '{}'", s));
-        }
-        Ok(ColonSeparatedList(
-            parts[0].to_string(),
-            parts[1].to_string(),
-        ))
-    }
-}
-
-impl From<ColonSeparatedList> for AllocTag {
-    fn from(value: ColonSeparatedList) -> Self {
-        AllocTag {
-            show: value.0,
-            tag: value.1,
-        }
-    }
 }
 
 impl JobQueueCli {
@@ -108,55 +53,18 @@ impl JobQueueCli {
     ///
     /// # Returns
     ///
-    /// A tuple of `(facility, alloc_tags, manual_tags, ignore_tags)`:
-    /// - `facility`      – Optional facility code (e.g. `"eat"`).
-    /// - `entire_shows`  – Name of shows to be completely scheduled (e.g. `show1`).
-    /// - `alloc_tags`    – Show/tag pairs tied to an allocation (e.g. `show1:general`).
-    /// - `manual_tags`   – Free-form tags not associated with an allocation.
-    /// - `ignore_tags`   – Tags to exclude when loading clusters.
-    #[allow(clippy::type_complexity)]
-    fn resolve_config(
-        &self,
-    ) -> (
-        Option<String>,
-        Vec<String>,
-        Vec<AllocTag>,
-        Vec<ManualTags>,
-        Vec<String>,
-    ) {
+    /// A tuple of `(facility, ignore_tags)`:
+    /// - `facility`    – Optional facility code (e.g. `"eat"`); scopes this
+    ///   instance to one facility's scheduler-managed clusters.
+    /// - `ignore_tags` – Tags to exclude when loading clusters.
+    ///
+    /// Show ownership itself is not configured here - it is driven entirely by
+    /// the `show.b_scheduler_managed` DB column.
+    fn resolve_config(&self) -> (Option<String>, Vec<String>) {
         let facility = if self.facility.is_some() {
             self.facility.clone()
         } else {
             CONFIG.scheduler.facility.clone()
-        };
-
-        let entire_shows: Vec<String> = if !self.entire_shows.is_empty() {
-            self.entire_shows.clone()
-        } else {
-            CONFIG.scheduler.entire_shows.clone()
-        };
-
-        let alloc_tags: Vec<AllocTag> = if !self.alloc_tags.is_empty() {
-            self.alloc_tags
-                .clone()
-                .into_iter()
-                .map(|item| item.into())
-                .collect()
-        } else {
-            CONFIG.scheduler.alloc_tags.clone()
-        };
-
-        let manual_tags = if !self.manual_tags.is_empty() {
-            self.manual_tags
-                .clone()
-                .into_iter()
-                .map(|item| ManualTags {
-                    show: item.0,
-                    tags: item.1.split(",").map(|t| t.to_string()).collect(),
-                })
-                .collect()
-        } else {
-            CONFIG.scheduler.manual_tags.clone()
         };
 
         let ignore_tags = if !self.ignore_tags.is_empty() {
@@ -165,11 +73,11 @@ impl JobQueueCli {
             CONFIG.scheduler.ignore_tags.clone()
         };
 
-        (facility, entire_shows, alloc_tags, manual_tags, ignore_tags)
+        (facility, ignore_tags)
     }
 
     async fn run(&self) -> miette::Result<()> {
-        let (facility, entire_shows, alloc_tags, manual_tags, ignore_tags) = self.resolve_config();
+        let (facility, ignore_tags) = self.resolve_config();
 
         // Lookup facility_id from facility name
         let facility_id = match &facility {
@@ -181,58 +89,11 @@ impl JobQueueCli {
             None => None,
         };
 
-        let mut clusters = Vec::new();
-
-        if let Some(facility_id) = &facility_id {
-            // Build Cluster::ComposedKey for each alloc_tag (show:tag format)
-            for alloc_tag in &alloc_tags {
-                let show_id = cluster::get_show_id(&alloc_tag.show)
-                    .await
-                    .wrap_err(format!("Could not find show {}.", alloc_tag.show))?;
-                clusters.push(Cluster::single_tag(
-                    facility_id.clone(),
-                    show_id,
-                    Tag {
-                        name: alloc_tag.tag.clone(),
-                        ttype: TagType::Alloc,
-                    },
-                ));
-            }
-
-            // Build Cluster::TagsKey for manual_tags
-            for manual_tag in &manual_tags {
-                let show_id = cluster::get_show_id(&manual_tag.show)
-                    .await
-                    .wrap_err(format!("Could not find show {}.", manual_tag.show))?;
-                clusters.push(Cluster::multiple_tag(
-                    facility_id.clone(),
-                    show_id,
-                    manual_tag
-                        .tags
-                        .iter()
-                        .map(|name| Tag {
-                            name: name.clone(),
-                            ttype: TagType::Manual,
-                        })
-                        .collect(),
-                ));
-            }
-        } else if !alloc_tags.is_empty() {
-            Err(miette!("Alloc tag requires a valid facility"))?
-        } else if !manual_tags.is_empty() {
-            Err(miette!("Manual tag requires a valid facility"))?
-        }
-
         let builder = match facility_id {
             Some(id) => ClusterFeed::facility(id),
             None => ClusterFeed::no_facility(),
         };
-        let cluster_feed = builder
-            .with_ignore_tags(ignore_tags)
-            .with_clusters(clusters)
-            .with_entire_shows(entire_shows)
-            .build()
-            .await?;
+        let cluster_feed = builder.with_ignore_tags(ignore_tags).build().await?;
 
         pipeline::run(cluster_feed).await
     }

--- a/rust/crates/scheduler/src/pipeline/entrypoint.rs
+++ b/rust/crates/scheduler/src/pipeline/entrypoint.rs
@@ -56,6 +56,10 @@ pub async fn run(cluster_feed: ClusterFeed) -> miette::Result<()> {
     info!("Starting scheduler feed");
 
     let (tx, cluster_receiver) = mpsc::channel(16);
+    // Periodically reload the cluster set from the DB so b_scheduler_managed
+    // flips (and host-tag/subscription churn) are picked up without a restart.
+    // No-op for feeds built from an explicit cluster list (tests).
+    cluster_feed.start_reload_loop();
     let feed_sender = cluster_feed.stream(tx).await;
 
     ReceiverStream::new(cluster_receiver)

--- a/rust/crates/scheduler/tests/util.rs
+++ b/rust/crates/scheduler/tests/util.rs
@@ -90,6 +90,7 @@ pub fn create_test_config() -> Config {
             memory_stranded_threshold: bytesize::ByteSize::mb(100),
             job_back_off_duration: Duration::from_secs(10),
             cluster_empty_sleep: Duration::from_secs(30),
+            cluster_reload_interval: Duration::from_secs(120),
             stream: scheduler::config::StreamConfig {
                 cluster_buffer_size: 4,
                 job_buffer_size: 8,


### PR DESCRIPTION
Latest changes split the decision of who is booking a show (Scheduler or Cuebot) split between a config file and the database new column on the show table (b_scheduler_managed).

After this change:

  - The scheduler automatically loads all clusters (allocation, manual, hostname, hardware host-tags)
  for every show where b_scheduler_managed = true, optionally scoped to one facility via --facility.
  - A background loop reloads the cluster set every queue.cluster_reload_interval (default 120s), so
  flipping cueadmin -scheduler-managed <show> on|off — or churn in host-tags / subscriptions — takes
  effect without a restart.
  - The reload swaps the live set only when it actually changed (set-equality gate); on a real change,
  the round-robin index resets to 0 and sleep_map / last_sent_map drop entries for clusters that no
  longer exist (survivors keep their backoff state).

  Removed surface

  - CLI: --entire_shows, --alloc_tags, --manual_tags (and the ColonSeparatedList parser).
  - Config: scheduler.entire_shows, scheduler.alloc_tags, scheduler.manual_tags,
  SchedulerConfig::show_names, the AllocTag / ManualTags structs, and the
  QUERY_ALLOC_CLUSTERS_WITH_SHOW_NAMES{,_AND_FACILITY} /
  QUERY_NON_ALLOC_CLUSTERS_WITH_SHOW_NAMES{,_AND_FACILITY} DAO variants.
  - cluster::get_show_id / ClusterDao::get_show_id (no longer used).

  Added surface

  - queue.cluster_reload_interval config (default 120s).
  - ClusterFeed::start_reload_loop — runs alongside stream(); no-op for feeds built from an explicit
  list (tests).
  - ClusterFeed::load_from_clusters — explicit cluster list constructor for tests.

  Correctness details worth flagging

  - Deterministic chunking: load_clusters now uses BTreeMap<…, BTreeSet<Tag>> for the per-show
  manual/hostname/hardware buckets. With HashMap/HashSet, randomized iteration order chunked tags
  differently each call, so the set-equality change-gate would fire on every reload and pointlessly swap
   the live set + reset round-robin position + clear backoff state for shows with more tags than the
  chunk size (default 50).
  - Prompt shutdown: the reload loop tokio::select!s its interval.tick().await against a
  tokio::sync::Notify that the receiver task pings when it sees FeedMessage::Stop. Uses notify_one() so
  the permit survives a mid-body race. Without this, shutdown could block up to cluster_reload_interval
  per outstanding tick.
  - Topology change preserves survivor state: apply_reload_inner uses retain(|k, _| new_set.contains(k))
   on both sleep_map and last_sent_map instead of clear(). Backoff and round-trip baselines are
  unrelated to other shows being added/removed; only entries for departed clusters need to go.
  - DAO stream return types pick up + Send since load_clusters now runs from a spawned task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduler periodically reloads clusters from the database (configurable interval) so show ownership and tag/host changes take effect without restart.
  * Support for facility-scoped scheduler instances and global ignore-tag exclusions for distributed deployments.

* **Documentation**
  * Deployment, migration, and troubleshooting docs updated to reflect DB-driven whole-show ownership toggled via cueadmin and facility-scoped operation; guidance to avoid overlapping facilities added.

* **Chores**
  * Removed legacy per-tag/manual cluster assignment options and simplified CLI/config surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->