### PR TITLE
[rqd] Improve logging on fs and caps errors

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Diego Tavares <dtavares@imageworks.com>"]
 edition = "2021"
-version = "0.1.10"
+version = "0.1.11"
 
 [workspace.dependencies]
 async-trait = "0.1"

--- a/rust/crates/rqd/src/frame/logging.rs
+++ b/rust/crates/rqd/src/frame/logging.rs
@@ -570,16 +570,19 @@ mod tests {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
     fn test_init_into_unwritable_dir_reports_failing_op() {
-        // root bypasses DAC, so the unwritable-dir scenario can't be reproduced there.
-        // SAFETY: geteuid is an always-successful syscall with no preconditions.
-        if unsafe { nix::libc::geteuid() } == 0 {
-            return;
-        }
-
         let dir = tempfile::tempdir().unwrap();
         let locked = dir.path().join("locked");
         fs::create_dir(&locked).unwrap();
         fs::set_permissions(&locked, Permissions::from_mode(0o000)).unwrap();
+
+        // If this process can still create files in the locked dir (running as root, or
+        // holding CAP_DAC_OVERRIDE), the unwritable-dir scenario can't be reproduced.
+        let probe = locked.join(".probe");
+        if File::create(&probe).is_ok() {
+            let _ = fs::remove_file(&probe);
+            let _ = fs::set_permissions(&locked, Permissions::from_mode(0o755));
+            return;
+        }
 
         let log_path = locked.join("frame.rqlog");
         let result = FrameFileLogger::init(log_path.to_string_lossy().to_string(), false, None);

--- a/rust/crates/rqd/src/frame/logging.rs
+++ b/rust/crates/rqd/src/frame/logging.rs
@@ -12,7 +12,7 @@
 
 use crate::config::RunnerConfig;
 use chrono::{DateTime, Local, Utc};
-use miette::{IntoDiagnostic, Result};
+use miette::{Context, IntoDiagnostic, Result};
 use opencue_proto::rqd::RunFrame;
 use serde_derive::Serialize;
 use std::collections::HashMap;
@@ -72,17 +72,31 @@ impl FrameFileLogger {
     ) -> Result<Self> {
         let log_path = Path::new(path.as_str());
         if log_path.exists() {
-            Self::rotate_existing_files(&path)?;
+            Self::rotate_existing_files(&path)
+                .wrap_err_with(|| format!("failed to rotate existing frame log {log_path:?}"))?;
         } else if let Some(parent_path) = log_path.parent() {
             if !parent_path.exists() {
-                fs::create_dir_all(parent_path).into_diagnostic()?;
+                if let Err(err) = fs::create_dir_all(parent_path) {
+                    let diag = Self::describe_path_failure(parent_path, uid_gid, Some(&err));
+                    return Err(err).into_diagnostic().wrap_err(format!(
+                        "failed to create parent log dir {parent_path:?}{diag}"
+                    ));
+                }
                 if let Some((uid, gid)) = uid_gid {
                     Self::change_ownership(parent_path, uid, gid)?;
                 }
             }
         }
 
-        let file = File::create(log_path).into_diagnostic()?;
+        let file = match File::create(log_path) {
+            Ok(file) => file,
+            Err(err) => {
+                let diag = Self::describe_path_failure(log_path, uid_gid, Some(&err));
+                return Err(err).into_diagnostic().wrap_err(format!(
+                    "failed to create frame log file {log_path:?}{diag}"
+                ));
+            }
+        };
         if let Some((uid, gid)) = uid_gid {
             Self::change_ownership(log_path, uid, gid)?;
         }
@@ -98,8 +112,6 @@ impl FrameFileLogger {
     fn change_ownership(path: &Path, uid: u32, gid: u32) -> Result<()> {
         use std::os::unix::fs::chown;
 
-        use miette::Context;
-
         fs::set_permissions(path, Permissions::from_mode(0o775))
             .into_diagnostic()
             .wrap_err(format!("Failed to change log dir permissions: {path:?}"))?;
@@ -112,6 +124,113 @@ impl FrameFileLogger {
     #[cfg(target_os = "windows")]
     fn change_ownership(_path: &Path, _uid: u32, _gid: u32) -> Result<()> {
         Ok(())
+    }
+
+    /// Best-effort diagnostics gathered when a log-path operation fails, so the error
+    /// explains *why* (process creds, the directory's ownership/mode/writability, and the
+    /// backing filesystem) instead of a bare `os error 13`. Never panics; only invoked on
+    /// the error path, so the cost is irrelevant.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    fn describe_path_failure(
+        path: &Path,
+        intended: Option<(u32, u32)>,
+        err: Option<&std::io::Error>,
+    ) -> String {
+        use std::os::unix::fs::MetadataExt;
+
+        // SAFETY: geteuid/getegid are always-successful syscalls with no preconditions.
+        let (euid, egid) = unsafe { (nix::libc::geteuid(), nix::libc::getegid()) };
+
+        let mut out = format!("\n  diagnostics: process euid={euid} egid={egid}");
+        if let Some((uid, gid)) = intended {
+            out.push_str(&format!(", intended chown uid={uid} gid={gid}"));
+        }
+
+        // The directory we actually need write access to (a new entry is created inside it).
+        let dir = path.parent().unwrap_or(path);
+        match fs::metadata(dir) {
+            Ok(md) => {
+                let writable = nix::unistd::access(dir, nix::unistd::AccessFlags::W_OK).is_ok();
+                out.push_str(&format!(
+                    "\n  parent dir {dir:?}: owner uid={} gid={} mode={:#o} writable_by_euid={writable}",
+                    md.uid(),
+                    md.gid(),
+                    md.mode() & 0o7777,
+                ));
+            }
+            Err(stat_err) => {
+                out.push_str(&format!("\n  parent dir {dir:?}: stat failed: {stat_err}"));
+            }
+        }
+
+        if let Some((fstype, source)) = Self::mount_for_path(path) {
+            out.push_str(&format!("\n  filesystem: type={fstype} source={source}"));
+
+            let denied = err.and_then(|e| e.raw_os_error()).is_some_and(|code| {
+                code == nix::libc::EACCES || code == nix::libc::EPERM || code == nix::libc::ESTALE
+            });
+            if denied && fstype.starts_with("nfs") && euid == 0 {
+                out.push_str(
+                    "\n  hint: a permission/stale error as root on an NFS path almost always means a \
+                     stale or divergent NFS mount (or a private mount namespace), not a permission \
+                     bug. Check: `findmnt -T <path>`; compare `/proc/<rqd-pid>/ns/mnt` against a \
+                     fresh shell; `nsenter -t <rqd-pid> -m -- touch <dir>/probe`.",
+                );
+            }
+        }
+
+        out
+    }
+
+    #[cfg(target_os = "windows")]
+    fn describe_path_failure(
+        _path: &Path,
+        _intended: Option<(u32, u32)>,
+        _err: Option<&std::io::Error>,
+    ) -> String {
+        String::new()
+    }
+
+    /// Returns `(fstype, source)` of the mount that contains `path`, matching the longest
+    /// mount-point prefix in `/proc/self/mountinfo` (Linux only).
+    #[cfg(target_os = "linux")]
+    fn mount_for_path(path: &Path) -> Option<(String, String)> {
+        let target = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+        let content = fs::read_to_string("/proc/self/mountinfo").ok()?;
+
+        let mut best: Option<(usize, String, String)> = None;
+        for line in content.lines() {
+            // mountinfo: `<fields...> - <fstype> <source> <super opts>`
+            let Some((left, right)) = line.split_once(" - ") else {
+                continue;
+            };
+            let left_fields: Vec<&str> = left.split_whitespace().collect();
+            let right_fields: Vec<&str> = right.split_whitespace().collect();
+            if left_fields.len() < 5 || right_fields.len() < 2 {
+                continue;
+            }
+            let mount_point = left_fields[4];
+            if target.starts_with(mount_point) {
+                let len = mount_point.len();
+                let better = match &best {
+                    Some((best_len, _, _)) => len > *best_len,
+                    None => true,
+                };
+                if better {
+                    best = Some((
+                        len,
+                        right_fields[0].to_string(),
+                        right_fields[1].to_string(),
+                    ));
+                }
+            }
+        }
+        best.map(|(_, fstype, source)| (fstype, source))
+    }
+
+    #[cfg(target_os = "macos")]
+    fn mount_for_path(_path: &Path) -> Option<(String, String)> {
+        None
     }
 
     fn rotate_existing_files(path: &String) -> Result<()> {
@@ -426,6 +545,61 @@ mod tests {
         file.read_to_string(&mut buffer).unwrap();
 
         assert_eq!(buffer, "First write. Second write. Third write.");
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn test_describe_path_failure_reports_creds_and_dir() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let path = temp_file.path();
+
+        let diag = FrameFileLogger::describe_path_failure(path, Some((1234, 5678)), None);
+
+        assert!(diag.contains("euid="), "diag missing euid: {diag}");
+        assert!(
+            diag.contains("intended chown uid=1234 gid=5678"),
+            "diag missing intended chown: {diag}"
+        );
+        assert!(
+            diag.contains("parent dir"),
+            "diag missing parent dir: {diag}"
+        );
+        assert!(diag.contains("mode="), "diag missing mode: {diag}");
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn test_init_into_unwritable_dir_reports_failing_op() {
+        // root bypasses DAC, so the unwritable-dir scenario can't be reproduced there.
+        // SAFETY: geteuid is an always-successful syscall with no preconditions.
+        if unsafe { nix::libc::geteuid() } == 0 {
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let locked = dir.path().join("locked");
+        fs::create_dir(&locked).unwrap();
+        fs::set_permissions(&locked, Permissions::from_mode(0o000)).unwrap();
+
+        let log_path = locked.join("frame.rqlog");
+        let result = FrameFileLogger::init(log_path.to_string_lossy().to_string(), false, None);
+
+        // Restore perms so the tempdir can be cleaned up.
+        let _ = fs::set_permissions(&locked, Permissions::from_mode(0o755));
+
+        let err = match result {
+            Ok(_) => panic!("expected init to fail on an unwritable dir"),
+            Err(err) => err,
+        };
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("failed to create frame log file"),
+            "error should name the failing op: {msg}"
+        );
+        assert!(
+            msg.contains("euid="),
+            "error should include diagnostics: {msg}"
+        );
     }
 
     #[test]

--- a/rust/crates/rqd/src/main.rs
+++ b/rust/crates/rqd/src/main.rs
@@ -19,7 +19,10 @@ use tracing_rolling_file::{RollingConditionBase, RollingFileAppenderBase};
 
 #[cfg(target_os = "macos")]
 use crate::frame::manager;
-use crate::{config::CONFIG, system::machine};
+use crate::{
+    config::CONFIG,
+    system::{capabilities, machine},
+};
 
 mod config;
 mod frame;
@@ -60,6 +63,10 @@ async fn async_main() -> miette::Result<()> {
     } else {
         log_builder.init();
     }
+
+    // Fail fast if the config requires elevated privileges the process does not hold,
+    // instead of letting every frame fail later with an opaque error.
+    capabilities::preflight(&CONFIG.runner)?;
 
     // Start a channel for communitating when machine_monitor fully started
     let (tx, rx) = oneshot::channel::<()>();

--- a/rust/crates/rqd/src/system/capabilities.rs
+++ b/rust/crates/rqd/src/system/capabilities.rs
@@ -1,0 +1,125 @@
+// Copyright Contributors to the OpenCue Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+//! Startup capability preflight.
+//!
+//! When `runner.run_as_user` is set, RQD switches the uid/gid of every frame process
+//! (`CAP_SETUID`/`CAP_SETGID`) and chowns artist-owned log directories it does not own
+//! (`CAP_CHOWN` plus `CAP_DAC_OVERRIDE`/`CAP_FOWNER` to write into them). If those
+//! effective capabilities are missing, every frame fails at launch with an opaque error.
+//! This module verifies them up front so a mis-provisioned node fails fast and loudly at
+//! startup instead of silently failing every frame.
+
+use crate::config::RunnerConfig;
+use miette::Result;
+
+#[cfg(target_os = "linux")]
+mod imp {
+    use super::*;
+    use miette::miette;
+
+    /// `(name, bit)` of the capabilities required when `run_as_user` is enabled.
+    /// Bit numbers per `<linux/capability.h>`.
+    const REQUIRED_CAPS: &[(&str, u8)] = &[
+        ("CAP_CHOWN", 0),
+        ("CAP_DAC_OVERRIDE", 1),
+        ("CAP_FOWNER", 3),
+        ("CAP_SETGID", 6),
+        ("CAP_SETUID", 7),
+    ];
+
+    /// Reads the effective capability bitmask (`CapEff`) of the current process from
+    /// `/proc/self/status`. Returns `None` if it can't be read or parsed.
+    fn effective_caps() -> Option<u64> {
+        let status = std::fs::read_to_string("/proc/self/status").ok()?;
+        for line in status.lines() {
+            if let Some(hex) = line.strip_prefix("CapEff:") {
+                return u64::from_str_radix(hex.trim(), 16).ok();
+            }
+        }
+        None
+    }
+
+    pub fn preflight(config: &RunnerConfig) -> Result<()> {
+        if !config.run_as_user {
+            return Ok(());
+        }
+
+        // root holds the full capability set implicitly, so there is nothing to verify.
+        // SAFETY: geteuid is an always-successful syscall with no preconditions.
+        if unsafe { nix::libc::geteuid() } == 0 {
+            return Ok(());
+        }
+
+        let caps = effective_caps().ok_or_else(|| {
+            miette!(
+                "runner.run_as_user is enabled but RQD could not read its effective \
+                 capabilities from /proc/self/status to verify it can switch frame users"
+            )
+        })?;
+
+        let missing: Vec<&str> = REQUIRED_CAPS
+            .iter()
+            .filter(|(_, bit)| (caps & (1u64 << *bit)) == 0)
+            .map(|(name, _)| *name)
+            .collect();
+
+        if missing.is_empty() {
+            return Ok(());
+        }
+
+        Err(miette!(
+            "runner.run_as_user is enabled but RQD is missing required Linux capabilities: {}. \
+             Without them every frame fails when switching to the artist's uid/gid or writing its \
+             log. Grant them to the binary (e.g. `setcap \
+             cap_setuid,cap_setgid,cap_chown,cap_dac_override,cap_fowner=ep /usr/bin/openrqd`) or \
+             run RQD as root.",
+            missing.join(", ")
+        ))
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn test_preflight_noop_when_run_as_user_disabled() {
+            let mut config = RunnerConfig::default();
+            config.run_as_user = false;
+            assert!(preflight(&config).is_ok());
+        }
+
+        #[test]
+        fn test_required_caps_bit_decoding() {
+            // A mask with only CAP_CHOWN(0) and CAP_SETUID(7) set.
+            let caps: u64 = (1 << 0) | (1 << 7);
+            let missing: Vec<&str> = REQUIRED_CAPS
+                .iter()
+                .filter(|(_, bit)| (caps & (1u64 << *bit)) == 0)
+                .map(|(name, _)| *name)
+                .collect();
+            assert_eq!(
+                missing,
+                vec!["CAP_DAC_OVERRIDE", "CAP_FOWNER", "CAP_SETGID"]
+            );
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub use imp::preflight;
+
+/// Capabilities are a Linux concept; nothing to verify on other platforms.
+#[cfg(not(target_os = "linux"))]
+pub fn preflight(_config: &RunnerConfig) -> Result<()> {
+    Ok(())
+}

--- a/rust/crates/rqd/src/system/capabilities.rs
+++ b/rust/crates/rqd/src/system/capabilities.rs
@@ -54,12 +54,9 @@ mod imp {
             return Ok(());
         }
 
-        // root holds the full capability set implicitly, so there is nothing to verify.
-        // SAFETY: geteuid is an always-successful syscall with no preconditions.
-        if unsafe { nix::libc::geteuid() } == 0 {
-            return Ok(());
-        }
-
+        // Validate the effective set even when running as root: in containers and user
+        // namespaces a uid-0 process can have a reduced CapEff and would otherwise fail
+        // at frame launch instead of here.
         let caps = effective_caps().ok_or_else(|| {
             miette!(
                 "runner.run_as_user is enabled but RQD could not read its effective \

--- a/rust/crates/rqd/src/system/mod.rs
+++ b/rust/crates/rqd/src/system/mod.rs
@@ -12,6 +12,7 @@
 
 use uuid::Uuid;
 
+pub mod capabilities;
 #[cfg(any(target_os = "linux", all(target_os = "macos", debug_assertions)))]
 pub mod linux;
 pub mod machine;


### PR DESCRIPTION
Whenever rqd starts without its required capabilities, it now fails right away, instead of waiting for a frame to fail trying to execute unauthorized ops. Besides that, endure fs errors are properly logged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Much richer diagnostics when log initialization fails: error messages now include process ownership, directory permissions and mount info to aid troubleshooting on Linux/macOS.
  * Startup now performs an early capability/privilege preflight when running as a non-default user and surfaces any missing privileges immediately to fail fast.
* **Tests**
  * Added unit/integration tests validating diagnostics content and preflight capability checks on supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->