### PR TITLE
[cueadmin/docs] Add lock-state filter and idle sort to host list

### DIFF
--- a/cueadmin/README.md
+++ b/cueadmin/README.md
@@ -39,6 +39,8 @@ cueadmin -lji
 
 # List hosts
 cueadmin -lh
+cueadmin -lh -lock-state NIMBY_LOCKED       # Only NIMBY-locked hosts
+cueadmin -lh -lock-state OPEN -sort-idle     # Unlocked hosts, most idle first
 
 # Job management
 cueadmin -pause JOB_NAME                    # Pause a job

--- a/cueadmin/cueadmin/common.py
+++ b/cueadmin/cueadmin/common.py
@@ -229,6 +229,17 @@ def getParser():
         # choices=["UP", "DOWN", "REPAIR"], type=str.upper,
         help="Filter host search by hardware state, up or down.",
     )
+    filter_grp.add_argument(
+        "-lock-state",
+        action="store",
+        choices=["OPEN", "LOCKED", "NIMBY_LOCKED"],
+        help="Filter -lh output to hosts in this lock state (e.g. NIMBY_LOCKED)",
+    )
+    filter_grp.add_argument(
+        "-sort-idle",
+        action="store_true",
+        help="Sort -lh output by most idle resources first",
+    )
 
     #
     # Show
@@ -1073,7 +1084,9 @@ def handleArgs(args):
     if args.lh:
         states = [Convert.strToHardwareState(s) for s in args.state]
         cueadmin.output.displayHosts(
-            opencue.api.getHosts(match=args.query, state=states, alloc=args.alloc)
+            opencue.api.getHosts(match=args.query, state=states, alloc=args.alloc),
+            lock_state=args.lock_state,
+            sort_idle=args.sort_idle,
         )
         return
 

--- a/cueadmin/cueadmin/output.py
+++ b/cueadmin/cueadmin/output.py
@@ -56,11 +56,27 @@ def displayProcs(procs):
         )
 
 
-def displayHosts(hosts):
+def displayHosts(hosts, lock_state=None, sort_idle=False):
     """Displays the host information on one line each.
     @type hosts: list<Host>
     @param hosts: Hosts to display information about
+    @type lock_state: str
+    @param lock_state: if set, only show hosts in this lock state
+                       (OPEN, LOCKED or NIMBY_LOCKED)
+    @type sort_idle: bool
+    @param sort_idle: if True, sort by most idle resources first
     """
+    hosts = list(hosts)
+    if lock_state:
+        hosts = [
+            host
+            for host in hosts
+            if opencue.api.host_pb2.LockState.Name(host.data.lock_state) == lock_state
+        ]
+    if sort_idle:
+        hosts.sort(key=lambda v: (-v.data.idle_cores, -v.data.idle_memory))
+    else:
+        hosts.sort(key=lambda v: v.data.name)
     host_format = (
         "%-15s %-4s %-5s %-8s %-8s %-9s %-5s %-5s %-16s %-8s %-8s %-6s %-9s %-10s %-7s"
     )
@@ -84,7 +100,7 @@ def displayHosts(hosts):
             "Thread",
         )
     )
-    for host in sorted(hosts, key=lambda v: v.data.name):
+    for host in hosts:
         print(
             host_format
             % (

--- a/docs/_docs/other-guides/desktop-rendering-control.md
+++ b/docs/_docs/other-guides/desktop-rendering-control.md
@@ -113,6 +113,18 @@ elif lock_state == host_pb2.LockState.Value('OPEN'):
     print("Host is unlocked")
 ```
 
+From the command line, filter the host list by lock state with `cueadmin`:
+```bash
+cueadmin -lh -lock-state NIMBY_LOCKED    # Hosts locked by user activity
+cueadmin -lh -lock-state OPEN -sort-idle # Available hosts, most idle first
+```
+
+This is useful for spotting idle workstations: `-lock-state OPEN -sort-idle`
+lists hosts that are available to OpenCue and doing the least work, while
+`NIMBY_LOCKED` indicates a user is active on the machine. `cueadmin -lh` reports
+current state only, so to track how long hosts have been idle over time, poll it
+on an interval and store the results.
+
 ## Desktop allocation architecture
 
 ### The `local.desktop` allocation

--- a/docs/_docs/reference/commands/cueadmin.md
+++ b/docs/_docs/reference/commands/cueadmin.md
@@ -101,7 +101,7 @@ Use `-limit` to limit the results to N logs.
 
 ### `-lh`
 
-Arguments: `[SUBSTR ...] [-state STATE] [-alloc ALLOC]`
+Arguments: `[SUBSTR ...] [-state STATE] [-alloc ALLOC] [-lock-state LOCK_STATE] [-sort-idle]`
 
 List hosts with optional name substring match.
 
@@ -146,6 +146,17 @@ Waiting frames are automatically filtered out.
 Arguments: `LIMIT`
 
 Limit the result of a proc search to N rows
+
+### `-lock-state`
+
+Arguments: `{OPEN,LOCKED,NIMBY_LOCKED}`
+
+Filter `-lh` output to hosts in this lock state (for example, `NIMBY_LOCKED`).
+
+### `-sort-idle`
+
+Sort `-lh` output by most idle resources first (idle cores, then idle
+memory) instead of by host name.
 
 ## Show Options
 

--- a/docs/_docs/reference/tools/cueadmin.md
+++ b/docs/_docs/reference/tools/cueadmin.md
@@ -156,7 +156,17 @@ cueadmin -lh render                 # Hosts matching "render"
 cueadmin -lh -state UP              # Only UP hosts
 cueadmin -lh -state DOWN REPAIR     # DOWN or REPAIR hosts
 cueadmin -lh -alloc main.render     # Hosts in specific allocation
+cueadmin -lh -lock-state NIMBY_LOCKED  # Only NIMBY-locked hosts (a user is active)
+cueadmin -lh -lock-state OPEN -sort-idle  # Available hosts, most idle first
 ```
+
+The `-lock-state` option filters the list to a single lock state
+(`OPEN`, `LOCKED`, or `NIMBY_LOCKED`), and `-sort-idle` sorts the output by
+most idle resources first (idle cores, then idle memory) instead of by host
+name. These help identify idle hosts: `-lock-state OPEN -sort-idle` surfaces
+hosts that are available to OpenCue and doing the least work, while
+`NIMBY_LOCKED` indicates a host locked because a user is active on the
+machine.
 
 #### List Subscriptions (`-lb`)
 
@@ -565,6 +575,20 @@ cueadmin -lh -state UP              # Only UP hosts
 cueadmin -lh -state DOWN            # Only DOWN hosts
 cueadmin -lh -state REPAIR          # Hosts needing repair
 ```
+
+### Lock State Filter
+
+Filter hosts by lock state, and optionally sort by idleness:
+
+```bash
+cueadmin -lh -lock-state OPEN            # Only unlocked hosts
+cueadmin -lh -lock-state LOCKED          # Only locked hosts
+cueadmin -lh -lock-state NIMBY_LOCKED    # Only NIMBY-locked hosts
+cueadmin -lh -lock-state OPEN -sort-idle # Unlocked hosts, most idle first
+```
+
+`-sort-idle` sorts by idle cores, then idle memory, instead of by host name.
+It can be combined with any filter or used on its own.
 
 ### Allocation Filter
 

--- a/docs/_docs/tutorials/cueadmin-tutorial.md
+++ b/docs/_docs/tutorials/cueadmin-tutorial.md
@@ -266,6 +266,10 @@ cueadmin -lh -alloc main.render | head -10
 
 # Filter by name pattern
 cueadmin -lh render | grep render01
+
+# Filter by lock state, and sort by idleness
+cueadmin -lh -lock-state NIMBY_LOCKED         # Hosts locked by user activity
+cueadmin -lh -lock-state OPEN -sort-idle       # Available hosts, most idle first
 ```
 
 ### Locking and Unlocking Hosts


### PR DESCRIPTION
## Related Issues
- https://github.com/AcademySoftwareFoundation/OpenCue/issues/2481

## Summarize your change.

[cueadmin] Add lock-state filter and idle sort to host list

Add two options to `cueadmin -lh` to help surface idle hosts:

- `-lock-state {OPEN,LOCKED,NIMBY_LOCKED}` filters the host list to a single lock state (e.g. NIMBY_LOCKED).
- `-sort-idle` sorts the output by most idle resources first (idle cores, then idle memory) instead of by host name.

Filtering and sorting are applied client-side in displayHosts(), so no gRPC or backend changes are required. Existing default behavior (sort by name, no filter) is unchanged.

[docs/cueadmin] Document -lock-state and -sort-idle host list options

Document the two new `cueadmin -lh` options for surfacing idle hosts:

- `-lock-state {OPEN,LOCKED,NIMBY_LOCKED}` filters the host list to a single lock state.
- `-sort-idle` sorts the output by most idle resources first.

Updates the cueadmin command and tools reference, the cueadmin tutorial, the desktop rendering control guide, and the cueadmin README, noting that NIMBY_LOCKED indicates an active user and that `-lh` reports current state only (poll over time to track idle duration).
