### PR TITLE
[cueweb/docs] Rename CueWeb to OpenCueWeb across documentation

### DIFF
--- a/docs/_docs/concepts/cueweb-rest-gateway.md
+++ b/docs/_docs/concepts/cueweb-rest-gateway.md
@@ -1,18 +1,18 @@
 ---
-title: "CueWeb and REST Gateway"
+title: "OpenCueWeb and REST Gateway"
 nav_order: 18
 parent: Concepts
 layout: default
-linkTitle: "CueWeb and REST Gateway"
+linkTitle: "OpenCueWeb and REST Gateway"
 date: 2024-09-17
 description: >
-  Understanding CueWeb and the OpenCue REST Gateway architecture
+  Understanding OpenCueWeb and the OpenCue REST Gateway architecture
 ---
 
-# CueWeb and REST Gateway
+# OpenCueWeb and REST Gateway
 {: .no_toc }
 
-Learn about CueWeb's web-based interface and the REST Gateway that enables HTTP communication with OpenCue.
+Learn about OpenCueWeb's web-based interface and the REST Gateway that enables HTTP communication with OpenCue.
 
 <details open markdown="block">
   <summary>
@@ -25,17 +25,17 @@ Learn about CueWeb's web-based interface and the REST Gateway that enables HTTP 
 
 ---
 
-## What is CueWeb?
+## What is OpenCueWeb?
 
-CueWeb is a web-based application that brings the core functionality of CueGUI to your browser. Built with Next.js and React, CueWeb provides a responsive, accessible interface for managing OpenCue render farms from anywhere on the network.
+OpenCueWeb is a web-based application that brings the core functionality of CueGUI to your browser. Built with Next.js and React, OpenCueWeb provides a responsive, accessible interface for managing OpenCue render farms from anywhere on the network.
 
 ### Key Features
 
-- **Persistent Global Header**: OpenCue logo + **CueWeb** wordmark, plus the full CueGUI menu bar (**File**, **Cuebot Facility**, **Cuetopia**, **CueCommander**, **Other** [Attributes / Immersive (full-screen) / Split view / Show Shortcuts / Notify on Shortcut], **Help** with a search box that finds commands across every menu), a theme toggle, and an always-visible Sign out button
+- **Persistent Global Header**: OpenCue logo + **OpenCueWeb** wordmark, plus the full CueGUI menu bar (**File**, **Cuebot Facility**, **Cuetopia**, **CueCommander**, **Other** [Attributes / Immersive (full-screen) / Split view / Show Shortcuts / Notify on Shortcut], **Help** with a search box that finds commands across every menu), a theme toggle, and an always-visible Sign out button
 - **Collapsible Left Sidebar**: Same six groups as the header, organized as accordion sections; persists open/closed state and overall collapsed-vs-expanded width across reloads
 - **Disable Job Interaction**: Global read-only safety toggle (File ▸ Disable Job Interaction) that dims every destructive action and shows an amber banner under the header
 - **Attributes Panel**: Docked drawer (Other ▸ Attributes) with a position picker (right / bottom / left / top), filter input, and a collapsible key/value tree of the selected entity
-- **Bottom Status Bar**: IDE-style 24-pixel fixed bar showing REST gateway reachability (Online / Offline + round-trip latency, polled every 10 seconds via `/api/health`), time since the jobs table last refreshed, and the CueWeb build version (`NEXT_PUBLIC_APP_VERSION`). Turns red when the gateway is unreachable.
+- **Bottom Status Bar**: IDE-style 24-pixel fixed bar showing REST gateway reachability (Online / Offline + round-trip latency, polled every 10 seconds via `/api/health`), time since the jobs table last refreshed, and the OpenCueWeb build version (`NEXT_PUBLIC_APP_VERSION`). Turns red when the gateway is unreachable.
 - **Breadcrumb Navigation**: detail views (frame log page, per-job comments page) render a "Home > Jobs > ..." trail above the content. Long labels truncate with an ellipsis; the full text is recoverable on hover.
 - **Job / Layer / Frame tables (CueGUI parity)**: Full CueGUI column sets (Comments / Launched / Eligible / Finished / User Color on Jobs; Eligible on Layers; LLU / Memory (RSS) / Memory (PSS) / Remain / Eligible Time / Submission Time / Last Line on Frames). The Jobs table's dedicated **Comments** column shows a sortable sticky-note icon next to Name, so jobs with comments can be pulled to the top in one click. Per-table substring filter, hide / show + `← / →` reorder + **Reset to Default** in each table's Columns dropdown. Both visibility and ordering persist in `localStorage`.
 - **Inline Layers + Frames panel**: Clicking a job row reveals the associated Layers and Frames tables stacked below the Jobs grid; clicking a layer narrows the frames panel to that layer and pushes the layer attributes into the docked Attributes panel; double-clicking a frame opens the log viewer.
@@ -51,12 +51,12 @@ CueWeb is a web-based application that brings the core functionality of CueGUI t
 - **Keyboard shortcuts + menu access**: press `?` (or use Other ▸ Show Shortcuts) for the cheat-sheet overlay. An opt-out toggle (Other ▸ Notify on Shortcut) controls whether a toast names every triggered shortcut.
 - **Dark/Light Mode**: Theme switching for user preference
 - **Mobile-friendly UI**: Hamburger-triggered nav drawer on phones, per-row `⋮` Actions button so touch users reach the right-click menu via a tap, swipeable wide data tables, and tappable key badges in the shortcuts overlay so single-letter shortcuts work without a physical keyboard.
-- **LAN access by default**: The same image works whether the browser loads CueWeb from `localhost`, a LAN IP, or a reverse-proxy host. Clipboard actions also work over plain-HTTP LAN access.
+- **LAN access by default**: The same image works whether the browser loads OpenCueWeb from `localhost`, a LAN IP, or a reverse-proxy host. Clipboard actions also work over plain-HTTP LAN access.
 - **Authentication Support**: Optional OAuth integration (GitHub, Google, Okta, LDAP)
 
-### CueWeb vs CueGUI
+### OpenCueWeb vs CueGUI
 
-| Feature | CueGUI | CueWeb |
+| Feature | CueGUI | OpenCueWeb |
 |---------|---------|---------|
 | **Platform** | Desktop application | Web browser |
 | **Installation** | Requires Python/Qt setup | No client installation |
@@ -76,7 +76,7 @@ The OpenCue REST Gateway is a production-ready HTTP service that provides RESTfu
 
 <div class="mermaid">
 graph LR
-    A["Web Client<br/>- CueWeb<br/>- Mobile App<br/>- curl/Scripts<br/>- Third-party"]
+    A["Web Client<br/>- OpenCueWeb<br/>- Mobile App<br/>- curl/Scripts<br/>- Third-party"]
     B["REST Gateway<br/>- Authentication<br/>- Request Trans.<br/>- Response Form.<br/>- Error Handling"]
     C["Cuebot<br/>- Job Mgmt<br/>- Scheduling<br/>- Resources<br/>- Monitoring"]
 
@@ -99,19 +99,19 @@ graph LR
 
 ### JWT Token System
 
-Both CueWeb and the REST Gateway use JSON Web Tokens (JWT) for secure authentication:
+Both OpenCueWeb and the REST Gateway use JSON Web Tokens (JWT) for secure authentication:
 
 - **Algorithm**: HMAC SHA256 (HS256)
 - **Header Format**: `Authorization: Bearer <token>`
 - **Expiration**: Configurable token lifetime
-- **Secret Sharing**: Same secret used by both CueWeb and REST Gateway
+- **Secret Sharing**: Same secret used by both OpenCueWeb and REST Gateway
 
 ### Token Lifecycle
 
 <div class="mermaid">
 sequenceDiagram
     participant U as User
-    participant C as CueWeb
+    participant C as OpenCueWeb
     participant G as Gateway
     participant B as Cuebot
 
@@ -135,7 +135,7 @@ sequenceDiagram
 
 ### Group-based authorization (optional)
 
-Authentication answers *who you are*; **authorization** answers *what you may do*. CueWeb adds an optional, opt-in authorization layer that restricts access by **group membership**, enforced server-side at a single middleware chokepoint. It is **off by default** - when disabled (or when no auth provider is configured) the middleware is a pure pass-through and every signed-in user is treated as an admin.
+Authentication answers *who you are*; **authorization** answers *what you may do*. OpenCueWeb adds an optional, opt-in authorization layer that restricts access by **group membership**, enforced server-side at a single middleware chokepoint. It is **off by default** - when disabled (or when no auth provider is configured) the middleware is a pure pass-through and every signed-in user is treated as an admin.
 
 The design separates **resolution** from **enforcement**, which is what keeps it both correct and fast:
 
@@ -144,50 +144,50 @@ The design separates **resolution** from **enforcement**, which is what keeps it
 
 Two gates are applied:
 
-- `CUEWEB_ALLOWED_GROUPS` - who may use CueWeb at all. A signed-in user outside this list is sent to an **Access denied** page (`/unauthorized`); API routes get a `403`.
+- `CUEWEB_ALLOWED_GROUPS` - who may use OpenCueWeb at all. A signed-in user outside this list is sent to an **Access denied** page (`/unauthorized`); API routes get a `403`.
 - `CUEWEB_ADMIN_GROUPS` - who may reach the **entire CueCommander section** (all of its pages, including Monitor Cue, Monitor Hosts and Stuck Frame), **job submission** (CueSubmit), and the **Manage facilities…** screen. On a restricted deployment those menus are hidden from everyone else; non-admins keep Cuetopia **Monitor Jobs** and the Dashboard.
 
 Infrastructure routes - the health probe, metrics, the auth flow, the login and unauthorized pages, and static assets - are never gated. **Prerequisite:** the gate only works when your identity provider emits the user's group memberships in the token; if the token carries no groups, the resolution seam can be extended (e.g. a directory lookup) without touching enforcement.
 
 ---
 
-## CueWeb Audit (web action audit)
+## OpenCueWeb Audit (web action audit)
 
-CueWeb keeps a **web audit trail**: an append-only record of who did which state-changing action, when, against which target, and with what outcome - for actions performed through CueWeb. It answers the operational question *"who killed that job?"* (or paused it, retried that frame, rebooted that host, changed a show) by recording each mutating action as a single timestamped entry. The trail is surfaced in an admin-only **Admin &rarr; CueWeb Audit** page (reachable from both the top menu and the left sidebar).
+OpenCueWeb keeps a **web audit trail**: an append-only record of who did which state-changing action, when, against which target, and with what outcome - for actions performed through OpenCueWeb. It answers the operational question *"who killed that job?"* (or paused it, retried that frame, rebooted that host, changed a show) by recording each mutating action as a single timestamped entry. The trail is surfaced in an admin-only **Admin &rarr; OpenCueWeb Audit** page (reachable from both the top menu and the left sidebar).
 
-![CueWeb Audit page](/assets/images/cueweb/cueweb_admin_cueweb_audit.png)
+![OpenCueWeb Audit page](/assets/images/cueweb/cueweb_admin_cueweb_audit.png)
 
 ### Where events are captured
 
-The architectural insight is that CueWeb proxies **every** mutating action through a **single chokepoint** - the server-side gateway request handler that signs and forwards each call to the facility's REST Gateway &rarr; Cuebot. Because all writes already funnel through that one place, instrumenting it once captures every mutating route with **no per-route changes**. It is also the only place where the three things an audit entry needs are available together: the **signed-in user identity**, the **selected facility**, and the **gRPC endpoint** being called. Read-only calls (`Get*` / `Find*` / `List*`) are skipped, so the trail stays focused on actions that change state. Sign in and sign out are captured separately, via the authentication layer's events, since they don't flow through the gateway.
+The architectural insight is that OpenCueWeb proxies **every** mutating action through a **single chokepoint** - the server-side gateway request handler that signs and forwards each call to the facility's REST Gateway &rarr; Cuebot. Because all writes already funnel through that one place, instrumenting it once captures every mutating route with **no per-route changes**. It is also the only place where the three things an audit entry needs are available together: the **signed-in user identity**, the **selected facility**, and the **gRPC endpoint** being called. Read-only calls (`Get*` / `Find*` / `List*`) are skipped, so the trail stays focused on actions that change state. Sign in and sign out are captured separately, via the authentication layer's events, since they don't flow through the gateway.
 
 Each record carries: the timestamp (`at`), the `actor`, a `category` (job, frame, layer, host, show, ..., or `auth`), the `action`, the `target`, the `facility`, the `result` (success or error) plus any `error` message, sanitized `details` (request parameters with secrets dropped), and the `endpoint` and `method`.
 
 ### How it's stored
 
-The trail is an **append-only JSONL file** - one JSON record per line - mirroring an existing CueWeb pattern (the per-facility override store). No database is introduced, so CueWeb stays **stateless** on the backend. The file path is configurable (`CUEWEB_AUDIT_STORE`), and its size is bounded (`CUEWEB_AUDIT_MAX_RECORDS`): once the cap is reached the oldest records are dropped. Because the default location is the OS temp directory, persisting the trail across restarts means pointing it at a mounted volume.
+The trail is an **append-only JSONL file** - one JSON record per line - mirroring an existing OpenCueWeb pattern (the per-facility override store). No database is introduced, so OpenCueWeb stays **stateless** on the backend. The file path is configurable (`CUEWEB_AUDIT_STORE`), and its size is bounded (`CUEWEB_AUDIT_MAX_RECORDS`): once the cap is reached the oldest records are dropped. Because the default location is the OS temp directory, persisting the trail across restarts means pointing it at a mounted volume.
 
 ### Who can see it
 
-Access reuses the same optional group-authorization gate described above. When no group authorization is configured (`CUEWEB_AUTHZ_ENABLED` off), the audit page is shown to everyone - consistent with CueWeb's "everyone is an admin" default. When authorization is active, only members of the admin groups (`CUEWEB_ADMIN_GROUPS`) can reach it.
+Access reuses the same optional group-authorization gate described above. When no group authorization is configured (`CUEWEB_AUTHZ_ENABLED` off), the audit page is shown to everyone - consistent with OpenCueWeb's "everyone is an admin" default. When authorization is active, only members of the admin groups (`CUEWEB_ADMIN_GROUPS`) can reach it.
 
 ### Scope and limitation
 
-This is a **CueWeb audit**, not a farm-wide audit: it records only actions taken **through CueWeb**. Actions performed from CueGUI, `cueman`, or `pycue` go straight to Cuebot and are not seen here. Capturing every client's actions would require an audit layer in the backend (Cuebot / gateway); the CueWeb trail is the pragmatic, no-new-infrastructure step that covers the web interface today.
+This is a **OpenCueWeb audit**, not a farm-wide audit: it records only actions taken **through OpenCueWeb**. Actions performed from CueGUI, `cueman`, or `pycue` go straight to Cuebot and are not seen here. Capturing every client's actions would require an audit layer in the backend (Cuebot / gateway); the OpenCueWeb trail is the pragmatic, no-new-infrastructure step that covers the web interface today.
 
 ---
 
 ## Cuebot facilities (multi-facility routing)
 
-A **facility** in OpenCue labels and separates farm resources - typically by physical location. Each facility is served by its own **Cuebot** (and, for CueWeb, its own REST Gateway). CueWeb mirrors CueGUI's *Cuebot Facility* concept: you work in **one facility at a time**, and a menu lets you switch between them.
+A **facility** in OpenCue labels and separates farm resources - typically by physical location. Each facility is served by its own **Cuebot** (and, for OpenCueWeb, its own REST Gateway). OpenCueWeb mirrors CueGUI's *Cuebot Facility* concept: you work in **one facility at a time**, and a menu lets you switch between them.
 
 ### What "switching a facility" means
 
-Switching the active facility re-points CueWeb at that facility's Cuebot and reloads the current view. You never see two facilities mixed together - the jobs, hosts, shows, and everything else you see belong to the selected facility. The active facility is shown as a chip on the menu and in the bottom status bar, and the selection is remembered for the session.
+Switching the active facility re-points OpenCueWeb at that facility's Cuebot and reloads the current view. You never see two facilities mixed together - the jobs, hosts, shows, and everything else you see belong to the selected facility. The active facility is shown as a chip on the menu and in the bottom status bar, and the selection is remembered for the session.
 
 ### How routing works
 
-Because the browser only talks to CueWeb's own `/api` routes, facility routing is resolved **server-side, per request**:
+Because the browser only talks to OpenCueWeb's own `/api` routes, facility routing is resolved **server-side, per request**:
 
 - The client sends the active facility with each API call; a server-side resolver picks the matching gateway URL and JWT secret for that facility, signs the request, and forwards it to that facility's gateway &rarr; Cuebot.
 - The facility list comes from `NEXT_PUBLIC_CUEBOT_FACILITIES` (default `local,dev,cloud,external`).
@@ -195,11 +195,11 @@ Because the browser only talks to CueWeb's own `/api` routes, facility routing i
 
 ### Why this design
 
-Keeping the per-facility gateway URLs and secrets **server-only** means the browser never holds a gateway credential - it only knows the facility *name*. This keeps the same security model as single-facility CueWeb (secrets live in the Node server, never in the client bundle) while letting one CueWeb deployment front many facilities. It also means a facility's gateway can change without touching the client.
+Keeping the per-facility gateway URLs and secrets **server-only** means the browser never holds a gateway credential - it only knows the facility *name*. This keeps the same security model as single-facility OpenCueWeb (secrets live in the Node server, never in the client bundle) while letting one OpenCueWeb deployment front many facilities. It also means a facility's gateway can change without touching the client.
 
 ### Per-facility health and runtime configuration
 
-Fronting many facilities raises two operational questions: *is each one reachable?* and *can I re-point one without a redeploy?* CueWeb answers both while preserving the server-only credential model.
+Fronting many facilities raises two operational questions: *is each one reachable?* and *can I re-point one without a redeploy?* OpenCueWeb answers both while preserving the server-only credential model.
 
 - **Live health per facility.** A server endpoint probes every configured facility's gateway in parallel and reports only reachability and round-trip latency (never gateway payloads). The Cuebot Facility menu polls it and shows a green/red dot next to each facility; a facility whose gateway is down can't be selected, so you can't switch into a dead facility by accident.
 - **Runtime overrides, layered over the env defaults.** Each facility's gateway URL and JWT secret can be edited at runtime from a **Manage facilities…** admin screen. The effective value is resolved as **override → per-facility env var → legacy default**, so an empty override store reproduces the env-only behavior exactly, and clearing an override falls back to the env/default. Overrides are persisted to a server-side file (`CUEWEB_FACILITY_STORE`) with an append-only audit log; the JWT secret is stored with restrictive permissions and is never logged or returned to a client.
@@ -208,9 +208,9 @@ Fronting many facilities raises two operational questions: *is each one reachabl
 
 ---
 
-## Plugins (extending CueWeb)
+## Plugins (extending OpenCueWeb)
 
-CueWeb is **extensible** through a small plugin system - the browser counterpart of CueGUI's plugin architecture, where each plugin declares metadata and exposes a component the host mounts. The same idea translates cleanly to the web:
+OpenCueWeb is **extensible** through a small plugin system - the browser counterpart of CueGUI's plugin architecture, where each plugin declares metadata and exposes a component the host mounts. The same idea translates cleanly to the web:
 
 - A **plugin** is a *manifest* (its name, title, version, route, and an optional description) plus a *lazily-loaded React component*. Each plugin mounts on its own route under `/plugins/<name>`.
 - Plugins are discovered from a **static registry** in the code rather than scanned at runtime. That registry is the single source of truth, which keeps discovery predictable and lets the bundler **code-split** each plugin into its own chunk that's only fetched when its page is opened - so unused plugins cost nothing.
@@ -222,24 +222,24 @@ CueWeb is **extensible** through a small plugin system - the browser counterpart
 
 ## Workspace layout (web-native windows)
 
-CueGUI is a desktop app, so it shapes the workspace with *windows*: saving window settings, toggling full-screen, and opening additional windows. CueWeb is a single browser tab, so it offers the same affordances in web-native form, and treats them all the same way - as **personal, client-side preferences** (browser `localStorage`, synced across tabs via the `storage` event), never server state:
+CueGUI is a desktop app, so it shapes the workspace with *windows*: saving window settings, toggling full-screen, and opening additional windows. OpenCueWeb is a single browser tab, so it offers the same affordances in web-native form, and treats them all the same way - as **personal, client-side preferences** (browser `localStorage`, synced across tabs via the `storage` event), never server state:
 
 - **View presets** replace CueGUI's *Save Window Settings*: a named snapshot of a table's column order/visibility, sort, filters, and page size. They're built on top of each table's existing per-column persistence and operate purely through the table component's own API, which is why they work uniformly across every table without per-table code.
 - **Immersive (full-screen) mode** replaces *Toggle Full-Screen*: the app shell drops the header, sidebar, and status bar so the active view fills the viewport.
 - **Split view** replaces *Add new window*: two pages share one tab as side-by-side panes. Each pane is a same-origin `<iframe>` so it keeps its **own** router context (URL, dynamic params), and the two pane targets live in the page's query string - so a split workspace is itself just a URL, making it bookmarkable, shareable, and reload-safe.
 
-**Why this design:** modeling these as URL- and `localStorage`-addressable state (rather than server-side window managers) keeps them stateless on the backend, shareable as links, and consistent with how the rest of CueWeb persists per-user preferences - enabling any of them never touches Cuebot.
+**Why this design:** modeling these as URL- and `localStorage`-addressable state (rather than server-side window managers) keeps them stateless on the backend, shareable as links, and consistent with how the rest of OpenCueWeb persists per-user preferences - enabling any of them never touches Cuebot.
 
 ---
 
 ## Frame logs (file-based and Loki)
 
-A frame's log can be read two ways, and CueWeb supports both behind the same viewer:
+A frame's log can be read two ways, and OpenCueWeb supports both behind the same viewer:
 
-- **File-based (default):** RQD writes each frame's output to a `.rqlog` file on a shared filesystem. CueWeb's server reads that file (so the render-log directory must be mounted into the CueWeb container). This is the zero-extra-infrastructure default.
-- **Loki (optional):** in studios that already centralize logs, RQD ships frame output to a [Grafana Loki](https://grafana.com/oss/loki/) server tagged with `frame_id` and `session_start_time` labels. Setting `NEXT_PUBLIC_LOKI_URL` makes CueWeb query Loki for a frame's lines instead of reading a file - the same model as CueGUI's Loki log viewer. There's no shared log mount to manage, logs survive the worker, and each frame **attempt** is a selectable version.
+- **File-based (default):** RQD writes each frame's output to a `.rqlog` file on a shared filesystem. OpenCueWeb's server reads that file (so the render-log directory must be mounted into the OpenCueWeb container). This is the zero-extra-infrastructure default.
+- **Loki (optional):** in studios that already centralize logs, RQD ships frame output to a [Grafana Loki](https://grafana.com/oss/loki/) server tagged with `frame_id` and `session_start_time` labels. Setting `NEXT_PUBLIC_LOKI_URL` makes OpenCueWeb query Loki for a frame's lines instead of reading a file - the same model as CueGUI's Loki log viewer. There's no shared log mount to manage, logs survive the worker, and each frame **attempt** is a selectable version.
 
-**Why this design:** the backend is a single deployment-time switch (`NEXT_PUBLIC_LOKI_URL` set or not), not a UI choice, and the viewer is identical either way - so a site adopts centralized logging without changing how artists view logs. Because the var is browser-readable (`NEXT_PUBLIC_*`), the Loki query goes straight from the browser to Loki, which must therefore be reachable from clients and allow CORS from the CueWeb origin.
+**Why this design:** the backend is a single deployment-time switch (`NEXT_PUBLIC_LOKI_URL` set or not), not a UI choice, and the viewer is identical either way - so a site adopts centralized logging without changing how artists view logs. Because the var is browser-readable (`NEXT_PUBLIC_*`), the Loki query goes straight from the browser to Loki, which must therefore be reachable from clients and allow CORS from the OpenCueWeb origin.
 
 ---
 
@@ -247,11 +247,11 @@ A frame's log can be read two ways, and CueWeb supports both behind the same vie
 
 ### Standalone Deployment
 
-CueWeb and REST Gateway run as separate services:
+OpenCueWeb and REST Gateway run as separate services:
 
 <div class="mermaid">
 graph LR
-    A["CueWeb<br/>Port: 3000"] --> B["REST Gateway<br/>Port: 8448"]
+    A["OpenCueWeb<br/>Port: 3000"] --> B["REST Gateway<br/>Port: 8448"]
     B --> C["Cuebot<br/>Port: 8443"]
 </div>
 
@@ -283,9 +283,9 @@ Load-balanced deployment for production environments:
 graph TD
     LB["Load Balancer"]
 
-    LB --> CW1["CueWeb #1"]
-    LB --> CW2["CueWeb #2"]
-    LB --> CW3["CueWeb #3"]
+    LB --> CW1["OpenCueWeb #1"]
+    LB --> CW2["OpenCueWeb #2"]
+    LB --> CW3["OpenCueWeb #3"]
 
     CW1 --> RG["REST Gateway<br/>(Clustered)"]
     CW2 --> RG
@@ -335,19 +335,19 @@ The REST Gateway exposes all OpenCue gRPC interfaces:
 
 ### Job Submission (CueSubmit)
 
-CueWeb's `/cuesubmit` route is a browser-based equivalent of the standalone CueSubmit CLI tool. The data path is:
+OpenCueWeb's `/cuesubmit` route is a browser-based equivalent of the standalone CueSubmit CLI tool. The data path is:
 
 1. The form serializes a typed payload (job info, layers, per-type options) to JSON.
 2. The Next.js route `POST /api/job/submit` parses + validates the payload with zod.
 3. The same route assembles an OpenCue job-spec XML document (the CJSL format that the standalone pyoutline tool also emits) and forwards it to `job.JobInterface/LaunchSpecAndWait` on the REST Gateway.
 4. The gateway calls the same gRPC RPC against cuebot. Cuebot creates the job, dispatches frames as RQDs become available, and returns the resolved `JobSeq` to the gateway.
-5. CueWeb redirects the browser to the tabbed `/jobs/<name>` detail view; the user can immediately watch their frames go WAITING -> RUNNING -> SUCCEEDED.
+5. OpenCueWeb redirects the browser to the tabbed `/jobs/<name>` detail view; the user can immediately watch their frames go WAITING -> RUNNING -> SUCCEEDED.
 
-The browser never needs `outline` / `pyoutline` / `pycuerun` runtime - the XML the CLI tool builds locally is built server-side inside CueWeb's Node process and posted straight to the gateway. This keeps the deploy footprint small and ensures that submissions from the browser are indistinguishable from CueGUI / CueSubmit-CLI submissions on cuebot's side.
+The browser never needs `outline` / `pyoutline` / `pycuerun` runtime - the XML the CLI tool builds locally is built server-side inside OpenCueWeb's Node process and posted straight to the gateway. This keeps the deploy footprint small and ensures that submissions from the browser are indistinguishable from CueGUI / CueSubmit-CLI submissions on cuebot's side.
 
 ### Real-time Updates
 
-CueWeb implements automatic updates through:
+OpenCueWeb implements automatic updates through:
 
 - **Polling Strategy**: Regular API calls to refresh data
 - **Configurable Intervals**: Adjustable refresh rates per table
@@ -358,14 +358,14 @@ CueWeb implements automatic updates through:
 
 ## Configuration and Environment Variables
 
-### CueWeb Configuration
+### OpenCueWeb Configuration
 
-Key environment variables for CueWeb:
+Key environment variables for OpenCueWeb:
 
 ```bash
 # Required
 NEXT_PUBLIC_OPENCUE_ENDPOINT=http://localhost:8448  # REST Gateway URL
-NEXT_PUBLIC_URL=http://localhost:3000               # CueWeb URL
+NEXT_PUBLIC_URL=http://localhost:3000               # OpenCueWeb URL
 NEXT_JWT_SECRET=your-secret-key                     # JWT signing secret
 
 # Authentication (optional)
@@ -404,7 +404,7 @@ RATE_LIMIT_RPS=100                                  # Rate limiting
 
 ## Performance and Scalability
 
-### CueWeb Performance
+### OpenCueWeb Performance
 
 - **Server-Side Rendering**: Fast initial page loads with Next.js SSR
 - **Code Splitting**: Automatic bundle optimization
@@ -422,7 +422,7 @@ RATE_LIMIT_RPS=100                                  # Rate limiting
 
 ### Scaling Considerations
 
-- **Horizontal Scaling**: Multiple CueWeb instances behind load balancer
+- **Horizontal Scaling**: Multiple OpenCueWeb instances behind load balancer
 - **Gateway Clustering**: Multiple REST Gateway instances for redundancy
 - **Database Optimization**: Efficient Cuebot database queries
 - **CDN Integration**: Static asset delivery optimization
@@ -479,6 +479,6 @@ RATE_LIMIT_RPS=100                                  # Rate limiting
 - **API Rate Limits**: Implement request throttling and caching strategies
 
 For detailed troubleshooting guides, see:
-- [CueWeb User Guide](/docs/user-guides/cueweb-user-guide)
+- [OpenCueWeb User Guide](/docs/user-guides/cueweb-user-guide)
 - [REST API Reference](/docs/reference/rest-api-reference/)
 - [Developer Guide](/docs/developer-guide/cueweb-development)

--- a/docs/_docs/concepts/cueweb-rest-gateway.md
+++ b/docs/_docs/concepts/cueweb-rest-gateway.md
@@ -99,12 +99,12 @@ graph LR
 
 ### JWT Token System
 
-Both OpenCueWeb and the REST Gateway use JSON Web Tokens (JWT) for secure authentication:
+The OpenCueWeb server and the REST Gateway use JSON Web Tokens (JWT) for secure authentication:
 
 - **Algorithm**: HMAC SHA256 (HS256)
 - **Header Format**: `Authorization: Bearer <token>`
 - **Expiration**: Configurable token lifetime
-- **Secret Sharing**: Same secret used by both OpenCueWeb and REST Gateway
+- **Secret Sharing**: The shared secret is held only by the OpenCueWeb server (which signs each token and forwards requests to the gateway) and the REST Gateway (which verifies it). It must never be exposed to browser or client code — the browser calls OpenCueWeb's own server-side routes, and those routes attach the gateway JWT server-side.
 
 ### Token Lifecycle
 
@@ -165,7 +165,7 @@ Each record carries: the timestamp (`at`), the `actor`, a `category` (job, frame
 
 ### How it's stored
 
-The trail is an **append-only JSONL file** - one JSON record per line - mirroring an existing OpenCueWeb pattern (the per-facility override store). No database is introduced, so OpenCueWeb stays **stateless** on the backend. The file path is configurable (`CUEWEB_AUDIT_STORE`), and its size is bounded (`CUEWEB_AUDIT_MAX_RECORDS`): once the cap is reached the oldest records are dropped. Because the default location is the OS temp directory, persisting the trail across restarts means pointing it at a mounted volume.
+The trail is an **append-only JSONL file** - one JSON record per line - mirroring an existing OpenCueWeb pattern (the per-facility override store). No database is introduced, so OpenCueWeb has **no database dependency** on the backend. The file path is configurable (`CUEWEB_AUDIT_STORE`), and its size is bounded (`CUEWEB_AUDIT_MAX_RECORDS`): once the cap is reached the oldest records are dropped. Because the default location is the OS temp directory, persisting the trail across restarts means pointing it at a mounted volume. The store is file-backed and single-process, so running multiple OpenCueWeb replicas means pointing them at shared storage (and the writes are last-writer-wins without a cross-process lock).
 
 ### Who can see it
 
@@ -173,7 +173,7 @@ Access reuses the same optional group-authorization gate described above. When n
 
 ### Scope and limitation
 
-This is a **OpenCueWeb audit**, not a farm-wide audit: it records only actions taken **through OpenCueWeb**. Actions performed from CueGUI, `cueman`, or `pycue` go straight to Cuebot and are not seen here. Capturing every client's actions would require an audit layer in the backend (Cuebot / gateway); the OpenCueWeb trail is the pragmatic, no-new-infrastructure step that covers the web interface today.
+This is an **OpenCueWeb audit**, not a farm-wide audit: it records only actions taken **through OpenCueWeb**. Actions performed from CueGUI, `cueman`, or `pycue` go straight to Cuebot and are not seen here. Capturing every client's actions would require an audit layer in the backend (Cuebot / gateway); the OpenCueWeb trail is the pragmatic, no-new-infrastructure step that covers the web interface today.
 
 ---
 

--- a/docs/_docs/concepts/glossary.md
+++ b/docs/_docs/concepts/glossary.md
@@ -64,7 +64,7 @@ A graphical user interface for configuring and launching rendering jobs.
 Typically runs as a plug-in within 3D software like Maya, Blender, or Nuke,
 allowing artists to submit jobs directly from their creative applications.
 
-## CueWeb
+## OpenCueWeb
 
 A web-based interface that brings CueGUI's core functionality to the browser.
 Offers job management, frame monitoring, real-time updates, and collaborative
@@ -118,7 +118,7 @@ be processed on remote *cores*.
 
 The time elapsed since a running *frame* last wrote to its log. A large LLU on a
 frame that is still running is the main signal that the frame may be *stuck* -
-the process is alive but no longer making progress. CueWeb's Stuck Frames page
+the process is alive but no longer making progress. OpenCueWeb's Stuck Frames page
 shows LLU per frame and uses it (relative to runtime) to flag stuck frames.
 
 ## Layers
@@ -180,7 +180,7 @@ An administrative action that reassigns the *cores* of busy *procs* to a target
 *job* that needs them. The *frames* currently running on those procs are killed
 so the freed cores can be booked onto the target job - a way to give a
 high-priority job capacity quickly. CueGUI's CueCommander Redirect plugin and
-CueWeb's Redirect page expose it.
+OpenCueWeb's Redirect page expose it.
 
 ## RQD (Python)
 
@@ -224,7 +224,7 @@ A running *frame* that appears hung: it keeps running but has stopped writing to
 its log, so its *Last Log Update (LLU)* keeps climbing relative to its runtime.
 A stuck frame is not a distinct frame state - it is detected heuristically (LLU
 vs. runtime vs. the *layer*'s average frame time). CueGUI's CueCommander Stuck
-Frame plugin and CueWeb's Stuck Frames page list them so you can retry, eat,
+Frame plugin and OpenCueWeb's Stuck Frames page list them so you can retry, eat,
 kill, or *core up* (raise the minimum cores of) the affected layer.
 
 ## Subscription

--- a/docs/_docs/concepts/opencue-overview.md
+++ b/docs/_docs/concepts/opencue-overview.md
@@ -59,7 +59,7 @@ OpenCue components:
 
 *   **CueGUI** - The desktop graphical user interface divided into two main workspaces: Cuetopia (artist-focused job monitoring) and CueCommander (administrator-focused system management). Provides comprehensive tools for job monitoring, frame inspection, host management, and system administration.
 
-*   **CueWeb** - A web-based interface that brings CueGUI's core functionality to the browser. Offers job management, frame monitoring, real-time updates, and collaborative features accessible from anywhere on the network without requiring client installation.
+*   **OpenCueWeb** - A web-based interface that brings CueGUI's core functionality to the browser. Offers job management, frame monitoring, real-time updates, and collaborative features accessible from anywhere on the network without requiring client installation.
 
 *   **CueSubmit** - A graphical user interface for configuring and launching rendering jobs. Typically runs as a plug-in within 3D software like Maya, Blender, or Nuke, allowing artists to submit jobs directly from their creative applications.
 

--- a/docs/_docs/concepts/versioning.md
+++ b/docs/_docs/concepts/versioning.md
@@ -46,7 +46,7 @@ OpenCueWeb participates in this shared versioning scheme rather than carrying a 
 1. **`NEXT_PUBLIC_APP_VERSION`** (env var / Docker build-arg) - always wins. CI injects the generated OpenCue version or a Git SHA here.
 2. **`cueweb/OVERRIDE_CUEWEB_VERSION.in`** - a small override file:
    - the default value, the sentinel `VERSION.in`, means "use the repo-root `VERSION.in`" - the same shared source of truth Cuebot and CueGUI read, so OpenCueWeb's number tracks the rest of OpenCue automatically;
-   - any other value is used **verbatim**, letting a site pin a OpenCueWeb-specific version when it needs to.
+   - any other value is used **verbatim**, letting a site pin an OpenCueWeb-specific version when it needs to.
 3. **`package.json`** `version` - a last-resort fallback.
 
 Separately, a **build SHA** is shown for provenance: it comes from the `NEXT_PUBLIC_GIT_SHA` build-arg (CI passes `git rev-parse --short HEAD`) and renders as `unknown` when not supplied.

--- a/docs/_docs/concepts/versioning.md
+++ b/docs/_docs/concepts/versioning.md
@@ -39,18 +39,18 @@ commit and re-submit it with an incremented minor version if needed.
 
 ---
 
-## How CueWeb sources its version
+## How OpenCueWeb sources its version
 
-CueWeb participates in this shared versioning scheme rather than carrying a version of its own. The version it displays (in the bottom status bar and the **Help &rarr; About CueWeb** dialog) is resolved **once at build time** and exposed to the client as `NEXT_PUBLIC_APP_VERSION`, using the first hit of this chain:
+OpenCueWeb participates in this shared versioning scheme rather than carrying a version of its own. The version it displays (in the bottom status bar and the **Help &rarr; About OpenCueWeb** dialog) is resolved **once at build time** and exposed to the client as `NEXT_PUBLIC_APP_VERSION`, using the first hit of this chain:
 
 1. **`NEXT_PUBLIC_APP_VERSION`** (env var / Docker build-arg) - always wins. CI injects the generated OpenCue version or a Git SHA here.
 2. **`cueweb/OVERRIDE_CUEWEB_VERSION.in`** - a small override file:
-   - the default value, the sentinel `VERSION.in`, means "use the repo-root `VERSION.in`" - the same shared source of truth Cuebot and CueGUI read, so CueWeb's number tracks the rest of OpenCue automatically;
-   - any other value is used **verbatim**, letting a site pin a CueWeb-specific version when it needs to.
+   - the default value, the sentinel `VERSION.in`, means "use the repo-root `VERSION.in`" - the same shared source of truth Cuebot and CueGUI read, so OpenCueWeb's number tracks the rest of OpenCue automatically;
+   - any other value is used **verbatim**, letting a site pin a OpenCueWeb-specific version when it needs to.
 3. **`package.json`** `version` - a last-resort fallback.
 
 Separately, a **build SHA** is shown for provenance: it comes from the `NEXT_PUBLIC_GIT_SHA` build-arg (CI passes `git rev-parse --short HEAD`) and renders as `unknown` when not supplied.
 
-**Why this design:** defaulting to the repo-root `VERSION.in` keeps CueWeb consistent with OpenCue's policy above (no separate number to bump), while the override file and build-arg give deployments an explicit escape hatch when they need to label a build differently - without code changes.
+**Why this design:** defaulting to the repo-root `VERSION.in` keeps OpenCueWeb consistent with OpenCue's policy above (no separate number to bump), while the override file and build-arg give deployments an explicit escape hatch when they need to label a build differently - without code changes.
 
-> In the Docker image the repo-root `VERSION.in` lives outside CueWeb's build context, so it is supplied through a `project_root` build context (see the CueWeb deployment guide).
+> In the Docker image the repo-root `VERSION.in` lives outside OpenCueWeb's build context, so it is supplied through a `project_root` build context (see the OpenCueWeb deployment guide).

--- a/docs/_docs/developer-guide/cueweb-development.md
+++ b/docs/_docs/developer-guide/cueweb-development.md
@@ -1,14 +1,14 @@
 ---
 layout: default
-title: CueWeb Development
+title: OpenCueWeb Development
 parent: Developer Guide
 nav_order: 97
 ---
 
-# CueWeb Development Guide
+# OpenCueWeb Development Guide
 {: .no_toc }
 
-Complete guide for developing, customizing, and deploying CueWeb.
+Complete guide for developing, customizing, and deploying OpenCueWeb.
 
 <details open markdown="block">
   <summary>
@@ -127,7 +127,7 @@ cueweb/
 │   │   ├── mobile-nav-sheet.tsx # Mobile drawer mirroring every sidebar group
 │   │   ├── sheet.tsx            # Side-slide panel primitive (Radix Dialog-based)
 │   │   ├── row-actions-cell.tsx # Per-row "⋮" Actions button (touch equivalent of right-click)
-│   │   ├── about-dialog.tsx     # "About CueWeb" dialog (Help → About)
+│   │   ├── about-dialog.tsx     # "About OpenCueWeb" dialog (Help → About)
 │   │   ├── attributes-panel.tsx # Docked Attributes drawer
 │   │   ├── breadcrumbs.tsx      # Detail-view breadcrumb primitive
 │   │   ├── read-only-banner.tsx # Amber strip when safety flag is on
@@ -138,7 +138,7 @@ cueweb/
 │   │   ├── job-details-inline.tsx # Inline Layers + Frames panel under the Jobs grid
 │   │   ├── simple-data-table.tsx # Shared TanStack-table wrapper for Layers/Frames
 │   │   ├── subscribe-bell.tsx   # Per-row bell in the Jobs Notify column
-│   │   ├── cuewebicon.tsx       # OpenCue icon + "CueWeb" wordmark
+│   │   ├── cuewebicon.tsx       # OpenCue icon + "OpenCueWeb" wordmark
 │   │   ├── theme-toggle.tsx     # Light/dark toggle
 │   │   ├── theme-provider.tsx   # next-themes wrapper
 │   │   └── ...                  # button, dialog, dropdown-menu, etc.
@@ -164,7 +164,7 @@ cueweb/
 
 The OpenCue brand assets that drive the icon/wordmark live at the repo
 root in `images/` (icon, horizontal, stacked × PNG + SVG × black + white)
-so other OpenCue projects can re-use them. The two PNGs CueWeb actually
+so other OpenCue projects can re-use them. The two PNGs OpenCueWeb actually
 loads at runtime are copies under `cueweb/public/`.
 
 ### Key Components
@@ -172,7 +172,7 @@ loads at runtime are copies under `cueweb/public/`.
 #### Core Components
 
 - **`AppHeader`** (`components/ui/app-header.tsx`): Persistent global header mounted by `app/layout.tsx`. Hidden on `/login*`. Composes:
-  - The OpenCue logo (theme-aware via Tailwind `block dark:hidden` / `hidden dark:block`) + the **CueWeb** wordmark.
+  - The OpenCue logo (theme-aware via Tailwind `block dark:hidden` / `hidden dark:block`) + the **OpenCueWeb** wordmark.
   - Six `DropdownMenu`s that mirror the CueGUI menu bar - **File** (Disable Job Interaction), **Cuebot Facility** (one item per facility), **Cuetopia**, **CueCommander** (both built from `NAV_MENUS` imported from `app/utils/menus.ts`), **Other** (Attributes toggle, Show Shortcuts launcher, Notify on Shortcut toggle), and a custom **Help** dropdown with a search input that searches the full `useMenuRegistry` list and renders matches as `Group > Label`.
   - The "Show Shortcuts" item dispatches a `cueweb:open-shortcuts` `CustomEvent` on `window` that `KeyboardShortcuts` (in `components/ui/shortcuts-overlay.tsx`) listens for; "Notify on Shortcut" reads/writes the `cueweb.shortcutNotifications` pref via `useShortcutNotifications()`.
   - The existing `ThemeToggle`.
@@ -185,7 +185,7 @@ loads at runtime are copies under `cueweb/public/`.
   - The companion route `app/api/health/route.ts` is a cheap JWT-signed reachability probe of the REST gateway (POST `show.ShowInterface/GetActiveShows` with a 5s `AbortController` timeout). It returns 200 in both healthy and unhealthy cases so the UI never sees an error response while polling.
   - The jobs data table dispatches `window.dispatchEvent(new CustomEvent("cueweb:jobs-refreshed", { detail: { at: ISO } }))` after each 5s reload tick; the status bar listens and updates the "last refresh" timer.
 - **`AppSessionProvider`** (`app/providers/session-provider.tsx`): Thin client wrapper around `next-auth/react`'s `SessionProvider` so `useSession()` works inside the header and any other client component.
-- **`CueWebIcon`** (`components/ui/cuewebicon.tsx`): OpenCue icon + **CueWeb** wordmark, sized off a single `height` prop. Used by the login page, LDAP login page, frame log page, and comments page. Reads the brand assets from `cueweb/public/opencue-icon-{black,white}.png`.
+- **`CueWebIcon`** (`components/ui/cuewebicon.tsx`): OpenCue icon + **OpenCueWeb** wordmark, sized off a single `height` prop. Used by the login page, LDAP login page, frame log page, and comments page. Reads the brand assets from `cueweb/public/opencue-icon-{black,white}.png`.
 - **`JobsTable`** (`app/jobs/data-table.tsx`): Main jobs dashboard table (no longer renders its own inline header - the global `AppHeader` owns that chrome). Each `TableRow` left-click dispatches `setAttributeSelection(...)` so the Attributes panel updates as the user inspects rows and also surfaces the inline Layers + Frames panel below the grid via `JobDetailsInline`. Destructive toolbar actions (Eat / Retry / Pause / Unpause / Kill) consume `useDisableJobInteraction()` and dim themselves when the safety flag is on. Wires TanStack's `columnVisibility`, `columnOrder`, and `globalFilter` state into the reducer State so each is persisted to `localStorage` (`columnVisibility`, `columnOrder`); the per-table substring filter is purely component-state.
 - **`JobDetailsInline`** (`components/ui/job-details-inline.tsx`): Inline Layers + Frames panel rendered below the Jobs table when a row is selected. Polls layers and frames every 5s with cancellation guards. Layer-row clicks toggle a frames-table filter to that layer and push the layer's attributes into the docked Attributes panel. When `useShowDependencyGraph()` is on, it also mounts `JobDependencyGraph` as a third stacked panel (`id="job-dependency-graph-panel"`) below Frames, with a header naming the focus job plus show/hide and close controls.
 - **`JobDependencyGraph`** (`components/ui/job-dependency-graph.tsx`): Read-only, interactive node graph of a job's dependency tree, built with React Flow (`@xyflow/react`) + dagre. Mirrors CueGUI's `JobMonitorGraph`. A breadth-first walk from the focus job follows both `GetDepends` (downstream) and `GetWhatDependsOnThis` (upstream, active-only), bounded by `maxDepth` (default 4) and a visited-set to break cycles. Each hop resolves a job name to its UUID via `/api/job/getjobs` anchored-regex (Cuebot rejects name-only depend lookups), memoized in a `Map` so the whole walk costs ~one lookup per distinct job. All BFS fetches go through a `silentPost` helper that bypasses `accessGetApi`, so jobs in other shows / unmonitored + pruned don't cascade into red toasts. The custom `DependencyNode` renderer truncates long names (full name in a `title` tooltip), color-codes the left border by kind (JOB/LAYER/FRAME), rings the focus job, and shows hierarchical labels for layer/frame nodes. dagre lays out fresh per call (no module-level singleton); the data fetch is keyed on `job.id` so flipping the theme doesn't re-walk the tree, and the crosshair-cursor SVG is scoped per instance via a `data-graph-id` attribute. It also fetches the focus job's layers (`ingestFocusLayers`) so a job with no cross-job depends still shows its layers. **Double-clicking** a node navigates (`onNodeNavigate(jobName)` or `router.push("/jobs/<jobName>?tab=overview")`); **right-clicking a layer node** opens a menu reusing the Layers-table actions (Auto Layout Nodes, View Dependencies / Dependency Wizard / Mark done, Reorder / Stagger, Properties, Kill / Eat / Retry / Retry Dead Frames).
@@ -194,7 +194,7 @@ loads at runtime are copies under `cueweb/public/`.
 - **`JobProgressBar` / `LayerProgressBar`** (`components/ui/{job,layer}-progress-bar.tsx`): Stacked progress bars with a hover tooltip showing per-state counts and percentages. Both delegate to the shared `<ProgressBar/>` renderer in `components/ui/progressbar.tsx`. Segment colors and ordering come from `app/utils/{job,layer}_progress_utils.ts`.
 - **`KeyboardShortcuts`** (`components/ui/shortcuts-overlay.tsx`): Global keyboard handler + cheat-sheet `Dialog` mounted once from `app/layout.tsx`. Exports `CUEWEB_REFRESH_NOW_EVENT`, `CUEWEB_FOCUS_SEARCH_EVENT`, and `CUEWEB_OPEN_SHORTCUTS_EVENT` so menu items / pages can subscribe without prop drilling. Fires a `toastSuccess(...)` on every triggered shortcut when `getShortcutNotificationsEnabled()` returns true (read imperatively so the latest pref applies on the next keypress).
 
-- **`AboutDialog`** (`components/ui/about-dialog.tsx`): CueGUI parity for Help → About. A `Dialog` mounted once from `app/layout.tsx`, opened via the exported `CUEWEB_OPEN_ABOUT_EVENT` (dispatched by the About CueWeb command in `useMenuRegistry`). Shows the build version (`NEXT_PUBLIC_APP_VERSION`) and SHA (`NEXT_PUBLIC_GIT_SHA`), the active facility (`useCuebotFacility`), the REST gateway URL masked by `maskGatewayUrl()` (scheme + port + first/last host chars, path/userinfo stripped), the Apache-2.0 license link, and credits. **Copy diagnostics** writes the fields (incl. the *masked* gateway) as JSON to the clipboard. The version is resolved at build time in `next.config.js`: `NEXT_PUBLIC_APP_VERSION` env wins, else `cueweb/OVERRIDE_CUEWEB_VERSION.in` (the `VERSION.in` sentinel reads the repo-root `VERSION.in`, supplied to the Docker build via the `project_root` named context; any other value pins an explicit version), else `package.json`.
+- **`AboutDialog`** (`components/ui/about-dialog.tsx`): CueGUI parity for Help → About. A `Dialog` mounted once from `app/layout.tsx`, opened via the exported `CUEWEB_OPEN_ABOUT_EVENT` (dispatched by the About OpenCueWeb command in `useMenuRegistry`). Shows the build version (`NEXT_PUBLIC_APP_VERSION`) and SHA (`NEXT_PUBLIC_GIT_SHA`), the active facility (`useCuebotFacility`), the REST gateway URL masked by `maskGatewayUrl()` (scheme + port + first/last host chars, path/userinfo stripped), the Apache-2.0 license link, and credits. **Copy diagnostics** writes the fields (incl. the *masked* gateway) as JSON to the clipboard. The version is resolved at build time in `next.config.js`: `NEXT_PUBLIC_APP_VERSION` env wins, else `cueweb/OVERRIDE_CUEWEB_VERSION.in` (the `VERSION.in` sentinel reads the repo-root `VERSION.in`, supplied to the Docker build via the `project_root` named context; any other value pins an explicit version), else `package.json`.
 - **`FrameViewer`**: Frame log viewer component. The frame log page (`app/frames/[frame-name]/page.tsx`) branches on `isLokiEnabled()`: by default it reads the on-disk `.rqlog` inline; when `NEXT_PUBLIC_LOKI_URL` is set it renders `LokiLogView` (`app/frames/[frame-name]/loki-log-view.tsx`) instead, which reuses the same Monaco editor, **Log versions** dropdown, and empty/loading states. See [Frame log backends](#frame-log-backends-file-based-and-loki).
 - **`SearchBar`**: Job search and filtering
 - **`ThemeProvider`**: Dark/light theme management
@@ -215,7 +215,7 @@ Subscriptions are stored as a `Record<jobId, JobSubscription>` under the `localS
 
 #### Application state hooks
 
-CueWeb keeps global UI state (which menus you toggled, which facility you
+OpenCueWeb keeps global UI state (which menus you toggled, which facility you
 picked, where you docked the Attributes panel) outside of React Context.
 Each piece of state lives in its own `localStorage` key with a module-level
 helper that broadcasts changes via a `CustomEvent` (same tab) and the
@@ -272,7 +272,7 @@ provider tree.
   &mdash; returns a flat `MenuCommand[]` aggregated from every menu in the
   app, plus a `filterMenuCommands(commands, query)` helper used by the
   Help search box. The Help group includes the external links from
-  `help_menu.ts` plus an **About CueWeb** command whose `run()` dispatches
+  `help_menu.ts` plus an **About OpenCueWeb** command whose `run()` dispatches
   `CUEWEB_OPEN_ABOUT_EVENT` to open the About dialog.
 - **`useShortcutNotifications`** (`app/utils/use_shortcut_notifications.ts`)
   &mdash; `{ enabled, setEnabled, toggle }`. Controls whether triggered
@@ -299,7 +299,7 @@ links and their env-var overrides live in `app/utils/help_menu.ts`.
 
 ### Cross-component window events
 
-CueWeb keeps cross-component wiring decoupled by dispatching `CustomEvent`s
+OpenCueWeb keeps cross-component wiring decoupled by dispatching `CustomEvent`s
 on `window` instead of prop-drilling shared state. Existing events:
 
 | Event | Dispatched by | Listened to by | Purpose |
@@ -324,7 +324,7 @@ cover the same-tab case.
 
 ### Table `meta` extensions
 
-TanStack tables thread shared callbacks to cell renderers via `useReactTable({ meta })`. CueWeb attaches the following keys:
+TanStack tables thread shared callbacks to cell renderers via `useReactTable({ meta })`. OpenCueWeb attaches the following keys:
 
 | Key | Type | Producer | Consumer | Purpose |
 |-----|------|----------|----------|---------|
@@ -366,24 +366,24 @@ graph TD
 <div class="mermaid">
 sequenceDiagram
     participant User
-    participant CueWeb
+    participant OpenCueWeb
     participant NextAuth
     participant OAuth
     participant API
 
-    User->>CueWeb: Access protected page
-    CueWeb->>NextAuth: Check auth status
+    User->>OpenCueWeb: Access protected page
+    OpenCueWeb->>NextAuth: Check auth status
     NextAuth->>OAuth: Redirect for login
     OAuth->>NextAuth: Return auth token
-    NextAuth->>CueWeb: Set session
-    CueWeb->>API: Generate JWT token
-    API->>CueWeb: Return API access token
-    CueWeb->>User: Show authenticated UI
+    NextAuth->>OpenCueWeb: Set session
+    OpenCueWeb->>API: Generate JWT token
+    API->>OpenCueWeb: Return API access token
+    OpenCueWeb->>User: Show authenticated UI
 </div>
 
 ### Authorization (group-based access gate)
 
-On top of authentication, CueWeb has an optional, opt-in authorization layer that restricts access by group membership. Files involved:
+On top of authentication, OpenCueWeb has an optional, opt-in authorization layer that restricts access by group membership. Files involved:
 
 ```text
 lib/authz.ts                 # pure, Edge-safe policy helpers + group extraction
@@ -411,9 +411,9 @@ Middleware flow: when the gate is inactive (disabled, or no auth provider) it is
 
 ---
 
-## CueWeb Audit (web action audit trail)
+## OpenCueWeb Audit (web action audit trail)
 
-CueWeb records **who** did **what**, **when**, against **which** target, and with **what outcome**, and surfaces the trail in an admin-only screen (**Admin &rarr; CueWeb Audit**). The whole feature is built on top of two pieces that already exist in the codebase - the single gateway chokepoint (`handleRoute`) and the group-based authorization layer (see [Authorization](#authorization-group-based-access-gate)) - so it adds **no** new infrastructure (no database, no ORM) and requires **no** changes to the ~120 individual route files.
+OpenCueWeb records **who** did **what**, **when**, against **which** target, and with **what outcome**, and surfaces the trail in an admin-only screen (**Admin &rarr; OpenCueWeb Audit**). The whole feature is built on top of two pieces that already exist in the codebase - the single gateway chokepoint (`handleRoute`) and the group-based authorization layer (see [Authorization](#authorization-group-based-access-gate)) - so it adds **no** new infrastructure (no database, no ORM) and requires **no** changes to the ~120 individual route files.
 
 ### File layout
 
@@ -432,11 +432,11 @@ cueweb/
 └── app/__tests__/lib/authz-admin.test.ts    # Effective-admin gating unit tests
 ```
 
-The store deliberately mirrors the JSONL pattern already proven by `lib/facility-store.ts`, so CueWeb stays stateless and the feature is just a file to operate.
+The store deliberately mirrors the JSONL pattern already proven by `lib/facility-store.ts`, so OpenCueWeb stays stateless and the feature is just a file to operate.
 
 ### Where events are captured (the chokepoint)
 
-Every state-changing CueWeb action is proxied to the OpenCue REST gateway through exactly one function - `handleRoute()` in `app/utils/gateway_server.ts` (used by ~120 routes). After each proxied call it invokes `auditGatewayCall(endpoint, method, body, ok, error)` from `lib/audit.ts`. Instrumenting that single function captures all ~40 mutating action routes (`/api/job/action/*`, `/api/host/action/*`, show/allocation/limit/subscription edits, job submit, ...) **with zero changes to the route files**, because `handleRoute` is the one place where the signed-in user (NextAuth `getServerSession`), the selected facility (the `cueweb.facility` cookie), and the gRPC endpoint are all available together.
+Every state-changing OpenCueWeb action is proxied to the OpenCue REST gateway through exactly one function - `handleRoute()` in `app/utils/gateway_server.ts` (used by ~120 routes). After each proxied call it invokes `auditGatewayCall(endpoint, method, body, ok, error)` from `lib/audit.ts`. Instrumenting that single function captures all ~40 mutating action routes (`/api/job/action/*`, `/api/host/action/*`, show/allocation/limit/subscription edits, job submit, ...) **with zero changes to the route files**, because `handleRoute` is the one place where the signed-in user (NextAuth `getServerSession`), the selected facility (the `cueweb.facility` cookie), and the gRPC endpoint are all available together.
 
 ```
             Next.js Route Handler (e.g. app/api/job/action/kill/route.ts)
@@ -473,7 +473,7 @@ Append-only JSONL, one JSON record per line, newest appended last:
 
 `GET /api/admin/audit` (`app/api/admin/audit/route.ts`, admin-gated) accepts filters (`actor`, `category`, `result`, `since`, `until`, `search`) plus pagination (`limit`, `offset`) and returns `{ records, total, facets: { actors, categories } }`. The page `app/admin/audit/page.tsx` is an admin-gated server component that does the access check and renders SSR initial data into the client table `app/admin/audit/audit-table.tsx`, which provides the filter controls, page-based pagination, auto-refresh, expandable per-row details, and CSV export.
 
-![CueWeb Audit page](/assets/images/cueweb/cueweb_admin_cueweb_audit.png)
+![OpenCueWeb Audit page](/assets/images/cueweb/cueweb_admin_cueweb_audit.png)
 
 ### Auth events (`lib/auth.ts`)
 
@@ -508,9 +508,9 @@ Each JSONL line is one record:
 ### Where to extend
 
 - **Capture a new action.** No route change is needed - adjust the classifier in `lib/audit.ts` (the read-skip predicate, the category/action mapping, or the target extractor).
-- **Swap the storage backend (future).** The page and API are structured so the storage behind `readAudit()` can be replaced - for example a Cuebot `audit_log` table (Flyway migration) plus a query RPC, with the REST gateway forwarding the JWT subject as gRPC metadata. The CueWeb Audit page could then read from that API instead of (or in addition to) the JSONL file.
+- **Swap the storage backend (future).** The page and API are structured so the storage behind `readAudit()` can be replaced - for example a Cuebot `audit_log` table (Flyway migration) plus a query RPC, with the REST gateway forwarding the JWT subject as gRPC metadata. The OpenCueWeb Audit page could then read from that API instead of (or in addition to) the JSONL file.
 
-**Limitations.** This captures **CueWeb actions only** - actions performed from CueGUI, `cueman`, or `pycue` are not seen. The store is single-process; multiple CueWeb replicas sharing one file would want a cross-process lock or a shared store (the same caveat as `facility-store.ts`).
+**Limitations.** This captures **OpenCueWeb actions only** - actions performed from CueGUI, `cueman`, or `pycue` are not seen. The store is single-process; multiple OpenCueWeb replicas sharing one file would want a cross-process lock or a shared store (the same caveat as `facility-store.ts`).
 
 ### Tests
 
@@ -526,7 +526,7 @@ npx jest app/__tests__/lib/audit-store.test.ts app/__tests__/lib/authz-admin.tes
 
 ## CueSubmit (browser-based job submission)
 
-CueWeb implements a TypeScript port of the standalone CueSubmit CLI tool under `/cuesubmit`. The form layout mirrors the dialog one-for-one; everything that ran inside `cuesubmit.ui.Submit` now lives in React components, and everything that ran inside `cuesubmit.Submission` + `outline.backend.cue.serialize` now lives in `app/cuesubmit/lib/*.ts`.
+OpenCueWeb implements a TypeScript port of the standalone CueSubmit CLI tool under `/cuesubmit`. The form layout mirrors the dialog one-for-one; everything that ran inside `cuesubmit.ui.Submit` now lives in React components, and everything that ran inside `cuesubmit.Submission` + `outline.backend.cue.serialize` now lives in `app/cuesubmit/lib/*.ts`.
 
 ### File layout
 
@@ -660,7 +660,7 @@ Both env vars are read at module scope: `NEXT_PUBLIC_EMAIL_DOMAIN` defaults to `
 
 `handleSend` builds a `mailto:` URL with `to`, `cc`, `bcc`, `subject`, and `body` via `URLSearchParams` (and `encodeURIComponent` on the `to` part) and assigns it to `window.location.href`. The OS hands the URL off to the user's default mail client.
 
-Browsers don't let `mailto:` override the user's mail account's `From:` header, so the dialog's **From** field is informational only. CueGUI's `EmailDialog` can spoof From because it sends through CueGUI's own SMTP relay; CueWeb's mailto-based equivalent uses whatever account the user's mail client is configured with. The dialog's `DialogDescription` calls this out so the user isn't surprised.
+Browsers don't let `mailto:` override the user's mail account's `From:` header, so the dialog's **From** field is informational only. CueGUI's `EmailDialog` can spoof From because it sends through CueGUI's own SMTP relay; OpenCueWeb's mailto-based equivalent uses whatever account the user's mail client is configured with. The dialog's `DialogDescription` calls this out so the user isn't surprised.
 
 The **Send** button is disabled when `to.trim()` is empty.
 
@@ -778,7 +778,7 @@ Two completely different lifecycles:
 | State lives on | Cuebot (persisted across browsers / users / machines) | The browser (`localStorage`) |
 | Notification channel | Email sent by Cuebot | In-app toast + optional desktop popup |
 | Trigger | `AddSubscriber` RPC | Polling loop in `JobSubscriptionPoller` |
-| Cancel | Outside CueWeb (whatever Cuebot supports) | Click the bell again |
+| Cancel | Outside OpenCueWeb (whatever Cuebot supports) | Click the bell again |
 | Survives reinstall | Yes | No (per-browser store) |
 
 They can be used together: a user can both click the bell to get a
@@ -922,7 +922,7 @@ mis-picked confirm step is a no-op rather than a hang.
 `JFBF` doesn't map to a single RPC. CueGUI's `Cuedepend.createHardDepend`
 iterates source/target layer pairs that share a layer type and fires
 `LayerInterface.CreateFrameByFrameDependency` once per pair. The
-CueWeb wrapper does the same and now scales to multi-picked target
+OpenCueWeb wrapper does the same and now scales to multi-picked target
 jobs: on **Done** the wizard runs one `getLayersForJob` for this job
 plus one per picked target job in parallel, then `createHardDepend`
 walks each target job's layer list, pairs them with this job's layers
@@ -1177,7 +1177,7 @@ The dialog is mounted once at the bottom of `DataTable`, decoupled from the menu
 
 ## Unbook job dialog (CueGUI parity)
 
-The Jobs table's right-click **Unbook...** entry opens a dialog that unbooks every proc the job currently holds, with an optional **Kill unbooked frames?** checkbox that adds a second kill-confirmation phase. It is the first CueWeb action to route through `ProcInterface`. Files involved:
+The Jobs table's right-click **Unbook...** entry opens a dialog that unbooks every proc the job currently holds, with an optional **Kill unbooked frames?** checkbox that adds a second kill-confirmation phase. It is the first OpenCueWeb action to route through `ProcInterface`. Files involved:
 
 ```
 cueweb/
@@ -1564,7 +1564,7 @@ app/api/layer/action/{getdepends,getoutputpaths,markdone,reorderframes,staggerfr
 
 The frame log page (`app/frames/[frame-name]/page.tsx`) supports two backends.
 By default it reads the `.rqlog` from the render-log directory mounted into the
-CueWeb server; when `NEXT_PUBLIC_LOKI_URL` is set it pulls the log from a
+OpenCueWeb server; when `NEXT_PUBLIC_LOKI_URL` is set it pulls the log from a
 [Grafana Loki](https://grafana.com/oss/loki/) server instead, mirroring CueGUI's
 `LokiViewPlugin` (`cuegui/cuegui/plugins/LokiViewPlugin.py`). Files involved:
 
@@ -1619,7 +1619,7 @@ for the current attempt.
 
 Because `NEXT_PUBLIC_LOKI_URL` is a `NEXT_PUBLIC_*` var, the fetches run in the
 browser: the Loki host must be reachable from clients and must allow CORS from
-the CueWeb origin. RQD must be configured to ship frame logs to Loki tagged with
+the OpenCueWeb origin. RQD must be configured to ship frame logs to Loki tagged with
 `frame_id` and `session_start_time` labels.
 
 ---
@@ -1806,7 +1806,7 @@ rather than unqualified success.
 
 ## Plugin system
 
-CueWeb has a minimal plugin architecture - the browser counterpart of the CueGUI
+OpenCueWeb has a minimal plugin architecture - the browser counterpart of the CueGUI
 plugin system (`cuegui/cuegui/Plugins.py`, `cuegui/cuegui/cueguiplugin/loader.py`).
 A plugin is a **manifest** plus a **lazily-loaded React component** that mounts on
 its own route under `/plugins/<name>`. Files involved:
@@ -1997,7 +1997,7 @@ npm run build -- --analyze
 
 ### OpenCue REST Gateway
 
-CueWeb communicates with OpenCue through the REST Gateway using JWT authentication.
+OpenCueWeb communicates with OpenCue through the REST Gateway using JWT authentication.
 
 #### API Client Setup
 
@@ -2055,7 +2055,7 @@ export function createJWTToken(secret: string, userId: string): string {
 
 ### Job Comments
 
-CueWeb implements the CueGUI Comments dialog (`cuegui/cuegui/Comments.py`) via four proxy routes that wrap the underlying gRPC services.
+OpenCueWeb implements the CueGUI Comments dialog (`cuegui/cuegui/Comments.py`) via four proxy routes that wrap the underlying gRPC services.
 
 #### Proxy routes
 
@@ -2483,7 +2483,7 @@ export function Button({ className, variant, size, ...props }: ButtonProps) {
 
 ## Usage metrics (Prometheus + Grafana)
 
-CueWeb exposes per-user usage metrics at `GET /api/metrics` (Prometheus text)
+OpenCueWeb exposes per-user usage metrics at `GET /api/metrics` (Prometheus text)
 so operators can see *who uses what, how often, and how fast*. Bounded
 cardinality is the design constraint: `page` / `action` label values come from
 fixed allow-lists, and the API counters carry no `user` label. Files involved:
@@ -2533,7 +2533,7 @@ app/utils/api_utils.ts            # accessActionApi calls trackActionEndpoint (p
 
 Prometheus scrapes `cueweb:3000/api/metrics`
 (`sandbox/config/prometheus-monitoring.yml`); Grafana auto-provisions
-`sandbox/config/grafana/dashboards/cueweb-usage.json` ("CueWeb User Usage", with
+`sandbox/config/grafana/dashboards/cueweb-usage.json` ("OpenCueWeb User Usage", with
 a `$user` variable). Use a fixed `[5m]` rate window for the latency percentile
 panels. Opt out of the client beacon with `NEXT_PUBLIC_USAGE_TRACKING=off`.
 

--- a/docs/_docs/developer-guide/sandbox-testing.md
+++ b/docs/_docs/developer-guide/sandbox-testing.md
@@ -6,7 +6,7 @@ layout: default
 date: 2025-08-06
 description: >
   Learn how to quickly set up and use the OpenCue sandbox environment
-  for local testing and development with Cuebot, RQD, CueGUI, CueSubmit, CueWeb, REST Gateway,
+  for local testing and development with Cuebot, RQD, CueGUI, CueSubmit, OpenCueWeb, REST Gateway,
   CueAdmin, CueCmd, CueMan, CueNimby, PyCue, and PyOutline.
 ---
 
@@ -133,7 +133,7 @@ The full stack deployment includes:
 
 Once deployed, access the services at:
 
-- **CueWeb UI**: [http://localhost:3000](http://localhost:3000)
+- **OpenCueWeb UI**: [http://localhost:3000](http://localhost:3000)
 - **REST Gateway**: [http://localhost:8448](http://localhost:8448)
 - **Cuebot gRPC**: localhost:8443
 - **PostgreSQL**: localhost:5432
@@ -142,7 +142,7 @@ Once deployed, access the services at:
 
 ### Using Desktop Client Tools
 
-The full stack deployment works with all OpenCue desktop client tools. To use them alongside CueWeb, install the client packages in a Python virtual environment:
+The full stack deployment works with all OpenCue desktop client tools. To use them alongside OpenCueWeb, install the client packages in a Python virtual environment:
 
 ```bash
 # Create and activate virtual environment
@@ -261,7 +261,7 @@ To verify your sandbox is working correctly:
 
 2. Click "Submit" to send the job to Cuebot
 
-3. Monitor the job in CueGUI or CueWeb:
+3. Monitor the job in CueGUI or OpenCueWeb:
    - You should see your job appear in the Jobs panel
    - The frames should begin processing on the RQD host
    - Each frame will sleep for 5 seconds then complete
@@ -270,9 +270,9 @@ To verify your sandbox is working correctly:
 
 Your sandbox is working correctly if:
 - Docker containers are running without errors
-- CueGUI/CueWeb connects to Cuebot and shows the RQD host
+- CueGUI/OpenCueWeb connects to Cuebot and shows the RQD host
 - CueSubmit can submit jobs successfully
-- Jobs appear in CueGUI/CueWeb and frames complete
+- Jobs appear in CueGUI/OpenCueWeb and frames complete
 
 ## Common Use Cases
 
@@ -335,7 +335,7 @@ If you encounter port conflicts, check these default ports:
 | PostgreSQL | 5432 |
 | RQD | 8444 |
 | REST Gateway | 8448 |
-| CueWeb | 3000 |
+| OpenCueWeb | 3000 |
 
 Ensure these ports are not in use by other applications.
 
@@ -355,12 +355,12 @@ If CueGUI cannot connect to Cuebot:
 - Check the Cuebot logs for errors
 - Ensure you're using the correct config file
 
-### CueWeb Not Loading
+### OpenCueWeb Not Loading
 
-If CueWeb is not responding:
+If OpenCueWeb is not responding:
 - Check that rest-gateway is healthy: `docker compose ps`
 - Verify the JWT secret is set correctly
-- Check CueWeb logs: `docker compose logs -f cueweb`
+- Check OpenCueWeb logs: `docker compose logs -f cueweb`
 
 ### REST Gateway Authentication Errors
 

--- a/docs/_docs/developer-guide/scheduler-stress-testing.md
+++ b/docs/_docs/developer-guide/scheduler-stress-testing.md
@@ -154,7 +154,7 @@ workflow.
 
 ### When it deliberately does not run
 
-- **PRs that don't touch the scheduler or schema** (Python, CueGUI, CueWeb,
+- **PRs that don't touch the scheduler or schema** (Python, CueGUI, OpenCueWeb,
   docs, …). The suite needs a migrated Postgres, a Docker daemon, and several
   minutes of runner time; for those changes it produces zero signal.
 - **As a performance gate.** Shared CI runners have noisy CPU/IO, so the

--- a/docs/_docs/getting-started/deploying-cueweb.md
+++ b/docs/_docs/getting-started/deploying-cueweb.md
@@ -1,14 +1,14 @@
 ---
 layout: default
-title: Deploying CueWeb
+title: Deploying OpenCueWeb
 parent: Getting Started
 nav_order: 31
 ---
 
-# Deploying CueWeb
+# Deploying OpenCueWeb
 {: .no_toc }
 
-Deploy and configure CueWeb for production use in your OpenCue render farm.
+Deploy and configure OpenCueWeb for production use in your OpenCue render farm.
 
 <details open markdown="block">
   <summary>
@@ -23,11 +23,11 @@ Deploy and configure CueWeb for production use in your OpenCue render farm.
 
 ## Overview
 
-CueWeb is a web-based interface for OpenCue that provides job management, monitoring, and control capabilities through a browser. This guide covers production deployment options for CueWeb.
+OpenCueWeb is a web-based interface for OpenCue that provides job management, monitoring, and control capabilities through a browser. This guide covers production deployment options for OpenCueWeb.
 
 ### Prerequisites
 
-Before deploying CueWeb, ensure you have:
+Before deploying OpenCueWeb, ensure you have:
 
 - **OpenCue REST Gateway** deployed and accessible
 - **Node.js** (version 18 or later) for building from source
@@ -39,20 +39,20 @@ Before deploying CueWeb, ensure you have:
 
 ## Quick Deployment with Docker
 
-### Build CueWeb Image
+### Build OpenCueWeb Image
 
 ```bash
-# Navigate to CueWeb directory
+# Navigate to OpenCueWeb directory
 cd cueweb
 
 # Build Docker image
 docker build -t cueweb:latest .
 ```
 
-### Run CueWeb Container
+### Run OpenCueWeb Container
 
 ```bash
-# Run CueWeb with basic configuration
+# Run OpenCueWeb with basic configuration
 docker run -d \
   --name cueweb \
   -p 3000:3000 \
@@ -75,14 +75,14 @@ docker logs cueweb
 curl http://localhost:3000
 ```
 
-Open `http://localhost:3000` in a browser. With no authentication provider configured the login page shows a single **CueWeb Home** button; with providers enabled it shows the matching sign-in buttons.
+Open `http://localhost:3000` in a browser. With no authentication provider configured the login page shows a single **OpenCueWeb Home** button; with providers enabled it shows the matching sign-in buttons.
 
-![CueWeb login page](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_login.png)
+![OpenCueWeb login page](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_login.png)
 
 
-After signing in (or clicking **CueWeb Home**), you land on the Dashboard, confirming the deployment is healthy.
+After signing in (or clicking **OpenCueWeb Home**), you land on the Dashboard, confirming the deployment is healthy.
 
-![CueWeb dashboard](/assets/images/cueweb/cueweb_dashboard.png)
+![OpenCueWeb dashboard](/assets/images/cueweb/cueweb_dashboard.png)
 
 
 ---
@@ -98,7 +98,7 @@ Create a production environment file:
 NEXT_PUBLIC_OPENCUE_ENDPOINT=https://api.renderfarm.company.com
 # Leave empty if the UI and the API are served from the same origin
 # (the common case): the client will build same-origin relative URLs
-# and CueWeb works correctly when accessed from any host. Only set
+# and OpenCueWeb works correctly when accessed from any host. Only set
 # this to an absolute URL when the API really lives on a different
 # origin than the UI.
 NEXT_PUBLIC_URL=
@@ -110,7 +110,7 @@ NEXT_TELEMETRY_DISABLED=1
 
 # Authentication (optional)
 # Comma-separated list of providers to enable on the /login page.
-# When empty, /login renders only a "CueWeb Home" button. The global
+# When empty, /login renders only a "OpenCueWeb Home" button. The global
 # header's Sign out button is always rendered regardless of this value;
 # clicking it routes to /login.
 NEXT_PUBLIC_AUTH_PROVIDER=okta,google,ldap
@@ -144,10 +144,10 @@ NEXTAUTH_SECRET=nextauth-production-secret
 # hidden from non-admins.
 # CUEWEB_FACILITY_STORE=/data/cueweb/facilities.json
 
-# CueWeb Audit trail (optional)
-# Path to the append-only JSONL file where CueWeb records state-changing
+# OpenCueWeb Audit trail (optional)
+# Path to the append-only JSONL file where OpenCueWeb records state-changing
 # actions and sign in / sign out events (who, what, when, target, facility,
-# outcome) for the admin-only Admin -> CueWeb Audit page. It defaults to a
+# outcome) for the admin-only Admin -> OpenCueWeb Audit page. It defaults to a
 # file in the OS temp dir (cueweb-audit.jsonl); point it at a mounted volume
 # to keep the trail across container restarts. The file is written 0600 with
 # in-process write serialization.
@@ -164,16 +164,16 @@ NEXTAUTH_SECRET=nextauth-production-secret
 # NEXT_PUBLIC_SUGGESTIONS_URL=https://github.com/AcademySoftwareFoundation/OpenCue/issues/new?labels=enhancement&template=enhancement.md
 # NEXT_PUBLIC_BUGS_URL=https://github.com/AcademySoftwareFoundation/OpenCue/issues/new?labels=bug&template=bug_report.md
 
-# Build version shown in the bottom status bar and the About CueWeb dialog
+# Build version shown in the bottom status bar and the About OpenCueWeb dialog
 # (optional). When unset it is resolved at build time from
 # cueweb/OVERRIDE_CUEWEB_VERSION.in: the "VERSION.in" sentinel (default) tracks
 # the repo-root VERSION.in (OpenCue's shared version), and any other value pins
-# an explicit CueWeb version; package.json is the last-resort fallback. In CI
+# an explicit OpenCueWeb version; package.json is the last-resort fallback. In CI
 # you typically override it with the generated version or a release tag:
 # `docker build --build-arg NEXT_PUBLIC_APP_VERSION=$(cat VERSION.in)`.
 # NEXT_PUBLIC_APP_VERSION=1.25
 #
-# Short Git SHA shown in the About CueWeb dialog (optional, build-time only).
+# Short Git SHA shown in the About OpenCueWeb dialog (optional, build-time only).
 # CI injects `--build-arg NEXT_PUBLIC_GIT_SHA=$(git rev-parse --short HEAD)`;
 # empty renders as "unknown".
 # NEXT_PUBLIC_GIT_SHA=
@@ -197,9 +197,9 @@ NEXTAUTH_SECRET=nextauth-production-secret
 # Optional Loki log backend. When set, the frame log viewer queries this
 # Grafana Loki server (by frame_id) instead of reading the on-disk .rqlog
 # file, mirroring CueGUI's Loki log viewer. Leave unset to use the default
-# file-based viewer. Base URL only (no trailing path; CueWeb appends
+# file-based viewer. Base URL only (no trailing path; OpenCueWeb appends
 # /loki/api/v1/...). The query runs in the browser, so Loki must be reachable
-# from clients and allow CORS from the CueWeb origin. Inlined at build time, so
+# from clients and allow CORS from the OpenCueWeb origin. Inlined at build time, so
 # pass it as a Docker build arg:
 #   docker build --build-arg NEXT_PUBLIC_LOKI_URL=http://your-loki-host:3100 ...
 # NEXT_PUBLIC_LOKI_URL=http://your-loki-host:3100
@@ -509,9 +509,9 @@ spec:
 
 LDAP authentication allows users to authenticate using their company directory credentials. This is useful for intranet deployments where OAuth providers may not be available.
 
-![CueWeb LDAP login button](/assets/images/cueweb/cueweb-ldap-button.png)
+![OpenCueWeb LDAP login button](/assets/images/cueweb/cueweb-ldap-button.png)
 
-![CueWeb LDAP login page](/assets/images/cueweb/cueweb-ldap-login-password-page.png)
+![OpenCueWeb LDAP login page](/assets/images/cueweb/cueweb-ldap-login-password-page.png)
 
 1. Configure the LDAP environment variables:
    ```bash
@@ -548,14 +548,14 @@ For development or internal deployments without authentication:
 # In .env file, comment out or remove:
 # NEXT_PUBLIC_AUTH_PROVIDER=okta,google
 
-# CueWeb will run without authentication requirements
+# OpenCueWeb will run without authentication requirements
 ```
 
-CueWeb runs unauthenticated in this mode.
+OpenCueWeb runs unauthenticated in this mode.
 
 ### Authorization (group-based access control)
 
-On top of authentication (*who* you are), CueWeb supports an optional, opt-in group-based authorization gate (*what* you may do), enforced server-side in `middleware.ts`. It can restrict who may use CueWeb at all, and limit the entire CueCommander section, job submission (CueSubmit) and the Manage facilities… screen to specific groups.
+On top of authentication (*who* you are), OpenCueWeb supports an optional, opt-in group-based authorization gate (*what* you may do), enforced server-side in `middleware.ts`. It can restrict who may use OpenCueWeb at all, and limit the entire CueCommander section, job submission (CueSubmit) and the Manage facilities… screen to specific groups.
 
 The gate is **off by default** and all variables are optional, so behavior is unchanged unless you configure it:
 
@@ -563,7 +563,7 @@ The gate is **off by default** and all variables are optional, so behavior is un
 # Enable the gate (opt-in; default off)
 CUEWEB_AUTHZ_ENABLED=true
 
-# Groups allowed to use CueWeb at all (empty = every signed-in user)
+# Groups allowed to use OpenCueWeb at all (empty = every signed-in user)
 CUEWEB_ALLOWED_GROUPS=
 
 # Groups allowed on the entire CueCommander section + CueSubmit + Manage facilities (empty = every signed-in user)
@@ -581,11 +581,11 @@ Notes:
 
 ---
 
-## CueWeb Audit trail
+## OpenCueWeb Audit trail
 
-CueWeb records an audit trail of every state-changing action taken through the UI (job/layer/frame/host/group/proc operations such as Kill, Eat, Retry, Pause, Redirect, host lock/reboot, facility-override edits, and so on) plus each **sign in** and **sign out**. Each record captures **who** (the signed-in user), **what** (the action), **when** (timestamp), the **target** it acted on, the **facility** it ran against, and the **outcome** (success or failure). The trail is browsable on the admin-only **Admin -> CueWeb Audit** page (reachable from both the top menu and the left sidebar).
+OpenCueWeb records an audit trail of every state-changing action taken through the UI (job/layer/frame/host/group/proc operations such as Kill, Eat, Retry, Pause, Redirect, host lock/reboot, facility-override edits, and so on) plus each **sign in** and **sign out**. Each record captures **who** (the signed-in user), **what** (the action), **when** (timestamp), the **target** it acted on, the **facility** it ran against, and the **outcome** (success or failure). The trail is browsable on the admin-only **Admin -> OpenCueWeb Audit** page (reachable from both the top menu and the left sidebar).
 
-![CueWeb Audit page](/assets/images/cueweb/cueweb_admin_cueweb_audit.png)
+![OpenCueWeb Audit page](/assets/images/cueweb/cueweb_admin_cueweb_audit.png)
 
 ### Audit trail persistence
 
@@ -606,26 +606,26 @@ The file is written with mode `0600`.
 
 **Size bounding.** `CUEWEB_AUDIT_MAX_RECORDS` caps how many records the trail retains; once the cap is reached, the **oldest records are dropped** on each new write. It defaults to `50000`; set it to `0` for an unbounded trail (in which case you are responsible for rotating or archiving the file yourself).
 
-**Access control.** The CueWeb Audit page is admin-gated through the same [group-based authorization](#authorization-group-based-access-control) mechanism as the other admin pages - enable the gate with `CUEWEB_AUTHZ_ENABLED=true` and list the allowed groups in `CUEWEB_ADMIN_GROUPS`. With no group authorization configured (the gate off, or `CUEWEB_ADMIN_GROUPS` empty), the page is **visible to everyone** who can reach CueWeb, so configure the admin gate if the trail should be restricted.
+**Access control.** The OpenCueWeb Audit page is admin-gated through the same [group-based authorization](#authorization-group-based-access-control) mechanism as the other admin pages - enable the gate with `CUEWEB_AUTHZ_ENABLED=true` and list the allowed groups in `CUEWEB_ADMIN_GROUPS`. With no group authorization configured (the gate off, or `CUEWEB_ADMIN_GROUPS` empty), the page is **visible to everyone** who can reach OpenCueWeb, so configure the admin gate if the trail should be restricted.
 
-**Multi-instance caveat.** The single-file store assumes a **single CueWeb instance**: concurrent appends are kept from interleaving by **in-process** write serialization only. If you run multiple replicas (for example the `replicas: 3` deployment above) all pointed at the same file, that in-process lock does not span processes - you would need a shared store with a cross-process lock, or a separate `CUEWEB_AUDIT_STORE` per replica, to avoid corrupting the trail.
+**Multi-instance caveat.** The single-file store assumes a **single OpenCueWeb instance**: concurrent appends are kept from interleaving by **in-process** write serialization only. If you run multiple replicas (for example the `replicas: 3` deployment above) all pointed at the same file, that in-process lock does not span processes - you would need a shared store with a cross-process lock, or a separate `CUEWEB_AUDIT_STORE` per replica, to avoid corrupting the trail.
 
 ---
 
 ## CueSubmit (browser-based job submission)
 
-The `/cuesubmit` route is a TypeScript port of the standalone CueSubmit CLI tool. It reuses the same REST gateway + cuebot path as the rest of CueWeb, so no extra services or env vars are needed.
+The `/cuesubmit` route is a TypeScript port of the standalone CueSubmit CLI tool. It reuses the same REST gateway + cuebot path as the rest of OpenCueWeb, so no extra services or env vars are needed.
 
 **Submit path**:
 1. Browser POSTs the form payload to `/api/job/submit` (the Next.js Node route).
 2. The route validates with zod, builds the OpenCue cjsl XML job spec server-side (same format pyoutline emits), and forwards it to `job.JobInterface/LaunchSpecAndWait` on the REST gateway.
-3. Cuebot creates the job and returns the resolved `JobSeq`. CueWeb redirects the browser to `/jobs/<name>` so the user can watch frames dispatch live.
+3. Cuebot creates the job and returns the resolved `JobSeq`. OpenCueWeb redirects the browser to `/jobs/<name>` so the user can watch frames dispatch live.
 
 **Sandbox-tuned defaults**: the form chooses values that produce a runnable job against the seeded sandbox out of the box:
 
 - **Memory** default `256m`. The seeded `default` service has a 3.2 GB minimum which most sandbox RQDs can't satisfy; without a smaller request, trivial test jobs sit in WAITING forever.
 - **Facility** default `local` (when the user picks `[Default]` in the form). Cuebot's internal fallback is `cloud`, which doesn't match the seeded sandbox RQD's `local.general` allocation.
-- **Per-user deterministic UID** in the range 1000-65000. Cuebot rejects `uid=0` with `Cannot launch jobs as root`, so CueWeb never emits zero.
+- **Per-user deterministic UID** in the range 1000-65000. Cuebot rejects `uid=0` with `Cannot launch jobs as root`, so OpenCueWeb never emits zero.
 
 **Production deployments**: change Memory to whatever the real services expect, override Facility from the dropdown if your deployment has more than one, and confirm `NEXT_PUBLIC_CUEBOT_FACILITIES` enumerates every facility the user should be able to pick.
 
@@ -635,9 +635,9 @@ The form auto-saves a draft to `localStorage` on every keystroke and keeps per-f
 
 ## Redirect tool
 
-The `/redirect` route (CueCommander &rarr; Redirect) reassigns the cores of busy procs to a target job. It ships with CueWeb and needs **no extra services or env vars** - it uses the same REST gateway + cuebot path as the rest of the app (RPCs `ProcInterface/GetProcs`, `HostInterface/FindHost`, `JobInterface/GetJobs` for the search, and `HostInterface/RedirectToJob` for the action).
+The `/redirect` route (CueCommander &rarr; Redirect) reassigns the cores of busy procs to a target job. It ships with OpenCueWeb and needs **no extra services or env vars** - it uses the same REST gateway + cuebot path as the rest of the app (RPCs `ProcInterface/GetProcs`, `HostInterface/FindHost`, `JobInterface/GetJobs` for the search, and `HostInterface/RedirectToJob` for the action).
 
-**It is a destructive administrative tool**: redirecting kills the frames currently running on the selected procs so their cores can be handed to the target job. Treat access to CueWeb accordingly - anyone who can reach the UI can issue redirects. If your deployment needs to restrict who can perform farm-wide actions, gate it at the authentication / reverse-proxy layer (CueWeb does not implement per-action role checks).
+**It is a destructive administrative tool**: redirecting kills the frames currently running on the selected procs so their cores can be handed to the target job. Treat access to OpenCueWeb accordingly - anyone who can reach the UI can issue redirects. If your deployment needs to restrict who can perform farm-wide actions, gate it at the authentication / reverse-proxy layer (OpenCueWeb does not implement per-action role checks).
 
 ---
 
@@ -651,15 +651,15 @@ The `/monitor-cue` route (CueCommander &rarr; Monitor Cue) needs **no extra serv
 
 The `/hosts` route (CueCommander &rarr; Monitor Hosts) and its bottom proc panel need **no extra services or env vars** - all host and proc operations go through the same REST gateway + cuebot path as the rest of the app (`HostInterface` for lock/unlock, reboot, tags, allocation, hardware/repair state, comments, and delete; `ProcInterface` for the proc list, unbook, and kill).
 
-Several of these are **destructive administrative actions** (Reboot kills running frames, Delete Host removes the record, Kill/Unbook stop procs). As with the Redirect tool, CueWeb does not implement per-action role checks, so if you need to limit who can perform them, gate access at the authentication / reverse-proxy layer or with the optional [group-based authorization](#authorization-group-based-access-control) admin gate (`/hosts` is one of the CueCommander admin pages). Predefined host-comment macros are stored per browser in `localStorage`, so they need no server-side storage.
+Several of these are **destructive administrative actions** (Reboot kills running frames, Delete Host removes the record, Kill/Unbook stop procs). As with the Redirect tool, OpenCueWeb does not implement per-action role checks, so if you need to limit who can perform them, gate access at the authentication / reverse-proxy layer or with the optional [group-based authorization](#authorization-group-based-access-control) admin gate (`/hosts` is one of the CueCommander admin pages). Predefined host-comment macros are stored per browser in `localStorage`, so they need no server-side storage.
 
 ---
 
 ## Stuck Frames page (log access)
 
-The `/stuck-frames` route (CueCommander &rarr; Stuck Frame) finds running frames that have stopped writing to their logs. It ships with CueWeb and needs no extra services - it reads running frames through the same REST gateway + cuebot path as the rest of the app. The one deployment-specific concern is **frame-log access**, which powers the page's **Last Line** column and the Tail/View Log actions.
+The `/stuck-frames` route (CueCommander &rarr; Stuck Frame) finds running frames that have stopped writing to their logs. It ships with OpenCueWeb and needs no extra services - it reads running frames through the same REST gateway + cuebot path as the rest of the app. The one deployment-specific concern is **frame-log access**, which powers the page's **Last Line** column and the Tail/View Log actions.
 
-**Mount the render log directory into the CueWeb container, read-only.** CueWeb's server reads frame logs from its own filesystem, so the directory where RQD writes logs (the sandbox uses `/tmp/rqd/logs`, matching cuebot's `CUE_FRAME_LOG_DIR`) must be visible to the CueWeb container at the same path:
+**Mount the render log directory into the OpenCueWeb container, read-only.** OpenCueWeb's server reads frame logs from its own filesystem, so the directory where RQD writes logs (the sandbox uses `/tmp/rqd/logs`, matching cuebot's `CUE_FRAME_LOG_DIR`) must be visible to the OpenCueWeb container at the same path:
 
 ```yaml
 # docker-compose.yml (cueweb service)
@@ -683,30 +683,30 @@ If the log directory is not mounted, the page still lists stuck frames, but the 
 CUEWEB_LOG_ROOTS=/net/render/logs
 ```
 
-**Using the page**: open **CueCommander &rarr; Stuck Frame**, tune the filter bar (Min LLU, % of Run Since LLU, Total Runtime) or add a per-service filter with **+**, then right-click a frame for Retry / Eat / Kill / View Log / **Core Up**. See the [CueWeb User Guide](/docs/user-guides/cueweb-user-guide/#stuck-frames) for the full walkthrough.
+**Using the page**: open **CueCommander &rarr; Stuck Frame**, tune the filter bar (Min LLU, % of Run Since LLU, Total Runtime) or add a per-service filter with **+**, then right-click a frame for Retry / Eat / Kill / View Log / **Core Up**. See the [OpenCueWeb User Guide](/docs/user-guides/cueweb-user-guide/#stuck-frames) for the full walkthrough.
 
 ## Frame log viewing (file-based or Loki)
 
 The frame log viewer has two backends, selected at deploy time:
 
-- **File-based (default):** CueWeb's server reads the `.rqlog` from its own filesystem, so mount the render-log directory into the container read-only - the **same mount described above** for the Stuck Frames page (`-v /path/to/logs:/tmp/rqd/logs:ro`). No other configuration is needed.
-- **Loki (optional):** if your studio centralizes logs in [Grafana Loki](https://grafana.com/oss/loki/), set `NEXT_PUBLIC_LOKI_URL` to the Loki HTTP API base URL (no trailing path; CueWeb appends `/loki/api/v1/...`). CueWeb then queries Loki for each frame's lines instead of reading a file, mirroring CueGUI's Loki log viewer. RQD must be configured to ship frame logs to Loki tagged with `frame_id` and `session_start_time` labels.
+- **File-based (default):** OpenCueWeb's server reads the `.rqlog` from its own filesystem, so mount the render-log directory into the container read-only - the **same mount described above** for the Stuck Frames page (`-v /path/to/logs:/tmp/rqd/logs:ro`). No other configuration is needed.
+- **Loki (optional):** if your studio centralizes logs in [Grafana Loki](https://grafana.com/oss/loki/), set `NEXT_PUBLIC_LOKI_URL` to the Loki HTTP API base URL (no trailing path; OpenCueWeb appends `/loki/api/v1/...`). OpenCueWeb then queries Loki for each frame's lines instead of reading a file, mirroring CueGUI's Loki log viewer. RQD must be configured to ship frame logs to Loki tagged with `frame_id` and `session_start_time` labels.
 
 ```bash
-# Loki backend: point CueWeb at your Loki HTTP API
+# Loki backend: point OpenCueWeb at your Loki HTTP API
 NEXT_PUBLIC_LOKI_URL=http://your-loki-host:3100
 ```
 
 Two deployment notes for the Loki backend:
 
-- **It's a build-time, browser-read variable.** `NEXT_PUBLIC_LOKI_URL` is baked into the client bundle, so set it as a Docker build arg (like the other `NEXT_PUBLIC_*` vars), not only at runtime. The Loki query runs **in the browser**, so the Loki host must be reachable from clients (not just from the CueWeb server) and must allow **CORS** from the CueWeb origin.
+- **It's a build-time, browser-read variable.** `NEXT_PUBLIC_LOKI_URL` is baked into the client bundle, so set it as a Docker build arg (like the other `NEXT_PUBLIC_*` vars), not only at runtime. The Loki query runs **in the browser**, so the Loki host must be reachable from clients (not just from the OpenCueWeb server) and must allow **CORS** from the OpenCueWeb origin.
 - **The log mount becomes optional.** With Loki configured, log viewing no longer reads from disk, so the render-log volume mount is not required for the viewer. (The Stuck Frames **Last Line** column still tails `.rqlog` files server-side, so keep the mount if you rely on that column.)
 
-When `NEXT_PUBLIC_LOKI_URL` is unset, CueWeb falls back to the file-based viewer with no other change.
+When `NEXT_PUBLIC_LOKI_URL` is unset, OpenCueWeb falls back to the file-based viewer with no other change.
 
 ## Plugins
 
-CueWeb's plugin system needs **no extra services or configuration**. Plugins are registered in the code (`cueweb/lib/plugins.ts`) and built into the image, so the only way to add or remove a plugin is at **build time** - there is no runtime plugin directory to mount and nothing to deploy alongside CueWeb. The bundled samples (Hello OpenCue, Cue Progress Bar) ship enabled per their manifest defaults.
+OpenCueWeb's plugin system needs **no extra services or configuration**. Plugins are registered in the code (`cueweb/lib/plugins.ts`) and built into the image, so the only way to add or remove a plugin is at **build time** - there is no runtime plugin directory to mount and nothing to deploy alongside OpenCueWeb. The bundled samples (Hello OpenCue, Cue Progress Bar) ship enabled per their manifest defaults.
 
 What a user does at **runtime** - which plugins show in the Plugins menu and each plugin's settings - is stored **client-side** in the browser's `localStorage` (`cueweb.plugin-menu.enabled`, `cueweb.plugin-settings.<key>`). It is per-user and per-browser, so it requires no server-side persistence and is not shared between users. To ship a custom plugin, add it to `app/plugins/<name>/`, register it, and rebuild the image (see the developer guide).
 
@@ -714,9 +714,9 @@ What a user does at **runtime** - which plugins show in the Plugins menu and eac
 
 ## Workspace layout (presets, immersive, split view)
 
-The workspace-layout features - saveable **view presets**, **immersive (full-screen) mode**, and the **split view** - need **no server-side configuration**. Like the rest of CueWeb's personalization, all state is per-user, per-browser `localStorage` (`cueweb.views.<page>`, `cueweb.layout.immersive`, `cueweb.split.ratio`); nothing is persisted on the server and nothing is shared between users.
+The workspace-layout features - saveable **view presets**, **immersive (full-screen) mode**, and the **split view** - need **no server-side configuration**. Like the rest of OpenCueWeb's personalization, all state is per-user, per-browser `localStorage` (`cueweb.views.<page>`, `cueweb.layout.immersive`, `cueweb.split.ratio`); nothing is persisted on the server and nothing is shared between users.
 
-One deployment detail to be aware of: **split view renders each pane as a same-origin `<iframe>`** of another CueWeb page (`/split?left=…&right=…`). For this to work behind a reverse proxy, the proxy and the app must allow CueWeb to frame **itself**:
+One deployment detail to be aware of: **split view renders each pane as a same-origin `<iframe>`** of another OpenCueWeb page (`/split?left=…&right=…`). For this to work behind a reverse proxy, the proxy and the app must allow OpenCueWeb to frame **itself**:
 
 - Don't send `X-Frame-Options: DENY`. If you set it, use `SAMEORIGIN`.
 - If you use a Content-Security-Policy, allow same-origin framing, e.g. `frame-ancestors 'self'`.
@@ -876,7 +876,7 @@ spec:
 
 ### Health Checks
 
-CueWeb provides health check endpoints:
+OpenCueWeb provides health check endpoints:
 
 ```bash
 # Basic health check
@@ -888,20 +888,20 @@ curl https://cueweb.company.com/api/health/detailed
 
 ### Prometheus Metrics (user usage)
 
-CueWeb exposes Prometheus usage metrics at **`GET /api/metrics`** (plain text,
+OpenCueWeb exposes Prometheus usage metrics at **`GET /api/metrics`** (plain text,
 never gated by the authorization gate). They answer *who uses what, how often,
 and how fast* - per user, per page/module, per action - with bounded
 cardinality. No setup beyond pointing Prometheus at the endpoint.
 
 The `/api/metrics` endpoint returns the metrics in Prometheus text format:
 
-![CueWeb /api/metrics endpoint - page view and action counters](/assets/images/cueweb/cueweb_user_usage_metrics_api_metrics_endpoint1.png)
+![OpenCueWeb /api/metrics endpoint - page view and action counters](/assets/images/cueweb/cueweb_user_usage_metrics_api_metrics_endpoint1.png)
 
-![CueWeb /api/metrics endpoint - per-endpoint API request counters](/assets/images/cueweb/cueweb_user_usage_metrics_api_metrics_endpoint2.png)
+![OpenCueWeb /api/metrics endpoint - per-endpoint API request counters](/assets/images/cueweb/cueweb_user_usage_metrics_api_metrics_endpoint2.png)
 
-![CueWeb /api/metrics endpoint - API request duration histogram](/assets/images/cueweb/cueweb_user_usage_metrics_api_metrics_endpoint3.png)
+![OpenCueWeb /api/metrics endpoint - API request duration histogram](/assets/images/cueweb/cueweb_user_usage_metrics_api_metrics_endpoint3.png)
 
-**1. Scrape CueWeb from Prometheus.** Add a job to your Prometheus config (the
+**1. Scrape OpenCueWeb from Prometheus.** Add a job to your Prometheus config (the
 sandbox already does this in `sandbox/config/prometheus-monitoring.yml`):
 
 ```yaml
@@ -916,15 +916,15 @@ Once scraped, the `cueweb_*` series are queryable in Prometheus:
 ![Querying a cueweb usage metric in Prometheus](/assets/images/cueweb/cueweb_user_usage_metrics_prometheus_query.png)
 
 **2. Import the Grafana dashboard.** The sandbox auto-provisions
-`sandbox/config/grafana/dashboards/cueweb-usage.json` ("CueWeb User Usage"):
+`sandbox/config/grafana/dashboards/cueweb-usage.json` ("OpenCueWeb User Usage"):
 overview stats, page/module views, actions, per-endpoint API latency
 (p50/p90/p99), and Top-N users, all filterable by a `$user` template variable.
 
-![CueWeb User Usage Grafana dashboard - overview and pages/modules](/assets/images/cueweb/cueweb_user_usage_metrics_grafana_charts1.png)
+![OpenCueWeb User Usage Grafana dashboard - overview and pages/modules](/assets/images/cueweb/cueweb_user_usage_metrics_grafana_charts1.png)
 
-![CueWeb User Usage Grafana dashboard - actions and API latency](/assets/images/cueweb/cueweb_user_usage_metrics_grafana_charts2.png)
+![OpenCueWeb User Usage Grafana dashboard - actions and API latency](/assets/images/cueweb/cueweb_user_usage_metrics_grafana_charts2.png)
 
-![CueWeb User Usage Grafana dashboard - per-user panels](/assets/images/cueweb/cueweb_user_usage_metrics_grafana_charts3.png)
+![OpenCueWeb User Usage Grafana dashboard - per-user panels](/assets/images/cueweb/cueweb_user_usage_metrics_grafana_charts3.png)
 
 **Metrics exposed:**
 
@@ -1047,7 +1047,7 @@ echo "your-jwt-secret" | docker secret create jwt_secret -
 ### Common Issues
 
 #### 502 Bad Gateway
-- Check if CueWeb container is running
+- Check if OpenCueWeb container is running
 - Verify port configuration
 - Check REST Gateway connectivity
 
@@ -1092,7 +1092,7 @@ kubectl logs -f -l app=cueweb -n opencue
 ### Updates
 
 ```bash
-# Update CueWeb
+# Update OpenCueWeb
 git pull origin master
 npm install
 npm run build
@@ -1123,7 +1123,7 @@ Monitor these metrics:
 
 ## Next Steps
 
-After deploying CueWeb:
+After deploying OpenCueWeb:
 
 1. **Configure Authentication**: Set up OAuth providers for user access
 2. **Train Users**: Provide training on the web interface
@@ -1131,6 +1131,6 @@ After deploying CueWeb:
 4. **Customize Interface**: Adapt UI for your workflow needs
 5. **Integration**: Connect with existing pipeline tools
 
-For detailed usage instructions, see the [CueWeb User Guide](/docs/user-guides/cueweb-user-guide).
+For detailed usage instructions, see the [OpenCueWeb User Guide](/docs/user-guides/cueweb-user-guide).
 
-For development and customization, see the [CueWeb Developer Guide](/docs/developer-guide/cueweb-development).
+For development and customization, see the [OpenCueWeb Developer Guide](/docs/developer-guide/cueweb-development).

--- a/docs/_docs/getting-started/deploying-cueweb.md
+++ b/docs/_docs/getting-started/deploying-cueweb.md
@@ -110,7 +110,7 @@ NEXT_TELEMETRY_DISABLED=1
 
 # Authentication (optional)
 # Comma-separated list of providers to enable on the /login page.
-# When empty, /login renders only a "OpenCueWeb Home" button. The global
+# When empty, /login renders only an "OpenCueWeb Home" button. The global
 # header's Sign out button is always rendered regardless of this value;
 # clicking it routes to /login.
 NEXT_PUBLIC_AUTH_PROVIDER=okta,google,ldap
@@ -637,7 +637,7 @@ The form auto-saves a draft to `localStorage` on every keystroke and keeps per-f
 
 The `/redirect` route (CueCommander &rarr; Redirect) reassigns the cores of busy procs to a target job. It ships with OpenCueWeb and needs **no extra services or env vars** - it uses the same REST gateway + cuebot path as the rest of the app (RPCs `ProcInterface/GetProcs`, `HostInterface/FindHost`, `JobInterface/GetJobs` for the search, and `HostInterface/RedirectToJob` for the action).
 
-**It is a destructive administrative tool**: redirecting kills the frames currently running on the selected procs so their cores can be handed to the target job. Treat access to OpenCueWeb accordingly - anyone who can reach the UI can issue redirects. If your deployment needs to restrict who can perform farm-wide actions, gate it at the authentication / reverse-proxy layer (OpenCueWeb does not implement per-action role checks).
+**It is a destructive administrative tool**: redirecting kills the frames currently running on the selected procs so their cores can be handed to the target job. When the optional group-authorization gate is active (`CUEWEB_AUTHZ_ENABLED`), `/redirect` is covered by the admin gate - like the rest of the CueCommander section, it is restricted to members of `CUEWEB_ADMIN_GROUPS`. When that gate is not configured, OpenCueWeb's "everyone is an admin" default applies and anyone who can reach the UI can issue redirects. The gate is section-level, not per-action, so if you need finer-grained control over who can perform farm-wide actions, additionally gate it at the authentication / reverse-proxy layer.
 
 ---
 

--- a/docs/_docs/getting-started/deploying-rest-gateway.md
+++ b/docs/_docs/getting-started/deploying-rest-gateway.md
@@ -32,21 +32,21 @@ You also need:
 
 ## Quick Start with Docker Compose (Recommended)
 
-The REST Gateway and CueWeb are included in OpenCue's main `docker-compose.yml` under the `cueweb` profile.
+The REST Gateway and OpenCueWeb are included in OpenCue's main `docker-compose.yml` under the `cueweb` profile.
 
 ### Step 1: Start OpenCue Stack with Web UI
 
 From the OpenCue repository root:
 
 ```bash
-# Start core services plus REST Gateway and CueWeb
+# Start core services plus REST Gateway and OpenCueWeb
 docker compose --profile cueweb up -d
 
 # Check service status
 docker compose ps
 ```
 
-The REST Gateway will be available at `http://localhost:8448` and CueWeb at `http://localhost:3000`.
+The REST Gateway will be available at `http://localhost:8448` and OpenCueWeb at `http://localhost:3000`.
 
 ### Step 2: Deploy REST Gateway Separately (Alternative)
 

--- a/docs/_docs/other-guides/cueweb.md
+++ b/docs/_docs/other-guides/cueweb.md
@@ -1,35 +1,35 @@
 ---
-title: "CueWeb System"
+title: "OpenCueWeb System"
 layout: default
 parent: Other Guides
 nav_order: 57
-linkTitle: "CueWeb system"
+linkTitle: "OpenCueWeb system"
 date: 2025-02-04
 description: >
-   CueWeb system: First web-based release of CueGUI with many features from Cuetopia
+   OpenCueWeb system: First web-based release of CueGUI with many features from Cuetopia
 ---
 
-# CueWeb
+# OpenCueWeb
 
 ### A web-based CueGUI alternative with job filtering, inspection, and interactive controls
 
 ---
 
-This guide provides an introduction to the CueWeb system, the web-based version of CueGUI.
+This guide provides an introduction to the OpenCueWeb system, the web-based version of CueGUI.
 
 ## Introduction
 
-[OpenCue](https://www.opencue.io/) has facilitated efficient management of rendering jobs through its application, CueGUI, which includes Cuetopia and CueCommander. Previously, OpenCue's capabilities were somewhat restricted as it was primarily limited to desktops/workstations running Qt-based applications. Because of that, the CueWeb system was created. CueWeb is a transformative, web-based application that extends access across multiple platforms, ensuring users can manage their rendering tasks from virtually anywhere.
+[OpenCue](https://www.opencue.io/) has facilitated efficient management of rendering jobs through its application, CueGUI, which includes Cuetopia and CueCommander. Previously, OpenCue's capabilities were somewhat restricted as it was primarily limited to desktops/workstations running Qt-based applications. Because of that, the OpenCueWeb system was created. OpenCueWeb is a transformative, web-based application that extends access across multiple platforms, ensuring users can manage their rendering tasks from virtually anywhere.
 
 ## A seamless transition to web accessibility 
 
-CueWeb replicates the core functionality of [CueGUI](https://www.opencue.io/docs/reference/cuegui-app/) (Cuetopia and Cuecommander) in a web-accessible format, enhancing usability while maintaining the familiar interface that users appreciate. This adaptation supports essential operations such as:
+OpenCueWeb replicates the core functionality of [CueGUI](https://www.opencue.io/docs/reference/cuegui-app/) (Cuetopia and Cuecommander) in a web-accessible format, enhancing usability while maintaining the familiar interface that users appreciate. This adaptation supports essential operations such as:
 
 1. **Persistent global header (every authenticated route):**
-   - OpenCue logo (theme-aware: black in light mode, white in dark mode) + the **CueWeb** wordmark.
-   - Six dropdown menus mirroring the CueGUI menu bar: **File** (Disable Job Interaction), **Cuebot Facility**, **Cuetopia** (Monitor Jobs), **CueCommander** (Allocations, Limits, Monitor Cue, Monitor Hosts, Redirect, Services, Shows, Stuck Frame, Subscription Graphs, Subscriptions), **Other** (Attributes, Immersive (full-screen), Split view, Show Shortcuts, Notify on Shortcut), and **Help** (search box across every menu command, plus Online User Guide / Make a Suggestion / Report a Bug / About CueWeb). Routes that are not yet implemented 404 gracefully.
+   - OpenCue logo (theme-aware: black in light mode, white in dark mode) + the **OpenCueWeb** wordmark.
+   - Six dropdown menus mirroring the CueGUI menu bar: **File** (Disable Job Interaction), **Cuebot Facility**, **Cuetopia** (Monitor Jobs), **CueCommander** (Allocations, Limits, Monitor Cue, Monitor Hosts, Redirect, Services, Shows, Stuck Frame, Subscription Graphs, Subscriptions), **Other** (Attributes, Immersive (full-screen), Split view, Show Shortcuts, Notify on Shortcut), and **Help** (search box across every menu command, plus Online User Guide / Make a Suggestion / Report a Bug / About OpenCueWeb). Routes that are not yet implemented 404 gracefully.
    - Theme toggle (light/dark).
-   - Always-visible **Sign out** button that calls NextAuth's `signOut()` and routes to `/login` - the `/login` page itself shows either the **CueWeb Home** button (when `NEXT_PUBLIC_AUTH_PROVIDER` is empty) or the configured provider buttons.
+   - Always-visible **Sign out** button that calls NextAuth's `signOut()` and routes to `/login` - the `/login` page itself shows either the **OpenCueWeb Home** button (when `NEXT_PUBLIC_AUTH_PROVIDER` is empty) or the configured provider buttons.
 2. **Collapsible left sidebar (every authenticated route):**
    - Same six groups as the header (**File**, **Cuebot Facility**, **Cuetopia**, **CueCommander**, **Other**, **Help**), organized as accordion sections; the group containing the active route auto-expands.
    - One click on the **Collapse** button shrinks the sidebar to an icon-only rail; overall and per-group state persist across reloads.
@@ -43,13 +43,13 @@ CueWeb replicates the core functionality of [CueGUI](https://www.opencue.io/docs
    - Fixed 24-pixel bar at the bottom of every authenticated route.
    - **Gateway** (left): a dot + `Online` / `Offline` + the last round-trip latency, refreshed every few seconds. The whole bar turns red when the gateway is unreachable.
    - **Last refresh** (center): a live "Ns ago" timer that updates whenever the jobs table refreshes.
-   - **Version** (right): the CueWeb build version.
+   - **Version** (right): the OpenCueWeb build version.
 6. **Breadcrumb navigation on detail views:**
    - Above the frame log page and the per-job comments page, a "Home > Jobs > ..." trail lets you click back to the jobs index or any parent in the path.
    - Long segment labels are truncated, with the full text shown in a tooltip on hover.
    - The last segment is the current page; the earlier segments are clickable links back to the index or any parent.
 7. **Secure user authentication:**
-   - Authentication through Github, Google, [Okta](https://www.okta.com/), LDAP, Apple, GitLab, Amazon, Microsoft Azure, LinkedIn, Atlassian, Auth0, etc. Other providers and login options can be easily configured and enabled in the CueWeb. LDAP authentication is particularly useful for intranet deployments using company directory credentials. See [NextAuth.js](https://next-auth.js.org/) authentication using email, credentials and providers: https://next-auth.js.org/providers/
+   - Authentication through Github, Google, [Okta](https://www.okta.com/), LDAP, Apple, GitLab, Amazon, Microsoft Azure, LinkedIn, Atlassian, Auth0, etc. Other providers and login options can be easily configured and enabled in the OpenCueWeb. LDAP authentication is particularly useful for intranet deployments using company directory credentials. See [NextAuth.js](https://next-auth.js.org/) authentication using email, credentials and providers: https://next-auth.js.org/providers/
 8. **Browser-based job submission (CueSubmit CLI parity):**
    - A dedicated `/cuesubmit` route reachable from the **CueSubmit** top-level dropdown in the header, the matching **CueSubmit > Submit Job** group in the left sidebar (and the mobile nav drawer) mirrors the standalone CueSubmit CLI tool with Job Info / Layer Info / per-type option panels for Shell / Maya / Nuke / Blender, a live read-only Final command preview, and a multi-layer Submission Details table with `+ / - / down / up` controls.
    - Browser-only improvements over the CLI: per-keystroke command preview, per-field autocomplete history (Job Name / Shot / Layer Name) saved in your browser, draft auto-save so an accidental refresh doesn't wipe a multi-layer setup, themed `?` help popovers for frame-spec patterns and cuebot tokens, themed confirmation dialogs, and a **Reset** button next to Cancel and Submit.
@@ -84,8 +84,8 @@ CueWeb replicates the core functionality of [CueGUI](https://www.opencue.io/docs
    - Optimized loading times, along with loading animations for a better user experience.
    - Users can add or remove multiple jobs directly from the search results, with existing jobs highlighted in green.
 16. **Enhanced security using Opencue API:**
-   - CueWeb authorizes its requests to the OpenCue REST API with signed security tokens.
-17. **CueWeb actions and context menu (CueGUI parity):**
+   - OpenCueWeb authorizes its requests to the OpenCue REST API with signed security tokens.
+17. **OpenCueWeb actions and context menu (CueGUI parity):**
    - Right-clicking any row in the Jobs, Layers, or Frames tables opens a context menu that mirrors the CueGUI Monitor Jobs / Monitor Job Details menus.
    - On touch devices, every row has a small **`⋮` Actions** button as its leftmost cell. Tapping it opens the same menu the desktop right-click opens.
    - **Job actions** include: Unmonitor, View Job, **View Job Details** (opens the tabbed `/jobs/<jobName>` page with Overview / Layers / Frames / Comments / Dependencies), **Copy Job Name**, Email Artist, Request Cores, Subscribe to Job, Comments, **View Dependencies...** (themed dialog rendering the job's depends), **Dependency Wizard...** (multi-step dialog covering every CueGUI `depend.DependType`, multi-select on every picker, cross-product fan-out on Done), **Drop External / Internal Dependencies** (one click, table auto-refreshes), Set / Clear User Color, **Set Priority...** (themed 1-100 slider + number input), Set Max Retries, Reorder / Stagger Frames, **Pause / Unpause** (single toggle - the label and icon flip with the job's paused state, and the entry is grayed out for Finished jobs), Auto-Eat On / Off, Retry / Eat Dead Frames, Unbook, Kill, Show Progress Bar.
@@ -96,8 +96,8 @@ CueWeb replicates the core functionality of [CueGUI](https://www.opencue.io/docs
    - **Layer actions** include: View Layer, **Copy Layer Name**, dependency items, Reorder / Stagger Frames, Properties, Kill, Eat, Retry, Retry Dead Frames.
    - **Frame actions** include: **Tail Log / View Log** (in-browser viewer), **View Log on \<editor\>** (external editor - see item 23), **Copy Log Path**, **Copy Frame Name**, View Host, dependency items (View / Drop / **Dependency Wizard**), **Mark as waiting**, Filter Selected Layers, Reorder, **Preview All** (external image viewer; command configurable via `NEXT_PUBLIC_PREVIEW_COMMAND` / `NEXT_PUBLIC_PREVIEW_URL`), Retry, Eat, Kill, **Mark done** / Eat and Mark done, View Processes. You can also drag (or shift-click) to select a contiguous **frame range** and Retry / Eat / Kill it at once. The job menu's **Show Progress Bar** shows a configurable CueProgBar launch command (`NEXT_PUBLIC_CUEPROGBAR_COMMAND`).
    - **Frame log viewer** also offers in-log **search** (highlight + match counter, case/regex toggles), **follow/tail** mode (auto-scroll, pause-on-scroll-up, jump-to-bottom; **Tail Log** opens it following by default), absolute **line numbers**, **per-line copy**, raw-log **download**, and a **frame preview thumbnail** panel.
-   - All copy actions work whether CueWeb is reached at `localhost` or at a LAN IP over plain HTTP.
-   - Menus scroll instead of overflowing on small viewports. Items that depend on dialogs / backend integrations not yet implemented in CueWeb surface a friendly placeholder toast. Destructive items are auto-disabled when **Disable Job Interaction** is on.
+   - All copy actions work whether OpenCueWeb is reached at `localhost` or at a LAN IP over plain HTTP.
+   - Menus scroll instead of overflowing on small viewports. Items that depend on dialogs / backend integrations not yet implemented in OpenCueWeb surface a friendly placeholder toast. Destructive items are auto-disabled when **Disable Job Interaction** is on.
 
 18. **Auto-reloading of tables:**
    - All tables (jobs, layers, frames) are auto-reloaded at regular intervals to display the latest data.
@@ -138,7 +138,7 @@ CueWeb replicates the core functionality of [CueGUI](https://www.opencue.io/docs
      - Empty value -> the menu item is hidden entirely.
    - The menu label is derived automatically from the URL. Unrecognized schemes fall back to "View Log in external editor".
    - Web browsers can't read the user's shell `$EDITOR` variable or launch arbitrary local programs the way CueGUI does. The URL-scheme approach is the web equivalent: the same trick GitHub's "Open in VSCode" button uses.
-   - If the chosen editor isn't installed on the user's machine, CueWeb shows a warning toast after a short delay pointing the user at the alternatives.
+   - If the chosen editor isn't installed on the user's machine, OpenCueWeb shows a warning toast after a short delay pointing the user at the alternatives.
    - When the frame hasn't started running yet (WAITING / DEPEND frames have no log file on disk), the menu item shows a friendly warning toast instead of handing a non-existent path to the editor.
 
 25. **Mobile-friendly UI:**
@@ -147,9 +147,9 @@ CueWeb replicates the core functionality of [CueGUI](https://www.opencue.io/docs
    - Every Jobs / Layers / Frames row has a small **`⋮` Actions** button as its leftmost cell. Tapping it opens the same context menu the desktop right-click opens (see item 16), so touch users get the full action set without a right-click event.
    - The keyboard-shortcuts overlay (item 21) is itself touch-friendly: every key badge in the list is tappable, so `/` (focus search), `r` (refresh), and `t` (toggle theme) work on phones without a physical keyboard.
 
-26. **LAN access (CueWeb usable from phones / tablets):**
-   - The same image works whether the browser reaches CueWeb at `localhost` on the dev machine or at a LAN IP from another device on the same network - no rebuild needed when you want to test on a phone. The build-time `NEXT_PUBLIC_URL` setting defaults to empty for this reason; only set it to an absolute URL if your deployment serves the API on a different origin than the UI.
-   - Copy actions (Copy Job / Layer / Frame Name, Copy Log Path) work even when CueWeb is reached over plain HTTP at a LAN IP, including on iOS Safari.
+26. **LAN access (OpenCueWeb usable from phones / tablets):**
+   - The same image works whether the browser reaches OpenCueWeb at `localhost` on the dev machine or at a LAN IP from another device on the same network - no rebuild needed when you want to test on a phone. The build-time `NEXT_PUBLIC_URL` setting defaults to empty for this reason; only set it to an absolute URL if your deployment serves the API on a different origin than the UI.
+   - Copy actions (Copy Job / Layer / Frame Name, Copy Log Path) work even when OpenCueWeb is reached over plain HTTP at a LAN IP, including on iOS Safari.
 
 27. **Job dependency graph (Cuetopia &rarr; View Job Graph):**
    - A read-only, interactive node graph of a job's dependency tree, mirroring CueGUI's Monitor-Jobs dependency-graph dock.
@@ -158,13 +158,13 @@ CueWeb replicates the core functionality of [CueGUI](https://www.opencue.io/docs
    - **Double-click** a node to open that job's detail page (a single click only selects it). **Right-click a layer node** for the CueGUI Job-Graph layer menu: **Auto Layout Nodes**; **Dependencies** (View Dependencies… / Dependency Wizard… / Mark done); **Reorder Frames…**; **Stagger Frames…**; **Properties…**; **Kill / Eat / Retry / Retry Dead Frames** - the same actions as the Layers table.
 
 28. **Monitor Cue (CueCommander &rarr; Monitor Cue):**
-   - A show-grouped job tree at `/monitor-cue`, the CueWeb equivalent of CueGUI's CueCommander Monitor Cue window (previously a dead sidebar link). Pick one or more shows from the **Shows** menu (All Shows / Clear / per-show, persisted) to load every job for those shows, grouped under their show and groups.
+   - A show-grouped job tree at `/monitor-cue`, the OpenCueWeb equivalent of CueGUI's CueCommander Monitor Cue window (previously a dead sidebar link). Pick one or more shows from the **Shows** menu (All Shows / Clear / per-show, persisted) to load every job for those shows, grouped under their show and groups.
    - **Full CueGUI column set**: Comment + Auto-eat icons, Job, Run, Cores, Gpus, Wait, Depend, Total, **Booking** (a running/waiting bar with cyan min-core and red max-core markers, mirroring CueGUI's booking bar), Min, Max, Min G, Max G, Pri, ETA, MaxRss, MaxGpuMem, Age, Readable Age, and Progress. Columns sort with header arrows; a Columns dropdown (show/hide + reorder) and a **Filter jobs...** box sit at the top-right (persisted). Rows are tinted by condition: blue = paused, red = dead, yellow = high peak memory, green = waiting, purple = all-depend.
    - **Toolbar**: Eat / Retry / Pause / Unpause / Kill (with icons; Kill confirms) on the selected jobs, Refresh + Auto-refresh (5s), Expand / Collapse All, and a **Select:** name/regex box that live-selects matching jobs (plus a select-mine button). A select-all header checkbox and Shift+click range selection pick rows in bulk.
    - **Job menu** reuses the Monitor Jobs right-click menu plus Monitor-Cue-only entries: **View Job**, **Send To Group...** (reparent the job into another group of its show), the resource/priority setters (Set Min/Max Cores, Set Minimum/Maximum Cores, Set Minimum/Maximum Gpus, Set Priority), Use Local Cores, Unbook Frames..., and Set / Clear User Color. Auto-eat is a single **Enable / Disable auto eating** toggle.
 
 29. **Monitor Hosts (CueCommander &rarr; Monitor Hosts) - full CueGUI parity:**
-   - A host registry at `/hosts`, the CueWeb equivalent of CueGUI's CueCommander Monitor Hosts plugin. Reached from the CueCommander menu / sidebar entry or the dashboard hosts widget's **View hosts** link.
+   - A host registry at `/hosts`, the OpenCueWeb equivalent of CueGUI's CueCommander Monitor Hosts plugin. Reached from the CueCommander menu / sidebar entry or the dashboard hosts widget's **View hosts** link.
    - **Full CueGUI column set**: Name, a Comments icon column, Load %, Swap, Physical, GPU Memory, Total Memory, Idle Memory, Temp, Temp Free, Temp Free %, Cores, Idle Cores, GPUs, Idle GPUs, GPU Mem, GPU Mem Idle, Ping, Boot Time, Hardware, Locked, ThreadMode, OS, Tags. Swap / Physical / GPU Memory / Temp render as red/green used-vs-free bars. Rows are tinted by condition: red for a non-`UP` hardware state, amber for `REBOOT_WHEN_IDLE`, yellow for an `UP` but `LOCKED` host. Column show/hide/reorder and saveable **Views** presets mirror the other tables.
    - **Filter bar**: name/regex box plus Allocation / HardwareState / LockState / OS multi-selects, with Auto-refresh / Refresh / Clear. Filtering is client-side and the active filters are mirrored in the URL so a filtered view is shareable. Auto-refreshes every 30 seconds.
    - **Host actions** via the row's right-click menu (CueGUI parity): **Comments…** (with reusable predefined-comment macros), **View Procs**, **Lock / Unlock / Take Ownership** (Take Ownership enabled only for a `NIMBY_LOCKED` host, with a confirmation dialog), **Edit Tags… / Rename Tag… / Change Allocation…**, **Reboot** (confirms - running frames are killed) **/ Reboot when idle / Delete Host**, and **Set / Clear Repair State**. Inapplicable items are greyed out by host state; the affected row updates immediately on success.
@@ -172,53 +172,53 @@ CueWeb replicates the core functionality of [CueGUI](https://www.opencue.io/docs
    - **Host detail page**: click a host's name to open a per-host page with Overview, Procs, Comments, and Tags tabs. The Procs tab lists the frames running on the host (auto-refreshing every 15 seconds); clicking a proc opens that frame's log.
 
 30. **Allocations (CueCommander &rarr; Allocations):**
-   - An allocations table at `/allocations`, the CueWeb equivalent of CueGUI's CueCommander Allocations window. Reached from the CueCommander menu / sidebar entry.
+   - An allocations table at `/allocations`, the OpenCueWeb equivalent of CueGUI's CueCommander Allocations window. Reached from the CueCommander menu / sidebar entry.
    - Columns mirror CueGUI: Name, Tag, a cores group (Cores, Idle, Locked, Down, Repair) and a hosts group (Hosts, Locked, Down, Repair). Numeric columns sort by their underlying value; column show/hide and the substring filter mirror the other tables. Auto-refreshes every 30 seconds.
    - Clicking an allocation's name navigates to the hosts list scoped to that allocation (`/hosts?allocation=<name>`).
 
 31. **Shows (CueCommander &rarr; Shows):**
-   - A shows registry at `/shows`, the CueWeb equivalent of CueGUI's CueCommander Shows window. Reached from the CueCommander menu / sidebar entry.
+   - A shows registry at `/shows`, the OpenCueWeb equivalent of CueGUI's CueCommander Shows window. Reached from the CueCommander menu / sidebar entry.
    - Sortable, filterable stats table with columns Show Name, Cores Run, Frames Run, Frames Pending, and Jobs (from `GetActiveShows`), auto-refreshing every 30 seconds. Click a show name to open its detail page.
    - **Create Show** dialog: enter a unique alphanumeric name and optionally subscribe the new show to one or more allocations (checkbox + Size + Burst per allocation).
    - **Show actions** via the row's right-click menu: **Show Properties** (a four-tab dialog - Settings with default max/min cores and comment email, Booking with enable booking / enable dispatch, read-only Statistics, and Raw Show Data) and **Create Subscription...** (subscribe a show to an allocation with Size and Burst).
 
 32. **Stuck Frames (CueCommander &rarr; Stuck Frame):**
-   - A stuck-frame finder at `/stuck-frames`, the CueWeb equivalent of CueGUI's CueCommander Stuck Frame window. Reached from the CueCommander menu / sidebar entry.
+   - A stuck-frame finder at `/stuck-frames`, the OpenCueWeb equivalent of CueGUI's CueCommander Stuck Frame window. Reached from the CueCommander menu / sidebar entry.
    - Scans every running frame across active jobs and flags the ones that look hung (the log has gone silent relative to runtime), grouped under their job. Columns: Name, Frame, Host, LLU, Runtime, % Stuck, Average, Last Line. Auto-refreshes on a timer, with **Refresh** / **Clear** controls.
    - **Detection filters** (saved per browser): % of Run Since LLU, Min LLU, % Avg Completion, Total Runtime, and Exclude Keywords. The **+** button adds a per-service filter row (catch-all "All Other Types" plus one row per render service, so e.g. Arnold can use looser thresholds than quicker services).
    - **Frame actions** via the row's right-click menu: Tail/View/View Last Log, Retry / Eat / Kill, Log Stuck Frame (and Log and Retry / Eat / Kill), Frame Not Stuck, Add Job to Excludes / Exclude and Remove Job, **Core Up** (raise the layer's minimum cores), and View Host.
    - **Job actions** via the job header's right-click menu: View Comments, Job Not Stuck, Add Job to Excludes / Exclude and Remove Job, and **Core Up** across the job's stuck layers.
 
 33. **Facility Service Defaults (CueCommander &rarr; Services):**
-   - A facility-wide service-defaults editor at `/services`, the CueWeb equivalent of CueGUI's Facility Service Defaults tab. Reached from the CueCommander menu / sidebar entry. It edits the default resource requirements applied to a layer when it runs a given service (for example `arnold`, `maya`, `nuke`, or `shell`).
+   - A facility-wide service-defaults editor at `/services`, the OpenCueWeb equivalent of CueGUI's Facility Service Defaults tab. Reached from the CueCommander menu / sidebar entry. It edits the default resource requirements applied to a layer when it runs a given service (for example `arnold`, `maya`, `nuke`, or `shell`).
    - Two panes: a left list of services (with **New** / **Del**) and a right edit form with Name, Threadable, Min/Max Threads (100 = 1 thread), Min Memory MB, Min Gpu Memory MB, Timeout, Timeout LLU, OOM Increase MB, and Tags (predefined checkboxes or a Custom Tags free-text toggle).
    - Because these are facility-wide defaults, **Save** asks for a confirmation before creating or updating, and **Del** confirms before removing a service; a toast reports the result.
 
 34. **Subscriptions (CueCommander &rarr; Subscriptions):**
-   - A per-show subscriptions table at `/subscriptions`, the CueWeb equivalent of CueGUI's CueCommander Subscriptions window. Pick a show from the dropdown to list its subscriptions, one row per allocation, with columns Alloc, Usage, Size, Burst, and Used. A subscription is a show's reservation against an allocation: **Size** is the guaranteed cores, **Burst** the maximum it may temporarily use.
+   - A per-show subscriptions table at `/subscriptions`, the OpenCueWeb equivalent of CueGUI's CueCommander Subscriptions window. Pick a show from the dropdown to list its subscriptions, one row per allocation, with columns Alloc, Usage, Size, Burst, and Used. A subscription is a show's reservation against an allocation: **Size** is the guaranteed cores, **Burst** the maximum it may temporarily use.
    - **Add Subscription** subscribes the show to another allocation (Size + Burst); **Show Properties** opens the same four-tab dialog as the Shows page.
    - **Row actions** via the right-click menu: **Edit Subscription Size...** (with a billing confirmation), **Edit Subscription Burst...**, and **Delete Subscription**.
 
 35. **Subscription Graphs (CueCommander &rarr; Subscription Graphs):**
-   - A visual view at `/subscription-graphs`, the CueWeb equivalent of CueGUI's CueCommander Subscription Graphs window. A **Shows** multi-select (All Shows / Clear / per-show) chooses which shows to graph; each gets one horizontal bar per subscription.
+   - A visual view at `/subscription-graphs`, the OpenCueWeb equivalent of CueGUI's CueCommander Subscription Graphs window. A **Shows** multi-select (All Shows / Clear / per-show) chooses which shows to graph; each gets one horizontal bar per subscription.
    - Each bar is scaled to the allocation's total cores and color-coded like CueGUI (legend at the top): sky-blue allocation capacity, yellow-green in-use cores, a blue size marker and a red burst marker. Hovering shows the exact values.
    - **Row actions** via the right-click menu match the Subscriptions table plus **Add new subscription**; right-clicking a show with no subscriptions offers **Add new subscription** to create the first one.
 
 36. **Limits (CueCommander &rarr; Limits):**
-   - A limits table at `/limits`, the CueWeb equivalent of CueGUI's CueCommander Limits window. Reached from the CueCommander menu / sidebar entry.
+   - A limits table at `/limits`, the OpenCueWeb equivalent of CueGUI's CueCommander Limits window. Reached from the CueCommander menu / sidebar entry.
    - Columns: Limit Name, Max Value, Current Running. Auto-refreshes every 30 seconds, with a **Refresh** button for an immediate reload.
    - **Add Limit** dialog creates a new limit (max value starts at 0).
    - **Limit actions** via the row's right-click menu: **Edit Max Value** (validates a non-negative integer), **Rename**, and **Delete Limit** (with a confirmation).
 
 37. **Redirect (CueCommander &rarr; Redirect):**
-   - An administrator tool at `/redirect`, the CueWeb equivalent of CueGUI's CueCommander Redirect window. Reached from the CueCommander menu / sidebar entry. It moves cores to a job that needs them by reassigning busy procs to a target job - the frames running on those procs are killed and the freed cores are booked onto the target.
+   - An administrator tool at `/redirect`, the OpenCueWeb equivalent of CueGUI's CueCommander Redirect window. Reached from the CueCommander menu / sidebar entry. It moves cores to a job that needs them by reassigning busy procs to a target job - the frames running on those procs are killed and the freed cores are booked onto the target.
    - **Target + auto-detect**: typing a target job name auto-fills the Show and minimum cores/memory from the job's layers (CueGUI `detect()`), so the search looks for procs large enough to help.
    - **Job filters** (Show, Include Groups, Require Services, Exclude Regex) and **resource filters** (Allocations, Minimum/Max Cores, Minimum Memory, Result Limit, Proc Hour Cutoff) scope the search. **Search** lists the matching hosts (Cores, Memory, PrcTime, Group, Service, Job Cores, Waiting Frames, LLU), expandable to their individual procs.
-   - **Redirect** the selected hosts (or **Select All**): CueWeb refuses if the target is gone / has no waiting frames / is at max cores, and asks for confirmation when the target is paused or a selected proc belongs to a different show (a cross-show redirect kills that show's frame).
+   - **Redirect** the selected hosts (or **Select All**): OpenCueWeb refuses if the target is gone / has no waiting frames / is at max cores, and asks for confirmation when the target is paused or a selected proc belongs to a different show (a cross-show redirect kills that show's frame).
 
 38. **Group-based authorization (optional, opt-in):**
    - An optional, environment-driven authorization gate enforced server-side in a single middleware chokepoint. **Off by default** - when disabled (or when no auth provider is configured) it is a pure pass-through and every signed-in user is treated as an admin.
-   - **`CUEWEB_ALLOWED_GROUPS`** restricts who may use CueWeb at all; **`CUEWEB_ADMIN_GROUPS`** restricts the entire CueCommander section (all pages, including Monitor Cue, Monitor Hosts and Stuck Frame), job submission (CueSubmit), and the Manage facilities… screen. A blocked user sees an **Access denied** page (`/unauthorized`); API routes return `403`, and those menus are hidden from non-admins. Cuetopia Monitor Jobs and the Dashboard stay available to non-admins.
+   - **`CUEWEB_ALLOWED_GROUPS`** restricts who may use OpenCueWeb at all; **`CUEWEB_ADMIN_GROUPS`** restricts the entire CueCommander section (all pages, including Monitor Cue, Monitor Hosts and Stuck Frame), job submission (CueSubmit), and the Manage facilities… screen. A blocked user sees an **Access denied** page (`/unauthorized`); API routes return `403`, and those menus are hidden from non-admins. Cuetopia Monitor Jobs and the Dashboard stay available to non-admins.
    - The user's groups are resolved **once at sign-in** (from the OIDC claim named by `CUEWEB_GROUPS_CLAIM`, default `groups`, or a credentials/LDAP `groups` field) and stamped on the session token; the Edge middleware only reads them, so there is no per-request directory lookup. Requires an identity provider whose token carries group memberships.
 
 39. **Plugin system (extensible add-ons):**
@@ -234,38 +234,38 @@ CueWeb replicates the core functionality of [CueGUI](https://www.opencue.io/docs
    - **Multi-pane split view** (CueGUI *Add new window*): the `/split?left=…&right=…` route opens two pages side-by-side in resizable, same-origin iframe panes, each with its own URL so the whole workspace is bookmarkable and reload-safe; drag/keyboard divider resize (ratio under `cueweb.split.ratio`), per-pane page picker, Swap, and Reset 50/50. Opened from **Other &rarr; Split view**.
 
 41. **Optional Loki log backend (CueGUI Loki log viewer parity):**
-   - The frame log viewer has two interchangeable backends. By default it reads the on-disk `.rqlog` file; when `NEXT_PUBLIC_LOKI_URL` points at a [Grafana Loki](https://grafana.com/oss/loki/) server it queries Loki for the frame's lines instead (the CueWeb counterpart of CueGUI's `LokiViewPlugin`), falling back to the file-based viewer when unset.
+   - The frame log viewer has two interchangeable backends. By default it reads the on-disk `.rqlog` file; when `NEXT_PUBLIC_LOKI_URL` points at a [Grafana Loki](https://grafana.com/oss/loki/) server it queries Loki for the frame's lines instead (the OpenCueWeb counterpart of CueGUI's `LokiViewPlugin`), falling back to the file-based viewer when unset.
    - Both backends share the same read-only editor, **Log versions** dropdown, and empty/loading states. With Loki, each "log version" is a separate **frame attempt** (`session_start_time`), newest first, with a **Refresh** button. The backend is chosen by the deployment, not in the UI.
 
 
-## CueWeb's user interface
+## OpenCueWeb's user interface
 
-Upon logging in through Okta/Google/GitHub/LDAP or another authentication method configured using [NextAuth.js](https://next-auth.js.org/) (Figure 1), users are welcomed by CueWeb's main dashboard, as shown in Figure 2.  The CueWeb main page contains a paginated table that is populated with the OpenCue jobs. 
+Upon logging in through Okta/Google/GitHub/LDAP or another authentication method configured using [NextAuth.js](https://next-auth.js.org/) (Figure 1), users are welcomed by OpenCueWeb's main dashboard, as shown in Figure 2.  The OpenCueWeb main page contains a paginated table that is populated with the OpenCue jobs. 
 
-**Figure 1: CueWeb authentication page**
-![CueWeb authentication page](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_login.png)
+**Figure 1: OpenCueWeb authentication page**
+![OpenCueWeb authentication page](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_login.png)
 
 
-**Figure 1a: CueWeb LDAP authentication button**
-![CueWeb LDAP authentication button](/assets/images/cueweb/cueweb-ldap-button.png)
+**Figure 1a: OpenCueWeb LDAP authentication button**
+![OpenCueWeb LDAP authentication button](/assets/images/cueweb/cueweb-ldap-button.png)
 
-**Figure 1b: CueWeb LDAP login page**
-![CueWeb LDAP login page](/assets/images/cueweb/cueweb-ldap-login-password-page.png)
+**Figure 1b: OpenCueWeb LDAP login page**
+![OpenCueWeb LDAP login page](/assets/images/cueweb/cueweb-ldap-login-password-page.png)
 
-**Note:** If the CueWeb login is disabled, the image below displays the initial CueWeb page. This page includes a button labelled "CueWeb Home", which opens the main CueWeb interface. For instructions on how to disable the CueWeb login, refer to the [cueweb/README.md](https://github.com/AcademySoftwareFoundation/OpenCue/blob/master/cueweb/README.md) file.
+**Note:** If the OpenCueWeb login is disabled, the image below displays the initial OpenCueWeb page. This page includes a button labelled "OpenCueWeb Home", which opens the main OpenCueWeb interface. For instructions on how to disable the OpenCueWeb login, refer to the [cueweb/README.md](https://github.com/AcademySoftwareFoundation/OpenCue/blob/master/cueweb/README.md) file.
 
-![CueWeb home button page](/assets/images/cueweb/cueweb-home-button.png)
+![OpenCueWeb home button page](/assets/images/cueweb/cueweb-home-button.png)
 
-**Figure 2: CueWeb main page**
-![CueWeb main page](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_mainpage.png)
+**Figure 2: OpenCueWeb main page**
+![OpenCueWeb main page](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_mainpage.png)
 
 
 ### Navigation and global controls
 
 Every authenticated page shares a global header and a collapsible left sidebar. The sidebar groups the same menus found in the header, with the group for the current page expanded by default (Figure 3).
 
-**Figure 3: CueWeb collapsible left sidebar menu**
-![CueWeb collapsible left sidebar menu](/assets/images/cueweb/cueweb_left_side_menu.png)
+**Figure 3: OpenCueWeb collapsible left sidebar menu**
+![OpenCueWeb collapsible left sidebar menu](/assets/images/cueweb/cueweb_left_side_menu.png)
 
 
 The **Cuetopia** menu opens the Monitor Jobs view (Figure 4).
@@ -275,7 +275,7 @@ The **Cuetopia** menu opens the Monitor Jobs view (Figure 4).
 
 
 The **Cuebot Facility** menu lets you choose which facility to connect to (Figure 5).
-Selecting a facility switches the active Cuebot: CueWeb re-fetches all data from
+Selecting a facility switches the active Cuebot: OpenCueWeb re-fetches all data from
 that facility's gateway, the active facility is shown both on the menu chip and in
 the bottom status bar, and your choice persists for the session. This mirrors
 CueGUI's "Cuebot Facility" menu, which connects to a single facility at a time.
@@ -320,13 +320,13 @@ The **Other** menu provides Attributes, Show Shortcuts, and Notify on Shortcut (
 **Figure 10: Help menu**
 ![Help menu](/assets/images/cueweb/cueweb_help_about_cueweb_menu.png)
 
-The Help menu also includes **About CueWeb**, which opens a dialog showing the
-CueWeb version and build SHA, the active Cuebot facility, the REST gateway URL
+The Help menu also includes **About OpenCueWeb**, which opens a dialog showing the
+OpenCueWeb version and build SHA, the active Cuebot facility, the REST gateway URL
 (masked), the Apache-2.0 license, and credits. A **Copy diagnostics** button
 copies all of these as JSON for bug reports (Figure 10b).
 
-**Figure 10b: About CueWeb dialog**
-![About CueWeb dialog](/assets/images/cueweb/cueweb_help_about_cueweb.png)
+**Figure 10b: About OpenCueWeb dialog**
+![About OpenCueWeb dialog](/assets/images/cueweb/cueweb_help_about_cueweb.png)
 
 
 A fixed status bar at the bottom of every page shows the gateway connection state, the time since the last refresh, and the application version (Figure 11).
@@ -335,20 +335,20 @@ A fixed status bar at the bottom of every page shows the gateway connection stat
 ![Bottom status bar indicators](/assets/images/cueweb/cueweb_status_indicators.png)
 
 
-### CueWeb Audit
+### OpenCueWeb Audit
 
-CueWeb keeps a built-in audit trail of everything that changes state, surfaced
-under **Admin -> CueWeb Audit** and reachable from both the top menu and the
+OpenCueWeb keeps a built-in audit trail of everything that changes state, surfaced
+under **Admin -> OpenCueWeb Audit** and reachable from both the top menu and the
 left sidebar (Figure 11a). Every record captures who performed an action, when
 it happened, which target it acted on, the Cuebot facility it ran against, and
 whether it succeeded or failed - alongside sign-in and sign-out events.
 Read-only browsing (opening tables, viewing logs, paging through results) is not
 recorded; only the actions that actually mutate state are.
 
-Because every mutating action in CueWeb is proxied through a single gateway
+Because every mutating action in OpenCueWeb is proxied through a single gateway
 chokepoint, the audit captures all of those actions uniformly - no individual
 button or context-menu entry has to opt in. It records actions taken **through
-CueWeb specifically**, so changes made from CueGUI, `cueman`, or `pycue` do not
+OpenCueWeb specifically**, so changes made from CueGUI, `cueman`, or `pycue` do not
 appear here; this is a record of what was done in the web interface.
 
 The audit is presented as a filterable, paginated table (Figure 11b). A search
@@ -360,31 +360,31 @@ and HTTP method that were called. Records are written to an append-only JSONL
 store configured by `CUEWEB_AUDIT_STORE` (mount a volume there to persist the
 trail) and bounded in size by `CUEWEB_AUDIT_MAX_RECORDS`.
 
-Access to the audit page is admin-gated and reuses CueWeb's optional
+Access to the audit page is admin-gated and reuses OpenCueWeb's optional
 group-authorization (see item 38). When no group authorization is configured the
 page is visible to everyone; otherwise it is restricted to the groups listed in
 `CUEWEB_ADMIN_GROUPS`.
 
-**Figure 11a: Admin -> CueWeb Audit menu**
-![CueWeb Audit menu](/assets/images/cueweb/cueweb_admin_cueweb_audit_menu.png)
+**Figure 11a: Admin -> OpenCueWeb Audit menu**
+![OpenCueWeb Audit menu](/assets/images/cueweb/cueweb_admin_cueweb_audit_menu.png)
 
-**Figure 11b: CueWeb Audit page**
-![CueWeb Audit page](/assets/images/cueweb/cueweb_admin_cueweb_audit.png)
+**Figure 11b: OpenCueWeb Audit page**
+![OpenCueWeb Audit page](/assets/images/cueweb/cueweb_admin_cueweb_audit.png)
 
 
 ### Dashboard page
 
 The Dashboard page provides an at-a-glance overview, reachable from its own entry in the navigation (Figures 12 and 13).
 
-**Figure 12: CueWeb Dashboard page**
-![CueWeb Dashboard page](/assets/images/cueweb/cueweb_dashboard.png)
+**Figure 12: OpenCueWeb Dashboard page**
+![OpenCueWeb Dashboard page](/assets/images/cueweb/cueweb_dashboard.png)
 
 
-**Figure 13: CueWeb Dashboard menu**
-![CueWeb Dashboard menu](/assets/images/cueweb/cueweb_dashboard_menu.png)
+**Figure 13: OpenCueWeb Dashboard menu**
+![OpenCueWeb Dashboard menu](/assets/images/cueweb/cueweb_dashboard_menu.png)
 
 
-## CueWeb dashboard (Jobs data table) - Similar to [CueGUI Cuetopia](https://www.opencue.io/docs/user-guides/monitoring-your-jobs/)'s functionalities
+## OpenCueWeb dashboard (Jobs data table) - Similar to [CueGUI Cuetopia](https://www.opencue.io/docs/user-guides/monitoring-your-jobs/)'s functionalities
 
 Here's what you can expect:
 
@@ -508,7 +508,7 @@ To remove a comment, select it and confirm the deletion; a notification confirms
 **Figure 36: Notification confirming the comment was deleted**
 ![Notification confirming the comment was deleted](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_comments_page_deleted_selected_comment_notification.png)
 
-CueWeb also supports predefined comments (saved macros) that you can reuse, add, edit, and delete (Figures 37 to 44).
+OpenCueWeb also supports predefined comments (saved macros) that you can reuse, add, edit, and delete (Figures 37 to 44).
 
 **Figure 37: Using a predefined comment**
 ![Using a predefined comment](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_comments_page_use_a_predefined_comment.png)
@@ -572,32 +572,32 @@ Selecting **Other -> Show Shortcuts** opens an overlay listing the available key
 ![Keyboard shortcuts overlay](/assets/images/cueweb/cueweb_other_menu_show_shortcuts.png)
 
 
-### CueWeb Actions for Jobs / Layers / Frames
+### OpenCueWeb Actions for Jobs / Layers / Frames
 
-The CueWeb system includes actions like `eat dead frames`, `retry dead frames`, `pause`, `unpause`, and `kill` for selected jobs in the table. Also, the ability to right-click jobs, layers, and frames to get a context menu popup with actions for that object type.
+The OpenCueWeb system includes actions like `eat dead frames`, `retry dead frames`, `pause`, `unpause`, and `kill` for selected jobs in the table. Also, the ability to right-click jobs, layers, and frames to get a context menu popup with actions for that object type.
 
 The Pause / Unpause entry in the job context menu is a single toggle: it reads **Pause** when the job is running (In Progress, Failing, Dependency), **Unpause** when the job is already paused, and is shown disabled (grayed) when the job is Finished.
 
 Figure 52 shows the `job` context menu with options to `un-monitor`, `comments`, `pause`, `retry dead frames`, `eat dead frames` and `kill` jobs and Figure 53 shows the successful message after selecting `kill` a job.
 
-**Figure 52: CueWeb with job context menu open**
-![CueWeb with job context menu open](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_job_context_menu_open.png)
+**Figure 52: OpenCueWeb with job context menu open**
+![OpenCueWeb with job context menu open](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_job_context_menu_open.png)
 
 **Figure 53: Pop-up showing a successful message after selecting `kill` a job**
 ![Pop-up showing successful kill job message](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_job_context_menu_open_and_success_notification.png)
 
 Figure 54 shows the `layer` context menu with options to `kill`, `eat`, `retry`, and `retry dead frames` and Figure 55 shows the successful message after selecting `retry` a layer.
 
-**Figure 54: CueWeb with layer context menu open**
-![CueWeb with layer context menu open](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_layer_context_menu_open.png)
+**Figure 54: OpenCueWeb with layer context menu open**
+![OpenCueWeb with layer context menu open](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_layer_context_menu_open.png)
 
 **Figure 55: Pop-up showing a successful message after selecting `retry` a layer**
 ![Pop-up showing successful retry layer message](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_layer_context_menu_open_and_success_notification.png)
 
 Finally, Figure 56 shows the `frame` context menu with options to `kill`, `eat`, and `retry` and Figure 57 shows the successful message after selecting `eat` a frame.
 
-**Figure 56: CueWeb with frame context menu open**
-![CueWeb with frame context menu open](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_frame_context_menu_open.png)
+**Figure 56: OpenCueWeb with frame context menu open**
+![OpenCueWeb with frame context menu open](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_frame_context_menu_open.png)
 
 **Figure 57: Pop-up showing a successful message after selecting `eat` a frame**
 ![Pop-up showing successful eat frame message](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_frame_context_menu_open_and_success_notification.png)
@@ -683,4 +683,4 @@ The checkable **Cuetopia &rarr; View Job Graph** entry (Figure 70) toggles a rea
 
 ## Conclusion
 
-In conclusion, the CueWeb system marks a significant advancement in rendering job management by providing a powerful, web-based interface that simplifies and enhances user interaction with the OpenCue system. With features like customizable job tables, efficient job filtering, and detailed inspections, along with the ability to view comprehensive logs and switch visual modes, CueWeb ensures that managing rendering jobs is more accessible and adaptable to a variety of user needs.
+In conclusion, the OpenCueWeb system marks a significant advancement in rendering job management by providing a powerful, web-based interface that simplifies and enhances user interaction with the OpenCue system. With features like customizable job tables, efficient job filtering, and detailed inspections, along with the ability to view comprehensive logs and switch visual modes, OpenCueWeb ensures that managing rendering jobs is more accessible and adaptable to a variety of user needs.

--- a/docs/_docs/quick-starts/index.md
+++ b/docs/_docs/quick-starts/index.md
@@ -8,4 +8,4 @@ permalink: /docs/quick-starts
 
 # Quick starts
 
-Try OpenCue in the sandbox environment on different operating systems and get started with CueWeb.
+Try OpenCue in the sandbox environment on different operating systems and get started with OpenCueWeb.

--- a/docs/_docs/quick-starts/quick-start-cueweb.md
+++ b/docs/_docs/quick-starts/quick-start-cueweb.md
@@ -1,14 +1,14 @@
 ---
 layout: default
-title: CueWeb Quick Start
+title: OpenCueWeb Quick Start
 parent: Quick Starts
 nav_order: 9
 ---
 
-# CueWeb Quick Start
+# OpenCueWeb Quick Start
 {: .no_toc }
 
-Get up and running with CueWeb, the web-based interface for OpenCue.
+Get up and running with OpenCueWeb, the web-based interface for OpenCue.
 
 <details open markdown="block">
   <summary>
@@ -23,13 +23,13 @@ Get up and running with CueWeb, the web-based interface for OpenCue.
 
 ## Overview
 
-CueWeb is a web-based application that brings the core functionality of CueGUI to your browser. It provides an intuitive interface for managing rendering jobs, monitoring frame status, and interacting with your OpenCue render farm from anywhere.
+OpenCueWeb is a web-based application that brings the core functionality of CueGUI to your browser. It provides an intuitive interface for managing rendering jobs, monitoring frame status, and interacting with your OpenCue render farm from anywhere.
 
 ### What you'll learn
 
-- How to set up and run CueWeb locally
+- How to set up and run OpenCueWeb locally
 - How to configure the REST Gateway dependency
-- How to access and navigate the CueWeb interface
+- How to access and navigate the OpenCueWeb interface
 - Basic job management operations
 
 ### Prerequisites
@@ -46,7 +46,7 @@ Before you begin, ensure you have:
 
 ## Step 1: Set up the REST Gateway
 
-CueWeb requires the OpenCue REST Gateway to communicate with Cuebot. The REST Gateway is **not included** in the main OpenCue Docker Compose stack and must be deployed separately.
+OpenCueWeb requires the OpenCue REST Gateway to communicate with Cuebot. The REST Gateway is **not included** in the main OpenCue Docker Compose stack and must be deployed separately.
 
 ### Build the REST Gateway
 
@@ -78,9 +78,9 @@ curl -s -o /dev/null -w "%{http_code}" http://localhost:8448/
 
 ---
 
-## Step 2: Configure CueWeb
+## Step 2: Configure OpenCueWeb
 
-Navigate to the CueWeb directory and set up the environment configuration.
+Navigate to the OpenCueWeb directory and set up the environment configuration.
 
 ```bash
 cd cueweb
@@ -95,7 +95,7 @@ Create a `.env` file with the following configuration:
 NEXT_PUBLIC_OPENCUE_ENDPOINT=http://localhost:8448
 
 # Leave empty so the client builds same-origin relative API URLs.
-# That way CueWeb works from any host the browser reached it at:
+# That way OpenCueWeb works from any host the browser reached it at:
 # http://localhost:3000 on this machine, or http://<lan-ip>:3000
 # from another device on the same network (useful for testing on a
 # phone). Only set this to an absolute URL if the API is served on
@@ -121,9 +121,9 @@ NEXTAUTH_SECRET=canbeanything
 
 # Optional: read frame logs from a Grafana Loki server instead of the
 # on-disk .rqlog file (mirrors CueGUI's Loki log viewer). Leave unset to
-# use the default file-based viewer. Base URL only - CueWeb appends
+# use the default file-based viewer. Base URL only - OpenCueWeb appends
 # /loki/api/v1/... The query runs in the browser, so Loki must be
-# reachable from clients and allow CORS from the CueWeb origin.
+# reachable from clients and allow CORS from the OpenCueWeb origin.
 # NEXT_PUBLIC_LOKI_URL=http://your-loki-host:3100
 
 # Optional: command shown by the job menu's "Show Progress Bar" ({job} is
@@ -134,7 +134,7 @@ NEXTAUTH_SECRET=canbeanything
 # NEXT_PUBLIC_PREVIEW_COMMAND=rv {paths}
 # NEXT_PUBLIC_PREVIEW_URL=
 
-# Optional: tune the CueWeb Audit trail (see "Review the audit trail" in
+# Optional: tune the OpenCueWeb Audit trail (see "Review the audit trail" in
 # Step 5). CUEWEB_AUDIT_STORE is the path to the append-only JSONL log
 # (default: cueweb-audit.jsonl in the OS temp dir) - point it at a mounted
 # volume to persist across restarts. CUEWEB_AUDIT_MAX_RECORDS caps how many
@@ -152,12 +152,12 @@ NEXTAUTH_SECRET=canbeanything
 
 ### Restrict access by group (optional)
 
-By default every signed-in user can use CueWeb. To limit access by **group membership**, opt in with these env vars (all off/empty by default):
+By default every signed-in user can use OpenCueWeb. To limit access by **group membership**, opt in with these env vars (all off/empty by default):
 
 ```bash
 # Turn the gate on (off by default — leave unset for an open deployment)
 CUEWEB_AUTHZ_ENABLED=true
-# Groups allowed to use CueWeb at all (empty = everyone signed in)
+# Groups allowed to use OpenCueWeb at all (empty = everyone signed in)
 CUEWEB_ALLOWED_GROUPS=renderwranglers,supervisors
 # Groups allowed on the entire CueCommander section + CueSubmit + Manage facilities (empty = everyone)
 CUEWEB_ADMIN_GROUPS=supervisors
@@ -169,7 +169,7 @@ The gate is enforced server-side: a user outside `CUEWEB_ALLOWED_GROUPS` sees an
 
 ---
 
-## Step 3: Install Dependencies and Run CueWeb
+## Step 3: Install Dependencies and Run OpenCueWeb
 
 ### Install Dependencies
 
@@ -177,7 +177,7 @@ The gate is enforced server-side: a user outside `CUEWEB_ALLOWED_GROUPS` sees an
 npm install
 ```
 
-### Start CueWeb in Development Mode
+### Start OpenCueWeb in Development Mode
 
 ```bash
 npm run dev
@@ -195,17 +195,17 @@ You should see output similar to:
 
 ---
 
-## Step 4: Access CueWeb
+## Step 4: Access OpenCueWeb
 
 1. Open your web browser
 2. Navigate to: **http://localhost:3000**
-3. You should see the CueWeb interface
+3. You should see the OpenCueWeb interface
 
 ### Expected Interface
 
-The CueWeb interface includes:
+The OpenCueWeb interface includes:
 
-- **Global Header**: Persistent across every page. Shows the OpenCue logo (theme-aware: black in light mode, white in dark mode) + the **CueWeb** wordmark on the left, six dropdown menus mirroring the CueGUI menu bar — **File**, **Cuebot Facility**, **Cuetopia**, **CueCommander**, **Other** (Attributes, Immersive (full-screen), Split view, Show Shortcuts, Notify on Shortcut), **Help** (with a search box that finds commands across every menu) — a theme toggle on the right, and an always-visible **Sign out** button. With auth disabled (`NEXT_PUBLIC_AUTH_PROVIDER=`), the Sign out button still appears — clicking it just navigates to `/login`, which shows a **CueWeb Home** button.
+- **Global Header**: Persistent across every page. Shows the OpenCue logo (theme-aware: black in light mode, white in dark mode) + the **OpenCueWeb** wordmark on the left, six dropdown menus mirroring the CueGUI menu bar — **File**, **Cuebot Facility**, **Cuetopia**, **CueCommander**, **Other** (Attributes, Immersive (full-screen), Split view, Show Shortcuts, Notify on Shortcut), **Help** (with a search box that finds commands across every menu) — a theme toggle on the right, and an always-visible **Sign out** button. With auth disabled (`NEXT_PUBLIC_AUTH_PROVIDER=`), the Sign out button still appears — clicking it just navigates to `/login`, which shows a **OpenCueWeb Home** button.
 - **Left Sidebar**: Same six groups as the header, organized as accordion sections. Click **Collapse** at the bottom to shrink to an icon-only rail.
 - **Jobs Dashboard**: View and manage rendering jobs, with CueGUI-parity columns (Launched, Eligible, Finished, User Color, ...).
 - **Layers / Frames panels**: Inline below the jobs table. Click a job row to reveal them; click a layer to filter the frames panel; double-click a frame row to open the log viewer.
@@ -219,23 +219,23 @@ The CueWeb interface includes:
 - **Job-finished Notifications**: Two channels - a per-row **Notify bell** for browser notifications (in-app toast + optional desktop popup) and a right-click **Subscribe to Job** entry for *email* notifications sent by Cuebot. Independent of each other.
 - **Disable Job Interaction**: Read-only safety toggle in File ▸ Disable Job Interaction (header or sidebar). When on, an amber banner appears under the header and destructive actions (Pause / Unpause / Retry / Eat / Kill) — in the toolbar and in the right-click menus — are dim and inert.
 - **Attributes Panel**: Other ▸ Attributes opens a docked drawer with a collapsible key/value tree of the selected entity. Click a row in the jobs table to populate it; pick the dock position (right / bottom / left / top) from the panel's title bar.
-- **Bottom Status Bar**: a fixed 24-pixel bar at the bottom of every page shows REST gateway status (a colored dot + Online/Offline + the last round-trip latency), the time since the jobs table last refreshed, and the CueWeb build version. The whole bar turns red when the gateway is unreachable.
+- **Bottom Status Bar**: a fixed 24-pixel bar at the bottom of every page shows REST gateway status (a colored dot + Online/Offline + the last round-trip latency), the time since the jobs table last refreshed, and the OpenCueWeb build version. The whole bar turns red when the gateway is unreachable.
 - **Breadcrumb Navigation**: detail views (frame log page, per-job comments page) render a small "Home > Jobs > ..." breadcrumb above the content so you can navigate back to the index. Long labels truncate with an ellipsis and the full text appears in a tooltip on hover.
 - **Keyboard shortcuts**: Press `?` anywhere (or use **Other ▸ Show Shortcuts**) to open the cheat-sheet. A small toast appears on every triggered shortcut so you know it registered; turn it off via **Other ▸ Notify on Shortcut** if you prefer silence.
 
-The login page (or the **CueWeb Home** button when authentication is disabled):
+The login page (or the **OpenCueWeb Home** button when authentication is disabled):
 
-![CueWeb login page](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_login.png)
+![OpenCueWeb login page](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_login.png)
 
 
 The Dashboard you land on after signing in:
 
-![CueWeb dashboard](/assets/images/cueweb/cueweb_dashboard.png)
+![OpenCueWeb dashboard](/assets/images/cueweb/cueweb_dashboard.png)
 
 
 The Cuetopia Monitor Jobs view with the jobs table:
 
-![CueWeb Monitor Jobs](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_mainpage.png)
+![OpenCueWeb Monitor Jobs](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_mainpage.png)
 
 
 ---
@@ -250,7 +250,7 @@ The Cuetopia Monitor Jobs view with the jobs table:
 
 Click a job row to reveal the inline Layers and Frames panels below the jobs table:
 
-![CueWeb inline layers and frames](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_layersframes.png)
+![OpenCueWeb inline layers and frames](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_layersframes.png)
 
 
 ### Job Management
@@ -272,10 +272,10 @@ Click a job row to reveal the inline Layers and Frames panels below the jobs tab
 
 The job right-click menu, and the tabbed Job Details page it can open:
 
-![CueWeb job context menu](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_job_context_menu_open.png)
+![OpenCueWeb job context menu](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_job_context_menu_open.png)
 
 
-![CueWeb Job Details overview](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_view_job_details_page_overview.png)
+![OpenCueWeb Job Details overview](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_view_job_details_page_overview.png)
 
 
 ### Frame Operations
@@ -288,8 +288,8 @@ The job right-click menu, and the tabbed Job Details page it can open:
 6. **Job Progress Tooltip**: Hover the stacked progress bar in the Jobs table to see exact frame counts and percentages for each state.
 7. **Subscribe to Completion - in browser**: Click the bell in the **Notify** column of the Jobs table to subscribe to a notification when the job reaches `FINISHED`. The subscription always succeeds; the browser's notification permission is an optional upgrade (granted = in-app toast + desktop popup; denied = in-app toast only). Subscriptions are saved in your browser and survive page reloads, and a background check runs on each subscribed job every 15 seconds. When the same job is open in several tabs, only one tab shows the notification.
 8. **Subscribe to Completion - by email**: For notifications that should survive a browser close, follow you between machines, or fan out to a team alias, right-click the job and pick **Subscribe to Job**. A dialog opens with the job name and an editable **To** address; Save registers the address with Cuebot so Cuebot emails the subscriber when the job finishes. Independent of the Notify bell.
-9. **Copy actions**: every row's context menu has copy items - **Copy Job Name** / **Copy Layer Name** / **Copy Frame Name** / **Copy Log Path** - that push the value to the clipboard with a confirmation toast. Works on `http://localhost:3000` and also when accessing CueWeb at a LAN IP over plain HTTP.
-10. **Mobile**: load CueWeb on a phone via `http://<lan-ip>:3000` from the same network (e.g. `ipconfig getifaddr en0` on the Mac shows the IP). The hamburger button at the top-left opens a nav drawer with every menu group; each row's leftmost `⋮` button replaces the right-click menu on touch.
+9. **Copy actions**: every row's context menu has copy items - **Copy Job Name** / **Copy Layer Name** / **Copy Frame Name** / **Copy Log Path** - that push the value to the clipboard with a confirmation toast. Works on `http://localhost:3000` and also when accessing OpenCueWeb at a LAN IP over plain HTTP.
+10. **Mobile**: load OpenCueWeb on a phone via `http://<lan-ip>:3000` from the same network (e.g. `ipconfig getifaddr en0` on the Mac shows the IP). The hamburger button at the top-left opens a nav drawer with every menu group; each row's leftmost `⋮` button replaces the right-click menu on touch.
 
 ### Search Functionality
 
@@ -297,30 +297,30 @@ The job right-click menu, and the tabbed Job Details page it can open:
 - **Regex Search**: Prefix with `!` for advanced patterns (e.g., "!.*test.*")
 - **Dropdown Suggestions**: Shows matching jobs as you type
 
-![CueWeb job search](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_search_jobs.png)
+![OpenCueWeb job search](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_search_jobs.png)
 
 ### Redirect cores to a job
 
 Open **CueCommander &rarr; Redirect** to hand cores to a job that needs them. The tool finds procs currently busy on other work and reassigns them to a **Target** job - the frames on those procs are killed and the freed cores are booked onto your target, so use it deliberately.
 
-![CueWeb Redirect page](/assets/images/cueweb/cueweb_cuecommander_redirect.png)
+![OpenCueWeb Redirect page](/assets/images/cueweb/cueweb_cuecommander_redirect.png)
 
 1. Type the **Target** job name (this auto-fills the Show and minimum cores/memory from its layers).
 2. Adjust the filters (Allocations, Minimum/Max Cores, Minimum Memory, Proc Hour Cutoff) and click **Search**.
-3. Tick the hosts to take from (or **Select All**) and click **Redirect**. CueWeb refuses if the target has no waiting frames or is at max cores, and warns before a paused-target or cross-show redirect.
+3. Tick the hosts to take from (or **Select All**) and click **Redirect**. OpenCueWeb refuses if the target has no waiting frames or is at max cores, and warns before a paused-target or cross-show redirect.
 
 ### Find stuck frames
 
 Open **CueCommander &rarr; Stuck Frame** to find running frames that look hung - frames that keep running but have stopped writing to their log. The page scans every running frame and lists the ones that cross the detection thresholds (Last Log Update vs. runtime), grouped by job.
 
-![CueWeb Stuck Frames page](/assets/images/cueweb/cueweb_cuecommander_stuck_frame.png)
+![OpenCueWeb Stuck Frames page](/assets/images/cueweb/cueweb_cuecommander_stuck_frame.png)
 
 - Tune the filter bar (**Min LLU**, **% of Run Since LLU**, **Total Runtime**) to control how aggressively frames are flagged; the **+** button adds a per-service filter row so long-running services (e.g. Arnold) can use looser limits than quicker ones.
 - Right-click a frame for **Retry / Eat / Kill**, **View Log**, or **Core Up** (raise the layer's minimum cores - a common fix when a frame is starved for resources). Right-click a job header for job-wide actions.
 
 ### Monitor the cue
 
-Open **CueCommander &rarr; Monitor Cue** to watch every job for the shows you pick, grouped under their show and groups (the CueWeb version of CueGUI's Monitor Cue window). Choose shows from the **Shows** menu to populate the tree.
+Open **CueCommander &rarr; Monitor Cue** to watch every job for the shows you pick, grouped under their show and groups (the OpenCueWeb version of CueGUI's Monitor Cue window). Choose shows from the **Shows** menu to populate the tree.
 
 - Full CueGUI columns (Run, Cores, Gpus, Wait, Depend, Total, a **Booking** bar with min/max core markers, Min/Max cores & GPUs, Pri, MaxRss, Age, Progress, …); sort by any header, show/hide & reorder via the **Columns** dropdown, and narrow with the **Filter jobs...** box. Rows are tinted by condition (blue = paused, red = dead, green = waiting, purple = all-depend).
 - Select jobs (checkboxes, Shift+click ranges, or the live **Select:** name/regex box) and act on them from the toolbar: **Eat / Retry / Pause / Unpause / Kill**. Right-click a job for the full menu, including **Send To Group...** and the resource/priority setters.
@@ -329,7 +329,7 @@ Open **CueCommander &rarr; Monitor Cue** to watch every job for the shows you pi
 
 Open **CueCommander &rarr; Monitor Hosts** to see every render host with the full CueGUI column set (Load %, Swap / Physical / GPU Memory / Temp usage bars, cores, GPUs, hardware/lock state, OS, tags). Rows are tinted by condition - red for a non-`UP` host, amber for one waiting to reboot when idle, yellow for an `UP` but locked host.
 
-![CueWeb Monitor Hosts page](/assets/images/cueweb/cueweb_cuecommander_monitor_hosts.png)
+![OpenCueWeb Monitor Hosts page](/assets/images/cueweb/cueweb_cuecommander_monitor_hosts.png)
 
 - Narrow the list with the **name/regex** box and the **Filter Allocation / HardwareState / LockState / OS** dropdowns (the filters are reflected in the URL, so a view is shareable).
 - Right-click a host for **Comments**, **View Procs**, **Lock / Unlock**, **Edit Tags / Rename Tag / Change Allocation**, **Reboot / Reboot when idle / Delete Host**, and **Set / Clear Repair State**.
@@ -337,33 +337,33 @@ Open **CueCommander &rarr; Monitor Hosts** to see every render host with the ful
 
 ### Switch Cuebot facilities
 
-If your render farm spans more than one **facility** (each with its own Cuebot), use the **Cuebot Facility** menu in the header to switch between them. CueWeb shows **one facility at a time** - the same behavior as CueGUI's Cuebot Facility menu.
+If your render farm spans more than one **facility** (each with its own Cuebot), use the **Cuebot Facility** menu in the header to switch between them. OpenCueWeb shows **one facility at a time** - the same behavior as CueGUI's Cuebot Facility menu.
 
 ![Cuebot Facility menu](/assets/images/cueweb/cueweb_cuebot_facility_menu.png)
 
-- Pick a facility from the menu; CueWeb re-routes to that facility's Cuebot and reloads whatever you are viewing. The active facility shows as a chip on the menu and in the bottom status bar, and your choice is remembered for the session.
+- Pick a facility from the menu; OpenCueWeb re-routes to that facility's Cuebot and reloads whatever you are viewing. The active facility shows as a chip on the menu and in the bottom status bar, and your choice is remembered for the session.
 - Each facility shows a **green/red health dot** - green when its REST gateway is reachable, red when it is down (polled every 30s). A facility whose gateway is down is **disabled**, so you can't switch into it.
 - The list of facilities comes from `NEXT_PUBLIC_CUEBOT_FACILITIES` (default `local,dev,cloud,external`). To point a facility at its own gateway, set the server-only pair `CUEBOT_<NAME>_REST_GATEWAY_URL` and `CUEBOT_<NAME>_JWT_SECRET` (e.g. `CUEBOT_DEV_REST_GATEWAY_URL`); a facility with no override falls back to `NEXT_PUBLIC_OPENCUE_ENDPOINT` / `NEXT_JWT_SECRET`. The single-facility sandbox works with just `local`.
 - To change a facility's gateway URL or JWT secret **without a redeploy**, choose **Manage facilities…** from the menu. The admin screen edits each facility's connection at runtime (applied immediately, layered over the env defaults) and keeps a change-history log. Persist these overrides across container restarts by pointing `CUEWEB_FACILITY_STORE` at a mounted volume.
 
-### Check the CueWeb version (About CueWeb)
+### Check the OpenCueWeb version (About OpenCueWeb)
 
-The build version is always visible at the right of the bottom status bar. For full build details, open **Help &rarr; About CueWeb**.
+The build version is always visible at the right of the bottom status bar. For full build details, open **Help &rarr; About OpenCueWeb**.
 
-![About CueWeb in the Help menu](/assets/images/cueweb/cueweb_help_about_cueweb_menu.png)
+![About OpenCueWeb in the Help menu](/assets/images/cueweb/cueweb_help_about_cueweb_menu.png)
 
 The dialog shows the **Version**, the **Build SHA**, and a license link, with a **Copy diagnostics** button that copies all fields as JSON (handy for bug reports).
 
-![About CueWeb dialog](/assets/images/cueweb/cueweb_help_about_cueweb.png)
+![About OpenCueWeb dialog](/assets/images/cueweb/cueweb_help_about_cueweb.png)
 
-- The **Version** is resolved at build time: an explicit `NEXT_PUBLIC_APP_VERSION` build-arg wins; otherwise `cueweb/OVERRIDE_CUEWEB_VERSION.in` decides - the default value `VERSION.in` means "track the repo-root `VERSION.in`" (OpenCue's shared version), while any other value is used verbatim as a CueWeb-specific override; `package.json` is the last-resort fallback.
+- The **Version** is resolved at build time: an explicit `NEXT_PUBLIC_APP_VERSION` build-arg wins; otherwise `cueweb/OVERRIDE_CUEWEB_VERSION.in` decides - the default value `VERSION.in` means "track the repo-root `VERSION.in`" (OpenCue's shared version), while any other value is used verbatim as a OpenCueWeb-specific override; `package.json` is the last-resort fallback.
 - The **Build SHA** comes from the `NEXT_PUBLIC_GIT_SHA` build-arg (CI injects `git rev-parse --short HEAD`); it shows `unknown` when not provided.
 
 ### Try a plugin
 
-CueWeb ships a small **plugin system** with two sample add-ons. Open the **Plugins** page (the **Plugins** menu sits to the right of CueSubmit in the header) to see the registered plugins.
+OpenCueWeb ships a small **plugin system** with two sample add-ons. Open the **Plugins** page (the **Plugins** menu sits to the right of CueSubmit in the header) to see the registered plugins.
 
-![CueWeb Plugins page](/assets/images/cueweb/cueweb_plugins.png)
+![OpenCueWeb Plugins page](/assets/images/cueweb/cueweb_plugins.png)
 
 - Each plugin has a **checkbox** that controls whether it appears in the **Plugins** menu; your choice is saved in your browser. Open a plugin to use it, and use its **Open plugin settings** control to tweak its options (also saved per browser).
 - **Cue Progress Bar** (on by default) draws a live frame-state bar for a job with pause / unpause / kill / retry-dead controls; **Hello OpenCue** (off by default) is a minimal example. Developers can add their own under `cueweb/app/plugins/<name>/`.
@@ -377,30 +377,30 @@ Three quick ways to shape the workspace (all saved in your browser):
   ![Views dropdown with saved presets](/assets/images/cueweb/cueweb_saveable_view_presets.png)
 - **Go full-screen:** press **`F`** (or use **Other &rarr; Immersive (full-screen)**) to hide the header, sidebar, and status bar so a table fills the screen. A floating **Exit immersive** button brings the chrome back.
 
-  ![CueWeb in immersive (full-screen) mode](/assets/images/cueweb/cueweb_full_screen_activated.png)
+  ![OpenCueWeb in immersive (full-screen) mode](/assets/images/cueweb/cueweb_full_screen_activated.png)
 
 - **Split the view:** open **Other &rarr; Split view** to see two pages side-by-side in resizable panes (e.g. Monitor Jobs next to a host). The layout lives in the URL (`/split?left=…&right=…`), so it's bookmarkable and reload-safe.
 
-  ![CueWeb split view](/assets/images/cueweb/cueweb_split_view_activated.png)
+  ![OpenCueWeb split view](/assets/images/cueweb/cueweb_split_view_activated.png)
 
 ### Review the audit trail
 
-Open **Admin &rarr; CueWeb Audit** (in the top header or the left sidebar) to see who changed what. CueWeb records every **state-changing** action - who did it, the action, the timestamp, the target entity, the Cuebot facility, and whether it succeeded or errored - plus sign in / sign out. Read-only views are not recorded.
+Open **Admin &rarr; OpenCueWeb Audit** (in the top header or the left sidebar) to see who changed what. OpenCueWeb records every **state-changing** action - who did it, the action, the timestamp, the target entity, the Cuebot facility, and whether it succeeded or errored - plus sign in / sign out. Read-only views are not recorded.
 
-![CueWeb Audit menu](/assets/images/cueweb/cueweb_admin_cueweb_audit_menu.png)
+![OpenCueWeb Audit menu](/assets/images/cueweb/cueweb_admin_cueweb_audit_menu.png)
 
-![CueWeb Audit page](/assets/images/cueweb/cueweb_admin_cueweb_audit.png)
+![OpenCueWeb Audit page](/assets/images/cueweb/cueweb_admin_cueweb_audit.png)
 
 - Filter by actor, category, or result, set a From/To time window, or type in the free-text search; expand a row to see sanitized details.
 - Page through results (First / Prev / Next / Last, "Page X of N", with a rows-per-page selector that defaults to 10), flip on **auto-refresh**, and use **Export CSV** to download the current view.
-- Access follows the same group gate as the rest of CueWeb: with no group authorization configured (no auth provider, `CUEWEB_AUTHZ_ENABLED` off, or no `CUEWEB_ADMIN_GROUPS` set) the page is open to everyone; when the gate is active, only members of `CUEWEB_ADMIN_GROUPS` can reach it. See **Restrict access by group** in Step 2.
+- Access follows the same group gate as the rest of OpenCueWeb: with no group authorization configured (no auth provider, `CUEWEB_AUTHZ_ENABLED` off, or no `CUEWEB_ADMIN_GROUPS` set) the page is open to everyone; when the gate is active, only members of `CUEWEB_ADMIN_GROUPS` can reach it. See **Restrict access by group** in Step 2.
 - The trail lives at `CUEWEB_AUDIT_STORE` and is bounded by `CUEWEB_AUDIT_MAX_RECORDS` (both shown in Step 2).
 
 ---
 
 ## Step 6 (optional): Submit a job from the browser (CueSubmit)
 
-CueWeb ships a browser-based equivalent of the standalone CueSubmit CLI tool so you don't need a separate desktop install just to launch a test job:
+OpenCueWeb ships a browser-based equivalent of the standalone CueSubmit CLI tool so you don't need a separate desktop install just to launch a test job:
 
 ![CueSubmit menu options](/assets/images/cueweb/cueweb_cuesubmit_menu_options.png)
 
@@ -410,7 +410,7 @@ CueWeb ships a browser-based equivalent of the standalone CueSubmit CLI tool so 
 2. In **Job Info** fill in a Job Name (e.g. `quickstart_test`), pick `testing` for Show, type a Shot like `test_shot`, leave Facility as `[Default]`, and confirm Username.
 3. In **Layer Info** fill in a Layer Name (e.g. `layer1`), set Frame Spec to `1-3`, leave Chunk Size at `1` and Memory at the `256m` default, and keep Job Type set to **Shell**.
 4. In **Shell options** type `sleep 5` for Command To Run. Watch the **Final command** field at the bottom update per-keystroke.
-5. Click **Submit**. CueWeb redirects you to the job's detail page where the three frames will go WAITING -> RUNNING -> SUCCEEDED in a few seconds.
+5. Click **Submit**. OpenCueWeb redirects you to the job's detail page where the three frames will go WAITING -> RUNNING -> SUCCEEDED in a few seconds.
 6. Click **View in Monitor Jobs** in the detail-page header to open Cuetopia with the new job already loaded.
 
 The form keeps an autocomplete history (per browser) for Job Name, Shot, and Layer Name across submissions, and auto-saves a draft on every keystroke so an accidental refresh never wipes a multi-layer setup. Click **Reset** to clear the form back to a blank canvas.
@@ -419,7 +419,7 @@ The form keeps an autocomplete history (per browser) for Job Name, Shot, and Lay
 
 ## Troubleshooting
 
-### CueWeb won't start
+### OpenCueWeb won't start
 
 **Problem**: npm run dev fails
 ```bash
@@ -484,19 +484,19 @@ npm install
 ## Production Deployment
 
 For production deployment, see:
-- [CueWeb User Guide](/docs/user-guides/cueweb-user-guide) - Complete user documentation
-- [CueWeb Developer Guide](/docs/developer-guide/cueweb-development) - Development and deployment guide
+- [OpenCueWeb User Guide](/docs/user-guides/cueweb-user-guide) - Complete user documentation
+- [OpenCueWeb Developer Guide](/docs/developer-guide/cueweb-development) - Development and deployment guide
 - [REST API Reference](/docs/reference/rest-api-reference/) - API documentation
 
 ---
 
 ## Next Steps
 
-Now that CueWeb is running:
+Now that OpenCueWeb is running:
 
 1. **Explore the Interface**: Familiarize yourself with job management features
 2. **Configure Authentication**: Set up OAuth providers for multi-user access
 3. **Customize Settings**: Adjust table columns and refresh intervals
 4. **Monitor Production**: Set up alerts and monitoring for your render farm
 
-For detailed usage instructions, see the [CueWeb User Guide](/docs/user-guides/cueweb-user-guide).
+For detailed usage instructions, see the [OpenCueWeb User Guide](/docs/user-guides/cueweb-user-guide).

--- a/docs/_docs/quick-starts/quick-start-cueweb.md
+++ b/docs/_docs/quick-starts/quick-start-cueweb.md
@@ -205,7 +205,7 @@ You should see output similar to:
 
 The OpenCueWeb interface includes:
 
-- **Global Header**: Persistent across every page. Shows the OpenCue logo (theme-aware: black in light mode, white in dark mode) + the **OpenCueWeb** wordmark on the left, six dropdown menus mirroring the CueGUI menu bar — **File**, **Cuebot Facility**, **Cuetopia**, **CueCommander**, **Other** (Attributes, Immersive (full-screen), Split view, Show Shortcuts, Notify on Shortcut), **Help** (with a search box that finds commands across every menu) — a theme toggle on the right, and an always-visible **Sign out** button. With auth disabled (`NEXT_PUBLIC_AUTH_PROVIDER=`), the Sign out button still appears — clicking it just navigates to `/login`, which shows a **OpenCueWeb Home** button.
+- **Global Header**: Persistent across every page. Shows the OpenCue logo (theme-aware: black in light mode, white in dark mode) + the **OpenCueWeb** wordmark on the left, six dropdown menus mirroring the CueGUI menu bar — **File**, **Cuebot Facility**, **Cuetopia**, **CueCommander**, **Other** (Attributes, Immersive (full-screen), Split view, Show Shortcuts, Notify on Shortcut), **Help** (with a search box that finds commands across every menu) — a theme toggle on the right, and an always-visible **Sign out** button. With auth disabled (`NEXT_PUBLIC_AUTH_PROVIDER=`), the Sign out button still appears — clicking it just navigates to `/login`, which shows an **OpenCueWeb Home** button.
 - **Left Sidebar**: Same six groups as the header, organized as accordion sections. Click **Collapse** at the bottom to shrink to an icon-only rail.
 - **Jobs Dashboard**: View and manage rendering jobs, with CueGUI-parity columns (Launched, Eligible, Finished, User Color, ...).
 - **Layers / Frames panels**: Inline below the jobs table. Click a job row to reveal them; click a layer to filter the frames panel; double-click a frame row to open the log viewer.
@@ -356,7 +356,7 @@ The dialog shows the **Version**, the **Build SHA**, and a license link, with a 
 
 ![About OpenCueWeb dialog](/assets/images/cueweb/cueweb_help_about_cueweb.png)
 
-- The **Version** is resolved at build time: an explicit `NEXT_PUBLIC_APP_VERSION` build-arg wins; otherwise `cueweb/OVERRIDE_CUEWEB_VERSION.in` decides - the default value `VERSION.in` means "track the repo-root `VERSION.in`" (OpenCue's shared version), while any other value is used verbatim as a OpenCueWeb-specific override; `package.json` is the last-resort fallback.
+- The **Version** is resolved at build time: an explicit `NEXT_PUBLIC_APP_VERSION` build-arg wins; otherwise `cueweb/OVERRIDE_CUEWEB_VERSION.in` decides - the default value `VERSION.in` means "track the repo-root `VERSION.in`" (OpenCue's shared version), while any other value is used verbatim as an OpenCueWeb-specific override; `package.json` is the last-resort fallback.
 - The **Build SHA** comes from the `NEXT_PUBLIC_GIT_SHA` build-arg (CI injects `git rev-parse --short HEAD`); it shows `unknown` when not provided.
 
 ### Try a plugin

--- a/docs/_docs/quick-starts/quick-start-monitoring.md
+++ b/docs/_docs/quick-starts/quick-start-monitoring.md
@@ -83,7 +83,7 @@ opencue.proc.events
 
 ### Step 3: Access Grafana
 
-1. Open Grafana at [http://localhost:3001](http://localhost:3001) (port 3001 to avoid conflict with CueWeb)
+1. Open Grafana at [http://localhost:3001](http://localhost:3001) (port 3001 to avoid conflict with OpenCueWeb)
 2. Log in with:
    - Username: `admin`
    - Password: `admin`

--- a/docs/_docs/quick-starts/quick-start-rest-gateway.md
+++ b/docs/_docs/quick-starts/quick-start-rest-gateway.md
@@ -413,17 +413,17 @@ for show in shows:
 
 ---
 
-## Deploy with CueWeb
+## Deploy with OpenCueWeb
 
-For a complete web interface, deploy CueWeb alongside the REST Gateway using the `cueweb` profile:
+For a complete web interface, deploy OpenCueWeb alongside the REST Gateway using the `cueweb` profile:
 
 ```bash
-# Start core services + Web UI (REST Gateway + CueWeb)
+# Start core services + Web UI (REST Gateway + OpenCueWeb)
 docker compose --profile cueweb up -d
 ```
 
 This deploys:
-- **CueWeb**: http://localhost:3000
+- **OpenCueWeb**: http://localhost:3000
 - **REST Gateway**: http://localhost:8448
 - **Cuebot**: localhost:8443
 - **RQD**: localhost:8444
@@ -437,7 +437,7 @@ Now that the REST Gateway is running:
 
 1. **Explore the API**: Try different endpoints from the [REST API Reference](/docs/reference/rest-api-reference/)
 2. **Build integrations**: Create scripts or applications using the API
-3. **Deploy CueWeb**: Set up the web interface for browser access
+3. **Deploy OpenCueWeb**: Set up the web interface for browser access
 4. **Production setup**: Review [Deploying REST Gateway](/docs/getting-started/deploying-rest-gateway/) for production configuration
 
 ---
@@ -448,4 +448,4 @@ Now that the REST Gateway is running:
 - [REST API Tutorial](/docs/tutorials/rest-api-tutorial/) - Step-by-step tutorial
 - [Deploying REST Gateway](/docs/getting-started/deploying-rest-gateway/) - Production deployment
 - [Using the REST API](/docs/user-guides/using-rest-api/) - User guide
-- [CueWeb Quick Start](/docs/quick-starts/quick-start-cueweb/) - Web interface setup
+- [OpenCueWeb Quick Start](/docs/quick-starts/quick-start-cueweb/) - Web interface setup

--- a/docs/_docs/reference/cueweb.md
+++ b/docs/_docs/reference/cueweb.md
@@ -81,7 +81,6 @@ OpenCueWeb is a web-based application that provides browser access to OpenCue re
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `NEXT_PUBLIC_OPENCUE_ENDPOINT` | REST Gateway URL | `http://localhost:8448` |
-| `NEXT_PUBLIC_URL` | OpenCueWeb public URL | `http://localhost:3000` |
 | `NEXT_JWT_SECRET` | JWT signing secret (must match REST Gateway) | `your-secret-key` |
 
 ### Optional Build-Time Variables
@@ -135,7 +134,7 @@ Optional, opt-in group-based access control enforced server-side in `middleware.
 
 ### Audit Variables
 
-Configuration for the [OpenCueWeb Audit](#cueweb-audit) trail, an append-only JSONL log of every state-changing action performed through OpenCueWeb. Both default to a working out-of-the-box configuration, so no setup is required to start auditing.
+Configuration for the [OpenCueWeb Audit](#opencueweb-audit) trail, an append-only JSONL log of every state-changing action performed through OpenCueWeb. Both default to a working out-of-the-box configuration, so no setup is required to start auditing.
 
 | Variable | Description | Default |
 |----------|-------------|---------|

--- a/docs/_docs/reference/cueweb.md
+++ b/docs/_docs/reference/cueweb.md
@@ -1,14 +1,14 @@
 ---
 layout: default
-title: CueWeb Reference
+title: OpenCueWeb Reference
 parent: Reference
 nav_order: 71
 ---
 
-# CueWeb Reference
+# OpenCueWeb Reference
 {: .no_toc }
 
-Complete reference documentation for CueWeb, the web-based interface for OpenCue.
+Complete reference documentation for OpenCueWeb, the web-based interface for OpenCue.
 
 <details open markdown="block">
   <summary>
@@ -23,7 +23,7 @@ Complete reference documentation for CueWeb, the web-based interface for OpenCue
 
 ## Overview
 
-CueWeb is a web-based application that provides browser access to OpenCue render farm management. Built with Next.js and React, it offers a responsive interface for monitoring jobs, managing frames, and controlling rendering operations.
+OpenCueWeb is a web-based application that provides browser access to OpenCue render farm management. Built with Next.js and React, it offers a responsive interface for monitoring jobs, managing frames, and controlling rendering operations.
 
 ### System Requirements
 
@@ -42,7 +42,7 @@ CueWeb is a web-based application that provides browser access to OpenCue render
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│                      CueWeb                              │
+│                      OpenCueWeb                          │
 │  ┌─────────────┐  ┌─────────────┐  ┌─────────────────┐  │
 │  │   Next.js   │  │    React    │  │   Shadcn UI     │  │
 │  │   Server    │  │  Components │  │   Components    │  │
@@ -66,8 +66,8 @@ CueWeb is a web-based application that provides browser access to OpenCue render
 
 ### Data Flow
 
-1. User interacts with CueWeb UI
-2. CueWeb generates JWT token using shared secret
+1. User interacts with OpenCueWeb UI
+2. OpenCueWeb generates JWT token using shared secret
 3. HTTP request sent to REST Gateway with JWT in Authorization header
 4. REST Gateway validates JWT and forwards to Cuebot via gRPC
 5. Response returned through the same path
@@ -81,15 +81,15 @@ CueWeb is a web-based application that provides browser access to OpenCue render
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `NEXT_PUBLIC_OPENCUE_ENDPOINT` | REST Gateway URL | `http://localhost:8448` |
-| `NEXT_PUBLIC_URL` | CueWeb public URL | `http://localhost:3000` |
+| `NEXT_PUBLIC_URL` | OpenCueWeb public URL | `http://localhost:3000` |
 | `NEXT_JWT_SECRET` | JWT signing secret (must match REST Gateway) | `your-secret-key` |
 
 ### Optional Build-Time Variables
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `NEXT_PUBLIC_APP_VERSION` | Build version shown in the bottom status bar and the About CueWeb dialog. When unset, resolved from `cueweb/OVERRIDE_CUEWEB_VERSION.in` (the `VERSION.in` sentinel tracks the repo-root `VERSION.in`; any other value pins an explicit version), then `cueweb/package.json#version`. | (resolved from `VERSION.in`) |
-| `NEXT_PUBLIC_GIT_SHA` | Short Git SHA shown in the About CueWeb dialog. Build-time only; CI injects `$(git rev-parse --short HEAD)`. Empty &rarr; "unknown". | (empty) |
+| `NEXT_PUBLIC_APP_VERSION` | Build version shown in the bottom status bar and the About OpenCueWeb dialog. When unset, resolved from `cueweb/OVERRIDE_CUEWEB_VERSION.in` (the `VERSION.in` sentinel tracks the repo-root `VERSION.in`; any other value pins an explicit version), then `cueweb/package.json#version`. | (resolved from `VERSION.in`) |
+| `NEXT_PUBLIC_GIT_SHA` | Short Git SHA shown in the About OpenCueWeb dialog. Build-time only; CI injects `$(git rev-parse --short HEAD)`. Empty &rarr; "unknown". | (empty) |
 | `NEXT_PUBLIC_CUEBOT_FACILITIES` | Comma-separated facility list shown in the Cuebot Facility menu. | `local,dev,cloud,external` |
 | `CUEBOT_<NAME>_REST_GATEWAY_URL` | Per-facility REST gateway base URL (server-only; `<NAME>` is the uppercased facility name). Falls back to `NEXT_PUBLIC_OPENCUE_ENDPOINT`. | (unset &rarr; default gateway) |
 | `CUEBOT_<NAME>_JWT_SECRET` | Per-facility JWT secret the target gateway trusts (server-only). Falls back to `NEXT_JWT_SECRET`. | (unset &rarr; default secret) |
@@ -97,9 +97,9 @@ CueWeb is a web-based application that provides browser access to OpenCue render
 | `NEXT_PUBLIC_DOCS_URL` | Online User Guide link in the Help menu. | `https://www.opencue.io/docs/` |
 | `NEXT_PUBLIC_SUGGESTIONS_URL` | Make a Suggestion link in the Help menu. | CueGUI default (GitHub issues, `enhancement` template) |
 | `NEXT_PUBLIC_BUGS_URL` | Report a Bug link in the Help menu. | CueGUI default (GitHub issues, `bug_report` template) |
-| `NEXT_PUBLIC_URL` | Base URL the client uses when calling the Next.js API routes. **Default empty** = the client builds same-origin relative URLs (`/api/job/getjobs`, ...) so CueWeb works from any host the browser reached it at (`http://localhost:3000` on the dev Mac, `http://<lan-ip>:3000` from a phone on the same network). Set to an absolute URL only if your deployment serves the API on a different origin than the UI. | (empty) |
+| `NEXT_PUBLIC_URL` | Base URL the client uses when calling the Next.js API routes. **Default empty** = the client builds same-origin relative URLs (`/api/job/getjobs`, ...) so OpenCueWeb works from any host the browser reached it at (`http://localhost:3000` on the dev Mac, `http://<lan-ip>:3000` from a phone on the same network). Set to an absolute URL only if your deployment serves the API on a different origin than the UI. | (empty) |
 | `NEXT_PUBLIC_LOG_EDITOR_URL` | URL template for the Frame context menu's **View Log on \<editor\>** item. The literal `{path}` is substituted with the absolute rqlog path at click time. Common values: `vscode://file{path}`, `vscode-insiders://file{path}`, `subl://open?url=file://{path}`, `txmt://open?url=file://{path}`, `idea://open?file={path}`. Empty hides the menu item entirely. The sandbox `docker-compose.yml` defaults to `vscode://file{path}`. | `vscode://file{path}` (sandbox) / empty (Dockerfile default) |
-| `NEXT_PUBLIC_LOKI_URL` | Base URL of a [Grafana Loki](https://grafana.com/oss/loki/) HTTP API (no trailing path; CueWeb appends `/loki/api/v1/...`). When set, the frame log viewer queries Loki by `frame_id` instead of reading the on-disk `.rqlog` file (CueGUI `LokiViewPlugin` parity); when empty, CueWeb uses the default file-based viewer. Read in the browser (`NEXT_PUBLIC_*`), so the Loki host must be reachable from clients and must allow CORS from the CueWeb origin. See [Frame log backends](#frame-log-backends). | (empty) |
+| `NEXT_PUBLIC_LOKI_URL` | Base URL of a [Grafana Loki](https://grafana.com/oss/loki/) HTTP API (no trailing path; OpenCueWeb appends `/loki/api/v1/...`). When set, the frame log viewer queries Loki by `frame_id` instead of reading the on-disk `.rqlog` file (CueGUI `LokiViewPlugin` parity); when empty, OpenCueWeb uses the default file-based viewer. Read in the browser (`NEXT_PUBLIC_*`), so the Loki host must be reachable from clients and must allow CORS from the OpenCueWeb origin. See [Frame log backends](#frame-log-backends). | (empty) |
 | `NEXT_PUBLIC_CUEPROGBAR_COMMAND` | Command shown in the job menu's **Show Progress Bar** dialog; `{job}` is substituted with the job name. Sites override it with their own launcher (e.g. `spawn launch cueprogbar {job}`). | `python -m cuegui.cueguiplugin.cueprogbar {job}` |
 | `NEXT_PUBLIC_CUEPROGBAR_URL` | Optional registered URL scheme the **Show Progress Bar** dialog's launch button hands off to a local handler. Empty hides the launch button. | (empty) |
 | `NEXT_PUBLIC_PREVIEW_COMMAND` | Command shown/copied by the frame menu's **Preview All** dialog to open rendered output in an external image viewer. Placeholders `{paths}` / `{job}` / `{layer}` / `{frame}` are substituted. | `rv {paths}` |
@@ -127,22 +127,22 @@ Optional, opt-in group-based access control enforced server-side in `middleware.
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `CUEWEB_AUTHZ_ENABLED` | Master switch for the authorization gate. When off, the middleware is a pure pass-through | unset (off) |
-| `CUEWEB_ALLOWED_GROUPS` | Comma-separated groups allowed to use CueWeb at all (empty ⇒ every signed-in user) | empty |
+| `CUEWEB_ALLOWED_GROUPS` | Comma-separated groups allowed to use OpenCueWeb at all (empty ⇒ every signed-in user) | empty |
 | `CUEWEB_ADMIN_GROUPS` | Comma-separated groups allowed to use the entire CueCommander section (all pages), job submission (CueSubmit), and the Manage facilities… screen (empty ⇒ every signed-in user) | empty |
 | `CUEWEB_GROUPS_CLAIM` | JWT/OIDC claim that carries the user's group memberships | `groups` |
 
-**Behavior:** when enabled, a signed-in user not in `CUEWEB_ALLOWED_GROUPS` is redirected to `/unauthorized` (API routes get `403`); a user not in `CUEWEB_ADMIN_GROUPS` is blocked the same way from the entire CueCommander section (Allocations, Limits, Monitor Cue, Monitor Hosts, Redirect, Services, Shows, Stuck Frame, Subscription Graphs, Subscriptions), job submission (CueSubmit), the Manage facilities… screen (`/settings/facilities`), and the CueWeb Audit page - and those admin-only menus are hidden from non-admins. Everything else stays open to non-admins, including Cuetopia Monitor Jobs and the Dashboard; the health probe (`/api/health`) and metrics (`/api/metrics`) are never gated. Group gating requires an auth provider whose token carries group memberships; when authentication is disabled the gate is inactive.
+**Behavior:** when enabled, a signed-in user not in `CUEWEB_ALLOWED_GROUPS` is redirected to `/unauthorized` (API routes get `403`); a user not in `CUEWEB_ADMIN_GROUPS` is blocked the same way from the entire CueCommander section (Allocations, Limits, Monitor Cue, Monitor Hosts, Redirect, Services, Shows, Stuck Frame, Subscription Graphs, Subscriptions), job submission (CueSubmit), the Manage facilities… screen (`/settings/facilities`), and the OpenCueWeb Audit page - and those admin-only menus are hidden from non-admins. Everything else stays open to non-admins, including Cuetopia Monitor Jobs and the Dashboard; the health probe (`/api/health`) and metrics (`/api/metrics`) are never gated. Group gating requires an auth provider whose token carries group memberships; when authentication is disabled the gate is inactive.
 
 ### Audit Variables
 
-Configuration for the [CueWeb Audit](#cueweb-audit) trail, an append-only JSONL log of every state-changing action performed through CueWeb. Both default to a working out-of-the-box configuration, so no setup is required to start auditing.
+Configuration for the [OpenCueWeb Audit](#cueweb-audit) trail, an append-only JSONL log of every state-changing action performed through OpenCueWeb. Both default to a working out-of-the-box configuration, so no setup is required to start auditing.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `CUEWEB_AUDIT_STORE` | Path to the append-only JSONL audit trail (one JSON record per line, newest appended last, `0600` file mode). Point it at a mounted volume to persist the trail across restarts. | (a `cueweb-audit.jsonl` file in the OS temp dir) |
 | `CUEWEB_AUDIT_MAX_RECORDS` | Maximum number of records retained; the oldest lines are dropped on write once the cap is reached. Set to `0` for no cap. | `50000` |
 
-**Access gating:** the CueWeb Audit page (`/admin/*`) and its read API (`/api/admin/*`) are gated by the [Authorization Variables](#authorization-variables) `CUEWEB_AUTHZ_ENABLED` and `CUEWEB_ADMIN_GROUPS`, exactly like the CueCommander admin pages. When the gate is inactive (no auth provider, `CUEWEB_AUTHZ_ENABLED` off, or no `CUEWEB_ADMIN_GROUPS` configured) the page is visible to everyone; when the gate is active, only members of `CUEWEB_ADMIN_GROUPS` can see the menu entry or reach the page/API.
+**Access gating:** the OpenCueWeb Audit page (`/admin/*`) and its read API (`/api/admin/*`) are gated by the [Authorization Variables](#authorization-variables) `CUEWEB_AUTHZ_ENABLED` and `CUEWEB_ADMIN_GROUPS`, exactly like the CueCommander admin pages. When the gate is inactive (no auth provider, `CUEWEB_AUTHZ_ENABLED` off, or no `CUEWEB_ADMIN_GROUPS` configured) the page is visible to everyone; when the gate is active, only members of `CUEWEB_ADMIN_GROUPS` can see the menu entry or reach the page/API.
 
 ### OAuth Provider Variables
 
@@ -265,7 +265,7 @@ The Frames table (`cueweb/app/frames/frame-columns.tsx`, rendered by `SimpleData
 | **Memory (RSS)** | `used_memory` while RUNNING, `max_rss` after stop. |
 | **Memory (PSS)** | `used_pss` while RUNNING, `max_pss` after stop. |
 | **GPU Memory** | `used_gpu_memory` while RUNNING, `max_gpu_memory` after stop. |
-| **Remain** | Placeholder column for CueGUI's ETA buffer; renders an em-dash until the predictor is wired into CueWeb. Hidden by default in the inline panel. |
+| **Remain** | Placeholder column for CueGUI's ETA buffer; renders an em-dash until the predictor is wired into OpenCueWeb. Hidden by default in the inline panel. |
 | **Start Time** | `frame.startTime` formatted `YYYY-MM-DD HH:MM`. |
 | **Stop Time** | `frame.stopTime` formatted `YYYY-MM-DD HH:MM`. |
 | **Eligible Time** | `frame.eligibleTime` formatted `YYYY-MM-DD HH:MM`. |
@@ -375,7 +375,7 @@ The frame log page (`app/frames/[frame-name]/page.tsx`) has two interchangeable 
 
 | | File-based (default) | Loki (`NEXT_PUBLIC_LOKI_URL` set) |
 |---|---|---|
-| **Source** | Reads the `.rqlog` file from the render-log directory mounted into the CueWeb server, via `/api/getlines`, `/api/countlines`, `/api/getlogversions`. | Queries the Loki HTTP API directly from the browser via `lib/loki.ts`. Mirrors CueGUI's `LokiViewPlugin` (`cuegui/cuegui/plugins/LokiViewPlugin.py`). |
+| **Source** | Reads the `.rqlog` file from the render-log directory mounted into the OpenCueWeb server, via `/api/getlines`, `/api/countlines`, `/api/getlogversions`. | Queries the Loki HTTP API directly from the browser via `lib/loki.ts`. Mirrors CueGUI's `LokiViewPlugin` (`cuegui/cuegui/plugins/LokiViewPlugin.py`). |
 | **Log versions dropdown** | Rotated log files found on disk for the frame. | Distinct `session_start_time` Loki label values (one per **frame attempt**), newest first, from `getFrameLogVersions()`. |
 | **Line loading** | Paginated/infinite scroll with "Scroll from Top" for very large logs. | `getFrameLogLines()` runs a backward `query_range` (so the most recent lines survive the 5000-line per-query cap), re-sorts ascending across streams, and scrolls to the bottom. A **Refresh** button re-fetches the selected attempt. |
 | **Empty/missing copy** | "Log file not found" / "No log output yet". | "No logs in Loki" / "No log output yet". |
@@ -413,7 +413,7 @@ A read-only, interactive node graph of a job's dependency tree, rendered with [R
 
 ### Monitor Cue
 
-A show-grouped job tree at `/monitor-cue` (`cueweb/app/monitor-cue/page.tsx`), the CueWeb equivalent of CueGUI's CueCommander Monitor Cue window. Reached from **CueCommander &rarr; Monitor Cue** (header dropdown and sidebar) - previously a dead sidebar link.
+A show-grouped job tree at `/monitor-cue` (`cueweb/app/monitor-cue/page.tsx`), the OpenCueWeb equivalent of CueGUI's CueCommander Monitor Cue window. Reached from **CueCommander &rarr; Monitor Cue** (header dropdown and sidebar) - previously a dead sidebar link.
 
 | Behavior | Description |
 |----------|-------------|
@@ -430,11 +430,11 @@ A show-grouped job tree at `/monitor-cue` (`cueweb/app/monitor-cue/page.tsx`), t
 
 ### Monitor Hosts
 
-A host registry at `/hosts` (`cueweb/app/hosts/page.tsx`), the CueWeb equivalent of CueGUI's `MonitorHostsPlugin` / `HostMonitorTree`. Reached from **CueCommander &rarr; Monitor Hosts** (header dropdown and sidebar) or the dashboard hosts widget's **View hosts** link.
+A host registry at `/hosts` (`cueweb/app/hosts/page.tsx`), the OpenCueWeb equivalent of CueGUI's `MonitorHostsPlugin` / `HostMonitorTree`. Reached from **CueCommander &rarr; Monitor Hosts** (header dropdown and sidebar) or the dashboard hosts widget's **View hosts** link.
 
 ![Monitor Hosts entry in the CueCommander menu](/assets/images/cueweb/cueweb_cuecommander_monitor_hosts_menu.png)
 
-![CueWeb Monitor Hosts page](/assets/images/cueweb/cueweb_cuecommander_monitor_hosts.png)
+![OpenCueWeb Monitor Hosts page](/assets/images/cueweb/cueweb_cuecommander_monitor_hosts.png)
 
 | Behavior | Description |
 |----------|-------------|
@@ -466,9 +466,9 @@ A per-host page at `/hosts/[host-name]` (`cueweb/app/hosts/[host-name]/page.tsx`
 
 ### Allocations
 
-An allocations table at `/allocations` (`cueweb/app/allocations/page.tsx`), the CueWeb equivalent of CueGUI's CueCommander Allocations window. Reached from **CueCommander &rarr; Allocations** (header dropdown and sidebar).
+An allocations table at `/allocations` (`cueweb/app/allocations/page.tsx`), the OpenCueWeb equivalent of CueGUI's CueCommander Allocations window. Reached from **CueCommander &rarr; Allocations** (header dropdown and sidebar).
 
-![CueWeb Allocations page](/assets/images/cueweb/cueweb_cuecommander_allocation.png)
+![OpenCueWeb Allocations page](/assets/images/cueweb/cueweb_cuecommander_allocation.png)
 
 | Behavior | Description |
 |----------|-------------|
@@ -479,9 +479,9 @@ An allocations table at `/allocations` (`cueweb/app/allocations/page.tsx`), the 
 
 ### Shows
 
-A shows registry at `/shows` (`cueweb/app/shows/page.tsx` + `shows-client.tsx`), the CueWeb equivalent of CueGUI's CueCommander Shows window. Reached from **CueCommander &rarr; Shows** (header dropdown and sidebar).
+A shows registry at `/shows` (`cueweb/app/shows/page.tsx` + `shows-client.tsx`), the OpenCueWeb equivalent of CueGUI's CueCommander Shows window. Reached from **CueCommander &rarr; Shows** (header dropdown and sidebar).
 
-![CueWeb Shows page](/assets/images/cueweb/cueweb_cuecommander_shows.png)
+![OpenCueWeb Shows page](/assets/images/cueweb/cueweb_cuecommander_shows.png)
 
 | Behavior | Description |
 |----------|-------------|
@@ -512,7 +512,7 @@ Save calls only the setters whose value changed (via the `action_utils` helpers 
 
 Clicking a show name opens `/shows/[showName]` (`cueweb/app/shows/[showName]/page.tsx`), a client page that resolves the show via `findShow()` (`app/utils/show_utils.ts` &rarr; `/api/show/findshow` &rarr; `show.ShowInterface/FindShow`) and renders its **group tree** (`components/group-tree/`).
 
-![CueWeb show detail page with the group tree](/assets/images/cueweb/cueweb_cuecommander_shows_group_tree_page.png)
+![OpenCueWeb show detail page with the group tree](/assets/images/cueweb/cueweb_cuecommander_shows_group_tree_page.png)
 
 | Behavior | Description |
 |----------|-------------|
@@ -523,9 +523,9 @@ Clicking a show name opens `/shows/[showName]` (`cueweb/app/shows/[showName]/pag
 
 ### Stuck Frames
 
-A stuck-frame finder at `/stuck-frames` (`cueweb/app/stuck-frames/page.tsx`), the CueWeb equivalent of CueGUI's CueCommander Stuck Frame window (`StuckFramePlugin`). Reached from **CueCommander &rarr; Stuck Frame** (header dropdown and sidebar).
+A stuck-frame finder at `/stuck-frames` (`cueweb/app/stuck-frames/page.tsx`), the OpenCueWeb equivalent of CueGUI's CueCommander Stuck Frame window (`StuckFramePlugin`). Reached from **CueCommander &rarr; Stuck Frame** (header dropdown and sidebar).
 
-![CueWeb Stuck Frames page](/assets/images/cueweb/cueweb_cuecommander_stuck_frame.png)
+![OpenCueWeb Stuck Frames page](/assets/images/cueweb/cueweb_cuecommander_stuck_frame.png)
 
 | Behavior | Description |
 |----------|-------------|
@@ -538,9 +538,9 @@ A stuck-frame finder at `/stuck-frames` (`cueweb/app/stuck-frames/page.tsx`), th
 
 ### Facility Service Defaults
 
-A facility-wide service-defaults editor at `/services` (`cueweb/app/services/page.tsx` + `components/ui/service-defaults-form.tsx`), the CueWeb equivalent of CueGUI's Facility Service Defaults tab (`ServiceDialog` / `ServiceForm`). Reached from **CueCommander &rarr; Services** (header dropdown and sidebar).
+A facility-wide service-defaults editor at `/services` (`cueweb/app/services/page.tsx` + `components/ui/service-defaults-form.tsx`), the OpenCueWeb equivalent of CueGUI's Facility Service Defaults tab (`ServiceDialog` / `ServiceForm`). Reached from **CueCommander &rarr; Services** (header dropdown and sidebar).
 
-![CueWeb Facility Service Defaults page](/assets/images/cueweb/cueweb_cuecommander_facility_services.png)
+![OpenCueWeb Facility Service Defaults page](/assets/images/cueweb/cueweb_cuecommander_facility_services.png)
 
 | Behavior | Description |
 |----------|-------------|
@@ -555,9 +555,9 @@ A facility-wide service-defaults editor at `/services` (`cueweb/app/services/pag
 
 ### Subscriptions
 
-A per-show subscriptions table at `/subscriptions` (`cueweb/app/subscriptions/page.tsx`), the CueWeb equivalent of CueGUI's CueCommander Subscriptions window. Reached from **CueCommander &rarr; Subscriptions** (header dropdown and sidebar).
+A per-show subscriptions table at `/subscriptions` (`cueweb/app/subscriptions/page.tsx`), the OpenCueWeb equivalent of CueGUI's CueCommander Subscriptions window. Reached from **CueCommander &rarr; Subscriptions** (header dropdown and sidebar).
 
-![CueWeb Subscriptions page](/assets/images/cueweb/cueweb_cuecommander_subscriptions.png)
+![OpenCueWeb Subscriptions page](/assets/images/cueweb/cueweb_cuecommander_subscriptions.png)
 
 | Behavior | Description |
 |----------|-------------|
@@ -574,9 +574,9 @@ A per-show subscriptions table at `/subscriptions` (`cueweb/app/subscriptions/pa
 
 ### Subscription Graphs
 
-A multi-show graph view at `/subscription-graphs` (`cueweb/app/subscription-graphs/page.tsx` + `components/ui/subscription-graph.tsx`), the CueWeb equivalent of CueGUI's CueCommander Subscription Graphs window (`SubscriptionGraphWidget` / `SubBookingBarDelegate`). Reached from **CueCommander &rarr; Subscription Graphs** (header dropdown and sidebar).
+A multi-show graph view at `/subscription-graphs` (`cueweb/app/subscription-graphs/page.tsx` + `components/ui/subscription-graph.tsx`), the OpenCueWeb equivalent of CueGUI's CueCommander Subscription Graphs window (`SubscriptionGraphWidget` / `SubBookingBarDelegate`). Reached from **CueCommander &rarr; Subscription Graphs** (header dropdown and sidebar).
 
-![CueWeb Subscription Graphs page](/assets/images/cueweb/cueweb_cuecommander_subscriptions_graphs.png)
+![OpenCueWeb Subscription Graphs page](/assets/images/cueweb/cueweb_cuecommander_subscriptions_graphs.png)
 
 | Behavior | Description |
 |----------|-------------|
@@ -588,9 +588,9 @@ A multi-show graph view at `/subscription-graphs` (`cueweb/app/subscription-grap
 
 ### Limits
 
-A limits table at `/limits` (`cueweb/app/limits/page.tsx`), the CueWeb equivalent of CueGUI's CueCommander Limits window. Reached from **CueCommander &rarr; Limits** (header dropdown and sidebar).
+A limits table at `/limits` (`cueweb/app/limits/page.tsx`), the OpenCueWeb equivalent of CueGUI's CueCommander Limits window. Reached from **CueCommander &rarr; Limits** (header dropdown and sidebar).
 
-![CueWeb Limits page](/assets/images/cueweb/cueweb_cuecommander_limits.png)
+![OpenCueWeb Limits page](/assets/images/cueweb/cueweb_cuecommander_limits.png)
 
 | Behavior | Description |
 |----------|-------------|
@@ -604,9 +604,9 @@ The action helpers (`createLimit` / `deleteLimit` / `renameLimit` / `setLimitMax
 
 ### Redirect
 
-An administrator tool at `/redirect` (`cueweb/app/redirect/page.tsx`), the CueWeb equivalent of CueGUI's CueCommander Redirect window (`Redirect.update()`). Reached from **CueCommander &rarr; Redirect** (header dropdown and sidebar). It reassigns busy procs to a target job: the running frames on the selected procs are killed and the freed cores are booked onto the target.
+An administrator tool at `/redirect` (`cueweb/app/redirect/page.tsx`), the OpenCueWeb equivalent of CueGUI's CueCommander Redirect window (`Redirect.update()`). Reached from **CueCommander &rarr; Redirect** (header dropdown and sidebar). It reassigns busy procs to a target job: the running frames on the selected procs are killed and the freed cores are booked onto the target.
 
-![CueWeb Redirect page](/assets/images/cueweb/cueweb_cuecommander_redirect.png)
+![OpenCueWeb Redirect page](/assets/images/cueweb/cueweb_cuecommander_redirect.png)
 
 | Behavior | Description |
 |----------|-------------|
@@ -654,7 +654,7 @@ Web-native equivalent of CueGUI's Toggle Full-Screen (`cuegui/cuegui/MainWindow.
 
 ### Multi-pane split workspace
 
-Web-native equivalent of CueGUI's Window ▸ "Add new window" entries (`cuegui/cuegui/MainWindow.py`) - open two CueWeb pages side-by-side in one tab.
+Web-native equivalent of CueGUI's Window ▸ "Add new window" entries (`cuegui/cuegui/MainWindow.py`) - open two OpenCueWeb pages side-by-side in one tab.
 
 | Aspect | Description |
 |--------|-------------|
@@ -704,7 +704,7 @@ Above the frames table, one filter chip is rendered per supported state. Each ch
 
 ### Job Comments Page
 
-CueWeb mirrors the CueGUI **Comments** dialog (`cuegui/cuegui/Comments.py`) at `/jobs/<job-name>/comments`.
+OpenCueWeb mirrors the CueGUI **Comments** dialog (`cuegui/cuegui/Comments.py`) at `/jobs/<job-name>/comments`.
 
 | Aspect | Description |
 |--------|-------------|
@@ -716,11 +716,11 @@ CueWeb mirrors the CueGUI **Comments** dialog (`cuegui/cuegui/Comments.py`) at `
 | **Predefined macros** | Stored in `localStorage` under `cueweb-comment-macros`. Scope is per-browser; not synced. |
 | **Indicator icon** | The Jobs table has a dedicated **Comments** column (right after Name) showing a sticky-note icon when `Job.hasComment` is true. The column is sortable so users can pull jobs-with-comments to the top. Updated on the regular jobs-table polling cycle. |
 
-### CueWeb Audit
+### OpenCueWeb Audit
 
-An admin-only audit trail at `/admin/audit` (`cueweb/app/admin/audit/page.tsx` + `audit-table.tsx`) that records **who** performed **which** action, **when**, against **which** target, and with **what outcome**. Every state-changing action proxied through CueWeb is captured at a single gateway chokepoint (`handleRoute` in `cueweb/app/utils/gateway_server.ts`); read-only queries (`Get*` / `Find*` / `List*`) are skipped. Reached from **Admin &rarr; CueWeb Audit** (header dropdown and sidebar), which is hidden from non-admins. Access is gated by [`CUEWEB_AUTHZ_ENABLED` / `CUEWEB_ADMIN_GROUPS`](#authorization-variables); the trail is configured with the [Audit Variables](#audit-variables).
+An admin-only audit trail at `/admin/audit` (`cueweb/app/admin/audit/page.tsx` + `audit-table.tsx`) that records **who** performed **which** action, **when**, against **which** target, and with **what outcome**. Every state-changing action proxied through OpenCueWeb is captured at a single gateway chokepoint (`handleRoute` in `cueweb/app/utils/gateway_server.ts`); read-only queries (`Get*` / `Find*` / `List*`) are skipped. Reached from **Admin &rarr; OpenCueWeb Audit** (header dropdown and sidebar), which is hidden from non-admins. Access is gated by [`CUEWEB_AUTHZ_ENABLED` / `CUEWEB_ADMIN_GROUPS`](#authorization-variables); the trail is configured with the [Audit Variables](#audit-variables).
 
-![CueWeb Audit page](/assets/images/cueweb/cueweb_admin_cueweb_audit.png)
+![OpenCueWeb Audit page](/assets/images/cueweb/cueweb_admin_cueweb_audit.png)
 
 The table renders these columns, in default order:
 
@@ -774,7 +774,7 @@ Authentication events (`Sign in` / `Sign out`) are captured separately via the N
 
 #### Audit API
 
-The CueWeb Audit page reads the trail through one admin-gated route.
+The OpenCueWeb Audit page reads the trail through one admin-gated route.
 
 | Aspect | Description |
 |--------|-------------|
@@ -827,7 +827,7 @@ Prefix with `!` for regex patterns:
 
 ## Context Menu Actions
 
-All three context menus (`JobContextMenu`, `LayerContextMenu`, `FrameContextMenu`) live in `cueweb/components/ui/context_menus/action-context-menu.tsx` and follow the CueGUI Monitor Jobs / Monitor Job Details structure. Items that depend on dialogs / backend integrations not yet implemented in CueWeb route through a `notYetImplemented(label)` placeholder. Destructive items are auto-disabled when **Disable Job Interaction** is on. Menus scroll instead of overflowing on small viewports.
+All three context menus (`JobContextMenu`, `LayerContextMenu`, `FrameContextMenu`) live in `cueweb/components/ui/context_menus/action-context-menu.tsx` and follow the CueGUI Monitor Jobs / Monitor Job Details structure. Items that depend on dialogs / backend integrations not yet implemented in OpenCueWeb route through a `notYetImplemented(label)` placeholder. Destructive items are auto-disabled when **Disable Job Interaction** is on. Menus scroll instead of overflowing on small viewports.
 
 ### Job Actions
 
@@ -906,7 +906,7 @@ The Frame context menu's **View Log on \<editor\>** item launches the log file i
 | **Env var** | `NEXT_PUBLIC_LOG_EDITOR_URL` (build-time). Default in the sandbox deployment is `vscode://file{path}`; the Dockerfile-level default is empty (item hidden). |
 | **Template** | The literal `{path}` is replaced with the absolute log path when the item is clicked. Common values: `vscode://file{path}`, `vscode-insiders://file{path}`, `subl://open?url=file://{path}`, `txmt://open?url=file://{path}`, `idea://open?file={path}`. |
 | **Why not `$EDITOR`?** | Web browsers can't read the user's shell environment or launch arbitrary local programs the way CueGUI does. The URL-scheme approach is the web equivalent: the same trick GitHub's "Open in VSCode" button uses. |
-| **Missing-handler detection** | If the chosen editor isn't installed on the user's machine, CueWeb shows a warning toast after a short delay pointing the user at the alternatives. |
+| **Missing-handler detection** | If the chosen editor isn't installed on the user's machine, OpenCueWeb shows a warning toast after a short delay pointing the user at the alternatives. |
 | **Frame-state guard** | When the frame hasn't been dispatched yet by RQD (no log file on disk), the handler shows a friendly warning toast instead of handing a non-existent path to the editor. |
 
 ---
@@ -952,7 +952,7 @@ Defaults derived from the row:
 
 Send mechanism: the **Send** button builds a `mailto:` URL with the dialog's `to`, `cc`, `bcc`, `subject`, and `body` and assigns it to `window.location.href`. The OS hands the URL to the user's default mail client (Mail.app, Outlook, Thunderbird, etc.).
 
-Browsers don't let `mailto:` override the user's account's `From:` header, so the **From** field in the dialog is informational only - it surfaces the support alias the team typically uses. CueGUI's `EmailDialog` can spoof From because it sends through CueGUI's own SMTP relay; CueWeb's mailto-based equivalent uses whatever account the user's mail client is configured with.
+Browsers don't let `mailto:` override the user's account's `From:` header, so the **From** field in the dialog is informational only - it surfaces the support alias the team typically uses. CueGUI's `EmailDialog` can spoof From because it sends through CueGUI's own SMTP relay; OpenCueWeb's mailto-based equivalent uses whatever account the user's mail client is configured with.
 
 Configurable at build time via two env vars (see [Environment Variables](#environment-variables)):
 
@@ -1207,7 +1207,7 @@ The screenshots below show the screen flow for each dependency type. Every picke
 
 ## CueSubmit (Job Submission UI)
 
-CueWeb ships a browser-based equivalent of the standalone CueSubmit CLI tool at the `/cuesubmit` route, reachable from the **CueSubmit** top-level dropdown in the header (and the matching entry in the sidebar / mobile nav drawer). It mirrors the CueSubmit dialog layout one-for-one with a few quality-of-life improvements made possible by running in the browser.
+OpenCueWeb ships a browser-based equivalent of the standalone CueSubmit CLI tool at the `/cuesubmit` route, reachable from the **CueSubmit** top-level dropdown in the header (and the matching entry in the sidebar / mobile nav drawer). It mirrors the CueSubmit dialog layout one-for-one with a few quality-of-life improvements made possible by running in the browser.
 
 ![CueSubmit menu options](/assets/images/cueweb/cueweb_cuesubmit_menu_options.png)
 
@@ -1236,7 +1236,7 @@ CueWeb ships a browser-based equivalent of the standalone CueSubmit CLI tool at 
 
 ### Username and the Edit override
 
-When CueWeb is deployed with `NEXT_PUBLIC_AUTH_PROVIDER` non-empty, the Username field is pre-populated from the signed-in session and rendered read-only. A small **Edit** checkbox to the right of the field toggles it editable. Unticking the box snaps the value back to the signed-in user. In sandbox mode (no auth) the field is always editable and the Edit checkbox is hidden.
+When OpenCueWeb is deployed with `NEXT_PUBLIC_AUTH_PROVIDER` non-empty, the Username field is pre-populated from the signed-in session and rendered read-only. A small **Edit** checkbox to the right of the field toggles it editable. Unticking the box snaps the value back to the signed-in user. In sandbox mode (no auth) the field is always editable and the Edit checkbox is hidden.
 
 ### Defaults tuned for the OpenCue sandbox
 
@@ -1244,7 +1244,7 @@ The form chooses defaults that produce a runnable submission against the seeded 
 
 - **Memory**: `256m`. The seeded `default` service has a 3.2 GB minimum, which the sandbox RQD usually can't satisfy. The 256 MB default keeps trivial jobs dispatchable.
 - **Facility**: `local` when the user picks `[Default]`. The seeded sandbox's RQD belongs to the `local.general` allocation; cuebot's internal fallback (`cloud`) does not match.
-- **UID**: derived deterministically from the username (1000-65000). Cuebot rejects `uid=0` with `Cannot launch jobs as root`, so CueWeb never emits zero.
+- **UID**: derived deterministically from the username (1000-65000). Cuebot rejects `uid=0` with `Cannot launch jobs as root`, so OpenCueWeb never emits zero.
 
 These three defaults match what the standalone CueSubmit CLI tool produces against the same sandbox.
 
@@ -1287,7 +1287,7 @@ The `?` buttons next to Frame Spec and Command To Run open small themed popovers
 
 ### JWT Token Generation
 
-CueWeb generates JWT tokens for REST Gateway authentication:
+OpenCueWeb generates JWT tokens for REST Gateway authentication:
 
 ```javascript
 // Token structure
@@ -1305,7 +1305,7 @@ CueWeb generates JWT tokens for REST Gateway authentication:
 
 ### API Endpoints Used
 
-CueWeb communicates with these REST Gateway endpoints:
+OpenCueWeb communicates with these REST Gateway endpoints:
 
 | Endpoint | Purpose |
 |----------|---------|
@@ -1347,7 +1347,7 @@ CueWeb communicates with these REST Gateway endpoints:
 | `host.HostInterface/Reboot` / `RebootWhenIdle` | Reboot a host immediately / when idle |
 | `host.HostInterface/AddTags` / `RemoveTags` | Add / remove host tags |
 
-### CueWeb Proxy Routes
+### OpenCueWeb Proxy Routes
 
 The browser does not call REST Gateway directly; it goes through Next.js API proxies that attach the JWT. Comment- and host-related routes:
 
@@ -1432,7 +1432,7 @@ Default Dockerfile exposes:
 
 | Port | Service |
 |------|---------|
-| 3000 | CueWeb HTTP |
+| 3000 | OpenCueWeb HTTP |
 
 Required volume mounts for log viewing (file-based backend):
 
@@ -1449,7 +1449,7 @@ When the deployment uses the Loki backend (`NEXT_PUBLIC_LOKI_URL` set), logs are
 
 `GET /api/metrics` exposes Prometheus usage metrics (plain text; never gated by the authorization gate) so operators can track *who uses what, how often, and how fast* - per user, per page/module, per action - with bounded cardinality.
 
-![CueWeb /api/metrics endpoint output](/assets/images/cueweb/cueweb_user_usage_metrics_api_metrics_endpoint1.png)
+![OpenCueWeb /api/metrics endpoint output](/assets/images/cueweb/cueweb_user_usage_metrics_api_metrics_endpoint1.png)
 
 | Metric | Type | Labels | Notes |
 |--------|------|--------|-------|
@@ -1460,23 +1460,23 @@ When the deployment uses the Loki backend (`NEXT_PUBLIC_LOKI_URL` set), logs are
 | `cueweb_logins_total` | Counter | `user` | Session starts. |
 | `cueweb_facility_selected_total` | Counter | `user`, `facility` | Cuebot Facility switches. |
 
-- **User label** is resolved server-side from the signed-in NextAuth session (`lib/track-user.ts`), so the client can never spoof it; it falls back to `anonymous` when there is no session. The forgeable `X-User` / `X-Forwarded-User` identity headers are honored **only** when `CUEWEB_TRUST_IDENTITY_HEADER=true` (off by default) - set it only when CueWeb sits behind a trusted reverse proxy / auth gateway that strips inbound copies and injects the authenticated identity. Only the username and coarse page/action names are recorded - no job names, search text, or file paths.
+- **User label** is resolved server-side from the signed-in NextAuth session (`lib/track-user.ts`), so the client can never spoof it; it falls back to `anonymous` when there is no session. The forgeable `X-User` / `X-Forwarded-User` identity headers are honored **only** when `CUEWEB_TRUST_IDENTITY_HEADER=true` (off by default) - set it only when OpenCueWeb sits behind a trusted reverse proxy / auth gateway that strips inbound copies and injects the authenticated identity. Only the username and coarse page/action names are recorded - no job names, search text, or file paths.
 - **Instrumentation**: `app/utils/gateway_server.ts` `handleRoute` records the API request + latency for all routes; the client `UsageTracker` + `accessActionApi` beacon page views and actions to `POST /api/track`. Disable the client beacon with `NEXT_PUBLIC_USAGE_TRACKING=off`.
-- **Wiring**: Prometheus scrapes `cueweb:3000/api/metrics` (`sandbox/config/prometheus-monitoring.yml`); Grafana auto-provisions the **CueWeb User Usage** dashboard (`sandbox/config/grafana/dashboards/cueweb-usage.json`) with a `$user` variable.
+- **Wiring**: Prometheus scrapes `cueweb:3000/api/metrics` (`sandbox/config/prometheus-monitoring.yml`); Grafana auto-provisions the **OpenCueWeb User Usage** dashboard (`sandbox/config/grafana/dashboards/cueweb-usage.json`) with a `$user` variable.
 
-![CueWeb User Usage Grafana dashboard](/assets/images/cueweb/cueweb_user_usage_metrics_grafana_charts1.png)
+![OpenCueWeb User Usage Grafana dashboard](/assets/images/cueweb/cueweb_user_usage_metrics_grafana_charts1.png)
 
 ---
 
 ## Global Application Header
 
-CueWeb mounts a persistent header at the top of every authenticated route
+OpenCueWeb mounts a persistent header at the top of every authenticated route
 via `app/layout.tsx`. The header is implemented in
 `components/ui/app-header.tsx` and is hidden on `/login*` routes only.
 
 Layout, left to right:
 
-- **OpenCue logo + "CueWeb" wordmark**: The logo swaps between
+- **OpenCue logo + "OpenCueWeb" wordmark**: The logo swaps between
   `public/opencue-icon-black.png` and
   `public/opencue-icon-white.png` (dark mode). Clicking the logo returns
   to `/` (Monitor Jobs).
@@ -1537,7 +1537,7 @@ Layout, left to right:
     [Keyboard shortcuts overlay (+ menu access)](#keyboard-shortcuts-overlay--menu-access).
 - **Help** dropdown - CueGUI parity:
   - A search input at the top that searches across **every** menu command
-    in CueWeb via the `useMenuRegistry` hook
+    in OpenCueWeb via the `useMenuRegistry` hook
     (`app/utils/use_menu_registry.ts`). Matches render as `Group > Label`.
   - Online User Guide - `NEXT_PUBLIC_DOCS_URL`
     (default `https://www.opencue.io/docs/`).
@@ -1545,7 +1545,7 @@ Layout, left to right:
     (default `https://github.com/AcademySoftwareFoundation/OpenCue/issues/new?labels=enhancement&template=enhancement.md`).
   - Report a Bug - `NEXT_PUBLIC_BUGS_URL`
     (default `https://github.com/AcademySoftwareFoundation/OpenCue/issues/new?labels=bug&template=bug_report.md`).
-  - About CueWeb - opens the About dialog (`components/ui/about-dialog.tsx`)
+  - About OpenCueWeb - opens the About dialog (`components/ui/about-dialog.tsx`)
     showing the version (`NEXT_PUBLIC_APP_VERSION`), build SHA
     (`NEXT_PUBLIC_GIT_SHA`), active Cuebot facility, masked REST gateway URL,
     Apache-2.0 license, and credits. A **Copy diagnostics** button copies those
@@ -1559,48 +1559,48 @@ Layout, left to right:
 
 The `/login` page handles both auth configurations:
 
-- `NEXT_PUBLIC_AUTH_PROVIDER=` (empty) renders only the **CueWeb Home**
+- `NEXT_PUBLIC_AUTH_PROVIDER=` (empty) renders only the **OpenCueWeb Home**
   button - useful for sandbox deployments without authentication.
 - `NEXT_PUBLIC_AUTH_PROVIDER=github,okta,google,ldap` (or any subset)
   renders one sign-in button per configured provider.
 
 The header dropdown menus:
 
-![CueWeb File menu](/assets/images/cueweb/cueweb_file_disable_job_interaction_menu.png)
+![OpenCueWeb File menu](/assets/images/cueweb/cueweb_file_disable_job_interaction_menu.png)
 
 
-![CueWeb Cuebot Facility menu](/assets/images/cueweb/cueweb_cuebot_facility_menu.png)
+![OpenCueWeb Cuebot Facility menu](/assets/images/cueweb/cueweb_cuebot_facility_menu.png)
 
 
-![CueWeb Cuetopia menu](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_menu.png)
+![OpenCueWeb Cuetopia menu](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_menu.png)
 
 
-![CueWeb CueCommander menu](/assets/images/cueweb/cueweb_cuecommander_menu_options.png)
+![OpenCueWeb CueCommander menu](/assets/images/cueweb/cueweb_cuecommander_menu_options.png)
 
 
-![CueWeb Other menu](/assets/images/cueweb/cueweb_other_menu_options.png)
+![OpenCueWeb Other menu](/assets/images/cueweb/cueweb_other_menu_options.png)
 
 
-![CueWeb Help menu](/assets/images/cueweb/cueweb_help_about_cueweb_menu.png)
+![OpenCueWeb Help menu](/assets/images/cueweb/cueweb_help_about_cueweb_menu.png)
 
 
-![CueWeb About dialog](/assets/images/cueweb/cueweb_help_about_cueweb.png)
+![OpenCueWeb About dialog](/assets/images/cueweb/cueweb_help_about_cueweb.png)
 
 
 The bottom status bar:
 
-![CueWeb status bar](/assets/images/cueweb/cueweb_status_indicators.png)
+![OpenCueWeb status bar](/assets/images/cueweb/cueweb_status_indicators.png)
 
 
 ---
 
 ## Left Sidebar
 
-CueWeb also mounts a collapsible sidebar to the left of the content area.
+OpenCueWeb also mounts a collapsible sidebar to the left of the content area.
 Implemented in `components/ui/app-sidebar.tsx` and hidden on `/login*` and
 on viewports smaller than the `md` breakpoint.
 
-![CueWeb left sidebar](/assets/images/cueweb/cueweb_left_side_menu.png)
+![OpenCueWeb left sidebar](/assets/images/cueweb/cueweb_left_side_menu.png)
 
 
 - Same six groups as the header (**File**, **Cuebot Facility**,
@@ -1656,8 +1656,8 @@ By default the client builds same-origin relative URLs for every API call, so th
 
 | Caveat | Workaround |
 |--------|-----------|
-| The modern browser clipboard API is restricted to secure contexts (HTTPS / `localhost`). On plain-HTTP LAN access it's either unavailable or rejected. | CueWeb automatically falls back to a legacy copy path outside secure contexts, including iOS Safari. **Copy Job Name** / **Copy Layer Name** / **Copy Frame Name** / **Copy Log Path** still work. |
-| Desktop notification popups also require a secure context. **Subscribe to Job** still works on LAN HTTP - the in-app toast always fires - but the optional OS-level notification banner is skipped. | Serve CueWeb over HTTPS (self-signed cert is enough for LAN testing) to enable the desktop popup. |
+| The modern browser clipboard API is restricted to secure contexts (HTTPS / `localhost`). On plain-HTTP LAN access it's either unavailable or rejected. | OpenCueWeb automatically falls back to a legacy copy path outside secure contexts, including iOS Safari. **Copy Job Name** / **Copy Layer Name** / **Copy Frame Name** / **Copy Log Path** still work. |
+| Desktop notification popups also require a secure context. **Subscribe to Job** still works on LAN HTTP - the in-app toast always fires - but the optional OS-level notification banner is skipped. | Serve OpenCueWeb over HTTPS (self-signed cert is enough for LAN testing) to enable the desktop popup. |
 
 ---
 
@@ -1684,7 +1684,7 @@ When the flag is on:
   toggle whose label flips on `isPaused` - both flavors are dimmed the
   same way. *Unmonitor* and *Comments* on the job menu remain active.
 
-![CueWeb read-only banner when job interaction is disabled](/assets/images/cueweb/cueweb_file_disable_job_interaction_enabled.png)
+![OpenCueWeb read-only banner when job interaction is disabled](/assets/images/cueweb/cueweb_file_disable_job_interaction_enabled.png)
 
 
 ---
@@ -1708,24 +1708,24 @@ implemented in `components/ui/attributes-panel.tsx`.
 
 The Attributes panel for a selected job and for a selected layer:
 
-![CueWeb attributes panel for a job](/assets/images/cueweb/cueweb_other_menu_attributes_job.png)
+![OpenCueWeb attributes panel for a job](/assets/images/cueweb/cueweb_other_menu_attributes_job.png)
 
 
-![CueWeb attributes panel for a layer](/assets/images/cueweb/cueweb_other_menu_attributes_layer.png)
+![OpenCueWeb attributes panel for a layer](/assets/images/cueweb/cueweb_other_menu_attributes_layer.png)
 
 
 The panel docked on each edge of the viewport - right, bottom, left, and top:
 
-![CueWeb attributes panel docked right](/assets/images/cueweb/cueweb_other_menu_attributes_dock_right.png)
+![OpenCueWeb attributes panel docked right](/assets/images/cueweb/cueweb_other_menu_attributes_dock_right.png)
 
 
-![CueWeb attributes panel docked bottom](/assets/images/cueweb/cueweb_other_menu_attributes_dock_bottom.png)
+![OpenCueWeb attributes panel docked bottom](/assets/images/cueweb/cueweb_other_menu_attributes_dock_bottom.png)
 
 
-![CueWeb attributes panel docked left](/assets/images/cueweb/cueweb_other_menu_attributes_dock_left.png)
+![OpenCueWeb attributes panel docked left](/assets/images/cueweb/cueweb_other_menu_attributes_dock_left.png)
 
 
-![CueWeb attributes panel docked top](/assets/images/cueweb/cueweb_other_menu_attributes_dock_top.png)
+![OpenCueWeb attributes panel docked top](/assets/images/cueweb/cueweb_other_menu_attributes_dock_top.png)
 
 
 ---
@@ -1758,7 +1758,7 @@ corresponding `BreadcrumbItem`.
 
 ## Status Bar
 
-CueWeb mounts an IDE-style fixed status bar at the bottom of every
+OpenCueWeb mounts an IDE-style fixed status bar at the bottom of every
 authenticated route. Implemented in `components/ui/status-bar.tsx` and
 hidden on `/login*`. Three metrics, each with a tooltip:
 
@@ -1781,12 +1781,12 @@ hidden on `/login*`. Three metrics, each with a tooltip:
      generated OpenCue version or a build tag).
   2. `cueweb/OVERRIDE_CUEWEB_VERSION.in`: the `VERSION.in` sentinel (default)
      reads the repo-root `VERSION.in` - OpenCue's shared version, also read by
-     cuebot / cuegui; any other value pins an explicit CueWeb version. In the
+     cuebot / cuegui; any other value pins an explicit OpenCueWeb version. In the
      Docker image the root `VERSION.in` is supplied via a `project_root` named
      build context (see `docker-compose.yml`).
   3. The `version` field in `cueweb/package.json` (last-resort fallback).
   - The Dockerfile exposes a matching `ARG NEXT_PUBLIC_APP_VERSION`, so CI can
-    override it directly. The About CueWeb dialog shows the same version plus
+    override it directly. The About OpenCueWeb dialog shows the same version plus
     the build SHA (`NEXT_PUBLIC_GIT_SHA`).
 
 ### `GET /api/health`
@@ -1823,7 +1823,7 @@ each facility's green/red dot and to disable a facility whose gateway is down.
 }
 ```
 
-![CueWeb per-facility health endpoint](/assets/images/cueweb/cueweb_cuebot_facility_health_endpoint.png)
+![OpenCueWeb per-facility health endpoint](/assets/images/cueweb/cueweb_cuebot_facility_health_endpoint.png)
 
 ### Per-facility health and runtime config
 
@@ -1832,7 +1832,7 @@ The **Manage facilities…** item in the Cuebot Facility menu opens
 editing each facility's REST gateway URL and JWT secret **at runtime, without a
 redeploy**.
 
-![CueWeb Manage Facilities screen](/assets/images/cueweb/cueweb_cuebot_facility_manage_facilities.png)
+![OpenCueWeb Manage Facilities screen](/assets/images/cueweb/cueweb_cuebot_facility_manage_facilities.png)
 
 | Behavior | Description |
 |----------|-------------|
@@ -1840,7 +1840,7 @@ redeploy**.
 | **Override store** | Edits are persisted to a JSON file at `CUEWEB_FACILITY_STORE` (defaults to the OS temp dir) by a `"use server"` action; a short in-process cache makes the change take effect within a few seconds. Point the var at a mounted volume to persist across restarts. The JWT secret is written `0600` and never returned to the client. |
 | **Audit log** | Every change appends an entry (`{ at, actor, facility, changes }`) to a `.audit.jsonl` file next to the store; the secret value is never recorded. The screen shows a change-history table. |
 | **Concurrency** | Writes are serialized through an in-process queue so concurrent saves can't lose updates (single Node process). |
-| **Authorization** | Fail-closed when authentication is configured (a signed-in user is required); open when auth is disabled (the sandbox default), matching the rest of CueWeb. When the group authorization gate is active, `/settings/facilities` is one of the admin paths restricted to `CUEWEB_ADMIN_GROUPS`, and the **Manage facilities…** menu item is hidden from non-admins. |
+| **Authorization** | Fail-closed when authentication is configured (a signed-in user is required); open when auth is disabled (the sandbox default), matching the rest of OpenCueWeb. When the group authorization gate is active, `/settings/facilities` is one of the admin paths restricted to `CUEWEB_ADMIN_GROUPS`, and the **Manage facilities…** menu item is hidden from non-admins. |
 
 The override-aware resolution lives in the server-only `lib/facility-server.ts`
 (layered over the client-safe `lib/facility.ts`) and the filesystem store in
@@ -1853,7 +1853,7 @@ The override-aware resolution lives in the server-only `lib/facility-server.ts`
 
 A minimal plugin system (`cueweb/lib/plugins.ts` + `cueweb/app/plugins/`), the browser equivalent of CueGUI's plugin loader. A plugin is a manifest plus a lazily-loaded React component mounted on its own route.
 
-![CueWeb Plugins page](/assets/images/cueweb/cueweb_plugins.png)
+![OpenCueWeb Plugins page](/assets/images/cueweb/cueweb_plugins.png)
 
 | Behavior | Description |
 |----------|-------------|
@@ -1870,14 +1870,14 @@ A minimal plugin system (`cueweb/lib/plugins.ts` + `cueweb/app/plugins/`), the b
 
 ### Theme Toggle
 
-CueWeb supports light and dark themes:
+OpenCueWeb supports light and dark themes:
 
 - **Light Mode**: Default theme with light backgrounds
 - **Dark Mode**: Dark theme for reduced eye strain
 
 Toggle via the sun/moon button in the global header (or press `t`). The choice persists across sessions. Every view has a dark equivalent; for example, the Monitor Jobs page in dark mode:
 
-![CueWeb Monitor Jobs in dark mode](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_mainpage_dark.png)
+![OpenCueWeb Monitor Jobs in dark mode](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_mainpage_dark.png)
 
 ### CSS Variables
 
@@ -1942,7 +1942,7 @@ Key theme variables (defined in Tailwind config):
 
 #### JWT Token Errors
 
-**Cause**: Secret mismatch between CueWeb and REST Gateway
+**Cause**: Secret mismatch between OpenCueWeb and REST Gateway
 
 **Solution**:
 1. Ensure `NEXT_JWT_SECRET` matches REST Gateway's `JWT_SECRET`
@@ -2008,9 +2008,9 @@ cueweb/
 
 ## Related Documentation
 
-- [CueWeb Quick Start](/docs/quick-starts/quick-start-cueweb/) - Getting started guide
-- [CueWeb User Guide](/docs/user-guides/cueweb-user-guide/) - Complete usage guide
-- [CueWeb Tutorial](/docs/tutorials/cueweb-tutorial/) - Step-by-step tutorial
-- [CueWeb Developer Guide](/docs/developer-guide/cueweb-development/) - Development reference
+- [OpenCueWeb Quick Start](/docs/quick-starts/quick-start-cueweb/) - Getting started guide
+- [OpenCueWeb User Guide](/docs/user-guides/cueweb-user-guide/) - Complete usage guide
+- [OpenCueWeb Tutorial](/docs/tutorials/cueweb-tutorial/) - Step-by-step tutorial
+- [OpenCueWeb Developer Guide](/docs/developer-guide/cueweb-development/) - Development reference
 - [REST API Reference](/docs/reference/rest-api-reference/) - API documentation
-- [Deploying CueWeb](/docs/getting-started/deploying-cueweb/) - Deployment guide
+- [Deploying OpenCueWeb](/docs/getting-started/deploying-cueweb/) - Deployment guide

--- a/docs/_docs/reference/rest-api-reference.md
+++ b/docs/_docs/reference/rest-api-reference.md
@@ -2655,4 +2655,4 @@ curl -X POST http://localhost:8448/layer.LayerInterface/SetTags \
 - [Using the REST API](/docs/user-guides/using-rest-api/) - Usage examples and integration
 - [REST API Tutorial](/docs/tutorials/rest-api-tutorial/) - Step-by-step walkthrough
 - [Deploying REST Gateway](/docs/getting-started/deploying-rest-gateway) - Deployment instructions
-- [CueWeb Developer Guide](/docs/developer-guide/cueweb-development) - Integration examples with CueWeb
+- [OpenCueWeb Developer Guide](/docs/developer-guide/cueweb-development) - Integration examples with OpenCueWeb

--- a/docs/_docs/tutorials/cueweb-tutorial.md
+++ b/docs/_docs/tutorials/cueweb-tutorial.md
@@ -1,18 +1,18 @@
 ---
-title: "CueWeb Tutorial"
+title: "OpenCueWeb Tutorial"
 nav_order: 85
 parent: Tutorials
 layout: default
-linkTitle: "Getting Started with CueWeb"
+linkTitle: "Getting Started with OpenCueWeb"
 date: 2024-09-17
 description: >
-  Step-by-step tutorial for using CueWeb to manage OpenCue render jobs
+  Step-by-step tutorial for using OpenCueWeb to manage OpenCue render jobs
 ---
 
-# CueWeb Tutorial
+# OpenCueWeb Tutorial
 {: .no_toc }
 
-Learn how to use CueWeb's web interface to monitor jobs, manage frames, and control your OpenCue render farm.
+Learn how to use OpenCueWeb's web interface to monitor jobs, manage frames, and control your OpenCue render farm.
 
 <details open markdown="block">
   <summary>
@@ -27,11 +27,11 @@ Learn how to use CueWeb's web interface to monitor jobs, manage frames, and cont
 
 ## Overview
 
-This tutorial will guide you through using CueWeb, OpenCue's web-based interface. You'll learn how to monitor jobs, manage frames, search for specific jobs, and perform common render farm operations through your browser.
+This tutorial will guide you through using OpenCueWeb, OpenCue's web-based interface. You'll learn how to monitor jobs, manage frames, search for specific jobs, and perform common render farm operations through your browser.
 
 ### What you'll learn
 
-- How to navigate the CueWeb interface
+- How to navigate the OpenCueWeb interface
 - Job monitoring and management techniques
 - Frame-level operations and troubleshooting
 - Search and filtering capabilities
@@ -39,7 +39,7 @@ This tutorial will guide you through using CueWeb, OpenCue's web-based interface
 
 ### Prerequisites
 
-- CueWeb deployed and accessible
+- OpenCueWeb deployed and accessible
 - OpenCue render farm with some test jobs
 - Basic understanding of render farm concepts
 
@@ -47,20 +47,20 @@ This tutorial will guide you through using CueWeb, OpenCue's web-based interface
 
 ## Getting Started
 
-### Accessing CueWeb
+### Accessing OpenCueWeb
 
 1. Open your web browser
-2. Navigate to your CueWeb URL (e.g., `http://cueweb.company.com:3000`)
+2. Navigate to your OpenCueWeb URL (e.g., `http://cueweb.company.com:3000`)
 3. If authentication is enabled, sign in with your credentials
 
-You should see the main CueWeb dashboard with the jobs table.
+You should see the main OpenCueWeb dashboard with the jobs table.
 
 ### Interface Overview
 
-The CueWeb interface consists of:
+The OpenCueWeb interface consists of:
 
 - **Global header (persistent across every authenticated route):**
-  - OpenCue logo (theme-aware: black in light mode, white in dark mode) + the **CueWeb** wordmark on the left, clickable as a link back to the jobs dashboard.
+  - OpenCue logo (theme-aware: black in light mode, white in dark mode) + the **OpenCueWeb** wordmark on the left, clickable as a link back to the jobs dashboard.
   - Six dropdown menus mirroring the CueGUI menu bar:
     - **File** -> Disable Job Interaction (read-only safety toggle).
     - **Cuebot Facility** -> switch between the options (e.g.: `local` / `dev` / `cloud` / `external`); the active facility is shown as a chip on the trigger.
@@ -73,27 +73,27 @@ The CueWeb interface consists of:
 - **Read-only banner:** appears only when *Disable Job Interaction* is on; describes the read-only state and offers a *Re-enable* button. Destructive toolbar buttons and right-click menu items are dim and inert in this state.
 - **Attributes panel:** docked drawer toggled from Other ▸ Attributes. Click a row in the jobs table to populate it; use the title-bar position picker to dock it on the right, bottom, left, or top of the viewport.
 - **Breadcrumb (detail pages only):** above the frame log and the per-job comments page, a small "Home > Jobs > ..." trail lets you click back to the jobs index or to any parent in the path. Long labels truncate with an ellipsis; hover any segment to see the full text.
-- **Bottom status bar:** fixed 24-pixel bar at the bottom of every page. Shows REST gateway status (a dot + Online/Offline + round-trip latency), the time since the jobs table last refreshed, and the CueWeb build version. The whole bar turns red when the gateway is unreachable.
+- **Bottom status bar:** fixed 24-pixel bar at the bottom of every page. Shows REST gateway status (a dot + Online/Offline + round-trip latency), the time since the jobs table last refreshed, and the OpenCueWeb build version. The whole bar turns red when the gateway is unreachable.
 - **Filter Bar**: Show selection, status filters, and search
 - **Jobs Table**: Main view of all jobs with sortable columns
 - **Action Buttons**: Job control operations
 
 The login page:
 
-![CueWeb login page](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_login.png)
+![OpenCueWeb login page](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_login.png)
 
 
 The Dashboard:
 
-![CueWeb dashboard](/assets/images/cueweb/cueweb_dashboard.png)
+![OpenCueWeb dashboard](/assets/images/cueweb/cueweb_dashboard.png)
 
 
 The Cuetopia Monitor Jobs view, with the collapsible left sidebar:
 
-![CueWeb Monitor Jobs](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_mainpage.png)
+![OpenCueWeb Monitor Jobs](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_mainpage.png)
 
 
-![CueWeb left sidebar](/assets/images/cueweb/cueweb_left_side_menu.png)
+![OpenCueWeb left sidebar](/assets/images/cueweb/cueweb_left_side_menu.png)
 
 
 ---
@@ -281,7 +281,7 @@ When you want to *see* a render chain rather than read a table of depends, turn 
 
 ### Viewing Job Details
 
-CueWeb has two ways to inspect a job:
+OpenCueWeb has two ways to inspect a job:
 
 1. **Inline panel (quick look)**: Click a job row in the Jobs table. The associated Layers and Frames tables appear stacked just below the Jobs grid - the CueGUI Monitor Jobs + Monitor Job Details dock layout.
 
@@ -302,16 +302,16 @@ CueWeb has two ways to inspect a job:
 
 The **View Job Details** menu item and the tabbed detail page (Overview / Layers / Frames):
 
-![CueWeb View Job Details menu](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_view_job_details_menu.png)
+![OpenCueWeb View Job Details menu](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_view_job_details_menu.png)
 
 
-![CueWeb Job Details overview tab](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_view_job_details_page_overview.png)
+![OpenCueWeb Job Details overview tab](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_view_job_details_page_overview.png)
 
 
-![CueWeb Job Details layers tab](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_view_job_details_page_layers.png)
+![OpenCueWeb Job Details layers tab](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_view_job_details_page_layers.png)
 
 
-![CueWeb Job Details frames tab](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_view_job_details_page_frames.png)
+![OpenCueWeb Job Details frames tab](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_view_job_details_page_frames.png)
 
 
 ### Understanding Layers
@@ -356,7 +356,7 @@ Frames are the individual rendering tasks within each layer.
    - If the deployment has `NEXT_PUBLIC_LOG_EDITOR_URL` configured, the Frame right-click menu also offers **View Log on \<editor\>** below **View Log**.
    - The sandbox `docker-compose.yml` ships with `vscode://file{path}` as the default → **View Log on VSCode**. Override the build arg to target Sublime / TextMate / IntelliJ instead (or set it empty to hide the item).
    - Tapping it launches the rqlog file directly in your desktop editor via the custom URL scheme - the same approach GitHub's "Open in VSCode" button uses. No need to copy the path and paste it into a terminal.
-   - If the editor isn't installed (no app registered for `vscode://`, `subl://`, etc.), CueWeb shows a warning toast after a short timeout pointing you at the alternatives.
+   - If the editor isn't installed (no app registered for `vscode://`, `subl://`, etc.), OpenCueWeb shows a warning toast after a short timeout pointing you at the alternatives.
 
 3. **Preview rendered frames** *(optional)*:
    - The Frame menu's **Preview All** opens the frame's rendered output in an external image viewer; the command it shows (and the optional **Launch** button) come from `NEXT_PUBLIC_PREVIEW_COMMAND` / `NEXT_PUBLIC_PREVIEW_URL` (default `rv {paths}`).
@@ -375,7 +375,7 @@ Frames are the individual rendering tasks within each layer.
 6. **Copy frame metadata**:
    - **Copy Frame Name** copies just the frame name (e.g. `0001-test_layer`).
    - **Copy Log Path** copies the absolute rqlog path so you can paste it into a terminal or another viewer.
-   - Both work on plain-HTTP LAN deployments (e.g. accessing CueWeb on your phone via the Mac's LAN IP), not just `localhost`.
+   - Both work on plain-HTTP LAN deployments (e.g. accessing OpenCueWeb on your phone via the Mac's LAN IP), not just `localhost`.
 
 7. **Filter by Frame State**:
    - The chips above the frames table — `WAITING`, `RUNNING`, `SUCCEEDED`, `DEAD`, `EATEN`, `DEPEND` — show the count for each state and act as toggles.
@@ -385,10 +385,10 @@ Frames are the individual rendering tasks within each layer.
 
 The frame right-click menu, and the confirmation toast shown after an action:
 
-![CueWeb frame context menu](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_frame_context_menu_open.png)
+![OpenCueWeb frame context menu](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_frame_context_menu_open.png)
 
 
-![CueWeb frame action success notification](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_frame_context_menu_open_and_success_notification.png)
+![OpenCueWeb frame action success notification](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_frame_context_menu_open_and_success_notification.png)
 
 ### Frame Troubleshooting
 
@@ -402,11 +402,11 @@ The frame right-click menu, and the confirmation toast shown after an action:
 
 ### Finding and clearing stuck frames
 
-Failed frames turn red, but a *stuck* frame is trickier: it keeps running (gray-green) while no longer making progress - the process is alive but has stopped writing to its log. CueWeb's **Stuck Frames** page finds these for you.
+Failed frames turn red, but a *stuck* frame is trickier: it keeps running (gray-green) while no longer making progress - the process is alive but has stopped writing to its log. OpenCueWeb's **Stuck Frames** page finds these for you.
 
 1. Open **CueCommander &rarr; Stuck Frame** from the header or sidebar.
 
-   ![CueWeb Stuck Frames page](/assets/images/cueweb/cueweb_cuecommander_stuck_frame.png)
+   ![OpenCueWeb Stuck Frames page](/assets/images/cueweb/cueweb_cuecommander_stuck_frame.png)
 
 2. The page scans every running frame and lists the ones whose log has gone silent relative to their runtime, grouped under their job. Read the **LLU** (time since the last log line), **Runtime**, and **% Stuck** columns to judge each frame - a high **% Stuck** means the log has been quiet for most of the run.
 3. If nothing shows up, loosen the filters at the top - lower **Min LLU** or **% of Run Since LLU**. To tune detection per render type, click **+** to add a service-specific filter row (so e.g. Arnold frames, which legitimately run long, use looser limits than quick ones).
@@ -424,10 +424,10 @@ Failed frames turn red, but a *stuck* frame is trickier: it keeps running (gray-
 
 The search bar supports multiple search patterns. As you type, a dropdown suggests matching jobs you can pick from:
 
-![CueWeb job search](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_search_jobs.png)
+![OpenCueWeb job search](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_search_jobs.png)
 
 
-![CueWeb job search pick from list](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_search_jobs_pick_from_list.png)
+![OpenCueWeb job search pick from list](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_search_jobs_pick_from_list.png)
 
 
 #### Simple Text Search
@@ -497,7 +497,7 @@ Prefix searches with `!` to enable regex patterns:
 
 Each of the three data tables (Jobs, Layers, Frames) has its own **Columns** dropdown in the per-table toolbar.
 
-![CueWeb column visibility dropdown](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_column%20_visibility_dropdown.png)
+![OpenCueWeb column visibility dropdown](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_column%20_visibility_dropdown.png)
 
 
 1. **Show / Hide columns**:
@@ -522,7 +522,7 @@ Both visibility and ordering choices are saved per table in your browser and sur
 
 ### Auto-refresh Settings
 
-* **Refresh Interval**: CueWeb uses a fixed 5-second update interval for all tables.
+* **Refresh Interval**: OpenCueWeb uses a fixed 5-second update interval for all tables.
 * **Job-finished Notifications**: Subscribe to specific jobs via the bell in the **Notify** column. A background poller checks each subscribed job every 15 seconds. When the job reaches `FINISHED` an in-app toast fires (always), and a desktop popup is layered on top when you have granted the browser's notification permission. Subscriptions are saved in your browser and survive page reloads; when several tabs are open for the same job, only one tab shows the notification.
 
 ### Monitoring Best Practices
@@ -543,11 +543,11 @@ Both visibility and ordering choices are saved per table in your browser and sur
 
 ## Mobile and Remote Monitoring
 
-CueWeb is responsive down to phone-sized viewports. Every action available on desktop has a mobile-equivalent path.
+OpenCueWeb is responsive down to phone-sized viewports. Every action available on desktop has a mobile-equivalent path.
 
-### Reaching CueWeb from a phone on the same network
+### Reaching OpenCueWeb from a phone on the same network
 
-1. On the machine running CueWeb, find the LAN IP: `ipconfig getifaddr en0` on macOS, `ip a` on Linux.
+1. On the machine running OpenCueWeb, find the LAN IP: `ipconfig getifaddr en0` on macOS, `ip a` on Linux.
 2. On the phone (same Wi-Fi), open `http://<lan-ip>:3000` in your browser (e.g. Safari or Google Chrome).
 3. The same UI loads. The client builds same-origin relative URLs for every API call, so it works correctly from any host (no rebuild needed). This requires `NEXT_PUBLIC_URL=` (empty, the default).
 
@@ -573,13 +573,13 @@ CueWeb is responsive down to phone-sized viewports. Every action available on de
 
 ### Clipboard, notifications, and external editor on LAN HTTP
 
-- **Clipboard works** on plain-HTTP LAN access. The browser's modern clipboard API is restricted to secure contexts (HTTPS / `localhost`), but CueWeb automatically uses a legacy copy path when the modern one isn't available.
-- **Subscribe to Job** still works - the in-app toast always fires. The optional desktop popup is skipped on LAN HTTP because the Web Notifications API also requires a secure context; serve CueWeb over HTTPS (self-signed cert is enough) to enable that path.
-- **View Log on \<editor\>** depends on the user's device having the URL scheme registered. iOS Safari doesn't route arbitrary custom schemes to apps the way macOS does, so the in-browser **View Log** is the reliable path on phones - CueWeb falls back to a warning toast when the scheme isn't handled.
+- **Clipboard works** on plain-HTTP LAN access. The browser's modern clipboard API is restricted to secure contexts (HTTPS / `localhost`), but OpenCueWeb automatically uses a legacy copy path when the modern one isn't available.
+- **Subscribe to Job** still works - the in-app toast always fires. The optional desktop popup is skipped on LAN HTTP because the Web Notifications API also requires a secure context; serve OpenCueWeb over HTTPS (self-signed cert is enough) to enable that path.
+- **View Log on \<editor\>** depends on the user's device having the URL scheme registered. iOS Safari doesn't route arbitrary custom schemes to apps the way macOS does, so the in-browser **View Log** is the reliable path on phones - OpenCueWeb falls back to a warning toast when the scheme isn't handled.
 
 ---
 
-## Submitting a job from CueWeb (CueSubmit tutorial)
+## Submitting a job from OpenCueWeb (CueSubmit tutorial)
 
 This walkthrough mirrors what you would do in the standalone CueSubmit CLI tool, but inside the browser. It assumes the OpenCue sandbox is running on `localhost:3000` and you have the `testing` show registered in cuebot (the default seed data includes it).
 
@@ -608,7 +608,7 @@ Click **CueSubmit > Submit Job** in the top header. The form opens at `/cuesubmi
 3. **Shell options** (the panel below Layer Info)
    - Command To Run: `echo "frame #IFRAME#" && sleep 2`. Click the `?` next to the field for the cuebot token cheatsheet (`#IFRAME#` is the current frame number).
 4. Watch the **Final command** preview at the bottom of the panel update per-keystroke. This is exactly what cuebot will execute on each frame.
-5. Click **Submit**. CueWeb redirects to the job detail page; the three frames cycle WAITING -> RUNNING -> SUCCEEDED in a few seconds.
+5. Click **Submit**. OpenCueWeb redirects to the job detail page; the three frames cycle WAITING -> RUNNING -> SUCCEEDED in a few seconds.
 
 ### Multi-layer chain with a Layer dependency
 
@@ -628,7 +628,7 @@ Flip Job Type to **Maya**, **Nuke**, or **Blender** to swap the per-type options
 - **Nuke** asks for a Nuke File (`.nk`) and optional comma-separated Write Nodes. The Final command becomes `nuke -F #IFRAME# [-X WriteNodes] -x <file>`.
 - **Blender** asks for a Blender File (`.blend`), an Output Path, and an Output Format. Simple ranges (`1-10`) use `-s/-e/-a`; more complex ranges use the per-frame `-f #IFRAME#` token.
 
-The CueWeb panel always preserves the inputs you typed even when you flip between types, so iterating doesn't lose your scene path or camera.
+The OpenCueWeb panel always preserves the inputs you typed even when you flip between types, so iterating doesn't lose your scene path or camera.
 
 ### Convenience features
 
@@ -643,16 +643,16 @@ The CueWeb panel always preserves the inputs you typed even when you flip betwee
 
 When a high-priority job is starved for cores, the **Redirect** tool (CueCommander &rarr; Redirect) lets an administrator take cores away from other running work and hand them to that job. **Redirecting kills the frames currently running on the chosen procs**, so it is a deliberate, admin-level action - not an everyday operation.
 
-![CueWeb Redirect page](/assets/images/cueweb/cueweb_cuecommander_redirect.png)
+![OpenCueWeb Redirect page](/assets/images/cueweb/cueweb_cuecommander_redirect.png)
 
 1. Open **CueCommander &rarr; Redirect**.
-2. In the **Target** field, type the job that should receive the cores. CueWeb resolves it and auto-fills the **Show** and the Minimum Cores / Minimum Memory from that job's layers, so the search looks for procs big enough to help.
+2. In the **Target** field, type the job that should receive the cores. OpenCueWeb resolves it and auto-fills the **Show** and the Minimum Cores / Minimum Memory from that job's layers, so the search looks for procs big enough to help.
 3. Tune the filters:
    - **Job filters** - narrow the candidate procs by Show, Include Groups, Require Services, or an Exclude Regex on the job name.
    - **Resource filters** - set the Allocations, Minimum / Max Cores, Minimum Memory, Result Limit, and a **Proc Hour Cutoff** so you don't kill procs that are nearly finished.
-4. Click **Search**. CueWeb lists the hosts whose busy procs match; expand a row to see the individual procs (which job/group/service each one is running).
+4. Click **Search**. OpenCueWeb lists the hosts whose busy procs match; expand a row to see the individual procs (which job/group/service each one is running).
 5. Tick the hosts you want to take cores from (or **Select All**), then click **Redirect**.
-6. CueWeb double-checks the target before acting: it **refuses** if the target job has disappeared, has no waiting frames, or is already at its max cores, and it **asks you to confirm** if the target is paused or if a selected proc belongs to a different show (that show's frame would be killed). On success the freed cores are booked onto your target job.
+6. OpenCueWeb double-checks the target before acting: it **refuses** if the target job has disappeared, has no waiting frames, or is already at its max cores, and it **asks you to confirm** if the target is paused or if a selected proc belongs to a different show (that show's frame would be killed). On success the freed cores are booked onto your target job.
 
    ![Confirm Redirect dialog](/assets/images/cueweb/cueweb_cuecommander_redirect_confirm_redirect.png)
 
@@ -666,7 +666,7 @@ Use **Clr** to reset the form and start a new search.
 
 ## Monitoring the cue (Monitor Cue)
 
-The **Monitor Cue** page (CueCommander &rarr; Monitor Cue) shows every job for the shows you choose, grouped under their show and groups - the CueWeb version of CueGUI's Monitor Cue window.
+The **Monitor Cue** page (CueCommander &rarr; Monitor Cue) shows every job for the shows you choose, grouped under their show and groups - the OpenCueWeb version of CueGUI's Monitor Cue window.
 
 1. Open **CueCommander &rarr; Monitor Cue**. The table is empty until you pick shows.
 2. Open the **Shows** menu and select one or more shows (or **All Shows**). The job tree loads, grouped by show and group. Use **Expand All** / **Collapse All** to open or fold the tree.
@@ -678,7 +678,7 @@ The **Monitor Cue** page (CueCommander &rarr; Monitor Cue) shows every job for t
 
 ## Managing render hosts (Monitor Hosts)
 
-The **Monitor Hosts** page (CueCommander &rarr; Monitor Hosts) is the CueWeb version of CueGUI's Monitor Hosts window, with the full column set and host actions.
+The **Monitor Hosts** page (CueCommander &rarr; Monitor Hosts) is the OpenCueWeb version of CueGUI's Monitor Hosts window, with the full column set and host actions.
 
 1. Open **CueCommander &rarr; Monitor Hosts**. The table shows every host, with Swap / Physical / GPU Memory / Temp as red/green usage bars and rows tinted by condition (red = a non-`UP` host, amber = waiting to reboot when idle, yellow = `UP` but locked).
 
@@ -718,13 +718,13 @@ The **Monitor Hosts** page (CueCommander &rarr; Monitor Hosts) is the CueWeb ver
 
 ## Switching Cuebot facilities
 
-If your farm spans more than one **facility** - each with its own Cuebot - CueWeb lets you move between them from the **Cuebot Facility** menu. You always work in one facility at a time, exactly like CueGUI's Cuebot Facility menu.
+If your farm spans more than one **facility** - each with its own Cuebot - OpenCueWeb lets you move between them from the **Cuebot Facility** menu. You always work in one facility at a time, exactly like CueGUI's Cuebot Facility menu.
 
 1. Look at the **Cuebot Facility** entry in the header (or the sidebar). The chip next to it shows the facility you are currently viewing.
 
    ![Cuebot Facility menu](/assets/images/cueweb/cueweb_cuebot_facility_menu.png)
 
-2. Open the menu and pick a different facility (for example `dev` or `cloud`). Each facility has a **status dot** next to it: green means its gateway is reachable, red means it is down (CueWeb re-checks every 30 seconds). A facility whose dot is red is **disabled** - you can't switch into a facility CueWeb can't reach. CueWeb re-routes to the chosen facility's Cuebot and reloads the view you are on, so the jobs, hosts, and shows you now see belong to the facility you chose.
+2. Open the menu and pick a different facility (for example `dev` or `cloud`). Each facility has a **status dot** next to it: green means its gateway is reachable, red means it is down (OpenCueWeb re-checks every 30 seconds). A facility whose dot is red is **disabled** - you can't switch into a facility OpenCueWeb can't reach. OpenCueWeb re-routes to the chosen facility's Cuebot and reloads the view you are on, so the jobs, hosts, and shows you now see belong to the facility you chose.
 3. Confirm the switch: the chip on the menu **and** the facility shown in the bottom status bar update to the new facility. Your choice is remembered for the rest of the session.
 4. Switch back the same way when you are done.
 
@@ -746,22 +746,22 @@ If your farm spans more than one **facility** - each with its own Cuebot - CueWe
 
 ---
 
-## Checking the CueWeb version (About CueWeb)
+## Checking the OpenCueWeb version (About OpenCueWeb)
 
-When you file a bug or confirm a deploy, you'll want to know exactly which build you're running. CueWeb makes that a two-second check.
+When you file a bug or confirm a deploy, you'll want to know exactly which build you're running. OpenCueWeb makes that a two-second check.
 
 1. Glance at the **bottom status bar** - the build version is shown at the right (e.g. `v1.4.0`).
-2. For the full picture, open the **Help** menu and choose **About CueWeb**.
+2. For the full picture, open the **Help** menu and choose **About OpenCueWeb**.
 
-   ![About CueWeb in the Help menu](/assets/images/cueweb/cueweb_help_about_cueweb_menu.png)
+   ![About OpenCueWeb in the Help menu](/assets/images/cueweb/cueweb_help_about_cueweb_menu.png)
 
 3. The dialog shows the **Version**, the **Build SHA**, and a license link.
 
-   ![About CueWeb dialog](/assets/images/cueweb/cueweb_help_about_cueweb.png)
+   ![About OpenCueWeb dialog](/assets/images/cueweb/cueweb_help_about_cueweb.png)
 
 4. Click **Copy diagnostics** to copy all of those fields as JSON, then paste them straight into a bug report - no retyping.
 
-**Good to know:** the version is decided when the image is built. By default CueWeb tracks OpenCue's shared `VERSION.in`, so its number matches Cuebot and CueGUI; a deployment can override it (via `OVERRIDE_CUEWEB_VERSION.in` or the `NEXT_PUBLIC_APP_VERSION` build-arg), and the Build SHA reads `unknown` unless CI injected `NEXT_PUBLIC_GIT_SHA`. See [Versioning](/docs/concepts/versioning/#how-cueweb-sources-its-version) for the full chain.
+**Good to know:** the version is decided when the image is built. By default OpenCueWeb tracks OpenCue's shared `VERSION.in`, so its number matches Cuebot and CueGUI; a deployment can override it (via `OVERRIDE_CUEWEB_VERSION.in` or the `NEXT_PUBLIC_APP_VERSION` build-arg), and the Build SHA reads `unknown` unless CI injected `NEXT_PUBLIC_GIT_SHA`. See [Versioning](/docs/concepts/versioning/#how-cueweb-sources-its-version) for the full chain.
 
 ---
 
@@ -771,33 +771,33 @@ Some deployments turn on **group-based authorization**, so what you can reach de
 
 **As a user:**
 1. Read-only Cuetopia monitoring (Monitor Jobs, job/frame inspection, logs) and the Dashboard are typically open to everyone who can sign in.
-2. If you open an area you're not authorized for - anything under **CueCommander** (including Monitor Cue, Monitor Hosts and Stuck Frame), **CueSubmit**, or **Manage facilities…** - CueWeb shows an **Access denied** page instead of the content, and hides those menus. A non-admin sees only the unrestricted menus (Dashboard, File, Cuebot Facility, Cuetopia, Plugins, Other, Help):
+2. If you open an area you're not authorized for - anything under **CueCommander** (including Monitor Cue, Monitor Hosts and Stuck Frame), **CueSubmit**, or **Manage facilities…** - OpenCueWeb shows an **Access denied** page instead of the content, and hides those menus. A non-admin sees only the unrestricted menus (Dashboard, File, Cuebot Facility, Cuetopia, Plugins, Other, Help):
 
-   ![CueWeb basic (non-admin) view with CueCommander and CueSubmit hidden](/assets/images/cueweb/cueweb_basic_view_dashboard_facility_cuetopia_plugins_other_help.png)
+   ![OpenCueWeb basic (non-admin) view with CueCommander and CueSubmit hidden](/assets/images/cueweb/cueweb_basic_view_dashboard_facility_cuetopia_plugins_other_help.png)
 3. If you believe you should have access, contact your OpenCue administrator; access is decided by the groups your account belongs to, not by anything you can change in the UI.
 
 **As an administrator enabling it:**
 1. Set `CUEWEB_AUTHZ_ENABLED=true` to turn the gate on (it's a pure pass-through when unset).
-2. List the groups allowed to use CueWeb at all in `CUEWEB_ALLOWED_GROUPS`, and the groups allowed on the entire CueCommander section + CueSubmit + Manage facilities… in `CUEWEB_ADMIN_GROUPS` (empty means "everyone signed in").
+2. List the groups allowed to use OpenCueWeb at all in `CUEWEB_ALLOWED_GROUPS`, and the groups allowed on the entire CueCommander section + CueSubmit + Manage facilities… in `CUEWEB_ADMIN_GROUPS` (empty means "everyone signed in").
 3. Make sure your identity provider includes the user's groups in the login token, and point `CUEWEB_GROUPS_CLAIM` at the claim that carries them (default `groups`). Groups are read once at sign-in and enforced server-side on every request - users can't bypass it from the browser.
 
 > See [Group-based authorization](/docs/concepts/cueweb-rest-gateway/#group-based-authorization-optional) for the concept and the deployment guide for the full configuration.
 
 ---
 
-## Reviewing the audit trail (CueWeb Audit)
+## Reviewing the audit trail (OpenCueWeb Audit)
 
-CueWeb keeps an **audit trail** of the actions people take through it - who did what, when, to which target, and whether it worked. The **CueWeb Audit** page lets you read that trail, filter it, and export it. Let's walk through it.
+OpenCueWeb keeps an **audit trail** of the actions people take through it - who did what, when, to which target, and whether it worked. The **OpenCueWeb Audit** page lets you read that trail, filter it, and export it. Let's walk through it.
 
 1. **Do something auditable first** so there's a fresh entry to look at. Jump back to [Pause and Resume Practice](#pause-and-resume-practice) and pause a job, or use [Adjusting Priority](#adjusting-priority) to set a job's priority. Either action is recorded the moment it succeeds.
 
-2. **Open the audit page.** From the top header (or the left sidebar) open the **Admin** menu and choose **CueWeb Audit**.
+2. **Open the audit page.** From the top header (or the left sidebar) open the **Admin** menu and choose **OpenCueWeb Audit**.
 
-   ![CueWeb Audit menu](/assets/images/cueweb/cueweb_admin_cueweb_audit_menu.png)
+   ![OpenCueWeb Audit menu](/assets/images/cueweb/cueweb_admin_cueweb_audit_menu.png)
 
 3. **Read the table.** Each row is one recorded action, newest first, so the pause or priority change you just made sits at the top.
 
-   ![CueWeb Audit page](/assets/images/cueweb/cueweb_admin_cueweb_audit.png)
+   ![OpenCueWeb Audit page](/assets/images/cueweb/cueweb_admin_cueweb_audit.png)
 
    The columns are:
    - **When** - the timestamp of the action.
@@ -821,15 +821,15 @@ CueWeb keeps an **audit trail** of the actions people take through it - who did 
 
 7. **Watch it live, then export.** Toggle **auto-refresh** to have the page pull new entries on an interval - handy while you're actively making changes. When you want a copy, click **Export to CSV** to download exactly the rows currently in view (filters included).
 
-> **What gets recorded:** CueWeb Audit captures state-changing actions performed *through CueWeb* - kill / pause / resume / eat / retry, priority and core changes, comments, job submit, host actions (lock, reboot, allocation, tags, delete, redirect), and show / allocation / limit / subscription edits - plus **Sign in** and **Sign out**. Read-only views (opening Monitor Jobs, viewing logs, browsing details) are **not** recorded, and actions taken from CueGUI, `cueman`, or `pycue` are not captured. Access to the page is **admin-gated**: when no group-based authorization is configured it's visible to everyone, otherwise only members of your admin groups can reach it (see [Access control: restricted areas](#access-control-restricted-areas)).
+> **What gets recorded:** OpenCueWeb Audit captures state-changing actions performed *through OpenCueWeb* - kill / pause / resume / eat / retry, priority and core changes, comments, job submit, host actions (lock, reboot, allocation, tags, delete, redirect), and show / allocation / limit / subscription edits - plus **Sign in** and **Sign out**. Read-only views (opening Monitor Jobs, viewing logs, browsing details) are **not** recorded, and actions taken from CueGUI, `cueman`, or `pycue` are not captured. Access to the page is **admin-gated**: when no group-based authorization is configured it's visible to everyone, otherwise only members of your admin groups can reach it (see [Access control: restricted areas](#access-control-restricted-areas)).
 
 ## Using plugins
 
-CueWeb can be extended with **plugins** - add-on panels that live on their own pages. Two samples ship in the box; here's how to use them.
+OpenCueWeb can be extended with **plugins** - add-on panels that live on their own pages. Two samples ship in the box; here's how to use them.
 
 1. **Open the Plugins page.** The **Plugins** menu sits in the header (and sidebar) to the right of CueSubmit. Open the menu and pick **Plugins** to see every registered plugin.
 
-   ![CueWeb Plugins page](/assets/images/cueweb/cueweb_plugins.png)
+   ![OpenCueWeb Plugins page](/assets/images/cueweb/cueweb_plugins.png)
 
 2. **Choose what's in your menu.** Each plugin has a checkbox. Tick the ones you want in the **Plugins** menu and untick the rest - your choice is saved in your browser and follows you across tabs. (Cue Progress Bar is on by default; Hello OpenCue is off.)
 
@@ -849,7 +849,7 @@ CueWeb can be extended with **plugins** - add-on panels that live on their own p
 
 ## Customizing your workspace
 
-CueWeb gives you three ways to tailor the workspace - and all three remember your choice in the browser. Let's try each.
+OpenCueWeb gives you three ways to tailor the workspace - and all three remember your choice in the browser. Let's try each.
 
 ### Save and reuse a view preset
 
@@ -873,15 +873,15 @@ CueWeb gives you three ways to tailor the workspace - and all three remember you
 
 1. Press **`F`** (or open **Other &rarr; Immersive (full-screen)**). The header, sidebar, and status bar disappear, and the table takes the whole screen.
 
-   ![CueWeb in immersive (full-screen) mode](/assets/images/cueweb/cueweb_full_screen_activated.png)
+   ![OpenCueWeb in immersive (full-screen) mode](/assets/images/cueweb/cueweb_full_screen_activated.png)
 
 2. Press **`F`** again, or click the floating **Exit immersive** button, to bring the chrome back. The mode is remembered, so a new tab opens immersed too until you turn it off.
 
 ### Work in a split view
 
-1. Open **Other &rarr; Split view**. CueWeb shows two pages side-by-side - Jobs on the left, Hosts on the right by default.
+1. Open **Other &rarr; Split view**. OpenCueWeb shows two pages side-by-side - Jobs on the left, Hosts on the right by default.
 
-   ![CueWeb split view](/assets/images/cueweb/cueweb_split_view_activated.png)
+   ![OpenCueWeb split view](/assets/images/cueweb/cueweb_split_view_activated.png)
 
 2. Use each pane's **page picker** to choose what it shows (for example, put Monitor Jobs on the left and a specific host's detail page on the right).
 3. **Drag the divider** to rebalance the panes (or nudge it with the arrow keys); use **Swap** to flip them and **Reset 50/50** to re-center.
@@ -931,7 +931,7 @@ When jobs run slowly:
 
 ### Additional Resources
 
-- **[CueWeb User Guide](/docs/user-guides/cueweb-user-guide)** - Complete reference manual
-- **[CueWeb Developer Guide](/docs/developer-guide/cueweb-development)** - For customization and development
+- **[OpenCueWeb User Guide](/docs/user-guides/cueweb-user-guide)** - Complete reference manual
+- **[OpenCueWeb Developer Guide](/docs/developer-guide/cueweb-development)** - For customization and development
 - **[REST API Reference](/docs/reference/rest-api-reference/)** - For automation and integration
 - **[OpenCue Community](/docs/concepts/opencue-overview#contact-us)** - Support and discussion

--- a/docs/_docs/tutorials/getting-started-tutorial.md
+++ b/docs/_docs/tutorials/getting-started-tutorial.md
@@ -33,14 +33,14 @@ OpenCue consists of several key components:
 
 - **Cuebot**: The central server that manages all jobs and distributes work
 - **RQD**: The daemon running on render nodes that executes jobs
-- **CueGUI/CueWeb**: User interfaces for monitoring and managing jobs
+- **CueGUI/OpenCueWeb**: User interfaces for monitoring and managing jobs
 - **CueSubmit**: Tool for submitting jobs to the render queue
 
 ## Step 2: Accessing the OpenCue Interface
 
 If you're using the sandbox environment, you can access OpenCue through:
 
-### Web Interface (CueWeb)
+### Web Interface (OpenCueWeb)
 1. Open your browser and navigate to `http://localhost:8080`
 2. You should see the OpenCue web interface with an empty job list
 

--- a/docs/_docs/user-guides/cueweb-user-guide.md
+++ b/docs/_docs/user-guides/cueweb-user-guide.md
@@ -115,7 +115,7 @@ OpenCueWeb supports secure authentication through multiple providers:
 ![OpenCueWeb authentication page](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_login.png)
 
 
-**Note**: If authentication is disabled for development, you'll see a "OpenCueWeb Home" button to access the interface directly.
+**Note**: If authentication is disabled for development, you'll see an "OpenCueWeb Home" button to access the interface directly.
 
 #### Restricted access
 
@@ -1744,7 +1744,7 @@ A plugin can expose its own settings. Open them from the plugin (the **Open plug
 
 ![Hello OpenCue plugin settings](/assets/images/cueweb/cueweb_plugins_hello_opencue_plugin_open_plugin_settings.png)
 
-**Cue Progress Bar** - a OpenCueWeb port of CueGUI's `cueprogbar` sample. It draws a live, color-coded frame-state bar for a job (with done / total / running labels) and offers pause / unpause / kill / retry-dead controls, polling Cuebot on a configurable interval. It is **on** in the menu by default.
+**Cue Progress Bar** - an OpenCueWeb port of CueGUI's `cueprogbar` sample. It draws a live, color-coded frame-state bar for a job (with done / total / running labels) and offers pause / unpause / kill / retry-dead controls, polling Cuebot on a configurable interval. It is **on** in the menu by default.
 
 ![Cue Progress Bar plugin](/assets/images/cueweb/cueweb_plugins_cue_progress_bar.png)
 

--- a/docs/_docs/user-guides/cueweb-user-guide.md
+++ b/docs/_docs/user-guides/cueweb-user-guide.md
@@ -1,14 +1,14 @@
 ---
 layout: default
-title: CueWeb User Guide
+title: OpenCueWeb User Guide
 parent: User Guides
 nav_order: 43
 ---
 
-# CueWeb User Guide
+# OpenCueWeb User Guide
 {: .no_toc }
 
-Complete guide to using CueWeb for OpenCue render farm management.
+Complete guide to using OpenCueWeb for OpenCue render farm management.
 
 <details open markdown="block">
   <summary>
@@ -23,7 +23,7 @@ Complete guide to using CueWeb for OpenCue render farm management.
 
 ## Overview
 
-CueWeb is a web-based interface for managing OpenCue render farms, replicating the core functionality of CueGUI (Cuetopia and CueCommander) in a web-accessible format. It extends OpenCue access across multiple platforms, ensuring users can manage their rendering tasks from virtually anywhere.
+OpenCueWeb is a web-based interface for managing OpenCue render farms, replicating the core functionality of CueGUI (Cuetopia and CueCommander) in a web-accessible format. It extends OpenCue access across multiple platforms, ensuring users can manage their rendering tasks from virtually anywhere.
 
 ### Key Benefits
 
@@ -97,57 +97,57 @@ CueWeb is a web-based interface for managing OpenCue render farms, replicating t
 
 ## Getting Started
 
-### Accessing CueWeb
+### Accessing OpenCueWeb
 
 1. Open your web browser
-2. Navigate to your CueWeb URL (typically `http://your-server:3000`)
+2. Navigate to your OpenCueWeb URL (typically `http://your-server:3000`)
 3. If authentication is enabled, sign in with your credentials
 
 ### Authentication
 
-CueWeb supports secure authentication through multiple providers:
+OpenCueWeb supports secure authentication through multiple providers:
 
 - **OAuth Providers**: GitHub, Google, Okta, Apple, GitLab, Amazon, Microsoft Azure, LinkedIn, Atlassian, Auth0
 - **Email Authentication**: Email-based login
 - **Custom Credentials**: Username/password authentication
 - **Other Providers**: Additional providers can be configured using [NextAuth.js](https://next-auth.js.org/)
 
-![CueWeb authentication page](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_login.png)
+![OpenCueWeb authentication page](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_login.png)
 
 
-**Note**: If authentication is disabled for development, you'll see a "CueWeb Home" button to access the interface directly.
+**Note**: If authentication is disabled for development, you'll see a "OpenCueWeb Home" button to access the interface directly.
 
 #### Restricted access
 
-Some deployments restrict access by group membership. If your account is not authorized for an area you open, CueWeb shows an **Access denied** page instead. The entire **CueCommander** section (including Monitor Cue, Monitor Hosts and Stuck Frame), **CueSubmit**, and **Manage facilities…** may be limited to administrators - on a restricted deployment those menus are hidden from non-admins. Cuetopia **Monitor Jobs** and the Dashboard stay available to everyone who can sign in. If you believe you should have access, contact your OpenCue administrator.
+Some deployments restrict access by group membership. If your account is not authorized for an area you open, OpenCueWeb shows an **Access denied** page instead. The entire **CueCommander** section (including Monitor Cue, Monitor Hosts and Stuck Frame), **CueSubmit**, and **Manage facilities…** may be limited to administrators - on a restricted deployment those menus are hidden from non-admins. Cuetopia **Monitor Jobs** and the Dashboard stay available to everyone who can sign in. If you believe you should have access, contact your OpenCue administrator.
 
 A non-admin sees only the unrestricted menus - **Dashboard**, **File**, **Cuebot Facility**, **Cuetopia**, **Plugins**, **Other**, and **Help** (no **CueCommander** or **CueSubmit**):
 
-![CueWeb basic (non-admin) view with CueCommander and CueSubmit hidden](/assets/images/cueweb/cueweb_basic_view_dashboard_facility_cuetopia_plugins_other_help.png)
+![OpenCueWeb basic (non-admin) view with CueCommander and CueSubmit hidden](/assets/images/cueweb/cueweb_basic_view_dashboard_facility_cuetopia_plugins_other_help.png)
 
 ### First Time Setup
 
-When you first access CueWeb, you'll see the main dashboard:
+When you first access OpenCueWeb, you'll see the main dashboard:
 
-![CueWeb main page](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_mainpage.png)
+![OpenCueWeb main page](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_mainpage.png)
 
-CueWeb ships light and dark themes; use the sun/moon toggle in the header to switch (your choice persists across sessions). The rest of this guide uses light-mode screenshots, but every view has a dark equivalent - here is the same Monitor Jobs view in dark mode:
+OpenCueWeb ships light and dark themes; use the sun/moon toggle in the header to switch (your choice persists across sessions). The rest of this guide uses light-mode screenshots, but every view has a dark equivalent - here is the same Monitor Jobs view in dark mode:
 
-![CueWeb main page in dark mode](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_mainpage_dark.png)
+![OpenCueWeb main page in dark mode](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_mainpage_dark.png)
 
 The screen is composed of:
 
 - **Global header** (persistent across every authenticated route):
-  - **Logo and wordmark**: OpenCue icon (black in light mode, white in dark mode) followed by **CueWeb**. Clicking the logo returns you to the jobs dashboard (`/`).
+  - **Logo and wordmark**: OpenCue icon (black in light mode, white in dark mode) followed by **OpenCueWeb**. Clicking the logo returns you to the jobs dashboard (`/`).
   - **Menus** (mirror the CueGUI menu bar):
     - **File** -> *Disable Job Interaction* (read-only safety toggle, see below).
     - **Cuebot Facility** -> switch between `local` · `dev` · `cloud` · `external` (the active facility is shown as a small chip on the menu trigger).
     - **Cuetopia** -> Monitor Jobs.
     - **CueCommander** -> Allocations, Limits, Monitor Cue, **Monitor Hosts** (see [Monitor Hosts](#monitor-hosts)), Redirect, Services, Shows, Stuck Frame, Subscription Graphs, Subscriptions. The remaining unimplemented routes 404 gracefully - they are placeholders for upcoming features.
     - **Other** -> *Attributes* (toggles the docked Attributes panel, see below).
-    - **Help** -> a search box that finds commands across **every** menu in CueWeb (CueGUI parity), plus Online User Guide, Make a Suggestion, Report a Bug, and About CueWeb.
+    - **Help** -> a search box that finds commands across **every** menu in OpenCueWeb (CueGUI parity), plus Online User Guide, Make a Suggestion, Report a Bug, and About OpenCueWeb.
   - **Theme toggle**: Switch between light and dark modes (your choice persists across sessions).
-  - **Sign out**: Always visible. When you are signed in, it shows your name or email next to the button and clicking it ends the session and returns you to `/login`. When you are not signed in (or when authentication is disabled in the deployment), clicking it just navigates to `/login` - the `/login` page itself shows the **CueWeb Home** button if no auth provider is configured, or the provider buttons otherwise.
+  - **Sign out**: Always visible. When you are signed in, it shows your name or email next to the button and clicking it ends the session and returns you to `/login`. When you are not signed in (or when authentication is disabled in the deployment), clicking it just navigates to `/login` - the `/login` page itself shows the **OpenCueWeb Home** button if no auth provider is configured, or the provider buttons otherwise.
 - **Left sidebar** (persistent across every authenticated route):
   - Same six groups as the header (**File**, **Cuebot Facility**, **Cuetopia**, **CueCommander**, **Other**, **Help**), organized as accordion sections. The group containing the active route auto-expands; the others remember their open/closed state per browser.
   - Click the **Collapse** button at the bottom to shrink the sidebar to an icon-only rail (your choice persists across reloads). Hover an icon to see its label.
@@ -158,14 +158,14 @@ The screen is composed of:
 - **Bottom status bar** (IDE-style, always visible): 24-pixel-tall fixed bar at the bottom of the viewport. Three metrics with tooltips:
   - **Gateway**: a colored dot plus `Online` / `Offline` plus the last round-trip latency. Polled every 10 seconds; the bar's surface turns red whenever the REST gateway is unreachable.
   - **Last refresh**: a live "just now" / "Ns ago" timer that updates every time the jobs table re-fetches.
-  - **Version**: the CueWeb build version (`v<x.y.z>`) baked in at build time.
+  - **Version**: the OpenCueWeb build version (`v<x.y.z>`) baked in at build time.
 - **Jobs Dashboard**: Central paginated table populated with OpenCue jobs (below the header).
 
 ### Navigation menus
 
 The left sidebar and the header menus give you the same set of groups. Use the sidebar's accordion sections to jump between pages, and collapse it to an icon-only rail when you want more room for the tables.
 
-![CueWeb left sidebar](/assets/images/cueweb/cueweb_left_side_menu.png)
+![OpenCueWeb left sidebar](/assets/images/cueweb/cueweb_left_side_menu.png)
 
 
 The **Cuetopia** menu opens Monitor Jobs and holds the checkable **View Job Graph** toggle (see [Job dependency graph](#job-dependency-graph)).
@@ -176,7 +176,7 @@ The **Cuetopia** menu opens Monitor Jobs and holds the checkable **View Job Grap
 
 
 The **Cuebot Facility** menu lets you switch the active facility. Choosing a
-facility re-routes CueWeb to that facility's Cuebot and reloads the data you are
+facility re-routes OpenCueWeb to that facility's Cuebot and reloads the data you are
 viewing, so you only ever see one facility at a time (the same behavior as
 CueGUI's "Cuebot Facility" menu). The active facility is shown as a chip on the
 menu and in the bottom status bar, and your choice is remembered for the session.
@@ -215,16 +215,16 @@ The **Other** menu collects the Attributes panel toggle, the shortcuts overlay, 
 ![Other menu](/assets/images/cueweb/cueweb_other_menu_options.png)
 
 
-The **Help** menu provides a search box that finds commands across every menu, plus links to the online guide and feedback forms, and an **About CueWeb** entry.
+The **Help** menu provides a search box that finds commands across every menu, plus links to the online guide and feedback forms, and an **About OpenCueWeb** entry.
 
 ![Help menu with search](/assets/images/cueweb/cueweb_help_about_cueweb_menu.png)
 
-**About CueWeb** opens a dialog with the CueWeb version and build SHA, the active
+**About OpenCueWeb** opens a dialog with the OpenCueWeb version and build SHA, the active
 Cuebot facility, the REST gateway URL (masked), the Apache-2.0 license, and
 credits. Use **Copy diagnostics** to copy all of these as JSON to paste into a
 bug report.
 
-![About CueWeb dialog](/assets/images/cueweb/cueweb_help_about_cueweb.png)
+![About OpenCueWeb dialog](/assets/images/cueweb/cueweb_help_about_cueweb.png)
 
 
 The bottom status bar shows the gateway connection, the last refresh time, and the build version.
@@ -238,7 +238,7 @@ The bottom status bar shows the gateway connection, the last refresh time, and t
 
 The **Dashboard** is a dedicated statistics page, separate from the Jobs table below. It summarizes farm activity at a glance.
 
-![CueWeb Dashboard](/assets/images/cueweb/cueweb_dashboard.png)
+![OpenCueWeb Dashboard](/assets/images/cueweb/cueweb_dashboard.png)
 
 
 Open it from the **Dashboard** entry in the navigation.
@@ -290,7 +290,7 @@ The Jobs table ships every CueGUI-parity column visible by default. You can hide
 
 Each of the three tables (Jobs, Layers, Frames) has its own **Columns** dropdown in the per-table toolbar (just left of the table). The dropdown contains, top to bottom:
 
-- A pinned **Reset to Default** button that clears both column visibility and order, restoring the table to the layout shipped by CueWeb.
+- A pinned **Reset to Default** button that clears both column visibility and order, restoring the table to the layout shipped by OpenCueWeb.
 - One row per hideable column with three controls:
   - A checkbox to hide / show the column.
   - A `←` button to nudge the column one slot left in the table.
@@ -316,7 +316,7 @@ The filter snaps you back to page 1 on every keystroke so you never sit on an em
 The Jobs toolbar has a **Group By** dropdown that lets you reshape the table the same way CueGUI does:
 
 - **Clear** keeps the flat list.
-- **Dependent** renders the jobs as a parent / child **tree**. A job that other monitored jobs depend on becomes a parent with a chevron in front of its name; the dependents nest under it at increasing depth. Click the chevron to collapse or expand a subtree. CueWeb fetches the dependency graph from Cuebot in the background, so the tree fills in within a second or two of switching modes.
+- **Dependent** renders the jobs as a parent / child **tree**. A job that other monitored jobs depend on becomes a parent with a chevron in front of its name; the dependents nest under it at increasing depth. Click the chevron to collapse or expand a subtree. OpenCueWeb fetches the dependency graph from Cuebot in the background, so the tree fills in within a second or two of switching modes.
 - **Show**, **Show-Shot**, and **Show-Shot-Username** group the rows under collapsible headers (with a count on each header). Useful for sorting jobs by who owns them.
 
 The default is **Clear**. Switching modes preserves your filters, column visibility, and substring search.
@@ -385,7 +385,7 @@ Right-click on a job, layer, or frame row to open a CueGUI-parity context menu. 
 The job context menu groups four dependency actions together so you can audit, create, or remove depends without leaving Monitor Jobs:
 
 - **View Dependencies...** opens a read-only dialog listing every depend on the job (Type, Target, Active, OnJob, OnLayer, OnFrame). Use **Refresh** to re-poll after creating or dropping depends elsewhere.
-- **Dependency Wizard...** opens a multi-step dialog that creates a new depend on the job. The CueWeb wizard supports every CueGUI `depend.DependType`: Job On Job / Layer / Frame, Frame By Frame for all layers (Hard Depend), Layer On Job / Layer / Frame, Frame By Frame, Frame On Job / Layer / Frame, and Layer on Simulation Frame. Every picker (source layers, source frames, target jobs, target layers, target frames) is multi-select; **Done** fires the full source x target cross-product in one batch.
+- **Dependency Wizard...** opens a multi-step dialog that creates a new depend on the job. The OpenCueWeb wizard supports every CueGUI `depend.DependType`: Job On Job / Layer / Frame, Frame By Frame for all layers (Hard Depend), Layer On Job / Layer / Frame, Frame By Frame, Frame On Job / Layer / Frame, and Layer on Simulation Frame. Every picker (source layers, source frames, target jobs, target layers, target frames) is multi-select; **Done** fires the full source x target cross-product in one batch.
 - **Drop External Dependencies** removes every external (cross-job) depend on the selected job in one click. The Jobs table re-polls immediately after success.
 - **Drop Internal Dependencies** removes every internal (within-job) depend in one click. Same auto-refresh.
 
@@ -447,12 +447,12 @@ The Frame menu shows an additional **View Log on \<editor\>** item when the depl
 Important notes:
 
 - The log file only exists on disk once **RQD has started running the frame**. Right-clicking a WAITING / DEPEND frame produces a warning toast instead of handing a non-existent path to your editor.
-- If the configured editor isn't installed (no app registered for `vscode://`, `subl://`, etc.), CueWeb shows a warning toast after a short timeout pointing you at the alternatives.
+- If the configured editor isn't installed (no app registered for `vscode://`, `subl://`, etc.), OpenCueWeb shows a warning toast after a short timeout pointing you at the alternatives.
 - Double-clicking the row (or choosing **View Log** / **Tail Log**) opens the in-browser Monaco log viewer instead - always available, no editor install required.
 
 **Note**: Destructive items (Pause / Unpause / Retry / Eat / Kill) are automatically disabled when the global **Disable Job Interaction** safety toggle is on, and the context menu always stays on-screen even on small viewports (it scrolls internally if it would overflow).
 
-   ![CueWeb with job context menu open](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_job_context_menu_open.png)
+   ![OpenCueWeb with job context menu open](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_job_context_menu_open.png)
 
    ![Pop-up showing successful kill job message](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_job_context_menu_open_and_success_notification.png)
 
@@ -525,7 +525,7 @@ The policy mirrors CueGUI and is per-action: **Kill**, **Eat**, and **Retry** al
 
 ## Job Comments
 
-CueWeb provides full per-job comments, equivalent to the **Comments** dialog in CueGUI.
+OpenCueWeb provides full per-job comments, equivalent to the **Comments** dialog in CueGUI.
 
 ### Opening the Comments page
 
@@ -542,7 +542,7 @@ The Comments page opens in a new tab.
 ![Job Comments page](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_comments_page.png)
 
 
-Both open the job's Comments page in a new browser tab. CueWeb identifies you from your signed-in session; only the author of a comment can edit or delete it, and everyone else sees it read-only.
+Both open the job's Comments page in a new browser tab. OpenCueWeb identifies you from your signed-in session; only the author of a comment can edit or delete it, and everyone else sees it read-only.
 
 ### Page layout
 
@@ -797,7 +797,7 @@ The graph is theme-aware: it follows the light/dark toggle without re-fetching t
 - **Retry**: Restart all frames in the layer
 - **Retry Dead Frames**: Restart only failed frames
 
-   ![CueWeb with layer context menu open](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_layer_context_menu_open.png)
+   ![OpenCueWeb with layer context menu open](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_layer_context_menu_open.png)
 
    ![Pop-up showing successful retry layer message](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_layer_context_menu_open_and_success_notification.png)
 
@@ -805,7 +805,7 @@ The graph is theme-aware: it follows the light/dark toggle without re-fetching t
 
 #### Frame State Filter Chips
 
-Above the frames table, CueWeb renders one filter chip per supported frame state - `WAITING`, `RUNNING`, `SUCCEEDED`, `DEAD`, `EATEN`, `DEPEND` - each annotated with the current count of frames in that state.
+Above the frames table, OpenCueWeb renders one filter chip per supported frame state - `WAITING`, `RUNNING`, `SUCCEEDED`, `DEAD`, `EATEN`, `DEPEND` - each annotated with the current count of frames in that state.
 
 - **Toggle**: Click a chip to add or remove its state from the filter. Selected chips switch to a solid (filled) style.
 - **OR semantics**: When multiple chips are selected, frames matching **any** of the selected states are shown.
@@ -832,7 +832,7 @@ Above the frames table, CueWeb renders one filter chip per supported frame state
 | **Memory (RSS)** | Resident-set memory usage (used memory for running, max RSS for completed). |
 | **Memory (PSS)** | Proportional-set-size memory usage (used PSS for running, max PSS for completed). |
 | **GPU Memory** | GPU memory usage (used for running, max for completed). |
-| **Remain** | CueGUI's ETA estimate. Hidden by default; the value is a placeholder (an em-dash) until the underlying predictor is wired into CueWeb. |
+| **Remain** | CueGUI's ETA estimate. Hidden by default; the value is a placeholder (an em-dash) until the underlying predictor is wired into OpenCueWeb. |
 | **Start Time** | Frame start timestamp in human-readable format. |
 | **Stop Time** | Frame completion timestamp (if finished). |
 | **Eligible Time** | Timestamp when the frame became eligible to dispatch. |
@@ -863,7 +863,7 @@ Frames are color-coded by status:
    - **Preview All**: open the frame's rendered output in an external image viewer (see below)
    - **View Processes**: list the procs running this frame
 
-   ![CueWeb with frame context menu open](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_frame_context_menu_open.png)
+   ![OpenCueWeb with frame context menu open](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_frame_context_menu_open.png)
 
    ![Pop-up showing successful eat frame message](/assets/images/cueweb/cueweb_cuetopia_monitor_jobs_frame_context_menu_open_and_success_notification.png)
 
@@ -889,8 +889,8 @@ The viewer adds CueGUI-style controls for working through large logs:
 
 The viewer has two interchangeable backends, and both look and behave the same - the same read-only editor, the same **Log versions** dropdown, and the same loading / empty states:
 
-- **File-based (default):** CueWeb reads the frame's `.rqlog` file from the render-log directory mounted into the server. The **Log versions** dropdown lists the rotated log files on disk, and you can scroll up through very large logs ("Scroll from Top").
-- **Loki (optional):** when your deployment is configured to pull logs from a [Grafana Loki](https://grafana.com/oss/loki/) server (the CueWeb equivalent of CueGUI's Loki log viewer), the viewer queries Loki for the frame's lines instead of reading a file. Here each entry in the **Log versions** dropdown is a separate **frame attempt** (newest first), and a **Refresh** button reloads the selected attempt's lines. You don't choose the backend in the UI - whichever one the deployment is set up for is used automatically. If you ever see "No logs in Loki" for a frame, it either hasn't started yet or its logs weren't shipped to Loki.
+- **File-based (default):** OpenCueWeb reads the frame's `.rqlog` file from the render-log directory mounted into the server. The **Log versions** dropdown lists the rotated log files on disk, and you can scroll up through very large logs ("Scroll from Top").
+- **Loki (optional):** when your deployment is configured to pull logs from a [Grafana Loki](https://grafana.com/oss/loki/) server (the OpenCueWeb equivalent of CueGUI's Loki log viewer), the viewer queries Loki for the frame's lines instead of reading a file. Here each entry in the **Log versions** dropdown is a separate **frame attempt** (newest first), and a **Refresh** button reloads the selected attempt's lines. You don't choose the backend in the UI - whichever one the deployment is set up for is used automatically. If you ever see "No logs in Loki" for a frame, it either hasn't started yet or its logs weren't shipped to Loki.
 
 ---
 
@@ -949,7 +949,7 @@ Docked on the top.
 
 ### Auto-refresh Settings
 
-CueWeb provides automatic real-time updates:
+OpenCueWeb provides automatic real-time updates:
 
 1. **Fixed Refresh Interval**: All tables automatically update every 5 seconds
 2. **All Tables**: Jobs, layers, and frames tables are auto-reloaded at regular intervals to display the latest data
@@ -969,16 +969,16 @@ Behavior:
 - The bell is disabled (faded, with tooltip) on jobs that are already `FINISHED` when first viewed; there is nothing to notify on.
 - The subscription always succeeds. After saving it, the browser's notification permission is requested as an optional upgrade for system-level popups. A toast tells you what you got:
   - **granted** &mdash; in-app toast plus a desktop popup when the job finishes.
-  - **denied** &mdash; in-app toast only. To also receive desktop popups, enable notifications for the CueWeb origin in your browser site settings.
+  - **denied** &mdash; in-app toast only. To also receive desktop popups, enable notifications for the OpenCueWeb origin in your browser site settings.
   - **default** &mdash; you dismissed the prompt without choosing. In-app toast only, same as `denied`.
 - A background poller checks each subscribed job every 15 seconds. When a job reaches `FINISHED` an in-app `toast.success("Job finished: <jobName>")` always fires; a desktop `Notification` popup is layered on top when the permission was granted at fire-time. The bell switches to filled with a green dot, and the entry is marked as notified.
-- When several CueWeb tabs are open for the same job, only one of them shows the notification, so you see exactly one notification per finished job per browser profile.
+- When several OpenCueWeb tabs are open for the same job, only one of them shows the notification, so you see exactly one notification per finished job per browser profile.
 - Subscriptions are saved in your browser and survive page reloads. They are scoped to the browser and profile; clearing site data removes them.
 - If a subscribed job is deleted from Cuebot (the API returns null), the subscription is removed automatically on the next poll.
 
 ### Subscribe to Job (email subscription)
 
-The **Notify bell** above is a *browser-side* subscription: it stays in your browser and fires a popup in your CueWeb tab. If you want Cuebot to send you an **email** when the job finishes - for example, so you get notified after closing the browser, or so a team alias is informed - use the **Subscribe to Job** entry in the job's right-click menu instead.
+The **Notify bell** above is a *browser-side* subscription: it stays in your browser and fires a popup in your OpenCueWeb tab. If you want Cuebot to send you an **email** when the job finishes - for example, so you get notified after closing the browser, or so a team alias is informed - use the **Subscribe to Job** entry in the job's right-click menu instead.
 
 The two are independent. You can use either, or both at the same time. Their differences in plain terms:
 
@@ -987,7 +987,7 @@ The two are independent. You can use either, or both at the same time. Their dif
 | Where the subscription lives | Your browser | Cuebot |
 | Notification channel | In-app toast (always) + desktop popup (when permission granted) | Email sent by Cuebot |
 | Survives a browser reset or new device | No | Yes |
-| Cancel | Click the bell again | Outside CueWeb (whatever Cuebot supports) |
+| Cancel | Click the bell again | Outside OpenCueWeb (whatever Cuebot supports) |
 
 **To subscribe by email:**
 
@@ -1011,7 +1011,7 @@ When the job reaches `FINISHED`, Cuebot sends the configured notification email 
 
 ## Monitor Cue
 
-The **Monitor Cue** page (CueCommander &rarr; Monitor Cue in the sidebar or header) is the CueWeb equivalent of CueGUI's CueCommander Monitor Cue window. Unlike Monitor Jobs (which searches across shows), Monitor Cue shows **every job for the shows you pick**, grouped under their show and groups.
+The **Monitor Cue** page (CueCommander &rarr; Monitor Cue in the sidebar or header) is the OpenCueWeb equivalent of CueGUI's CueCommander Monitor Cue window. Unlike Monitor Jobs (which searches across shows), Monitor Cue shows **every job for the shows you pick**, grouped under their show and groups.
 
 ### Choose shows
 
@@ -1041,7 +1041,7 @@ Right-click a job for the same menu as Monitor Jobs, plus Monitor-Cue-only entri
 
 ## Monitor Hosts
 
-The **Monitor Hosts** page (CueCommander &rarr; Monitor Hosts in the sidebar or header, or the **View hosts** link on the dashboard hosts widget) lists the render hosts registered with Cuebot. It is the CueWeb equivalent of CueGUI's CueCommander Monitor Hosts plugin, and mirrors the jobs table interactions (sortable columns, substring filter, column show/hide, pagination).
+The **Monitor Hosts** page (CueCommander &rarr; Monitor Hosts in the sidebar or header, or the **View hosts** link on the dashboard hosts widget) lists the render hosts registered with Cuebot. It is the OpenCueWeb equivalent of CueGUI's CueCommander Monitor Hosts plugin, and mirrors the jobs table interactions (sortable columns, substring filter, column show/hide, pagination).
 
 Open it from the **CueCommander** menu (or the matching entry in the left sidebar).
 
@@ -1049,7 +1049,7 @@ Open it from the **CueCommander** menu (or the matching entry in the left sideba
 
 The page renders the full CueGUI Monitor Hosts column set in a sortable, filterable table of every host:
 
-![CueWeb Monitor Hosts page](/assets/images/cueweb/cueweb_cuecommander_monitor_hosts.png)
+![OpenCueWeb Monitor Hosts page](/assets/images/cueweb/cueweb_cuecommander_monitor_hosts.png)
 
 ### Host columns
 
@@ -1095,7 +1095,7 @@ The menu mirrors CueGUI's Monitor Hosts menu: **Comments…**, **View Procs**, *
 
 #### Lock and unlock
 
-Locking a host takes it out of the booking pool so it stops picking up new frames; frames already running keep going. CueWeb asks you to confirm, listing the host(s) affected. **Unlock** returns the host to the booking pool; a `NIMBY_LOCKED` host can't be unlocked this way, so **Unlock Host** stays disabled for those.
+Locking a host takes it out of the booking pool so it stops picking up new frames; frames already running keep going. OpenCueWeb asks you to confirm, listing the host(s) affected. **Unlock** returns the host to the booking pool; a `NIMBY_LOCKED` host can't be unlocked this way, so **Unlock Host** stays disabled for those.
 
 ![Lock host confirmation](/assets/images/cueweb/cueweb_cuecommander_monitor_hosts_lock_host.png)
 
@@ -1127,7 +1127,7 @@ Choosing it asks you to confirm; on success the host is owned by the signed-in u
 
 #### Reboot and reboot when idle
 
-**Reboot** issues an immediate reboot. Any frames running on the host are killed, so CueWeb asks you to confirm first.
+**Reboot** issues an immediate reboot. Any frames running on the host are killed, so OpenCueWeb asks you to confirm first.
 
 ![Reboot host confirmation](/assets/images/cueweb/cueweb_cuecommander_monitor_hosts_reboot_host.png)
 
@@ -1137,7 +1137,7 @@ Choosing it asks you to confirm; on success the host is owned by the signed-in u
 
 #### Delete host
 
-**Delete Host** removes the host record from Cuebot. This is an administrator action, so CueWeb confirms first and lists the host(s) to be deleted. (A live host that is still reporting will re-register on its next ping.)
+**Delete Host** removes the host record from Cuebot. This is an administrator action, so OpenCueWeb confirms first and lists the host(s) to be deleted. (A live host that is still reporting will re-register on its next ping.)
 
 ![Delete selected hosts confirmation](/assets/images/cueweb/cueweb_cuecommander_monitor_hosts_delete_selected_hosts.png)
 
@@ -1167,7 +1167,7 @@ Like CueGUI's Comments dialog, you can save reusable **predefined comments** (ma
 
 ### Proc monitor panel
 
-The panel below the table shows the procs (running frames) on one or more hosts - the CueWeb equivalent of CueGUI's Monitor Hosts proc view. Populate it by **left-clicking a host row** (which also loads the host into the Attributes panel), by choosing **View Procs** from a host's right-click menu, or by typing host names (space-separated) into the **Procs** box. It auto-refreshes every 30 seconds (toggle with the panel's own **Auto-refresh** / **Refresh**), and **Clr** empties it.
+The panel below the table shows the procs (running frames) on one or more hosts - the OpenCueWeb equivalent of CueGUI's Monitor Hosts proc view. Populate it by **left-clicking a host row** (which also loads the host into the Attributes panel), by choosing **View Procs** from a host's right-click menu, or by typing host names (space-separated) into the **Procs** box. It auto-refreshes every 30 seconds (toggle with the panel's own **Auto-refresh** / **Refresh**), and **Clr** empties it.
 
 Each proc row shows Name, Cores, Mem Reserved, Mem Used, GPU Used, Age, Unbooked, Frame, and Job. Right-click a proc for **View Job** (opens the job detail page), **Unbook** (release the proc after the current frame), **Kill** (kill the running frame), and **Unbook and Kill**.
 
@@ -1197,7 +1197,7 @@ Click a host's **Name** in the table to open its detail page. The page has four 
 
 ## Allocations
 
-The **Allocations** page (CueCommander &rarr; Allocations in the sidebar or header) lists the allocations configured in Cuebot. It is the CueWeb equivalent of CueGUI's CueCommander Allocations window, with a sortable, filterable table.
+The **Allocations** page (CueCommander &rarr; Allocations in the sidebar or header) lists the allocations configured in Cuebot. It is the OpenCueWeb equivalent of CueGUI's CueCommander Allocations window, with a sortable, filterable table.
 
 Open it from the **CueCommander** menu (or the matching entry in the left sidebar).
 
@@ -1205,7 +1205,7 @@ Open it from the **CueCommander** menu (or the matching entry in the left sideba
 
 The page renders a sortable, filterable table of every allocation.
 
-![CueWeb Allocations page](/assets/images/cueweb/cueweb_cuecommander_allocation.png)
+![OpenCueWeb Allocations page](/assets/images/cueweb/cueweb_cuecommander_allocation.png)
 
 ### Allocation columns
 
@@ -1237,7 +1237,7 @@ Clicking an allocation's **Name** navigates to the hosts list scoped to that all
 
 ## Shows
 
-The **Shows** page (CueCommander &rarr; Shows in the sidebar or header) lists the active shows registered with Cuebot. It is the CueWeb equivalent of CueGUI's CueCommander Shows window, with a sortable, filterable stats table, a **Create Show** button, and a per-row actions menu.
+The **Shows** page (CueCommander &rarr; Shows in the sidebar or header) lists the active shows registered with Cuebot. It is the OpenCueWeb equivalent of CueGUI's CueCommander Shows window, with a sortable, filterable stats table, a **Create Show** button, and a per-row actions menu.
 
 Open it from the **CueCommander** menu (or the matching entry in the left sidebar).
 
@@ -1245,7 +1245,7 @@ Open it from the **CueCommander** menu (or the matching entry in the left sideba
 
 The page renders a sortable, filterable table of the active shows.
 
-![CueWeb Shows page](/assets/images/cueweb/cueweb_cuecommander_shows.png)
+![OpenCueWeb Shows page](/assets/images/cueweb/cueweb_cuecommander_shows.png)
 
 ### Show columns
 
@@ -1303,13 +1303,13 @@ Right-click a show row to open its actions menu: **Show Properties** and **Creat
 
 ![Create Subscription dialog](/assets/images/cueweb/cueweb_cuecommander_shows_create_subscription_window.png)
 
-A show can have only one subscription per allocation; if one already exists, CueWeb reports that instead of creating a duplicate.
+A show can have only one subscription per allocation; if one already exists, OpenCueWeb reports that instead of creating a duplicate.
 
 ### Show detail page (group tree)
 
 Clicking a show name (or navigating to `/shows/<show>`) opens the show's **group tree** - the nested groups and jobs that make up the show, mirroring the grouping in CueGUI's Cuetopia. The breadcrumbs and header show the show name and whether it is active, and a **Refresh** button reloads the tree.
 
-![CueWeb show detail page with the group tree](/assets/images/cueweb/cueweb_cuecommander_shows_group_tree_page.png)
+![OpenCueWeb show detail page with the group tree](/assets/images/cueweb/cueweb_cuecommander_shows_group_tree_page.png)
 
 - **Expand or collapse** a group to load and reveal its jobs. Each job links to its job detail page and shows a frame-state progress bar, a dead-frame count when any frames have died, and a job-state indicator dot. The set of expanded groups is kept in the page URL (`?expanded=...`), so a particular view is bookmarkable and shareable.
 - **Drag to reparent**: drag a group onto another group to make it a child of that group, or drag a job onto a group to move the job into it. Only valid drop targets highlight - you cannot drop a group into itself or one of its own descendants. Moves are applied one at a time and roll back automatically if Cuebot rejects the change.
@@ -1318,7 +1318,7 @@ Clicking a show name (or navigating to `/shows/<show>`) opens the show's **group
 
 ## Stuck Frames
 
-The **Stuck Frames** page (CueCommander &rarr; Stuck Frame in the sidebar or header) helps you find running frames that appear to be hung - frames that keep running but have stopped writing to their log. It is the CueWeb equivalent of CueGUI's CueCommander Stuck Frame window.
+The **Stuck Frames** page (CueCommander &rarr; Stuck Frame in the sidebar or header) helps you find running frames that appear to be hung - frames that keep running but have stopped writing to their log. It is the OpenCueWeb equivalent of CueGUI's CueCommander Stuck Frame window.
 
 Open it from the **CueCommander** menu (or the matching entry in the left sidebar).
 
@@ -1326,7 +1326,7 @@ Open it from the **CueCommander** menu (or the matching entry in the left sideba
 
 The page scans every running frame across all active jobs and lists the ones that match the current detection filters, grouped under their job.
 
-![CueWeb Stuck Frames page](/assets/images/cueweb/cueweb_cuecommander_stuck_frame.png)
+![OpenCueWeb Stuck Frames page](/assets/images/cueweb/cueweb_cuecommander_stuck_frame.png)
 
 ### Stuck Frame columns
 
@@ -1393,7 +1393,7 @@ Right-click a job header row for job-level actions.
 
 ## Facility Service Defaults
 
-The **Facility Service Defaults** page (CueCommander &rarr; Services in the sidebar or header) edits the facility-wide service templates - the default resource requirements that apply to a layer when it runs a given service (for example `arnold`, `maya`, `nuke`, or `shell`). It is the CueWeb equivalent of CueGUI's Facility Service Defaults tab.
+The **Facility Service Defaults** page (CueCommander &rarr; Services in the sidebar or header) edits the facility-wide service templates - the default resource requirements that apply to a layer when it runs a given service (for example `arnold`, `maya`, `nuke`, or `shell`). It is the OpenCueWeb equivalent of CueGUI's Facility Service Defaults tab.
 
 > **Note:** These are facility-wide defaults. A change here affects every job that uses the service, so the page asks you to confirm before saving. Editing should normally be left to administrators.
 
@@ -1403,7 +1403,7 @@ Open it from the **CueCommander** menu (or the matching entry in the left sideba
 
 The page has two panes: the list of services on the left, and the edit form for the selected service on the right.
 
-![CueWeb Facility Service Defaults page](/assets/images/cueweb/cueweb_cuecommander_facility_services.png)
+![OpenCueWeb Facility Service Defaults page](/assets/images/cueweb/cueweb_cuecommander_facility_services.png)
 
 ### Service fields
 
@@ -1423,7 +1423,7 @@ The numeric fields take non-negative whole numbers.
 
 ### Create a service
 
-Click **New**, fill in the form, and click **Save**. CueWeb asks you to confirm the facility-wide change before creating the service.
+Click **New**, fill in the form, and click **Save**. OpenCueWeb asks you to confirm the facility-wide change before creating the service.
 
 ![New service form](/assets/images/cueweb/cueweb_cuecommander_facility_services_new_service.png)
 
@@ -1451,7 +1451,7 @@ A toast confirms the deletion.
 
 ## Subscriptions
 
-The **Subscriptions** page (CueCommander &rarr; Subscriptions in the sidebar or header) shows how much of each allocation a show is allowed to use, and how much it is using right now. It is the CueWeb equivalent of CueGUI's CueCommander Subscriptions window.
+The **Subscriptions** page (CueCommander &rarr; Subscriptions in the sidebar or header) shows how much of each allocation a show is allowed to use, and how much it is using right now. It is the OpenCueWeb equivalent of CueGUI's CueCommander Subscriptions window.
 
 A *subscription* is one show's reservation against one allocation. It has a **Size** - the cores the show is guaranteed - and a **Burst** - the extra cores the show may temporarily grab when they are idle. Sizes and bursts are expressed in cores.
 
@@ -1461,7 +1461,7 @@ Open it from the **CueCommander** menu (or the matching entry in the left sideba
 
 Pick a show from the dropdown at the top left. The table then lists that show's subscriptions, one row per allocation.
 
-![CueWeb Subscriptions page](/assets/images/cueweb/cueweb_cuecommander_subscriptions.png)
+![OpenCueWeb Subscriptions page](/assets/images/cueweb/cueweb_cuecommander_subscriptions.png)
 
 ### Subscription columns
 
@@ -1477,7 +1477,7 @@ Numeric columns sort by their underlying value. Use the **Columns** menu to show
 
 ### Add a subscription
 
-Click **Add Subscription** to subscribe the selected show to another allocation. Pick the **Show** and **Alloc**, set the **Size** and **Burst** (defaults 100 and 110), then click **OK**. A show can have only one subscription per allocation; if one already exists, CueWeb tells you instead of creating a duplicate.
+Click **Add Subscription** to subscribe the selected show to another allocation. Pick the **Show** and **Alloc**, set the **Size** and **Burst** (defaults 100 and 110), then click **OK**. A show can have only one subscription per allocation; if one already exists, OpenCueWeb tells you instead of creating a duplicate.
 
 ![Create Subscription dialog](/assets/images/cueweb/cueweb_cuecommander_subscriptions_add_subscription.png)
 
@@ -1509,7 +1509,7 @@ Right-click a subscription row to open its actions menu: **Edit Subscription Siz
 
 ## Subscription Graphs
 
-The **Subscription Graphs** page (CueCommander &rarr; Subscription Graphs in the sidebar or header) is a visual companion to the Subscriptions table: it draws each subscription as a horizontal bar so you can see at a glance how much of an allocation a show is using against its size and burst. It is the CueWeb equivalent of CueGUI's CueCommander Subscription Graphs window.
+The **Subscription Graphs** page (CueCommander &rarr; Subscription Graphs in the sidebar or header) is a visual companion to the Subscriptions table: it draws each subscription as a horizontal bar so you can see at a glance how much of an allocation a show is using against its size and burst. It is the OpenCueWeb equivalent of CueGUI's CueCommander Subscription Graphs window.
 
 ![Subscription Graphs entry in the CueCommander menu](/assets/images/cueweb/cueweb_cuecommander_subscriptions_graphs_menu.png)
 
@@ -1528,7 +1528,7 @@ Each bar is scaled to the allocation's total core count and uses the same color 
 - **Size** (blue line) - the subscription's guaranteed cores.
 - **Burst** (red line) - the subscription's maximum cores.
 
-![CueWeb Subscription Graphs page](/assets/images/cueweb/cueweb_cuecommander_subscriptions_graphs.png)
+![OpenCueWeb Subscription Graphs page](/assets/images/cueweb/cueweb_cuecommander_subscriptions_graphs.png)
 
 Hover over a bar to see the exact In use, Size, Burst, Allocation, and Usage values.
 
@@ -1550,7 +1550,7 @@ The page refreshes every 15 seconds.
 
 ## Limits
 
-The **Limits** page (CueCommander &rarr; Limits in the sidebar or header) lists the limits configured in Cuebot. It is the CueWeb equivalent of CueGUI's CueCommander Limits window, with an **Add Limit** button and a per-row actions menu.
+The **Limits** page (CueCommander &rarr; Limits in the sidebar or header) lists the limits configured in Cuebot. It is the OpenCueWeb equivalent of CueGUI's CueCommander Limits window, with an **Add Limit** button and a per-row actions menu.
 
 Open it from the **CueCommander** menu (or the matching entry in the left sidebar).
 
@@ -1558,7 +1558,7 @@ Open it from the **CueCommander** menu (or the matching entry in the left sideba
 
 The page renders a sortable, filterable table with columns **Limit Name**, **Max Value**, and **Current Running**. Use **Refresh** to reload immediately; the table also auto-refreshes every 30 seconds.
 
-![CueWeb Limits page](/assets/images/cueweb/cueweb_cuecommander_limits.png)
+![OpenCueWeb Limits page](/assets/images/cueweb/cueweb_cuecommander_limits.png)
 
 ### Add a limit
 
@@ -1592,7 +1592,7 @@ Right-click a limit row to open its actions menu: **Edit Max Value**, **Delete L
 
 ## Redirect
 
-The **Redirect** page (CueCommander &rarr; Redirect in the sidebar or header) is an administrator tool for **moving cores to a job that needs them**. It finds render procs that are currently busy on other work and reassigns ("redirects") them to a target job - the running frames on those procs are killed and the freed cores are booked onto your target. It is the CueWeb equivalent of CueGUI's CueCommander Redirect window.
+The **Redirect** page (CueCommander &rarr; Redirect in the sidebar or header) is an administrator tool for **moving cores to a job that needs them**. It finds render procs that are currently busy on other work and reassigns ("redirects") them to a target job - the running frames on those procs are killed and the freed cores are booked onto your target. It is the OpenCueWeb equivalent of CueGUI's CueCommander Redirect window.
 
 > **This is a destructive admin action.** Redirecting kills the frames currently running on the selected procs so their cores can be handed to the target job. Use it deliberately.
 
@@ -1600,14 +1600,14 @@ Open it from the **CueCommander** menu (or the matching entry in the left sideba
 
 ![Redirect entry in the CueCommander menu](/assets/images/cueweb/cueweb_cuecommander_redirect_menu.png)
 
-![CueWeb Redirect page](/assets/images/cueweb/cueweb_cuecommander_redirect.png)
+![OpenCueWeb Redirect page](/assets/images/cueweb/cueweb_cuecommander_redirect.png)
 
 ### How it works
 
 1. Set a **Target** job (the job that should receive the cores). Typing a job name auto-fills the **Show** and the Minimum Cores / Minimum Memory from that job's layers, so the search looks for procs big enough to help it.
 2. Narrow the search with the filters (below).
-3. Click **Search**. CueWeb lists the hosts whose busy procs match - each row shows what would be freed.
-4. Tick the hosts you want (or **Select All**), then click **Redirect**. CueWeb confirms the target is valid, warns about anything risky, kills the selected procs' frames, and books the cores onto the target job.
+3. Click **Search**. OpenCueWeb lists the hosts whose busy procs match - each row shows what would be freed.
+4. Tick the hosts you want (or **Select All**), then click **Redirect**. OpenCueWeb confirms the target is valid, warns about anything risky, kills the selected procs' frames, and books the cores onto the target job.
 
 ### Job filters
 
@@ -1628,7 +1628,7 @@ Open it from the **CueCommander** menu (or the matching entry in the left sideba
 
 Each result row is a **host**, with columns for Cores, Memory, PrcTime, Group, Service, Job Cores, Waiting Frames, and LLU; expand a row to see the individual procs. Select the hosts you want and click **Redirect**.
 
-Before redirecting, CueWeb checks the target job and refuses or warns:
+Before redirecting, OpenCueWeb checks the target job and refuses or warns:
 
 - **Refuses** if the target job no longer exists, has no waiting frames, or has already reached its max cores.
 - **Warns** (asks you to confirm) if the target job is **paused**, or if any selected proc belongs to a **different show** - redirecting it will kill that other show's frame.
@@ -1643,17 +1643,17 @@ Use **Clr** to reset the form.
 
 ---
 
-## CueWeb Audit
+## OpenCueWeb Audit
 
-The **CueWeb Audit** page records every state-changing action performed through CueWeb, giving administrators a searchable trail of who did what, when, and with what result. It is an admin/monitoring tool with no CueGUI equivalent - it audits the CueWeb application itself.
+The **OpenCueWeb Audit** page records every state-changing action performed through OpenCueWeb, giving administrators a searchable trail of who did what, when, and with what result. It is an admin/monitoring tool with no CueGUI equivalent - it audits the OpenCueWeb application itself.
 
-Open it from **Admin &rarr; CueWeb Audit**, available from both the top menu and the left sidebar.
+Open it from **Admin &rarr; OpenCueWeb Audit**, available from both the top menu and the left sidebar.
 
-![CueWeb Audit menu](/assets/images/cueweb/cueweb_admin_cueweb_audit_menu.png)
+![OpenCueWeb Audit menu](/assets/images/cueweb/cueweb_admin_cueweb_audit_menu.png)
 
 The page loads the most recent records and presents them in a sortable, filterable table.
 
-![CueWeb Audit page](/assets/images/cueweb/cueweb_admin_cueweb_audit.png)
+![OpenCueWeb Audit page](/assets/images/cueweb/cueweb_admin_cueweb_audit.png)
 
 ### Who can see it
 
@@ -1661,7 +1661,7 @@ The Audit page is admin-gated. When no group authorization is configured for the
 
 ### What gets recorded
 
-The trail captures every **state-changing action** taken through CueWeb, including:
+The trail captures every **state-changing action** taken through OpenCueWeb, including:
 
 - **Job / layer / frame actions**: kill, pause, resume, eat, retry, mark-done, mark-as-waiting, and similar.
 - **Setters**: set priority, set min/max cores, set max retries, auto-eat on/off, and the like.
@@ -1671,7 +1671,7 @@ The trail captures every **state-changing action** taken through CueWeb, includi
 - **Admin edits**: show, allocation, limit, subscription, and service (facility service default) create/edit/delete.
 - **Authentication**: sign in and sign out.
 
-Read-only views (loading the jobs table, opening a log, browsing hosts) are **not** recorded. The trail captures actions done **through CueWeb only** - changes made with CueGUI, `cueman`, or the `pycue` API do not appear here.
+Read-only views (loading the jobs table, opening a log, browsing hosts) are **not** recorded. The trail captures actions done **through OpenCueWeb only** - changes made with CueGUI, `cueman`, or the `pycue` API do not appear here.
 
 ### Audit columns
 
@@ -1714,13 +1714,13 @@ The table paginates the matching records with **First / Prev / Next / Last** con
 
 ### Where the trail is stored
 
-The audit trail persists to a JSONL file on the server, configured by the `CUEWEB_AUDIT_STORE` environment variable (defaults to the OS temporary directory; mount a volume to that path to keep the trail across restarts). The file is size-bounded by `CUEWEB_AUDIT_MAX_RECORDS` (default `50000`; set it to `0` to remove the cap). These are deployment-time settings - see the [CueWeb Developer Guide](/docs/developer-guide/cueweb-development) for the operational details.
+The audit trail persists to a JSONL file on the server, configured by the `CUEWEB_AUDIT_STORE` environment variable (defaults to the OS temporary directory; mount a volume to that path to keep the trail across restarts). The file is size-bounded by `CUEWEB_AUDIT_MAX_RECORDS` (default `50000`; set it to `0` to remove the cap). These are deployment-time settings - see the [OpenCueWeb Developer Guide](/docs/developer-guide/cueweb-development) for the operational details.
 
 ---
 
 ## Plugins
 
-CueWeb has a small **plugin system** - the browser counterpart of CueGUI's plugins. A plugin is an add-on panel that lives on its own page under `/plugins/<name>` and can be surfaced in a **Plugins** menu next to CueSubmit. Two samples ship in the box, and developers can add their own (see the [developer guide](/docs/developer-guide/cueweb-development/#plugin-system)).
+OpenCueWeb has a small **plugin system** - the browser counterpart of CueGUI's plugins. A plugin is an add-on panel that lives on its own page under `/plugins/<name>` and can be surfaced in a **Plugins** menu next to CueSubmit. Two samples ship in the box, and developers can add their own (see the [developer guide](/docs/developer-guide/cueweb-development/#plugin-system)).
 
 ### The Plugins menu and page
 
@@ -1730,7 +1730,7 @@ The **Plugins** menu (in the header and sidebar, to the right of CueSubmit) list
 
 To see everything available and choose what appears in the menu, open the **Plugins** page. It's a searchable, paginated index of every registered plugin, each with a checkbox that controls whether it shows up in the Plugins menu. Your selection is saved in your browser and synced across tabs.
 
-![CueWeb Plugins page](/assets/images/cueweb/cueweb_plugins.png)
+![OpenCueWeb Plugins page](/assets/images/cueweb/cueweb_plugins.png)
 
 ### Plugin settings
 
@@ -1744,7 +1744,7 @@ A plugin can expose its own settings. Open them from the plugin (the **Open plug
 
 ![Hello OpenCue plugin settings](/assets/images/cueweb/cueweb_plugins_hello_opencue_plugin_open_plugin_settings.png)
 
-**Cue Progress Bar** - a CueWeb port of CueGUI's `cueprogbar` sample. It draws a live, color-coded frame-state bar for a job (with done / total / running labels) and offers pause / unpause / kill / retry-dead controls, polling Cuebot on a configurable interval. It is **on** in the menu by default.
+**Cue Progress Bar** - a OpenCueWeb port of CueGUI's `cueprogbar` sample. It draws a live, color-coded frame-state bar for a job (with done / total / running labels) and offers pause / unpause / kill / retry-dead controls, polling Cuebot on a configurable interval. It is **on** in the menu by default.
 
 ![Cue Progress Bar plugin](/assets/images/cueweb/cueweb_plugins_cue_progress_bar.png)
 
@@ -1792,11 +1792,11 @@ Immersive mode hides the header, sidebar, and status bar so the active table get
 
 While immersed, a floating **Exit immersive** button stays on screen so you're never trapped once the chrome is hidden. Your choice persists per browser and syncs across tabs.
 
-![CueWeb in immersive (full-screen) mode](/assets/images/cueweb/cueweb_full_screen_activated.png)
+![OpenCueWeb in immersive (full-screen) mode](/assets/images/cueweb/cueweb_full_screen_activated.png)
 
 ### Split view (two pages side-by-side)
 
-Split view opens **two CueWeb pages in one tab**, side by side in resizable panes - the web equivalent of CueGUI's *Add new window*. Open it from **Other &rarr; Split view** (Jobs on the left, Hosts on the right by default).
+Split view opens **two OpenCueWeb pages in one tab**, side by side in resizable panes - the web equivalent of CueGUI's *Add new window*. Open it from **Other &rarr; Split view** (Jobs on the left, Hosts on the right by default).
 
 ![Split view in the Other menu](/assets/images/cueweb/cueweb_split_view_menu.png)
 
@@ -1804,13 +1804,13 @@ Split view opens **two CueWeb pages in one tab**, side by side in resizable pane
 - **Drag the divider** (or nudge it with the arrow keys; Home/End jump) to rebalance the panes; the ratio is remembered. **Swap** flips the panes and **Reset 50/50** re-centers.
 - The workspace lives in the URL (`/split?left=/jobs&right=/hosts/<name>`), so it's **bookmarkable and reload-safe** - navigating inside a pane updates that URL, and reloading restores both panes. On phones the panes stack vertically.
 
-![CueWeb split view](/assets/images/cueweb/cueweb_split_view_activated.png)
+![OpenCueWeb split view](/assets/images/cueweb/cueweb_split_view_activated.png)
 
 ---
 
 ## Keyboard Shortcuts
 
-CueWeb registers a small set of global keyboard shortcuts. Single-letter keys are ignored while typing into a text field, and modifier-key combos (Ctrl / Cmd / Alt) are passed through to the browser, so they will not collide with native shortcuts such as Ctrl+R.
+OpenCueWeb registers a small set of global keyboard shortcuts. Single-letter keys are ignored while typing into a text field, and modifier-key combos (Ctrl / Cmd / Alt) are passed through to the browser, so they will not collide with native shortcuts such as Ctrl+R.
 
 | Key | Action | Where it works |
 |-----|--------|----------------|
@@ -1841,7 +1841,7 @@ A small toast appears every time you trigger a shortcut so you know it registere
 
 ## Submitting Jobs (CueSubmit)
 
-CueWeb has a browser-based equivalent of the standalone CueSubmit CLI tool. Open it from the **CueSubmit > Submit Job** menu in the header (or from the matching entry in the sidebar / mobile drawer) to reach the `/cuesubmit` form.
+OpenCueWeb has a browser-based equivalent of the standalone CueSubmit CLI tool. Open it from the **CueSubmit > Submit Job** menu in the header (or from the matching entry in the sidebar / mobile drawer) to reach the `/cuesubmit` form.
 
 ![CueSubmit menu options](/assets/images/cueweb/cueweb_cuesubmit_menu_options.png)
 
@@ -1854,7 +1854,7 @@ CueWeb has a browser-based equivalent of the standalone CueSubmit CLI tool. Open
    - **Show** - pick one from the dropdown (populated from the shows registered in cuebot).
    - **Shot** - free text. Letters, numbers, `.`, `-`, `_`.
    - **Facility** - leave as `[Default]` to use the sandbox's local facility, or pick another if your deployment runs multiple.
-   - **Username** - pre-filled with your signed-in identity when CueWeb is deployed with authentication. Tick the **Edit** checkbox next to the field to submit as someone else; unticking snaps it back to you.
+   - **Username** - pre-filled with your signed-in identity when OpenCueWeb is deployed with authentication. Tick the **Edit** checkbox next to the field to submit as someone else; unticking snaps it back to you.
 
 2. **Layer Info** describes the first (and possibly only) layer:
    - **Layer Name** - free text.
@@ -1875,7 +1875,7 @@ CueWeb has a browser-based equivalent of the standalone CueSubmit CLI tool. Open
 
 5. **Submission Details** is the layers table at the bottom. Use the `+` button to add a second layer (or third, etc.); use `−` to remove the selected layer; the `↑ / ↓` buttons reorder. Clicking a row loads it back into the Layer Info section above for editing.
 
-6. Click **Submit**. CueWeb sends the job to cuebot and redirects you to its detail page so you can watch the frames cycle through WAITING -> RUNNING -> SUCCEEDED.
+6. Click **Submit**. OpenCueWeb sends the job to cuebot and redirects you to its detail page so you can watch the frames cycle through WAITING -> RUNNING -> SUCCEEDED.
 
 ### Convenience features
 
@@ -1892,7 +1892,7 @@ The form ships with defaults tuned for the OpenCue sandbox so a fresh `sleep 5` 
 
 ## Mobile and Responsive Usage
 
-CueWeb works on phone-sized viewports, not just desktops.
+OpenCueWeb works on phone-sized viewports, not just desktops.
 
 ### Hamburger nav drawer
 
@@ -1919,11 +1919,11 @@ without needing a physical keyboard.
 
 ### LAN access
 
-CueWeb works correctly when you load it from a LAN IP (e.g. `http://XXX.XXX.XXX.XXX:3000` from a phone reaching your sandbox) - not just from `localhost`. API requests follow whichever host served the page, so the same image works from any address without rebuilding.
+OpenCueWeb works correctly when you load it from a LAN IP (e.g. `http://XXX.XXX.XXX.XXX:3000` from a phone reaching your sandbox) - not just from `localhost`. API requests follow whichever host served the page, so the same image works from any address without rebuilding.
 
 Two caveats on plain-HTTP LAN access:
 
-- **Clipboard**: the modern browser clipboard API is restricted to secure contexts (HTTPS / `localhost`). CueWeb automatically falls back to a legacy copy path outside secure contexts, so **Copy Job Name** / **Copy Layer Name** / **Copy Frame Name** / **Copy Log Path** still work on LAN HTTP.
+- **Clipboard**: the modern browser clipboard API is restricted to secure contexts (HTTPS / `localhost`). OpenCueWeb automatically falls back to a legacy copy path outside secure contexts, so **Copy Job Name** / **Copy Layer Name** / **Copy Frame Name** / **Copy Log Path** still work on LAN HTTP.
 - **Desktop notification popups** (the optional upgrade for **Subscribe to Job**) require a secure context. On LAN HTTP, the subscription itself still works and the **in-app toast** still fires when the job finishes; you just don't get the OS-level notification banner. Serve the app over HTTPS (self-signed cert is enough for LAN testing) to enable that path.
 
 ---
@@ -1972,4 +1972,4 @@ For advanced users and developers:
 - **Integration Tools**: Connect with external monitoring systems
 - **Webhook Support**: Real-time notifications to external services
 
-For advanced configuration and development, see the [CueWeb Developer Guide](/docs/developer-guide/cueweb-development).
+For advanced configuration and development, see the [OpenCueWeb Developer Guide](/docs/developer-guide/cueweb-development).

--- a/docs/index.md
+++ b/docs/index.md
@@ -140,7 +140,7 @@ permalink: /
                         <i class="fa-solid fa-desktop" aria-hidden="true"></i>
                     </div>
                     <div class="walkthrough-item-text">
-                        <h3>Monitoring with CueGUI or CueWeb</h3>
+                        <h3>Monitoring with CueGUI or OpenCueWeb</h3>
                         <p>Navigate Shows, Allocations, Subscriptions, Monitor Host, Services, and Log views.</p>
                     </div>
                 </div>

--- a/docs/news/2024-05-24-opencue-project-review-2024.md
+++ b/docs/news/2024-05-24-opencue-project-review-2024.md
@@ -24,7 +24,7 @@ Diego Tavares, Chair of the Technical Steering Committee, presented an overview 
 ## Highlights from the Presentation:
 
 - New TSC chair appointed while maintaining strong continuity in leadership.
-- Preview of CueWeb, the new browser-based UI.
+- Preview of OpenCueWeb, the new browser-based UI.
 - Performance improvements, including Out-of-Memory (OOM) prevention and database schema upgrades.
 - Integration updates: Blender plugin, PySide6 migration, and better Windows support.
 - Community engagement: ~2 pull requests merged per week, with a growing number of contributors.
@@ -32,7 +32,7 @@ Diego Tavares, Chair of the Technical Steering Committee, presented an overview 
 ## Looking Ahead:
 
 - Upgrade Cuebot to Java 21.
-- Release CueWeb officially.
+- Release OpenCueWeb officially.
 - Improve contributor experience by reducing stale issues/PRs.
 - Update and maintain the OpenCue homepage with TSC meeting notes and blog posts.
 

--- a/docs/news/2025-08-10-opencue-project-review-2025.md
+++ b/docs/news/2025-08-10-opencue-project-review-2025.md
@@ -35,8 +35,8 @@ OpenCue is an open-source render farm management system that distributes workloa
 
 ## Major Announcements
 
-### CueWeb Release
-Official announcement and release of CueWeb, our new browser-based visual interface featuring:
+### OpenCueWeb Release
+Official announcement and release of OpenCueWeb, our new browser-based visual interface featuring:
 - Modern login integration
 - Comprehensive job monitoring
 - Advanced filtering capabilities
@@ -87,7 +87,7 @@ pip install opencue-proto opencue-pycue opencue-pyoutline opencue-rqd opencue-cu
 - [opencue-cuegui](https://pypi.org/project/opencue-cuegui/)
   - `pip install opencue-cuegui`
 
-**Note:** Cuebot, Opencue REST Gateway, and CueWeb are deployed using Docker. For more information, see the Opencue's docker compose file (PostgreSQL, Cuebot, Flyway, RQD, OpenCue REST Gateway, and CueWeb): [docker-compose.yml](https://github.com/AcademySoftwareFoundation/OpenCue/blob/master/docker-compose.yml). 
+**Note:** Cuebot, Opencue REST Gateway, and OpenCueWeb are deployed using Docker. For more information, see the Opencue's docker compose file (PostgreSQL, Cuebot, Flyway, RQD, OpenCue REST Gateway, and OpenCueWeb): [docker-compose.yml](https://github.com/AcademySoftwareFoundation/OpenCue/blob/master/docker-compose.yml). 
 
 #### Getting Started
 - [Using the OpenCue Sandbox for Testing](https://docs.opencue.io/docs/developer-guide/sandbox-testing/)

--- a/docs/news/2026-01-21-opencue-major-releases-2026-roadmap.md
+++ b/docs/news/2026-01-21-opencue-major-releases-2026-roadmap.md
@@ -39,13 +39,13 @@ Diego Tavares ([DiegoTavares](https://github.com/DiegoTavares)), Ramon Figueired
 
 **200 commits** - A very productive year with major new features.
 
-2024 focused on OpenCue's modernization, introducing web-based interfaces and containerization support. CueWeb brought CueGUI functionality to the browser, alongside a new REST API Gateway that opens OpenCue to modern integration patterns. Docker Jobs support enabled running frames in containerized environments, significantly improving reproducibility and isolation. On the infrastructure side, Cuebot gained Prometheus metrics and HTTP healthchecks for better observability, while RQD received hard/soft memory limits for finer resource control. CueGUI was enhanced with an output viewer, job dependency visualization through the Node Graph plugin, and numerous usability improvements. The year also saw important CI/CD modernization, including dropping CY2022 support and migrating from CentOS 7.
+2024 focused on OpenCue's modernization, introducing web-based interfaces and containerization support. OpenCueWeb brought CueGUI functionality to the browser, alongside a new REST API Gateway that opens OpenCue to modern integration patterns. Docker Jobs support enabled running frames in containerized environments, significantly improving reproducibility and isolation. On the infrastructure side, Cuebot gained Prometheus metrics and HTTP healthchecks for better observability, while RQD received hard/soft memory limits for finer resource control. CueGUI was enhanced with an output viewer, job dependency visualization through the Node Graph plugin, and numerous usability improvements. The year also saw important CI/CD modernization, including dropping CY2022 support and migrating from CentOS 7.
 
 ### Major Features (2024)
 
 | Feature | PR | Description |
 |---------|-----|-------------|
-| **CueWeb** | [#1596](https://github.com/AcademySoftwareFoundation/OpenCue/pull/1596) | First web-based release of CueGUI with Cuetopia features |
+| **OpenCueWeb** | [#1596](https://github.com/AcademySoftwareFoundation/OpenCue/pull/1596) | First web-based release of CueGUI with Cuetopia features |
 | **REST Gateway** | [#1355](https://github.com/AcademySoftwareFoundation/OpenCue/pull/1355) | REST API gateway for OpenCue |
 | **Docker Jobs** | [#1549](https://github.com/AcademySoftwareFoundation/OpenCue/pull/1549) | Run frames in containerized Docker environments |
 | **Hard/Soft Memory Limits** | [#1589](https://github.com/AcademySoftwareFoundation/OpenCue/pull/1589) | Memory limit controls for RQD |
@@ -128,7 +128,7 @@ Diego Tavares ([DiegoTavares](https://github.com/DiegoTavares)), Ramon Figueired
 
 **287 commits** - Focused on architectural changes and new tooling.
 
-2025 focused on architectural changes to improve performance and scalability. RQD was completely rewritten in Rust, delivering a 5x smaller binary with 50% reduced CPU usage. A new Rust-based Distributed Scheduler was introduced to eliminate database bottlenecks in large-scale deployments. Observability improved with Loki integration for centralized log aggregation and event-driven monitoring with dashboards. New tools like CueNimby (system tray NIMBY control) and Cueman (advanced CLI for job management) were introduced, while CueWeb gained LDAP authentication for enterprise environments. The documentation was migrated into the main repository with a Jekyll-based site featuring dark mode support. All Python modules were published to PyPI for the first time, simplifying installation and dependency management.
+2025 focused on architectural changes to improve performance and scalability. RQD was completely rewritten in Rust, delivering a 5x smaller binary with 50% reduced CPU usage. A new Rust-based Distributed Scheduler was introduced to eliminate database bottlenecks in large-scale deployments. Observability improved with Loki integration for centralized log aggregation and event-driven monitoring with dashboards. New tools like CueNimby (system tray NIMBY control) and Cueman (advanced CLI for job management) were introduced, while OpenCueWeb gained LDAP authentication for enterprise environments. The documentation was migrated into the main repository with a Jekyll-based site featuring dark mode support. All Python modules were published to PyPI for the first time, simplifying installation and dependency management.
 
 ### Major Features (2025)
 
@@ -140,7 +140,7 @@ Diego Tavares ([DiegoTavares](https://github.com/DiegoTavares)), Ramon Figueired
 | **Cueman** | [#1791](https://github.com/AcademySoftwareFoundation/OpenCue/pull/1791) | CLI for advanced job and batch management |
 | **Cuecmd** | [#2028](https://github.com/AcademySoftwareFoundation/OpenCue/pull/2028) | Module for batch command execution |
 | **Loki Integration** | [#1577](https://github.com/AcademySoftwareFoundation/OpenCue/pull/1577) | Log aggregation for frame logs |
-| **CueWeb LDAP** | [#2096](https://github.com/AcademySoftwareFoundation/OpenCue/pull/2096) | LDAP authentication for CueWeb |
+| **OpenCueWeb LDAP** | [#2096](https://github.com/AcademySoftwareFoundation/OpenCue/pull/2096) | LDAP authentication for OpenCueWeb |
 | **Show Archive Automation** | [#2024](https://github.com/AcademySoftwareFoundation/OpenCue/pull/2024) | Automated show archiving |
 | **PyPI Packages** | [#1681](https://github.com/AcademySoftwareFoundation/OpenCue/pull/1681) | Split proto and packages for all Python modules |
 | **Event-Driven Monitoring** | [#2086](https://github.com/AcademySoftwareFoundation/OpenCue/pull/2086) | Full metrics, dashboards, and documentation |
@@ -168,7 +168,7 @@ Complete ground-up rewrite with extensive features:
 
 Major migration and modernization:
 - Migrate docs into main repo with Jekyll, GitHub Pages, modern UI, dark mode ([#1784](https://github.com/AcademySoftwareFoundation/OpenCue/pull/1784))
-- Comprehensive CueWeb documentation ([#1955](https://github.com/AcademySoftwareFoundation/OpenCue/pull/1955))
+- Comprehensive OpenCueWeb documentation ([#1955](https://github.com/AcademySoftwareFoundation/OpenCue/pull/1955))
 - REST Gateway documentation ([#1940](https://github.com/AcademySoftwareFoundation/OpenCue/pull/1940))
 - Cuetopia monitoring system docs ([#1805](https://github.com/AcademySoftwareFoundation/OpenCue/pull/1805))
 - Cueman documentation and tutorials ([#1801](https://github.com/AcademySoftwareFoundation/OpenCue/pull/1801))
@@ -248,7 +248,7 @@ Major migration and modernization:
 - Docker build jobs ([#2098](https://github.com/AcademySoftwareFoundation/OpenCue/pull/2098))
 - Full stack sandbox deployment ([#2103](https://github.com/AcademySoftwareFoundation/OpenCue/pull/2103))
 
-### CueWeb (2025)
+### OpenCueWeb (2025)
 
 - LDAP Authentication ([#2096](https://github.com/AcademySoftwareFoundation/OpenCue/pull/2096))
 - Professional Toolbar with grouped actions ([#1906](https://github.com/AcademySoftwareFoundation/OpenCue/pull/1906))
@@ -276,7 +276,7 @@ Major migration and modernization:
 
 ### 2026 Goals
 
-In 2026, our focus shifts to completing the Rust migration, advancing distributed scheduling capabilities, and expanding the platform's reach. We aim to finalize the transition to Rust RQD across all platforms for improved performance and reliability, while evolving the Distributed Scheduler with automatic cluster coordination and self-healing capabilities. On the user experience front, CueWeb will achieve feature parity with the desktop applications, enabling full web-based studio adoption. We're also investing heavily in observability through CueInsight, a new monitoring system with AI-driven analytics, and delivering production-grade GPU support for the growing demand in GPU-accelerated rendering workflows.
+In 2026, our focus shifts to completing the Rust migration, advancing distributed scheduling capabilities, and expanding the platform's reach. We aim to finalize the transition to Rust RQD across all platforms for improved performance and reliability, while evolving the Distributed Scheduler with automatic cluster coordination and self-healing capabilities. On the user experience front, OpenCueWeb will achieve feature parity with the desktop applications, enabling full web-based studio adoption. We're also investing heavily in observability through CueInsight, a new monitoring system with AI-driven analytics, and delivering production-grade GPU support for the growing demand in GPU-accelerated rendering workflows.
 
 1. **Complete Rust RQD Migration**: Full transition to the Rust-based RQD across all platforms
 2. **Distributed Scheduler v2**: Automatic cluster distribution with:
@@ -286,7 +286,7 @@ In 2026, our focus shifts to completing the Rust migration, advancing distribute
    - Load balancing across schedulers
 
 3. **Farm Auto-scaling**: Native autoscaling capabilities for cloud infrastructure optimization
-4. **Enhanced CueWeb**: Complete feature parity with CueGUI (Cuetopia/CueCommander), professional UI/UX redesign, and production-ready interface for full studio adoption
+4. **Enhanced OpenCueWeb**: Complete feature parity with CueGUI (Cuetopia/CueCommander), professional UI/UX redesign, and production-ready interface for full studio adoption
 5. **CueInsight**: Event-driven monitoring system with real-time dashboards, automated job grading, proactive alerting, and AI-driven analytics for render farm intelligence
 6. **Production-Grade GPU Support**: Cross-platform GPU discovery (NVIDIA/Apple Metal), vendor-aware scheduling, per-device telemetry, frame isolation, and comprehensive documentation ([#2036](https://github.com/AcademySoftwareFoundation/OpenCue/pull/2036))
 

--- a/docs/releases/announcing-the-release-of-opencue-v1.13.8.md
+++ b/docs/releases/announcing-the-release-of-opencue-v1.13.8.md
@@ -41,7 +41,7 @@ This release brings a large number of new features, enhancements, bug fixes, and
 
 ## User Interface and Usability
 
-- **CueWeb**
+- **OpenCueWeb**
   - Professional-style toolbar with grouped action buttons
     ([#1906](https://github.com/AcademySoftwareFoundation/OpenCue/pull/1906))
   - Enhanced documentation with mermaid diagram support
@@ -80,7 +80,7 @@ This release brings a large number of new features, enhancements, bug fixes, and
 ## Documentation and Ecosystem
 
 - **Documentation Enhancements and Corrections:**
-  - New, comprehensive documentation for CueWeb, REST Gateway, and CueProgBar
+  - New, comprehensive documentation for OpenCueWeb, REST Gateway, and CueProgBar
     ([#1955](https://github.com/AcademySoftwareFoundation/OpenCue/pull/1955)), ([#1940](https://github.com/AcademySoftwareFoundation/OpenCue/pull/1940)), ([#1962](https://github.com/AcademySoftwareFoundation/OpenCue/pull/1962))
   - Improved navigation, release notes, and contributor information
     ([#1937](https://github.com/AcademySoftwareFoundation/OpenCue/pull/1937)), ([#1895](https://github.com/AcademySoftwareFoundation/OpenCue/pull/1895)), ([#1944](https://github.com/AcademySoftwareFoundation/OpenCue/pull/1944)), ([#2030](https://github.com/AcademySoftwareFoundation/OpenCue/pull/2030))

--- a/docs/releases/announcing-the-release-of-opencue-v1.19.1.md
+++ b/docs/releases/announcing-the-release-of-opencue-v1.19.1.md
@@ -15,7 +15,7 @@ nav_order: 0
 
 To learn how to install and configure OpenCue, see our [Getting Started guide](https://docs.opencue.io/docs/quick-starts).
 
-This release brings major new capabilities including a distributed scheduler written in Rust, comprehensive RQD improvements (OOM prevention, Windows support, PSS memory), CueWeb LDAP authentication, a full-stack sandbox deployment, and numerous bug fixes and stability improvements across the ecosystem.
+This release brings major new capabilities including a distributed scheduler written in Rust, comprehensive RQD improvements (OOM prevention, Windows support, PSS memory), OpenCueWeb LDAP authentication, a full-stack sandbox deployment, and numerous bug fixes and stability improvements across the ecosystem.
 
 ## Major Features
 
@@ -27,12 +27,12 @@ This release brings major new capabilities including a distributed scheduler wri
   Added a full event-driven monitoring stack with enhanced metrics, dashboards, and comprehensive documentation.  
   ([#2086](https://github.com/AcademySoftwareFoundation/OpenCue/pull/2086))
 
-- **CueWeb LDAP Authentication**  
-  Added LDAP authentication support for CueWeb, enabling enterprise directory integration.  
+- **OpenCueWeb LDAP Authentication**  
+  Added LDAP authentication support for OpenCueWeb, enabling enterprise directory integration.  
   ([#2096](https://github.com/AcademySoftwareFoundation/OpenCue/pull/2096))
 
 - **Full-Stack Sandbox Deployment**  
-  Introduced a unified Docker Compose sandbox deployment with CueWeb, REST Gateway, core-only defaults, monitoring profiles, and quick start documentation.  
+  Introduced a unified Docker Compose sandbox deployment with OpenCueWeb, REST Gateway, core-only defaults, monitoring profiles, and quick start documentation.  
   ([#2103](https://github.com/AcademySoftwareFoundation/OpenCue/pull/2103)), ([#2110](https://github.com/AcademySoftwareFoundation/OpenCue/pull/2110)), ([#2166](https://github.com/AcademySoftwareFoundation/OpenCue/pull/2166))
 
 - **RQD Windows Support (Release Candidate)**  
@@ -176,7 +176,7 @@ This release brings major new capabilities including a distributed scheduler wri
     ([#2197](https://github.com/AcademySoftwareFoundation/OpenCue/pull/2197))
   - Added Docker setup for building documentation  
     ([#2130](https://github.com/AcademySoftwareFoundation/OpenCue/pull/2130))
-  - Updated CueWeb documentation with correct healthcheck using wget  
+  - Updated OpenCueWeb documentation with correct healthcheck using wget  
     ([#2132](https://github.com/AcademySoftwareFoundation/OpenCue/pull/2132))
   - Added nav_order management utilities for documentation  
     ([#2055](https://github.com/AcademySoftwareFoundation/OpenCue/pull/2055))


### PR DESCRIPTION
## Related Issues
- #1800

## Summarize your change.
- Update product name in docs, headings, frontmatter titles, UI labels, table cells, image alt text, and link display text across 26 docs files
- Rename rendered diagram labels (mermaid sequence diagram, ASCII architecture box) and .env/bash code-block comments for consistency
- Preserve verbatim PR/commit titles in release notes, the CueWebIcon component identifier, and the literal kill-reason string
- Leave lowercase cueweb slugs, URLs, permalinks, image paths, CUEWEB_* env vars, and file names unchanged to avoid breaking links
