### PR TITLE
[cueweb] Layer Management: Layer property edit dialog (memory, cores, tags)

### DIFF
--- a/cueweb/app/__tests__/api/utils/layer-properties.test.ts
+++ b/cueweb/app/__tests__/api/utils/layer-properties.test.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright Contributors to the OpenCue Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { editLayerProperties } from '@/app/utils/action_utils';
+import { accessActionApi } from '@/app/utils/api_utils';
+import { handleError, toastSuccess } from '@/app/utils/notify_utils';
+import { parseMemoryToKb, formatKbToGbInput } from '@/app/utils/layers_frames_utils';
+
+jest.mock('@/app/utils/api_utils', () => ({
+  accessActionApi: jest.fn(),
+}));
+jest.mock('@/app/utils/notify_utils', () => ({
+  toastSuccess: jest.fn(),
+  toastWarning: jest.fn(),
+  handleError: jest.fn(),
+}));
+jest.mock('@/app/utils/get_utils', () => ({
+  getJobForLayer: jest.fn(),
+}));
+
+const mockLayer: any = {
+  id: 'layer-id',
+  name: 'layer-name',
+  minCores: 1,
+  minMemory: '4194304', // 4 GB in KB
+  tags: ['general'],
+};
+
+describe('editLayerProperties', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('POSTs only the changed fields and toasts once on success', async () => {
+    (accessActionApi as jest.Mock).mockResolvedValue({ success: true });
+    const ok = await editLayerProperties(mockLayer, {
+      minMemory: 8388608,
+      minCores: 2,
+      tags: ['general', 'desktop'],
+    });
+    expect(ok).toBe(true);
+    expect(accessActionApi).toHaveBeenNthCalledWith(
+      1, '/api/layer/action/setminmemory', [JSON.stringify({ layer: mockLayer, memory: 8388608 })],
+    );
+    expect(accessActionApi).toHaveBeenNthCalledWith(
+      2, '/api/layer/action/setmincores', [JSON.stringify({ layer: mockLayer, cores: 2 })],
+    );
+    expect(accessActionApi).toHaveBeenNthCalledWith(
+      3, '/api/layer/action/settags', [JSON.stringify({ layer: mockLayer, tags: ['general', 'desktop'] })],
+    );
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips fields not present in the change set', async () => {
+    (accessActionApi as jest.Mock).mockResolvedValue({ success: true });
+    const ok = await editLayerProperties(mockLayer, { minCores: 4 });
+    expect(ok).toBe(true);
+    expect(accessActionApi).toHaveBeenCalledTimes(1);
+    expect(accessActionApi).toHaveBeenCalledWith(
+      '/api/layer/action/setmincores', [JSON.stringify({ layer: mockLayer, cores: 4 })],
+    );
+  });
+
+  it('sends a zero-core change (typeof number guard, not truthiness)', async () => {
+    (accessActionApi as jest.Mock).mockResolvedValue({ success: true });
+    const ok = await editLayerProperties(mockLayer, { minCores: 0 });
+    expect(ok).toBe(true);
+    expect(accessActionApi).toHaveBeenCalledTimes(1);
+    expect(accessActionApi).toHaveBeenCalledWith(
+      '/api/layer/action/setmincores', [JSON.stringify({ layer: mockLayer, cores: 0 })],
+    );
+  });
+
+  it('stops after the first failing call and surfaces the error without toasting', async () => {
+    (accessActionApi as jest.Mock).mockResolvedValueOnce({ success: false, error: 'boom' });
+    const ok = await editLayerProperties(mockLayer, { minMemory: 8388608, minCores: 2 });
+    expect(ok).toBe(false);
+    expect(accessActionApi).toHaveBeenCalledTimes(1);
+    expect(handleError).toHaveBeenCalled();
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+});
+
+describe('parseMemoryToKb', () => {
+  it('treats a bare number as GB (CueGUI parity)', () => {
+    expect(parseMemoryToKb('4')).toBe(4 * 1024 * 1024);
+    expect(parseMemoryToKb('2.5')).toBe(Math.round(2.5 * 1024 * 1024));
+  });
+
+  it('honours K/M/G/T unit suffixes case-insensitively', () => {
+    expect(parseMemoryToKb('512K')).toBe(512);
+    expect(parseMemoryToKb('512kb')).toBe(512);
+    expect(parseMemoryToKb('512M')).toBe(512 * 1024);
+    expect(parseMemoryToKb('4GB')).toBe(4 * 1024 * 1024);
+    expect(parseMemoryToKb('1t')).toBe(1024 * 1024 * 1024);
+  });
+
+  it('tolerates whitespace between the number and unit', () => {
+    expect(parseMemoryToKb('  2 GB ')).toBe(2 * 1024 * 1024);
+  });
+
+  it('rejects blank, non-numeric, non-positive and unknown-unit input', () => {
+    expect(parseMemoryToKb('')).toBeNull();
+    expect(parseMemoryToKb('   ')).toBeNull();
+    expect(parseMemoryToKb('abc')).toBeNull();
+    expect(parseMemoryToKb('0')).toBeNull();
+    expect(parseMemoryToKb('-4')).toBeNull();
+    expect(parseMemoryToKb('4PB')).toBeNull();
+    expect(parseMemoryToKb('4 GB extra')).toBeNull();
+  });
+});
+
+describe('formatKbToGbInput', () => {
+  it('formats KB as a trimmed GB string', () => {
+    expect(formatKbToGbInput(4 * 1024 * 1024)).toBe('4');
+    expect(formatKbToGbInput(Math.round(2.5 * 1024 * 1024))).toBe('2.5');
+  });
+
+  it('round-trips with parseMemoryToKb for whole-GB values', () => {
+    const kb = 8 * 1024 * 1024;
+    expect(parseMemoryToKb(formatKbToGbInput(kb))).toBe(kb);
+  });
+
+  it('returns an empty string for non-positive or non-finite input', () => {
+    expect(formatKbToGbInput(0)).toBe('');
+    expect(formatKbToGbInput(-1)).toBe('');
+    expect(formatKbToGbInput(Number.NaN)).toBe('');
+  });
+});

--- a/cueweb/app/api/layer/action/setmincores/route.ts
+++ b/cueweb/app/api/layer/action/setmincores/route.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Contributors to the OpenCue Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { handleRoute } from '@/app/utils/api_utils';
+import { NextRequest, NextResponse } from "next/server";
+
+// Set a layer's minimum reserved cores. Request: { layer, cores: number }
+// where `cores` is whole cores (e.g. 1 = one core); Cuebot scales it to
+// core units internally. RPC: /job.LayerInterface/SetMinCores
+// (LayerSetMinCoresRequest).
+const MIN_CORES = 0;
+const MAX_CORES = 50000;
+
+export async function POST(request: NextRequest) {
+  const endpoint = "/job.LayerInterface/SetMinCores";
+  const method = request.method;
+  if (method !== 'POST') {
+    return NextResponse.json({ error: 'Invalid method. Only POST is allowed.' }, { status: 405 });
+  }
+
+  let jsonBody: any;
+  try {
+    jsonBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+  if (
+    !jsonBody
+    || typeof jsonBody !== 'object'
+    || Array.isArray(jsonBody)
+    || !jsonBody.layer
+    || typeof jsonBody.cores !== 'number'
+  ) {
+    return NextResponse.json({ error: 'Invalid request body (need {layer, cores:number})' }, { status: 400 });
+  }
+
+  if (!Number.isFinite(jsonBody.cores) || jsonBody.cores < MIN_CORES || jsonBody.cores > MAX_CORES) {
+    return NextResponse.json(
+      { error: `cores must be a number between ${MIN_CORES} and ${MAX_CORES}` },
+      { status: 400 },
+    );
+  }
+
+  const body = JSON.stringify(jsonBody);
+  const response = await handleRoute(method, endpoint, body, true);
+  const responseData = await response.json();
+
+  if (!response.ok) return NextResponse.json({ error: responseData.error }, { status: response.status });
+  return NextResponse.json({ data: responseData.data }, { status: response.status });
+}

--- a/cueweb/app/api/layer/action/setminmemory/route.ts
+++ b/cueweb/app/api/layer/action/setminmemory/route.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Contributors to the OpenCue Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { handleRoute } from '@/app/utils/api_utils';
+import { NextRequest, NextResponse } from "next/server";
+
+// Set a layer's minimum reserved memory. Request: { layer, memory: number }
+// where `memory` is in KB (matching the Layer.min_memory field). RPC:
+// /job.LayerInterface/SetMinMemory (LayerSetMinMemoryRequest).
+//
+// 1 KB .. 1 TB guards against fat-fingered values; Cuebot still enforces
+// its own per-show limits.
+const MIN_MEMORY_KB = 1;
+const MAX_MEMORY_KB = 1024 * 1024 * 1024; // 1 TB in KB
+
+export async function POST(request: NextRequest) {
+  const endpoint = "/job.LayerInterface/SetMinMemory";
+  const method = request.method;
+  if (method !== 'POST') {
+    return NextResponse.json({ error: 'Invalid method. Only POST is allowed.' }, { status: 405 });
+  }
+
+  let jsonBody: any;
+  try {
+    jsonBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+  if (
+    !jsonBody
+    || typeof jsonBody !== 'object'
+    || Array.isArray(jsonBody)
+    || !jsonBody.layer
+    || typeof jsonBody.memory !== 'number'
+  ) {
+    return NextResponse.json({ error: 'Invalid request body (need {layer, memory:number})' }, { status: 400 });
+  }
+
+  if (!Number.isFinite(jsonBody.memory) || jsonBody.memory < MIN_MEMORY_KB || jsonBody.memory > MAX_MEMORY_KB) {
+    return NextResponse.json(
+      { error: `memory must be a number between ${MIN_MEMORY_KB} and ${MAX_MEMORY_KB} (KB)` },
+      { status: 400 },
+    );
+  }
+
+  const body = JSON.stringify(jsonBody);
+  const response = await handleRoute(method, endpoint, body, true);
+  const responseData = await response.json();
+
+  if (!response.ok) return NextResponse.json({ error: responseData.error }, { status: response.status });
+  return NextResponse.json({ data: responseData.data }, { status: response.status });
+}

--- a/cueweb/app/api/layer/action/settags/route.ts
+++ b/cueweb/app/api/layer/action/settags/route.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Contributors to the OpenCue Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { handleRoute } from '@/app/utils/api_utils';
+import { NextRequest, NextResponse } from "next/server";
+
+// Replace a layer's tags. Request: { layer, tags: string[] }. SetTags is a
+// wholesale replace (not add/remove), so the client sends the full desired
+// set. Cuebot rejects an empty tag set, and CueGUI requires at least one
+// tag, so we guard for a non-empty array here too. RPC:
+// /job.LayerInterface/SetTags (LayerSetTagsRequest).
+export async function POST(request: NextRequest) {
+  const endpoint = "/job.LayerInterface/SetTags";
+  const method = request.method;
+  if (method !== 'POST') {
+    return NextResponse.json({ error: 'Invalid method. Only POST is allowed.' }, { status: 405 });
+  }
+
+  let jsonBody: any;
+  try {
+    jsonBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+  if (
+    !jsonBody
+    || typeof jsonBody !== 'object'
+    || Array.isArray(jsonBody)
+    || !jsonBody.layer
+    || !Array.isArray(jsonBody.tags)
+  ) {
+    return NextResponse.json({ error: 'Invalid request body (need {layer, tags:string[]})' }, { status: 400 });
+  }
+
+  if (jsonBody.tags.length === 0 || !jsonBody.tags.every((t: unknown) => typeof t === 'string' && t.trim() !== '')) {
+    return NextResponse.json({ error: 'tags must be a non-empty array of non-empty strings' }, { status: 400 });
+  }
+
+  const body = JSON.stringify(jsonBody);
+  const response = await handleRoute(method, endpoint, body, true);
+  const responseData = await response.json();
+
+  if (!response.ok) return NextResponse.json({ error: responseData.error }, { status: response.status });
+  return NextResponse.json({ data: responseData.data }, { status: response.status });
+}

--- a/cueweb/app/jobs/[job-name]/page.tsx
+++ b/cueweb/app/jobs/[job-name]/page.tsx
@@ -36,7 +36,12 @@ import {
 import { handleError } from "@/app/utils/notify_utils";
 import { Breadcrumbs } from "@/components/ui/breadcrumbs";
 import { Button } from "@/components/ui/button";
+import { EditLayerPropertiesDialog } from "@/components/ui/edit-layer-properties-dialog";
 import { EmptyState } from "@/components/ui/empty-state";
+import {
+  LAYERS_CHANGED_EVENT,
+  type LayersChangedDetail,
+} from "@/components/ui/layer-action-events";
 import { SimpleDataTable } from "@/components/ui/simple-data-table";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -208,6 +213,23 @@ export default function JobDetailPage() {
     };
   }, [job, tab]);
 
+  // Optimistic patch from the layer property editor: when a layer's min
+  // memory / min cores / tags change, update the matching row immediately so
+  // the change reflects without waiting for the next 5s poll (which then
+  // reconciles with Cuebot).
+  React.useEffect(() => {
+    function handler(e: Event) {
+      const detail = (e as CustomEvent<LayersChangedDetail>).detail;
+      if (!detail?.layerIds?.length) return;
+      const ids = new Set(detail.layerIds);
+      setLayers((prev) =>
+        prev.map((l) => (ids.has(l.id) ? { ...l, ...detail.patch } : l)),
+      );
+    }
+    window.addEventListener(LAYERS_CHANGED_EVENT, handler);
+    return () => window.removeEventListener(LAYERS_CHANGED_EVENT, handler);
+  }, []);
+
   const setTab = React.useCallback(
     (next: string) => {
       if (!isTabKey(next) || next === tab) return;
@@ -327,6 +349,10 @@ export default function JobDetailPage() {
           </TabsContent>
         </Tabs>
       )}
+
+      {/* Mounted once for the whole page; opened by the layer row context
+          menu's "Properties..." action via a CustomEvent. */}
+      <EditLayerPropertiesDialog />
     </div>
   );
 }

--- a/cueweb/app/jobs/data-table.tsx
+++ b/cueweb/app/jobs/data-table.tsx
@@ -51,6 +51,7 @@ import { DependencyWizardDialog } from "@/components/ui/dependency-wizard-dialog
 import { EmailArtistDialog } from "@/components/ui/email-artist-dialog";
 import { JobDetailsInline } from "@/components/ui/job-details-inline";
 import { RequestCoresDialog } from "@/components/ui/request-cores-dialog";
+import { EditLayerPropertiesDialog } from "@/components/ui/edit-layer-properties-dialog";
 import { SetCoresDialog } from "@/components/ui/set-cores-dialog";
 import { SetPriorityDialog } from "@/components/ui/set-priority-dialog";
 import { SubscribeToJobDialog } from "@/components/ui/subscribe-to-job-dialog";
@@ -2044,6 +2045,12 @@ export function DataTable({ columns, username }: DataTableProps) {
           a `cueweb:open-set-cores` CustomEvent fired from the row context
           menu's "Set Min/Max Cores..." entry. */}
       <SetCoresDialog />
+
+      {/* Layer Properties dialog. Mounted once here; opens in response to a
+          `cueweb:open-layer-properties` CustomEvent fired from the layer row
+          context menu (in the inline job details below) "Properties..."
+          entry. */}
+      <EditLayerPropertiesDialog />
 
       {/* Email Artist dialog. Mounted once here; opens in response to
           a `cueweb:open-email-artist` CustomEvent fired from the row

--- a/cueweb/app/utils/action_utils.ts
+++ b/cueweb/app/utils/action_utils.ts
@@ -290,6 +290,51 @@ export async function rebootHostsWhenIdle(hosts: Host[]): Promise<boolean> {
 }
 
 /**************************************/
+// Layer properties (CueGUI LayerDialog parity)
+/**************************************/
+
+// Apply min memory (KB), min cores (whole cores) and/or tags to a layer.
+// Cuebot exposes SetMinMemory / SetMinCores / SetTags as separate RPCs, so
+// we POST each provided field in turn and surface a single toast on full
+// success. Only the fields present in `changes` are sent, so the dialog can
+// diff against the layer's current values and skip untouched ones. Returns
+// true only when every requested change applied, so the caller can gate its
+// optimistic row patch on success (mirrors setJobCores).
+export async function editLayerProperties(
+  layer: Layer,
+  changes: { minMemory?: number; minCores?: number; tags?: string[] },
+): Promise<boolean> {
+  try {
+    if (typeof changes.minMemory === "number") {
+      const res = await accessActionApi(
+        "/api/layer/action/setminmemory",
+        [JSON.stringify({ layer, memory: changes.minMemory })],
+      );
+      if (!res?.success) throw new Error(res?.error ?? "Failed to set min memory");
+    }
+    if (typeof changes.minCores === "number") {
+      const res = await accessActionApi(
+        "/api/layer/action/setmincores",
+        [JSON.stringify({ layer, cores: changes.minCores })],
+      );
+      if (!res?.success) throw new Error(res?.error ?? "Failed to set min cores");
+    }
+    if (changes.tags) {
+      const res = await accessActionApi(
+        "/api/layer/action/settags",
+        [JSON.stringify({ layer, tags: changes.tags })],
+      );
+      if (!res?.success) throw new Error(res?.error ?? "Failed to set tags");
+    }
+    toastSuccess(`Updated properties on ${layer.name}`);
+    return true;
+  } catch (error) {
+    handleError(error, `Error updating properties on ${layer.name}`);
+    return false;
+  }
+}
+
+/**************************************/
 // Host Tags (CueCommander parity)
 /**************************************/
 
@@ -695,6 +740,22 @@ export function retryLayerFramesGivenRow(row: Row<any>) {
 export function retryLayerDeadFramesGivenRow(row: Row<any>) {
     const layers = [row.original]
     retryLayersDeadFrames(layers);
+}
+
+// Right-click "Properties..." handler. Dispatches a CustomEvent that the
+// EditLayerPropertiesDialog (mounted at the page level) listens for; the
+// dialog opens pre-filled with the row's min memory / min cores / tags and
+// calls editLayerProperties on Save. Decoupled this way so the free-function
+// context-menu handlers don't need to reach into the table's component state
+// (same pattern as setCoresGivenRow / editHostTagsGivenRow).
+export function editLayerPropertiesGivenRow(row: Row<any>) {
+    const layer = row.original as Layer;
+    if (typeof window === "undefined") return;
+    window.dispatchEvent(
+      new CustomEvent("cueweb:open-layer-properties", {
+        detail: { layer },
+      }),
+    );
 }
 
 /********************************/

--- a/cueweb/app/utils/layers_frames_utils.ts
+++ b/cueweb/app/utils/layers_frames_utils.ts
@@ -62,6 +62,52 @@ export const convertMemoryToString = (kmem: number, object: string): string => {
   return `${mem.toFixed(1)}G`;
 };
 
+// Parse a user-entered memory string into KB (the unit Cuebot stores layer
+// min_memory in). Accepts an optional unit suffix - K/KB, M/MB, G/GB,
+// T/TB (case-insensitive); a bare number is interpreted as GB, matching
+// CueGUI's LayerDialog whose memory spinner is labelled in GB. Returns null
+// when the input is blank, not a finite positive number, or carries an
+// unrecognised unit, so callers can surface a validation error.
+//
+//   "4"     -> 4 GB  -> 4194304 KB
+//   "512M"  -> 512 MB -> 524288 KB
+//   "2.5gb" -> 2.5 GB -> 2621440 KB
+export const parseMemoryToKb = (input: string): number | null => {
+  const trimmed = input.trim();
+  if (trimmed === "") return null;
+
+  const match = trimmed.match(/^([0-9]*\.?[0-9]+)\s*([a-zA-Z]*)$/);
+  if (!match) return null;
+
+  const value = Number.parseFloat(match[1]);
+  if (!Number.isFinite(value) || value <= 0) return null;
+
+  const unit = match[2].toLowerCase();
+  const multipliers: Record<string, number> = {
+    "": 1024 * 1024, // bare number == GB (CueGUI parity)
+    k: 1,
+    kb: 1,
+    m: 1024,
+    mb: 1024,
+    g: 1024 * 1024,
+    gb: 1024 * 1024,
+    t: 1024 * 1024 * 1024,
+    tb: 1024 * 1024 * 1024,
+  };
+  if (!(unit in multipliers)) return null;
+
+  return Math.round(value * multipliers[unit]);
+};
+
+// Format a KB amount as a GB string for editing (e.g. 4194304 -> "4"). Used
+// to seed the memory input of the layer property dialog. Keeps up to two
+// decimals and trims trailing zeros so common round values stay tidy.
+export const formatKbToGbInput = (kb: number): string => {
+  if (!Number.isFinite(kb) || kb <= 0) return "";
+  const gb = kb / (1024 * 1024);
+  return Number.parseFloat(gb.toFixed(2)).toString();
+};
+
 // Converts seconds to a string formatted as HH:MM:SS
 export const secondsToHHMMSS = (sec: number): string => {
   // Floor the input so fractional inputs (e.g. (Date.now()/1000) deltas)

--- a/cueweb/components/ui/context_menus/action-context-menu.tsx
+++ b/cueweb/components/ui/context_menus/action-context-menu.tsx
@@ -33,6 +33,7 @@ import {
   eatJobsDeadFramesGivenRow,
   eatLayerFramesGivenRow,
   editHostTagsGivenRow,
+  editLayerPropertiesGivenRow,
   emailArtistGivenRow,
   killFrameGivenRow,
   killJobGivenRow,
@@ -520,7 +521,7 @@ export const LayerContextMenu: React.FC<LayerContextMenuProps> = ({
 
     sep("group-properties"),
 
-    { label: "Properties...", onClick: notYetImplemented("Properties"), isActive: true, component: <TbSettings className="mr-1" size={14} /> },
+    { label: "Properties...", onClick: editLayerPropertiesGivenRow, isActive: true, component: <TbSettings className="mr-1" size={14} /> },
 
     sep("group-actions"),
 

--- a/cueweb/components/ui/edit-layer-properties-dialog.tsx
+++ b/cueweb/components/ui/edit-layer-properties-dialog.tsx
@@ -1,0 +1,328 @@
+"use client";
+
+/*
+ * Copyright Contributors to the OpenCue Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+import { X } from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Button } from "@/components/ui/button";
+import type { Layer } from "@/app/layers/layer-columns";
+import { editLayerProperties } from "@/app/utils/action_utils";
+import { getJobForLayer, getLayersForJob } from "@/app/utils/get_utils";
+import { formatKbToGbInput, parseMemoryToKb } from "@/app/utils/layers_frames_utils";
+import {
+  LAYERS_CHANGED_EVENT,
+  OPEN_LAYER_PROPERTIES_EVENT,
+  type LayersChangedDetail,
+  type OpenLayerPropertiesDetail,
+} from "@/components/ui/layer-action-events";
+
+/**
+ * Layer property editor dialog (#2291). Mirrors CueGUI's LayerDialog
+ * (Resource Options + Tags), scoped to the three fields the issue calls for:
+ * min memory, min cores and tags. Mounted once at the page level and opened
+ * by a `cueweb:open-layer-properties` CustomEvent from the layer row context
+ * menu (editLayerPropertiesGivenRow).
+ *
+ * Memory is entered with a unit suffix (a bare number is GB, matching
+ * CueGUI's GB spinner) and validated via parseMemoryToKb. Tags render as
+ * removable chips with a cmdk autocomplete seeded from the other layers in
+ * the same job (the closest CueWeb analog to CueGUI's show-wide allowed
+ * tags). On Save each field is diffed against the layer's current value and
+ * only the changes are sent (SetMinMemory / SetMinCores / SetTags); a
+ * `cueweb:layers-changed` event then patches the table optimistically.
+ */
+
+const uniqSorted = (xs: string[]): string[] => Array.from(new Set(xs)).sort();
+
+export function EditLayerPropertiesDialog() {
+  const [open, setOpen] = React.useState(false);
+  const [layer, setLayer] = React.useState<Layer | null>(null);
+
+  // Original values, captured on open so we can diff on Save.
+  const [originalMemoryKb, setOriginalMemoryKb] = React.useState(0);
+  const [originalCores, setOriginalCores] = React.useState(0);
+  const [originalTags, setOriginalTags] = React.useState<string[]>([]);
+
+  // Working state.
+  const [memoryInput, setMemoryInput] = React.useState("");
+  const [cores, setCores] = React.useState(0);
+  const [tags, setTags] = React.useState<string[]>([]);
+  const [allTags, setAllTags] = React.useState<string[]>([]);
+  const [query, setQuery] = React.useState("");
+  const [submitting, setSubmitting] = React.useState(false);
+
+  React.useEffect(() => {
+    function handler(e: Event) {
+      const detail = (e as CustomEvent<OpenLayerPropertiesDetail>).detail;
+      if (!detail?.layer) return;
+      const l = detail.layer;
+      const memKb = Number.parseInt(l.minMemory);
+      const startMemKb = Number.isFinite(memKb) ? memKb : 0;
+      const startCores = Number.isFinite(Number(l.minCores)) ? Number(l.minCores) : 0;
+      const startTags = uniqSorted(l.tags ?? []);
+
+      setLayer(l);
+      setOriginalMemoryKb(startMemKb);
+      setOriginalCores(startCores);
+      setOriginalTags(startTags);
+      setMemoryInput(formatKbToGbInput(startMemKb));
+      setCores(startCores);
+      setTags(startTags);
+      setAllTags(startTags);
+      setQuery("");
+      setSubmitting(false);
+      setOpen(true);
+
+      // Seed tag autocomplete from the other layers in this job. Best-effort:
+      // if the lookup fails we still have this layer's own tags as
+      // suggestions (CueGUI offers a show-wide ALLOWED_TAGS list; CueWeb has
+      // no equivalent registry endpoint, so sibling layers are the closest
+      // source of "tags from the existing show").
+      getJobForLayer(l)
+        .then((job) => (job ? getLayersForJob(job) : []))
+        .then((layers) => setAllTags(uniqSorted(layers.flatMap((x) => x.tags ?? []))))
+        .catch(() => {});
+    }
+    window.addEventListener(OPEN_LAYER_PROPERTIES_EVENT, handler);
+    return () => window.removeEventListener(OPEN_LAYER_PROPERTIES_EVENT, handler);
+  }, []);
+
+  const addTag = React.useCallback((raw: string) => {
+    const v = raw.trim();
+    setQuery("");
+    if (!v) return;
+    setTags((prev) => (prev.includes(v) ? prev : [...prev, v]));
+  }, []);
+
+  const removeTag = React.useCallback((t: string) => {
+    setTags((prev) => prev.filter((x) => x !== t));
+  }, []);
+
+  const suggestions = React.useMemo(
+    () => allTags.filter((t) => !tags.includes(t)),
+    [allTags, tags],
+  );
+  const trimmedQuery = query.trim();
+  const showCreate =
+    trimmedQuery.length > 0 && !tags.includes(trimmedQuery) && !allTags.includes(trimmedQuery);
+
+  // Validation. Memory must parse to a valid KB amount; cores must be a
+  // finite, non-negative number; at least one tag is required (CueGUI's
+  // LayerTagsWidget.verify enforces the same).
+  const memoryKb = parseMemoryToKb(memoryInput);
+  const memoryValid = memoryKb !== null;
+  const coresValid = Number.isFinite(cores) && cores >= 0;
+  const tagsValid = tags.length > 0;
+
+  // Per-field dirty flags so Save only POSTs what changed.
+  const memoryDirty = memoryValid && memoryKb !== originalMemoryKb;
+  const coresDirty = coresValid && cores !== originalCores;
+  const tagsDirty =
+    tags.length !== originalTags.length || tags.some((t) => !originalTags.includes(t));
+
+  const dirty = memoryDirty || coresDirty || tagsDirty;
+  const valid = memoryValid && coresValid && tagsValid;
+
+  async function handleSave() {
+    if (!layer || !valid || !dirty) return;
+    setSubmitting(true);
+    try {
+      const changes: { minMemory?: number; minCores?: number; tags?: string[] } = {};
+      if (memoryDirty && memoryKb !== null) changes.minMemory = memoryKb;
+      if (coresDirty) changes.minCores = cores;
+      if (tagsDirty) changes.tags = tags;
+
+      const ok = await editLayerProperties(layer, changes);
+      // Only patch the row optimistically when the action actually
+      // succeeded; editLayerProperties surfaces failures via a toast and
+      // returns false, so a rejected change leaves the table at its true
+      // value instead of flickering.
+      if (ok) {
+        const patch: LayersChangedDetail["patch"] = {};
+        if (changes.minMemory !== undefined) patch.minMemory = String(changes.minMemory);
+        if (changes.minCores !== undefined) patch.minCores = changes.minCores;
+        if (changes.tags !== undefined) patch.tags = changes.tags;
+        window.dispatchEvent(
+          new CustomEvent<LayersChangedDetail>(LAYERS_CHANGED_EVENT, {
+            detail: { layerIds: [layer.id], patch },
+          }),
+        );
+        setOpen(false);
+      }
+    } catch (error) {
+      console.error("Failed to update layer properties:", error);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={submitting ? () => {} : setOpen}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Layer Properties</DialogTitle>
+          <DialogDescription>
+            {layer ? (
+              <span className="font-mono break-all">{layer.name}</span>
+            ) : (
+              "Edit the layer's resource requirements."
+            )}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {/* Min memory + min cores. */}
+          <div className="flex items-start gap-4">
+            <label className="flex flex-1 flex-col gap-1 text-sm">
+              <span className="text-foreground/70">Min Memory</span>
+              <input
+                type="text"
+                inputMode="decimal"
+                value={memoryInput}
+                onChange={(e) => setMemoryInput(e.target.value)}
+                disabled={submitting}
+                aria-label="Minimum memory"
+                placeholder="e.g. 4GB"
+                className="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm font-mono"
+              />
+              <span className="text-xs text-muted-foreground">
+                Units: K/M/G/T (a plain number is GB).
+              </span>
+              {!memoryValid && memoryInput.trim() !== "" && (
+                <span className="text-xs text-destructive">
+                  Enter a positive amount with an optional K/M/G/T unit.
+                </span>
+              )}
+            </label>
+            <label className="flex flex-1 flex-col gap-1 text-sm">
+              <span className="text-foreground/70">Min Cores</span>
+              <input
+                type="number"
+                min={0}
+                max={50000}
+                step={0.1}
+                value={cores}
+                onChange={(e) => setCores(Number(e.target.value))}
+                disabled={submitting}
+                aria-label="Minimum cores"
+                className="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm font-mono"
+              />
+              <span className="text-xs text-muted-foreground">Whole cores (1 = one core).</span>
+              {!coresValid && (
+                <span className="text-xs text-destructive">Cores must be 0 or greater.</span>
+              )}
+            </label>
+          </div>
+
+          {/* Tags: removable chips + autocomplete. */}
+          <div className="space-y-2">
+            <span className="text-sm text-foreground/70">Tags</span>
+            <div className="flex min-h-[2rem] flex-wrap gap-1.5 rounded-md border bg-muted/30 p-2">
+              {tags.length === 0 ? (
+                <span className="text-xs text-muted-foreground">No tags</span>
+              ) : (
+                tags.map((t) => (
+                  <span
+                    key={t}
+                    className="inline-flex items-center gap-1 rounded-full border border-border bg-background px-2 py-0.5 text-xs font-medium"
+                  >
+                    {t}
+                    <button
+                      type="button"
+                      aria-label={`Remove tag ${t}`}
+                      title={`Remove ${t}`}
+                      onClick={() => removeTag(t)}
+                      disabled={submitting}
+                      className="rounded-full p-0.5 text-muted-foreground hover:bg-foreground/10 hover:text-foreground"
+                    >
+                      <X className="h-3 w-3" aria-hidden="true" />
+                    </button>
+                  </span>
+                ))
+              )}
+            </div>
+            <Command className="rounded-md border">
+              <CommandInput
+                value={query}
+                onValueChange={setQuery}
+                onXClick={() => setQuery("")}
+                placeholder="Add a tag..."
+              />
+              <CommandList className="max-h-40">
+                {!showCreate && suggestions.length === 0 ? (
+                  <CommandEmpty>No tags to suggest</CommandEmpty>
+                ) : null}
+                <CommandGroup>
+                  {showCreate ? (
+                    <CommandItem value={trimmedQuery} onSelect={() => addTag(trimmedQuery)}>
+                      Create &quot;{trimmedQuery}&quot;
+                    </CommandItem>
+                  ) : null}
+                  {suggestions.map((t) => (
+                    <CommandItem key={t} value={t} onSelect={() => addTag(t)}>
+                      {t}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+            {!tagsValid && (
+              <span className="text-xs text-destructive">
+                A layer must have at least one tag. Changing tags may stop the layer from running.
+              </span>
+            )}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setOpen(false)}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSave}
+            disabled={submitting || !valid || !dirty}
+          >
+            {submitting ? "Saving…" : "Save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/cueweb/components/ui/job-details-inline.tsx
+++ b/cueweb/components/ui/job-details-inline.tsx
@@ -25,6 +25,10 @@ import { handleError } from "@/app/utils/notify_utils";
 import { setAttributeSelection } from "@/app/utils/use_attribute_selection";
 import { useShowDependencyGraph } from "@/app/utils/use_show_dependency_graph";
 import { EmptyState } from "@/components/ui/empty-state";
+import {
+  LAYERS_CHANGED_EVENT,
+  type LayersChangedDetail,
+} from "@/components/ui/layer-action-events";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ChevronDown, ChevronRight, Inbox, X } from "lucide-react";
 import { JobDependencyGraph } from "./job-dependency-graph";
@@ -106,6 +110,22 @@ export function JobDetailsInline({ job, username }: JobDetailsInlineProps) {
     },
     [job],
   );
+
+  // Optimistic patch from the layer property editor: apply min memory / min
+  // cores / tags changes to the matching row immediately so the edit reflects
+  // without waiting for the next 5s poll (which then reconciles with Cuebot).
+  React.useEffect(() => {
+    function handler(e: Event) {
+      const detail = (e as CustomEvent<LayersChangedDetail>).detail;
+      if (!detail?.layerIds?.length) return;
+      const ids = new Set(detail.layerIds);
+      setLayers((prev) =>
+        prev.map((l) => (ids.has(l.id) ? { ...l, ...detail.patch } : l)),
+      );
+    }
+    window.addEventListener(LAYERS_CHANGED_EVENT, handler);
+    return () => window.removeEventListener(LAYERS_CHANGED_EVENT, handler);
+  }, []);
 
   // If the selected layer disappears (e.g. job switched, layer removed by
   // the next poll), clear it so the frames filter doesn't leave the table

--- a/cueweb/components/ui/layer-action-events.ts
+++ b/cueweb/components/ui/layer-action-events.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Contributors to the OpenCue Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Layer } from "@/app/layers/layer-columns";
+
+// Shared CustomEvent names + payload types for the Layer row actions. Kept
+// in one module so the dialog that dispatches/handles these events and the
+// page that reconciles them agree on the contract, without importing across
+// sibling components. Mirrors host-action-events.ts.
+
+// Opens the layer property editor (EditLayerPropertiesDialog).
+export const OPEN_LAYER_PROPERTIES_EVENT = "cueweb:open-layer-properties";
+export type OpenLayerPropertiesDetail = {
+  layer: Layer;
+};
+
+// Fired after a layer property edit so the open layers table can update the
+// affected row immediately (optimistic) instead of waiting for the next 5s
+// poll. The page applies `patch` to every row whose id is in layerIds, then
+// the poll reconciles with Cuebot.
+export const LAYERS_CHANGED_EVENT = "cueweb:layers-changed";
+export type LayersChangedDetail = {
+  layerIds: string[];
+  patch: Partial<Pick<Layer, "minMemory" | "minCores" | "tags">>;
+};


### PR DESCRIPTION
## Related Issues
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/2291

## Summarize your change.

[cueweb] Layer Management: Layer property edit dialog (memory, cores, tags)

Add a "Properties..." row action on layers that opens a dialog for editing min memory, min cores, and tags, saved via REST. Mirrors CueGUI's LayerDialog (Resource Options + Tags), scoped to the three fields the issue calls for.

- New routes proxy to the gRPC gateway: SetMinMemory, SetMinCores, SetTags (/api/layer/action/setminmemory|setmincores|settags), with request validation.
- EditLayerPropertiesDialog: memory input with unit validation (K/M/G/T; a bare number is GB, matching CueGUI's GB spinner), cores input, and tag chips + autocomplete seeded from the other layers in the same job. Diffs each field and only POSTs what changed; requires at least one tag. 
- Wire the layer context menu "Properties..." entry to open the dialog (was a not-yet-implemented toast).
- Mount the dialog on the job detail page and the inline job details; both listen for a cueweb:layers-changed event to patch the row optimistically so the edit reflects immediately, with the 5s poll reconciling.
- Add parseMemoryToKb / formatKbToGbInput helpers and editLayerProperties action; cores are sent as whole cores (Cuebot scales to core units).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Layer property editor now available via context menu; edit minimum memory, cores, and tags with validation support.
  * Memory input accepts unit suffixes (K/M/G/T, case-insensitive) for flexible entry.
  * Changes display immediately after saving without requiring a page refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->