### PR TITLE
[cuebot] Fix Silent frame double booking

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java
@@ -37,6 +37,8 @@ import com.imageworks.spcue.StrandedCores;
 import com.imageworks.spcue.VirtualProc;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.dao.DataAccessException;
 import org.springframework.transaction.annotation.Propagation;
@@ -84,6 +86,9 @@ public class DispatchSupportService implements DispatchSupport {
     private BookingDao bookingDao;
     private KafkaEventPublisher kafkaEventPublisher;
     private MonitoringEventBuilder monitoringEventBuilder;
+
+    @Autowired
+    private Environment env;
 
     private ConcurrentHashMap<String, StrandedCores> strandedCores =
             new ConcurrentHashMap<String, StrandedCores>();
@@ -516,6 +521,26 @@ public class DispatchSupportService implements DispatchSupport {
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void lostProc(VirtualProc proc, String reason, int exitStatus) {
         long numCleared = clearedProcs.incrementAndGet();
+
+        /*
+         * Kill the frame on RQD before releasing it back to a bookable state. Without this, a host
+         * that is merely flapping (transient unreachable/DOWN report, GC pause, dropped report)
+         * keeps rendering the frame while the dispatcher resets it to WAITING and re-books it
+         * elsewhere, silently double-booking the frame onto two hosts. Killing first means a
+         * reachable host stops the frame before it becomes re-bookable; a genuinely dead host times
+         * out (caught below), and release is then safe because no live RQD remains.
+         * EXIT_STATUS_FAILED_KILL is skipped because the caller (JobManagerSupport.kill) already
+         * attempted this exact kill and it threw.
+         */
+        if (proc.frameId != null && exitStatus != Dispatcher.EXIT_STATUS_FAILED_KILL
+                && env.getProperty("dispatcher.kill_running_frame_before_release_enabled",
+                        Boolean.class, true)) {
+            try {
+                rqdClient.killFrame(proc, "kill-before-release: " + reason);
+            } catch (Throwable t) {
+                logger.info("kill-before-release failed for " + proc.getName() + ", " + t);
+            }
+        }
 
         unbookProc(proc, "proc " + proc.getName() + " is #" + numCleared + " cleared: " + reason);
 

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java
@@ -537,8 +537,8 @@ public class DispatchSupportService implements DispatchSupport {
                         Boolean.class, true)) {
             try {
                 rqdClient.killFrame(proc, "kill-before-release: " + reason);
-            } catch (Throwable t) {
-                logger.info("kill-before-release failed for " + proc.getName() + ", " + t);
+            } catch (Exception e) {
+                logger.info("kill-before-release failed for " + proc.getName() + ", " + e);
             }
         }
 

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
@@ -981,20 +981,30 @@ public class HostReportHandler {
     }
 
     /**
-     * Number of seconds before running frames have to exist before being verified against the DB.
+     * Default number of seconds running frames must exist before being verified against the DB.
+     * Overridable via the dispatcher.frame_verification_grace_period_seconds property.
      */
     private static final long FRAME_VERIFICATION_GRACE_PERIOD_SECONDS = 120;
 
     /**
-     * Verify all running frames in the given report against the DB. Frames that have not been
-     * running for at least FRAME_VERIFICATION_GRACE_PERIOD_SECONDS are skipped.
+     * Verify all running frames in the given report against the DB.
      *
-     * If a frame->proc mapping is not verified then the record for the proc is pulled from the DB.
-     * If the proc doesn't exist at all, then the frame is killed with the message: "but the DB did
-     * not reflect this"
+     * A running frame is "verified" when its resource_id (the proc UUID, regenerated per booking)
+     * still maps to a proc assigned to exactly that frame. When the mapping does not hold, the
+     * reported frame may be a zombie left behind by a free-then-rebook: a free path reset the frame
+     * back to a bookable state and it was re-dispatched elsewhere while this RQD kept rendering.
      *
-     * The main reason why a proc no longer exists is that the cue though the host went down and
-     * cleared out all running frames.
+     * - If resource_id maps to a proc assigned to a *different* frame, the reported frame is
+     * demonstrably no longer owned by this resource, so it is killed immediately (strict fencing),
+     * skipping the grace period and the isOrphan ping wait. The proc and its current frame are
+     * never touched: proc ids are reused when a host picks up its next frame, so that proc may be
+     * validly rendering another frame, and the RQD kill is frame-scoped so it cannot harm it.
+     *
+     * - If resource_id maps to no proc at all, it is either a deleted-proc zombie or a freshly
+     * booked proc whose row is not yet visible to this (possibly different) Cuebot. The grace
+     * period applies only here, to shield the legitimate book first-report propagation window;
+     * past the grace period the frame is killed. Orphaned procs themselves are reclaimed by
+     * MaintenanceManagerSupport (which now kills RQD before releasing), not by this method.
      *
      * @param report
      */
@@ -1002,12 +1012,55 @@ public class HostReportHandler {
         List<RunningFrameInfo> runningFrames =
                 new ArrayList<RunningFrameInfo>(report.getFramesCount());
 
+        long gracePeriodSeconds =
+                env.getProperty("dispatcher.frame_verification_grace_period_seconds", Long.class,
+                        FRAME_VERIFICATION_GRACE_PERIOD_SECONDS);
+        boolean strictFencingEnabled = env.getProperty(
+                "dispatcher.frame_verification_strict_fencing_enabled", Boolean.class, true);
+
         for (RunningFrameInfo runningFrame : report.getFramesList()) {
             long runtimeSeconds =
                     (System.currentTimeMillis() - runningFrame.getStartTime()) / 1000l;
 
-            // Don't test frames that haven't been running long enough.
-            if (runtimeSeconds < FRAME_VERIFICATION_GRACE_PERIOD_SECONDS) {
+            // The proc still owns exactly this frame: verified.
+            if (hostManager.verifyRunningProc(runningFrame.getResourceId(),
+                    runningFrame.getFrameId())) {
+                runningFrames.add(runningFrame);
+                continue;
+            }
+
+            // The proc->frame mapping is not verified. Resolve the proc by resource_id.
+            String msg;
+            VirtualProc proc = null;
+            try {
+                proc = hostManager.getVirtualProc(runningFrame.getResourceId());
+                msg = "Virtual proc " + proc.getProcId() + " is assigned to " + proc.getFrameId()
+                        + " not " + runningFrame.getFrameId();
+            } catch (Exception e) {
+                msg = "Virtual proc did not exist.";
+            }
+
+            if (proc != null) {
+                /*
+                 * Strict fencing: resource_id maps to a proc that owns a different frame, so the
+                 * reported frame is demonstrably running under a stale resource. Kill it
+                 * immediately, skipping the grace period. Never touch the proc or its current
+                 * frame.
+                 */
+                DispatchSupport.accountingErrors.incrementAndGet();
+                if (strictFencingEnabled) {
+                    killUnverifiedRunningFrame(runningFrame, report, runtimeSeconds,
+                            "FrameFencingError", msg);
+                }
+                continue;
+            }
+
+            /*
+             * resource_id maps to no proc. Apply the grace period here only: this is the window
+             * where a just-booked proc's row may not yet be visible (book->first-report
+             * propagation).
+             */
+            if (runtimeSeconds < gracePeriodSeconds) {
                 logger.info("verified " + runningFrame.getJobName() + "/"
                         + runningFrame.getFrameName() + " on " + report.getHost().getName()
                         + " by grace period " + runtimeSeconds + " seconds.");
@@ -1015,63 +1068,38 @@ public class HostReportHandler {
                 continue;
             }
 
-            if (hostManager.verifyRunningProc(runningFrame.getResourceId(),
-                    runningFrame.getFrameId())) {
-                runningFrames.add(runningFrame);
-                continue;
-            }
-
-            /*
-             * The frame this proc is running is no longer assigned to this proc. Don't ever touch
-             * the frame record. If we make it here that means the proc has been running for over 2
-             * min.
-             */
-            String msg;
-            VirtualProc proc = null;
-
-            try {
-                proc = hostManager.getVirtualProc(runningFrame.getResourceId());
-                msg = "Virtual proc " + proc.getProcId() + "is assigned to " + proc.getFrameId()
-                        + " not " + runningFrame.getFrameId();
-            } catch (Exception e) {
-                /*
-                 * This will happen if the host goes offline and then comes back. In this case, we
-                 * don't touch the frame since it might already be running somewhere else. We do
-                 * however kill the proc.
-                 */
-                msg = "Virtual proc did not exist.";
-            }
-
             DispatchSupport.accountingErrors.incrementAndGet();
-            if (proc != null && hostManager.isOprhan(proc)) {
-                dispatchSupport.clearVirtualProcAssignement(proc);
-                dispatchSupport.unbookProc(proc);
-                proc = null;
-            }
-            if (proc == null) {
-                // A frameCompleteReport might have been delivered before this report was
-                // processed
-                FrameDetail frameLatestVersion =
-                        jobManager.getFrameDetail(runningFrame.getFrameId());
-                if (frameLatestVersion.state != FrameState.RUNNING) {
-                    logger.info("DelayedVerification, the proc " + runningFrame.getResourceId()
-                            + " on host " + report.getHost().getName() + " has already Completed "
-                            + runningFrame.getJobName() + "/" + runningFrame.getFrameName());
-                } else if (killFrame(runningFrame.getFrameId(), report.getHost().getName(),
-                        KillCause.FrameVerificationFailure)) {
-                    logger.info("FrameVerificationError, the proc " + runningFrame.getResourceId()
-                            + " on host " + report.getHost().getName() + " was running for "
-                            + (runtimeSeconds / 60.0f) + " minutes " + runningFrame.getJobName()
-                            + "/" + runningFrame.getFrameName() + " but the DB did not "
-                            + "reflect this. " + msg);
-                } else {
-                    logger.warn("FrameStuckWarning: frameId=" + runningFrame.getFrameId()
-                            + " render_node=" + report.getHost().getName() + " - "
-                            + runningFrame.getJobName() + "/" + runningFrame.getFrameName());
-                }
-            }
+            killUnverifiedRunningFrame(runningFrame, report, runtimeSeconds,
+                    "FrameVerificationError", msg);
         }
         return runningFrames;
+    }
+
+    /**
+     * Kill a running frame whose proc->frame mapping could not be verified, unless a
+     * FrameCompleteReport has already moved it out of RUNNING (a late/reordered report), in which
+     * case it is only logged. The kill targets the reported frame on the reporting host; it never
+     * touches any proc record.
+     */
+    private void killUnverifiedRunningFrame(RunningFrameInfo runningFrame, HostReport report,
+            long runtimeSeconds, String errorLabel, String msg) {
+        // A frameCompleteReport might have been delivered before this report was processed.
+        FrameDetail frameLatestVersion = jobManager.getFrameDetail(runningFrame.getFrameId());
+        if (frameLatestVersion.state != FrameState.RUNNING) {
+            logger.info("DelayedVerification, the proc " + runningFrame.getResourceId()
+                    + " on host " + report.getHost().getName() + " has already Completed "
+                    + runningFrame.getJobName() + "/" + runningFrame.getFrameName());
+        } else if (killFrame(runningFrame.getFrameId(), report.getHost().getName(),
+                KillCause.FrameVerificationFailure)) {
+            logger.info(errorLabel + ", the proc " + runningFrame.getResourceId() + " on host "
+                    + report.getHost().getName() + " was running for " + (runtimeSeconds / 60.0f)
+                    + " minutes " + runningFrame.getJobName() + "/" + runningFrame.getFrameName()
+                    + " but the DB did not reflect this. " + msg);
+        } else {
+            logger.warn("FrameStuckWarning: frameId=" + runningFrame.getFrameId() + " render_node="
+                    + report.getHost().getName() + " - " + runningFrame.getJobName() + "/"
+                    + runningFrame.getFrameName());
+        }
     }
 
     public HostManager getHostManager() {

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/HostReportHandler.java
@@ -1002,8 +1002,8 @@ public class HostReportHandler {
      *
      * - If resource_id maps to no proc at all, it is either a deleted-proc zombie or a freshly
      * booked proc whose row is not yet visible to this (possibly different) Cuebot. The grace
-     * period applies only here, to shield the legitimate book first-report propagation window;
-     * past the grace period the frame is killed. Orphaned procs themselves are reclaimed by
+     * period applies only here, to shield the legitimate book first-report propagation window; past
+     * the grace period the frame is killed. Orphaned procs themselves are reclaimed by
      * MaintenanceManagerSupport (which now kills RQD before releasing), not by this method.
      *
      * @param report
@@ -1036,8 +1036,15 @@ public class HostReportHandler {
                 proc = hostManager.getVirtualProc(runningFrame.getResourceId());
                 msg = "Virtual proc " + proc.getProcId() + " is assigned to " + proc.getFrameId()
                         + " not " + runningFrame.getFrameId();
-            } catch (Exception e) {
+            } catch (EmptyResultDataAccessException e) {
+                // resource_id maps to no proc row.
                 msg = "Virtual proc did not exist.";
+            } catch (Exception e) {
+                // Transient lookup failure: do not treat it as a missing proc, which (past grace)
+                // would trigger a false kill. Skip this frame and re-verify on the next report.
+                logger.warn("Failed to verify proc " + runningFrame.getResourceId() + " on host "
+                        + report.getHost().getName() + ", skipping verification this report: " + e);
+                continue;
             }
 
             if (proc != null) {
@@ -1084,7 +1091,17 @@ public class HostReportHandler {
     private void killUnverifiedRunningFrame(RunningFrameInfo runningFrame, HostReport report,
             long runtimeSeconds, String errorLabel, String msg) {
         // A frameCompleteReport might have been delivered before this report was processed.
-        FrameDetail frameLatestVersion = jobManager.getFrameDetail(runningFrame.getFrameId());
+        FrameDetail frameLatestVersion;
+        try {
+            frameLatestVersion = jobManager.getFrameDetail(runningFrame.getFrameId());
+        } catch (EmptyResultDataAccessException e) {
+            // The frame no longer exists in the DB (e.g. the job was removed); nothing to verify or
+            // kill. Don't let a single stale frame abort processing of the rest of the report.
+            logger.info("DelayedVerification, the proc " + runningFrame.getResourceId()
+                    + " on host " + report.getHost().getName() + " reported frame "
+                    + runningFrame.getFrameId() + " which no longer exists in the DB.");
+            return;
+        }
         if (frameLatestVersion.state != FrameState.RUNNING) {
             logger.info("DelayedVerification, the proc " + runningFrame.getResourceId()
                     + " on host " + report.getHost().getName() + " has already Completed "

--- a/cuebot/src/main/resources/opencue.properties
+++ b/cuebot/src/main/resources/opencue.properties
@@ -145,6 +145,21 @@ dispatcher.oom_frame_overboard_allowed_threshold=-1.0
 # the frame as stuck
 dispatcher.frame_kill_retry_limit=3
 
+# Prevent silent frame double-booking (free-then-rebook): when a running frame is released back to
+# a bookable state (lost/down/orphaned proc), kill the frame on RQD before clearing the proc so a
+# still-rendering host cannot keep working a frame that gets re-booked elsewhere. A genuinely dead
+# host simply times out and release proceeds. Default = true.
+dispatcher.kill_running_frame_before_release_enabled=true
+
+# When a reported running frame's resource_id maps to a proc that now owns a different frame, the
+# frame is demonstrably owned elsewhere: kill it immediately instead of waiting for the grace and
+# isOrphan windows. Set to false to fall back to the legacy lenient behavior. Default = true.
+dispatcher.frame_verification_strict_fencing_enabled=true
+
+# Seconds a reported running frame whose resource_id maps to no proc is shielded from verification
+# kills, covering the book->first-report propagation window for a just-booked proc. Default = 120.
+dispatcher.frame_verification_grace_period_seconds=120
+
 # Whether to turn off booking for all allocations.
 # On this mode, host will report their status but will never get booked.
 # Default = false

--- a/cuebot/src/main/resources/opencue.properties
+++ b/cuebot/src/main/resources/opencue.properties
@@ -153,7 +153,8 @@ dispatcher.kill_running_frame_before_release_enabled=true
 
 # When a reported running frame's resource_id maps to a proc that now owns a different frame, the
 # frame is demonstrably owned elsewhere: kill it immediately instead of waiting for the grace and
-# isOrphan windows. Set to false to fall back to the legacy lenient behavior. Default = true.
+# isOrphan windows. Set to false to disable this immediate kill; such mismatched frames are then
+# left untouched by host-report verification (neither killed nor reclaimed here). Default = true.
 dispatcher.frame_verification_strict_fencing_enabled=true
 
 # Seconds a reported running frame whose resource_id maps to no proc is shielded from verification

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/ProcDaoTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/ProcDaoTests.java
@@ -312,6 +312,43 @@ public class ProcDaoTests extends AbstractTransactionalJUnit4SpringContextTests 
     @Test
     @Transactional
     @Rollback(true)
+    public void testVerifyRunningProcAfterReassignment() {
+        // Pins the proc-reuse semantics that strict fencing relies on: a proc id is retained when a
+        // host picks up its next frame, so verifyRunningProc must report the proc as owning only
+        // its
+        // *current* frame, not the previous one.
+        DispatchHost host = createHost();
+
+        JobDetail job = launchJob();
+        FrameDetail frame1 = frameDao.findFrameDetail(job, "0001-pass_1");
+        FrameDetail frame2 = frameDao.findFrameDetail(job, "0002-pass_1");
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = PK_ALLOC;
+        proc.coresReserved = 100;
+        proc.hostId = host.id;
+        proc.hostName = host.name;
+        proc.jobId = job.id;
+        proc.frameId = frame1.id;
+        proc.layerId = frame1.layerId;
+        proc.showId = frame1.showId;
+
+        procDao.insertVirtualProc(proc);
+        assertTrue(procDao.verifyRunningProc(proc.getId(), frame1.getId()));
+        assertFalse(procDao.verifyRunningProc(proc.getId(), frame2.getId()));
+
+        proc.frameId = frame2.id;
+        procDao.updateVirtualProcAssignment(proc);
+
+        // After reuse the proc owns frame2; a stale report referencing frame1 is no longer
+        // verified.
+        assertFalse(procDao.verifyRunningProc(proc.getId(), frame1.getId()));
+        assertTrue(procDao.verifyRunningProc(proc.getId(), frame2.getId()));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
     public void testUpdateProcMemoryUsage() {
 
         DispatchHost host = createHost();

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/DispatchSupportServiceLostProcTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/DispatchSupportServiceLostProcTests.java
@@ -1,0 +1,138 @@
+
+/*
+ * Copyright Contributors to the OpenCue Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.imageworks.spcue.test.dispatcher;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.springframework.core.env.Environment;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.imageworks.spcue.FrameInterface;
+import com.imageworks.spcue.VirtualProc;
+import com.imageworks.spcue.dao.FrameDao;
+import com.imageworks.spcue.dao.JobDao;
+import com.imageworks.spcue.dao.LayerDao;
+import com.imageworks.spcue.dao.ProcDao;
+import com.imageworks.spcue.dao.ShowDao;
+import com.imageworks.spcue.dispatcher.DispatchSupportService;
+import com.imageworks.spcue.dispatcher.Dispatcher;
+import com.imageworks.spcue.grpc.job.FrameState;
+import com.imageworks.spcue.rqd.RqdClient;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the kill-before-release behavior added to {@link DispatchSupportService#lostProc}.
+ * lostProc is {@code @Transactional(NOT_SUPPORTED)} and its nested DAO calls open independent
+ * transactions, which does not play well with the commit-and-rollback embedded-DB harness. These
+ * tests therefore exercise the method directly with mocked collaborators so the kill/release
+ * ordering can be asserted deterministically.
+ */
+public class DispatchSupportServiceLostProcTests {
+
+    private static final String KILL_BEFORE_RELEASE_PROPERTY =
+            "dispatcher.kill_running_frame_before_release_enabled";
+
+    private DispatchSupportService dispatchSupport;
+    private RqdClient rqdClient;
+    private ProcDao procDao;
+    private FrameDao frameDao;
+    private Environment env;
+    private VirtualProc proc;
+
+    @Before
+    public void setup() {
+        dispatchSupport = new DispatchSupportService();
+        rqdClient = mock(RqdClient.class);
+        procDao = mock(ProcDao.class);
+        frameDao = mock(FrameDao.class);
+        env = mock(Environment.class);
+
+        dispatchSupport.setRqdClient(rqdClient);
+        dispatchSupport.setProcDao(procDao);
+        dispatchSupport.setFrameDao(frameDao);
+        dispatchSupport.setShowDao(mock(ShowDao.class));
+        dispatchSupport.setJobDao(mock(JobDao.class));
+        dispatchSupport.setLayerDao(mock(LayerDao.class));
+        ReflectionTestUtils.setField(dispatchSupport, "env", env);
+
+        // Kill-before-release enabled by default.
+        when(env.getProperty(eq(KILL_BEFORE_RELEASE_PROPERTY), eq(Boolean.class), eq(true)))
+                .thenReturn(true);
+
+        proc = new VirtualProc();
+        proc.id = "00000000-0000-0000-0000-000000000001";
+        proc.frameId = "00000000-0000-0000-0000-0000000000f1";
+        proc.hostName = "test-host";
+
+        when(procDao.deleteVirtualProc(any(VirtualProc.class))).thenReturn(true);
+        when(frameDao.getFrame(proc.frameId)).thenReturn(mock(FrameInterface.class));
+        when(frameDao.updateFrameStopped(any(FrameInterface.class), any(FrameState.class),
+                anyInt())).thenReturn(true);
+    }
+
+    @Test
+    public void killsRqdBeforeReleasingProc() {
+        dispatchSupport.lostProc(proc, "orphaned", Dispatcher.EXIT_STATUS_FRAME_ORPHAN);
+
+        InOrder inOrder = inOrder(rqdClient, procDao);
+        inOrder.verify(rqdClient, times(1)).killFrame(eq(proc), anyString());
+        inOrder.verify(procDao, times(1)).deleteVirtualProc(proc);
+    }
+
+    @Test
+    public void skipsRqdKillForFailedKillExitStatus() {
+        // The failed-kill path already attempted this exact kill, so lostProc must not re-issue it.
+        dispatchSupport.lostProc(proc, "failed kill", Dispatcher.EXIT_STATUS_FAILED_KILL);
+
+        verify(rqdClient, never()).killFrame(any(VirtualProc.class), anyString());
+        verify(procDao, times(1)).deleteVirtualProc(proc);
+    }
+
+    @Test
+    public void releasesProcWhenRqdKillThrows() {
+        // A genuinely dead/unreachable host makes the kill throw; release must still proceed.
+        doThrow(new RuntimeException("host unreachable")).when(rqdClient)
+                .killFrame(any(VirtualProc.class), anyString());
+
+        dispatchSupport.lostProc(proc, "down host", Dispatcher.EXIT_STATUS_DOWN_HOST);
+
+        verify(rqdClient, times(1)).killFrame(eq(proc), anyString());
+        verify(procDao, times(1)).deleteVirtualProc(proc);
+    }
+
+    @Test
+    public void skipsRqdKillWhenDisabledByProperty() {
+        when(env.getProperty(eq(KILL_BEFORE_RELEASE_PROPERTY), eq(Boolean.class), eq(true)))
+                .thenReturn(false);
+
+        dispatchSupport.lostProc(proc, "orphaned", Dispatcher.EXIT_STATUS_FRAME_ORPHAN);
+
+        verify(rqdClient, never()).killFrame(any(VirtualProc.class), anyString());
+        verify(procDao, times(1)).deleteVirtualProc(proc);
+    }
+}

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HostReportHandlerTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/HostReportHandlerTests.java
@@ -39,6 +39,7 @@ import com.imageworks.spcue.dispatcher.Dispatcher;
 import com.imageworks.spcue.dispatcher.HostReportHandler;
 import com.imageworks.spcue.FacilityInterface;
 import com.imageworks.spcue.FrameDetail;
+import com.imageworks.spcue.dao.FrameDao;
 import com.imageworks.spcue.grpc.host.HardwareState;
 import com.imageworks.spcue.grpc.host.LockState;
 import com.imageworks.spcue.grpc.report.CoreDetail;
@@ -87,6 +88,9 @@ public class HostReportHandlerTests extends TransactionalTest {
 
     @Resource
     CommentManager commentManager;
+
+    @Resource
+    FrameDao frameDao;
 
     private static final String HOSTNAME = "beta";
     private static final String NEW_HOSTNAME = "gamma";
@@ -391,6 +395,119 @@ public class HostReportHandlerTests extends TransactionalTest {
         FrameDetail frame = jobManager.getFrameDetail(proc.getFrameId());
         assertEquals(frame.dateLLU, new Timestamp(now / 1000 * 1000));
         assertEquals(420000, frame.maxRss);
+    }
+
+    /**
+     * Strict fencing: a reported running frame whose resource_id maps to a proc that now owns a
+     * different frame is a zombie and must be killed immediately, skipping the grace period. The
+     * proc that owns the resource_id (and its current frame) must not be touched.
+     */
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testStrictFencingKillsZombieWhenProcOwnsDifferentFrame() {
+        jobLauncher.testMode = true;
+        jobLauncher.launch(new File("src/test/resources/conf/jobspec/jobspec_multiple_frames.xml"));
+
+        DispatchHost host = getHost(hostname);
+        List<VirtualProc> procs = dispatcher.dispatchHost(host);
+        assertEquals(3, procs.size());
+        VirtualProc proc1 = procs.get(0);
+        VirtualProc proc2 = procs.get(1);
+
+        // proc1's resource_id reports running proc2's frame. proc1 actually owns frame1, so the
+        // reported frame is demonstrably running under a stale resource. startTime is "now" to
+        // prove
+        // the kill happens within the grace window.
+        RunningFrameInfo info = RunningFrameInfo.newBuilder().setJobId(proc2.getJobId())
+                .setLayerId(proc2.getLayerId()).setFrameId(proc2.getFrameId())
+                .setResourceId(proc1.getProcId()).setStartTime(System.currentTimeMillis()).build();
+        HostReport report = HostReport.newBuilder().setHost(getRenderHost(hostname))
+                .setCoreInfo(getCoreDetail(200, 200, 0, 0)).addFrames(info).build();
+
+        long killCount = DispatchSupport.killedOffenderProcs.get();
+        hostReportHandler.handleHostReport(report, false);
+        assertEquals(killCount + 1, DispatchSupport.killedOffenderProcs.get());
+
+        // The procs and their real frames are untouched.
+        assertEquals(FrameState.RUNNING, jobManager.getFrameDetail(proc1.getFrameId()).state);
+        assertEquals(FrameState.RUNNING, jobManager.getFrameDetail(proc2.getFrameId()).state);
+        assertEquals(proc1.getFrameId(),
+                hostManager.getVirtualProc(proc1.getProcId()).getFrameId());
+    }
+
+    /**
+     * A reported frame whose resource_id maps to a proc on a different frame, but whose own state
+     * is no longer RUNNING, is just a late/reordered report (e.g. proc reuse after a FrameComplete)
+     * and must not be killed.
+     */
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testStrictFencingSkipsKillWhenReportedFrameNotRunning() {
+        jobLauncher.testMode = true;
+        jobLauncher.launch(new File("src/test/resources/conf/jobspec/jobspec_multiple_frames.xml"));
+
+        DispatchHost host = getHost(hostname);
+        List<VirtualProc> procs = dispatcher.dispatchHost(host);
+        assertEquals(3, procs.size());
+        VirtualProc proc1 = procs.get(0);
+        VirtualProc proc2 = procs.get(1);
+
+        // The reported frame (proc2's) is no longer RUNNING.
+        frameDao.updateFrameState(frameDao.getFrame(proc2.getFrameId()), FrameState.SUCCEEDED);
+
+        RunningFrameInfo info = RunningFrameInfo.newBuilder().setJobId(proc2.getJobId())
+                .setLayerId(proc2.getLayerId()).setFrameId(proc2.getFrameId())
+                .setResourceId(proc1.getProcId()).setStartTime(System.currentTimeMillis()).build();
+        HostReport report = HostReport.newBuilder().setHost(getRenderHost(hostname))
+                .setCoreInfo(getCoreDetail(200, 200, 0, 0)).addFrames(info).build();
+
+        long killCount = DispatchSupport.killedOffenderProcs.get();
+        hostReportHandler.handleHostReport(report, false);
+        assertEquals(killCount, DispatchSupport.killedOffenderProcs.get());
+    }
+
+    /**
+     * The grace period applies only when the resource_id maps to no proc (the book-&gt;first-report
+     * propagation window). Within grace the frame is kept; past grace it is killed.
+     */
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testGracePeriodAppliesOnlyWhenProcMissing() {
+        jobLauncher.testMode = true;
+        jobLauncher.launch(new File("src/test/resources/conf/jobspec/jobspec_simple.xml"));
+
+        DispatchHost host = getHost(hostname);
+        List<VirtualProc> procs = dispatcher.dispatchHost(host);
+        assertEquals(1, procs.size());
+        VirtualProc proc = procs.get(0);
+
+        // resource_id maps to no proc; the reported frame is the real RUNNING frame.
+        String unknownResourceId = UUID.randomUUID().toString();
+
+        // Within grace: kept, not killed.
+        RunningFrameInfo withinGrace = RunningFrameInfo.newBuilder().setJobId(proc.getJobId())
+                .setLayerId(proc.getLayerId()).setFrameId(proc.getFrameId())
+                .setResourceId(unknownResourceId).setStartTime(System.currentTimeMillis()).build();
+        HostReport graceReport = HostReport.newBuilder().setHost(getRenderHost(hostname))
+                .setCoreInfo(getCoreDetail(200, 200, 0, 0)).addFrames(withinGrace).build();
+
+        long killCount = DispatchSupport.killedOffenderProcs.get();
+        hostReportHandler.handleHostReport(graceReport, false);
+        assertEquals(killCount, DispatchSupport.killedOffenderProcs.get());
+
+        // Past grace (grace period defaults to 120s): killed.
+        RunningFrameInfo pastGrace = RunningFrameInfo.newBuilder().setJobId(proc.getJobId())
+                .setLayerId(proc.getLayerId()).setFrameId(proc.getFrameId())
+                .setResourceId(unknownResourceId)
+                .setStartTime(System.currentTimeMillis() - 130 * 1000L).build();
+        HostReport killReport = HostReport.newBuilder().setHost(getRenderHost(hostname))
+                .setCoreInfo(getCoreDetail(200, 200, 0, 0)).addFrames(pastGrace).build();
+
+        hostReportHandler.handleHostReport(killReport, false);
+        assertEquals(killCount + 1, DispatchSupport.killedOffenderProcs.get());
     }
 
     @Test

--- a/cuebot/src/test/resources/opencue.properties
+++ b/cuebot/src/test/resources/opencue.properties
@@ -64,6 +64,13 @@ dispatcher.oom_max_safe_used_swap_memory_threshold=0.2
 dispatcher.oom_frame_overboard_allowed_threshold=0.6
 dispatcher.frame_kill_retry_limit=3
 
+# Kill the frame on RQD before releasing a lost/down/orphaned proc back to a bookable state.
+dispatcher.kill_running_frame_before_release_enabled=true
+# Immediately kill a reported frame whose resource_id maps to a proc on a different frame.
+dispatcher.frame_verification_strict_fencing_enabled=true
+# Grace seconds shielding a reported frame whose resource_id maps to no proc (propagation window).
+dispatcher.frame_verification_grace_period_seconds=120
+
 # A comma separated list of services that should have their frames considered
 # selfish. A selfish frame will reserve all the available cores to avoid
 # having to share resources with other renders.


### PR DESCRIPTION
## Related Issues

#2438 

Production changes
- **`DispatchSupportService.java`** — Fix A (kill-before-release): `lostProc` now issues a synchronous `rqdClient.killFrame(proc, …)` **before** `unbookProc`/frame reset, in a try/catch so a genuinely dead host still releases. Skips re-kill on `EXIT_STATUS_FAILED_KILL`. Added `@Autowired Environment env`.
- **`HostReportHandler.java`** — Fix B (strict `resource_id` fencing): the grace period now shields **only** the `proc == null` book→first-report window. When a reported frame's `resource_id` maps to a proc on a *different* frame, the zombie frame is killed **immediately** (no 120s grace / 300s `isOrphan` wait), and the proc/its current frame are never touched (safe under proc-reuse, since the RQD kill is frame-scoped). Removed the unsafe inline orphan-clear; extracted a `killUnverifiedRunningFrame` helper; grace period is now configurable.
- **`opencue.properties`** (main + test) — three new tunables, all defaulting to the prior behavior: `kill_running_frame_before_release_enabled=true`, `frame_verification_strict_fencing_enabled=true`, `frame_verification_grace_period_seconds=120`.

- **`DispatchSupportServiceLostProcTests`** (new, pure JUnit+Mockito) — **4 tests, passing locally**: kill-before-release ordering, FAILED_KILL skip, release-when-kill-throws, property-disabled. (Pure-unit because `lostProc` is `@Transactional(NOT_SUPPORTED)`, which fights the embedded-DB harness.)
- **`HostReportHandlerTests`** (+3) and **`ProcDaoTests`** (+1) — fencing/grace/proc-reuse coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Improved host report frame verification to reduce double-booking and misassignment risks.
  * Added optional “kill-before-release” for lost/unavailable procs to terminate running frames on RQD before making the proc bookable again.
  * Introduced new dispatcher settings to tune strict fencing behavior and apply a grace period when proc mappings are temporarily missing.

* **Tests**
  * Expanded automated coverage for frame verification and lost-proc release behavior, including configuration on/off cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## LLM Usage Disclaimer

Claude Opus was used to investigate the issue and suggests the fixes on this PR