### PR TITLE
[cuebot] Release procs on frame-complete for scheduler-managed shows

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/FrameCompleteHandler.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/FrameCompleteHandler.java
@@ -530,6 +530,17 @@ public class FrameCompleteHandler {
                     || newFrameState.equals(FrameState.SUCCEEDED)) {
 
                 /*
+                 * Scheduler-managed shows: the standalone Rust scheduler owns dispatch. Don't
+                 * reuse/rebook the proc here (that races the scheduler and strands pk_frame=NULL
+                 * procs with reserved cores). Release it so its cores return to idle and let the
+                 * scheduler own rebooking. Local dispatches are always Cuebot-managed.
+                 */
+                if (!proc.isLocalDispatch && showDao.isSchedulerManaged(proc.getShowId())) {
+                    dispatchSupport.unbookProc(proc, "scheduler-managed show, releasing proc");
+                    return;
+                }
+
+                /*
                  * Check for stranded cores on the host.
                  */
                 if (!proc.isLocalDispatch && dispatchSupport.hasStrandedCores(proc)

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/FrameCompleteHandlerTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/FrameCompleteHandlerTests.java
@@ -37,7 +37,6 @@ import com.imageworks.spcue.ServiceOverrideEntity;
 import com.imageworks.spcue.VirtualProc;
 import com.imageworks.spcue.dao.FrameDao;
 import com.imageworks.spcue.dao.LayerDao;
-import com.imageworks.spcue.dao.ProcDao;
 import com.imageworks.spcue.dao.ShowDao;
 import com.imageworks.spcue.dispatcher.Dispatcher;
 import com.imageworks.spcue.dispatcher.DispatchSupport;
@@ -55,15 +54,18 @@ import com.imageworks.spcue.service.ServiceManager;
 import com.imageworks.spcue.test.TransactionalTest;
 import com.imageworks.spcue.util.CueUtil;
 
-import org.springframework.dao.EmptyResultDataAccessException;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import org.springframework.transaction.CannotCreateTransactionException;
 
@@ -103,12 +105,6 @@ public class FrameCompleteHandlerTests extends TransactionalTest {
 
     @Resource
     ServiceManager serviceManager;
-
-    @Resource
-    ProcDao procDao;
-
-    @Resource
-    ShowDao showDao;
 
     private static final String HOSTNAME = "beta";
     private static final String HOSTNAME2 = "zeta";
@@ -546,13 +542,21 @@ public class FrameCompleteHandlerTests extends TransactionalTest {
     }
 
     /**
-     * Runs a frame completion through the proc-reuse path (the job still has a WAITING frame, so it
-     * stays dispatchable) and returns whether the proc survived. When the show is
-     * scheduler-managed, the standalone scheduler owns dispatch, so Cuebot must release (unbook)
-     * the proc instead of rebooking it on the same proc, otherwise the proc lingers with
-     * pk_frame=NULL holding reserved cores. When it is not scheduler-managed, the proc is reused.
+     * Drives a frame completion through the proc-reuse branch (the job still has a WAITING frame,
+     * so it stays dispatchable) and asserts whether the scheduler-managed release path fired. When
+     * the show is scheduler-managed, the standalone scheduler owns dispatch, so Cuebot must release
+     * (unbook) the proc here instead of rebooking it on the same proc — otherwise the proc lingers
+     * with pk_frame=NULL holding reserved cores. The release is identified by the unique reason
+     * string passed to unbookProc, which makes this independent of the nondeterministic downstream
+     * dispatch.
+     *
+     * <p>
+     * isSchedulerManaged is stubbed on a spy rather than written to the DB on purpose: the real
+     * flag lives in an in-memory cache on ShowDaoJdbc that is NOT rolled back with the transaction,
+     * so a real write would leak scheduler-managed behavior into other tests sharing the Spring
+     * context.
      */
-    private boolean procSurvivesReuseAfterComplete(boolean schedulerManaged) {
+    private void executeProcReuseGate(boolean schedulerManaged) {
         JobDetail job = jobManager.findJobDetail("pipe-default-testuser_test_depend");
         jobManager.setJobPaused(job, false);
 
@@ -560,10 +564,6 @@ public class FrameCompleteHandlerTests extends TransactionalTest {
         List<VirtualProc> procs = dispatcher.dispatchHost(host);
         assertEquals(1, procs.size());
         VirtualProc proc = procs.get(0);
-
-        if (schedulerManaged) {
-            showDao.updateSchedulerManaged(showDao.getShowDetail(proc.getShowId()), true);
-        }
 
         RunningFrameInfo info = RunningFrameInfo.newBuilder().setJobId(proc.getJobId())
                 .setLayerId(proc.getLayerId()).setFrameId(proc.getFrameId())
@@ -576,15 +576,25 @@ public class FrameCompleteHandlerTests extends TransactionalTest {
         FrameDetail frameDetail = jobManager.getFrameDetail(report.getFrame().getFrameId());
         dispatchSupport.stopFrame(dispatchFrame, FrameState.SUCCEEDED, report.getExitStatus(),
                 report.getFrame().getMaxRss());
-        frameCompleteHandler.handlePostFrameCompleteOperations(proc, report, dispatchJob,
-                dispatchFrame, FrameState.SUCCEEDED, frameDetail);
 
+        ShowDao originalShowDao = frameCompleteHandler.getShowDao();
+        DispatchSupport originalDispatchSupport = frameCompleteHandler.getDispatchSupport();
+        ShowDao spyShowDao = spy(originalShowDao);
+        DispatchSupport spyDispatchSupport = spy(originalDispatchSupport);
+        doReturn(schedulerManaged).when(spyShowDao).isSchedulerManaged(proc.getShowId());
+
+        frameCompleteHandler.setShowDao(spyShowDao);
+        frameCompleteHandler.setDispatchSupport(spyDispatchSupport);
         try {
-            procDao.getVirtualProc(proc.getId());
-            return true;
-        } catch (EmptyResultDataAccessException e) {
-            return false;
+            frameCompleteHandler.handlePostFrameCompleteOperations(proc, report, dispatchJob,
+                    dispatchFrame, FrameState.SUCCEEDED, frameDetail);
+        } finally {
+            frameCompleteHandler.setShowDao(originalShowDao);
+            frameCompleteHandler.setDispatchSupport(originalDispatchSupport);
         }
+
+        verify(spyDispatchSupport, schedulerManaged ? times(1) : never())
+                .unbookProc(any(VirtualProc.class), eq("scheduler-managed show, releasing proc"));
     }
 
     @Test
@@ -592,14 +602,14 @@ public class FrameCompleteHandlerTests extends TransactionalTest {
     @Rollback(true)
     public void testSchedulerManagedShowReleasesProc() {
         // Scheduler-managed: the proc must be unbooked (released), not reused.
-        assertFalse(procSurvivesReuseAfterComplete(true));
+        executeProcReuseGate(true);
     }
 
     @Test
     @Transactional
     @Rollback(true)
     public void testNonSchedulerManagedShowReusesProc() {
-        // Control: the proc is reused on the same host, so it still exists.
-        assertTrue(procSurvivesReuseAfterComplete(false));
+        // Control: the scheduler-managed release branch must not fire.
+        executeProcReuseGate(false);
     }
 }

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/FrameCompleteHandlerTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/FrameCompleteHandlerTests.java
@@ -37,6 +37,8 @@ import com.imageworks.spcue.ServiceOverrideEntity;
 import com.imageworks.spcue.VirtualProc;
 import com.imageworks.spcue.dao.FrameDao;
 import com.imageworks.spcue.dao.LayerDao;
+import com.imageworks.spcue.dao.ProcDao;
+import com.imageworks.spcue.dao.ShowDao;
 import com.imageworks.spcue.dispatcher.Dispatcher;
 import com.imageworks.spcue.dispatcher.DispatchSupport;
 import com.imageworks.spcue.dispatcher.FrameCompleteHandler;
@@ -52,6 +54,8 @@ import com.imageworks.spcue.service.JobManager;
 import com.imageworks.spcue.service.ServiceManager;
 import com.imageworks.spcue.test.TransactionalTest;
 import com.imageworks.spcue.util.CueUtil;
+
+import org.springframework.dao.EmptyResultDataAccessException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -99,6 +103,12 @@ public class FrameCompleteHandlerTests extends TransactionalTest {
 
     @Resource
     ServiceManager serviceManager;
+
+    @Resource
+    ProcDao procDao;
+
+    @Resource
+    ShowDao showDao;
 
     private static final String HOSTNAME = "beta";
     private static final String HOSTNAME2 = "zeta";
@@ -533,5 +543,63 @@ public class FrameCompleteHandlerTests extends TransactionalTest {
     public void testDependRetryExhausted() {
         // All three calls fail — depend remains unsatisfied, frame stays in DEPEND
         executeDependWithRetry(3, 1, FrameState.DEPEND);
+    }
+
+    /**
+     * Runs a frame completion through the proc-reuse path (the job still has a WAITING frame, so it
+     * stays dispatchable) and returns whether the proc survived. When the show is
+     * scheduler-managed, the standalone scheduler owns dispatch, so Cuebot must release (unbook)
+     * the proc instead of rebooking it on the same proc, otherwise the proc lingers with
+     * pk_frame=NULL holding reserved cores. When it is not scheduler-managed, the proc is reused.
+     */
+    private boolean procSurvivesReuseAfterComplete(boolean schedulerManaged) {
+        JobDetail job = jobManager.findJobDetail("pipe-default-testuser_test_depend");
+        jobManager.setJobPaused(job, false);
+
+        DispatchHost host = getHost(HOSTNAME);
+        List<VirtualProc> procs = dispatcher.dispatchHost(host);
+        assertEquals(1, procs.size());
+        VirtualProc proc = procs.get(0);
+
+        if (schedulerManaged) {
+            showDao.updateSchedulerManaged(showDao.getShowDetail(proc.getShowId()), true);
+        }
+
+        RunningFrameInfo info = RunningFrameInfo.newBuilder().setJobId(proc.getJobId())
+                .setLayerId(proc.getLayerId()).setFrameId(proc.getFrameId())
+                .setResourceId(proc.getProcId()).build();
+        FrameCompleteReport report =
+                FrameCompleteReport.newBuilder().setFrame(info).setExitStatus(0).build();
+
+        DispatchJob dispatchJob = jobManager.getDispatchJob(proc.getJobId());
+        DispatchFrame dispatchFrame = jobManager.getDispatchFrame(report.getFrame().getFrameId());
+        FrameDetail frameDetail = jobManager.getFrameDetail(report.getFrame().getFrameId());
+        dispatchSupport.stopFrame(dispatchFrame, FrameState.SUCCEEDED, report.getExitStatus(),
+                report.getFrame().getMaxRss());
+        frameCompleteHandler.handlePostFrameCompleteOperations(proc, report, dispatchJob,
+                dispatchFrame, FrameState.SUCCEEDED, frameDetail);
+
+        try {
+            procDao.getVirtualProc(proc.getId());
+            return true;
+        } catch (EmptyResultDataAccessException e) {
+            return false;
+        }
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testSchedulerManagedShowReleasesProc() {
+        // Scheduler-managed: the proc must be unbooked (released), not reused.
+        assertFalse(procSurvivesReuseAfterComplete(true));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testNonSchedulerManagedShowReusesProc() {
+        // Control: the proc is reused on the same host, so it still exists.
+        assertTrue(procSurvivesReuseAfterComplete(false));
     }
 }

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/FrameCompleteHandlerTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/FrameCompleteHandlerTests.java
@@ -570,8 +570,15 @@ public class FrameCompleteHandlerTests extends TransactionalTest {
         RunningFrameInfo info = RunningFrameInfo.newBuilder().setJobId(proc.getJobId())
                 .setLayerId(proc.getLayerId()).setFrameId(proc.getFrameId())
                 .setResourceId(proc.getProcId()).build();
-        FrameCompleteReport report =
-                FrameCompleteReport.newBuilder().setFrame(info).setExitStatus(0).build();
+        // The report must carry a healthy host (UP, plenty of free memory), otherwise the handler
+        // unbooks the proc early (e.g. the < 512MB low-memory check) and returns before reaching
+        // the
+        // WAITING/SUCCEEDED proc-reuse branch that the scheduler-managed gate lives in.
+        RenderHost reportHost =
+                RenderHost.newBuilder().setName(HOSTNAME).setFreeMem((int) CueUtil.GB8)
+                        .setNimbyEnabled(false).setState(HardwareState.UP).build();
+        FrameCompleteReport report = FrameCompleteReport.newBuilder().setFrame(info)
+                .setHost(reportHost).setExitStatus(0).build();
 
         DispatchJob dispatchJob = jobManager.getDispatchJob(proc.getJobId());
         DispatchFrame dispatchFrame = jobManager.getDispatchFrame(report.getFrame().getFrameId());

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/FrameCompleteHandlerTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/FrameCompleteHandlerTests.java
@@ -57,11 +57,13 @@ import com.imageworks.spcue.util.CueUtil;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -577,14 +579,18 @@ public class FrameCompleteHandlerTests extends TransactionalTest {
         dispatchSupport.stopFrame(dispatchFrame, FrameState.SUCCEEDED, report.getExitStatus(),
                 report.getFrame().getMaxRss());
 
+        // The DAO beans are Spring JDK dynamic proxies (final), so they can't be spied. Wrap them
+        // in interface mocks that delegate to the real bean for everything except the one method we
+        // stub, while still recording invocations for verification.
         ShowDao originalShowDao = frameCompleteHandler.getShowDao();
         DispatchSupport originalDispatchSupport = frameCompleteHandler.getDispatchSupport();
-        ShowDao spyShowDao = spy(originalShowDao);
-        DispatchSupport spyDispatchSupport = spy(originalDispatchSupport);
-        doReturn(schedulerManaged).when(spyShowDao).isSchedulerManaged(proc.getShowId());
+        ShowDao mockShowDao = mock(ShowDao.class, delegatesTo(originalShowDao));
+        DispatchSupport mockDispatchSupport =
+                mock(DispatchSupport.class, delegatesTo(originalDispatchSupport));
+        doReturn(schedulerManaged).when(mockShowDao).isSchedulerManaged(proc.getShowId());
 
-        frameCompleteHandler.setShowDao(spyShowDao);
-        frameCompleteHandler.setDispatchSupport(spyDispatchSupport);
+        frameCompleteHandler.setShowDao(mockShowDao);
+        frameCompleteHandler.setDispatchSupport(mockDispatchSupport);
         try {
             frameCompleteHandler.handlePostFrameCompleteOperations(proc, report, dispatchJob,
                     dispatchFrame, FrameState.SUCCEEDED, frameDetail);
@@ -593,7 +599,7 @@ public class FrameCompleteHandlerTests extends TransactionalTest {
             frameCompleteHandler.setDispatchSupport(originalDispatchSupport);
         }
 
-        verify(spyDispatchSupport, schedulerManaged ? times(1) : never())
+        verify(mockDispatchSupport, schedulerManaged ? times(1) : never())
                 .unbookProc(any(VirtualProc.class), eq("scheduler-managed show, releasing proc"));
     }
 

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/FrameCompleteHandlerTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/FrameCompleteHandlerTests.java
@@ -558,7 +558,7 @@ public class FrameCompleteHandlerTests extends TransactionalTest {
      * so a real write would leak scheduler-managed behavior into other tests sharing the Spring
      * context.
      */
-    private void executeProcReuseGate(boolean schedulerManaged) {
+    private void executeProcReuseGate(boolean schedulerManaged, FrameState terminalState) {
         JobDetail job = jobManager.findJobDetail("pipe-default-testuser_test_depend");
         jobManager.setJobPaused(job, false);
 
@@ -583,7 +583,7 @@ public class FrameCompleteHandlerTests extends TransactionalTest {
         DispatchJob dispatchJob = jobManager.getDispatchJob(proc.getJobId());
         DispatchFrame dispatchFrame = jobManager.getDispatchFrame(report.getFrame().getFrameId());
         FrameDetail frameDetail = jobManager.getFrameDetail(report.getFrame().getFrameId());
-        dispatchSupport.stopFrame(dispatchFrame, FrameState.SUCCEEDED, report.getExitStatus(),
+        dispatchSupport.stopFrame(dispatchFrame, terminalState, report.getExitStatus(),
                 report.getFrame().getMaxRss());
 
         // The DAO beans are Spring JDK dynamic proxies (final), so they can't be spied. Wrap them
@@ -600,7 +600,7 @@ public class FrameCompleteHandlerTests extends TransactionalTest {
         frameCompleteHandler.setDispatchSupport(mockDispatchSupport);
         try {
             frameCompleteHandler.handlePostFrameCompleteOperations(proc, report, dispatchJob,
-                    dispatchFrame, FrameState.SUCCEEDED, frameDetail);
+                    dispatchFrame, terminalState, frameDetail);
         } finally {
             frameCompleteHandler.setShowDao(originalShowDao);
             frameCompleteHandler.setDispatchSupport(originalDispatchSupport);
@@ -614,15 +614,32 @@ public class FrameCompleteHandlerTests extends TransactionalTest {
     @Transactional
     @Rollback(true)
     public void testSchedulerManagedShowReleasesProc() {
-        // Scheduler-managed: the proc must be unbooked (released), not reused.
-        executeProcReuseGate(true);
+        // Scheduler-managed, SUCCEEDED: the proc must be unbooked (released), not reused.
+        executeProcReuseGate(true, FrameState.SUCCEEDED);
     }
 
     @Test
     @Transactional
     @Rollback(true)
     public void testNonSchedulerManagedShowReusesProc() {
-        // Control: the scheduler-managed release branch must not fire.
-        executeProcReuseGate(false);
+        // Control, SUCCEEDED: the scheduler-managed release branch must not fire.
+        executeProcReuseGate(false, FrameState.SUCCEEDED);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testSchedulerManagedShowReleasesProcWaiting() {
+        // Scheduler-managed, WAITING: the other side of the WAITING/SUCCEEDED gate must also
+        // release the proc.
+        executeProcReuseGate(true, FrameState.WAITING);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testNonSchedulerManagedShowReusesProcWaiting() {
+        // Control, WAITING: the scheduler-managed release branch must not fire.
+        executeProcReuseGate(false, FrameState.WAITING);
     }
 }


### PR DESCRIPTION
After #2323, the frame-complete proc-reuse path in FrameCompleteHandler still rebooked procs for scheduler-managed shows. That races the Rust scheduler, stranding pk_frame=NULL procs that hold reserved cores, so hosts report too few idle cores.

Gate the reuse path on showDao.isSchedulerManaged: for non-local procs on scheduler-managed shows, unbookProc immediately instead of queueing DispatchNextFrame. This frees the cores and avoids double-dispatching a frame the scheduler owns.

Add FrameCompleteHandlerTests coverage for both the scheduler-managed (proc released) and control (proc reused) cases.

## LLM usage disclosure
Claude Opus was used to investigate and propose a fix for this issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Procs for scheduler-managed shows are now released immediately after frame completion, preventing unnecessary retention, stranded-core checks, and redundant re-dispatch/next-frame scheduling.

* **Tests**
  * Added tests confirming scheduler-managed shows release procs on terminal states and non-scheduler-managed shows continue through the existing reuse flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->