### PR TITLE
[rqd] Frame log based exit status override

### DIFF
--- a/docs/_docs/reference/rust-rqd.md
+++ b/docs/_docs/reference/rust-rqd.md
@@ -239,6 +239,35 @@ Key configuration sections:
 - Logging configuration
 - NIMBY (Not In My Back Yard) settings
 - Container runtime settings (when enabled)
+- Log-based exit-status rules (see below)
+
+### Log-Based Exit-Status Rules
+
+When a frame exits with a non-zero code, RQD can reclassify the failure by scanning the tail of the frame log against operator-defined regular expressions. On the first matching rule, RQD reports that rule's `exit_status` to Cuebot instead of the process's real exit code. This lets operators single out failures that deserve special dispatcher handling — for example a Houdini license shortage that exits `3` but should be retried differently — without the render wrapper having to translate the error into an exit code itself.
+
+Configure it in the `runner` section of `rqd.yaml`:
+
+```yaml
+runner:
+  # Number of trailing log lines scanned on failure (default: 50).
+  # Set to 0, or leave log_exit_status_rules empty, to disable scanning.
+  log_scan_last_lines: 50
+
+  # Ordered regex -> exit-status rules. Evaluated top-to-bottom; first match wins.
+  log_exit_status_rules:
+    - name: "HOUDINI_LICENSE_ERROR"
+      regex: "A usable license to run the application is installed but they are all in use"
+      exit_status: 330
+```
+
+Behavior notes:
+
+- **Disabled by default**: the feature does nothing until `log_exit_status_rules` is non-empty and `log_scan_last_lines` is greater than `0`.
+- **Failures only**: successful frames (exit `0`) are never scanned, so there is no overhead on the happy path.
+- **First match wins**: place more specific patterns above general ones.
+- **`name`**: a human-readable identifier used only in RQD's log messages to make matches easy to trace.
+- **Invalid regex is skipped** (with a warning) rather than disabling the whole rule set.
+- **Efficient tail read**: the log tail is read backward in fixed-size chunks and stops once enough lines are collected — typically only a few kilobytes are read even for large logs, with a hard 1 MiB cap so a pathologically large log is never read in full.
 
 ## Testing
 
@@ -336,6 +365,7 @@ rust/
 - **NIMBY support**: Automatic idle detection and resource management
 - **Signal handling**: Graceful shutdown and frame cleanup
 - **Reservation system**: Resource allocation and management
+- **Log-based exit-status rules**: Reclassify failed frames by matching their log output against configurable regex rules (e.g. flag license shortages)
 
 ### Experimental Features
 

--- a/docs/news/2019-04-18-season-of-docs-2019.md
+++ b/docs/news/2019-04-18-season-of-docs-2019.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Apr 18, 2019: Season of Docs 2019"
 parent: News
-nav_order: 12
+nav_order: 13
 ---
 
 # Season of Docs 2019

--- a/docs/news/2019-07-08-opencue-birds-of-a-feather-at-siggraph.md
+++ b/docs/news/2019-07-08-opencue-birds-of-a-feather-at-siggraph.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Jul 8, 2019: OpenCue Birds of a Feather at SIGGRAPH"
 parent: News
-nav_order: 11
+nav_order: 12
 ---
 
 # OpenCue Birds of a Feather at SIGGRAPH

--- a/docs/news/2019-07-22-opencue-steering-committee-at-siggraph.md
+++ b/docs/news/2019-07-22-opencue-steering-committee-at-siggraph.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Jul 22, 2019: OpenCue Steering Committee at SIGGRAPH"
 parent: News
-nav_order: 10
+nav_order: 11
 ---
 
 # OpenCue Steering Committee at SIGGRAPH

--- a/docs/news/2019-09-20-opencue-at-siggraph-recording.md
+++ b/docs/news/2019-09-20-opencue-at-siggraph-recording.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Sept 20, 2019: OpenCue at SIGGRAPH recording"
 parent: News
-nav_order: 9
+nav_order: 10
 ---
 
 # OpenCue at SIGGRAPH recording

--- a/docs/news/2019-12-05-la-pipeline-developers-meetup.md
+++ b/docs/news/2019-12-05-la-pipeline-developers-meetup.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Dec 5, 2019: LA Pipeline Developers Meetup"
 parent: News
-nav_order: 8
+nav_order: 9
 ---
 
 # JLA Pipeline Developers Meetup

--- a/docs/news/2019-12-18-sony-pictures-imageworks-case-study.md
+++ b/docs/news/2019-12-18-sony-pictures-imageworks-case-study.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Dec 18, 2019: Sony Pictures Imageworks case study"
 parent: News
-nav_order: 7
+nav_order: 8
 ---
 
 # Sony Pictures Imageworks case study

--- a/docs/news/2020-08-27-google-summer-of-code-20-cloud-plugin.md
+++ b/docs/news/2020-08-27-google-summer-of-code-20-cloud-plugin.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Aug 27, 2020: Google Summer of Code '20 - Cloud Plugin"
 parent: News
-nav_order: 6
+nav_order: 7
 ---
 
 # Google Summer of Code '20 - Cloud Plugin

--- a/docs/news/2021-08-04-open-source-days-2021.md
+++ b/docs/news/2021-08-04-open-source-days-2021.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Aug 4, 2021: Open Source Days 2021"
 parent: News
-nav_order: 5
+nav_order: 6
 ---
 
 # Open Source Days 2021

--- a/docs/news/2024-05-24-opencue-project-review-2024.md
+++ b/docs/news/2024-05-24-opencue-project-review-2024.md
@@ -2,7 +2,7 @@
 layout: default
 title: "May 24, 2024: OpenCue Project Review 2024"
 parent: News
-nav_order: 4
+nav_order: 5
 ---
 
 # OpenCue Project Review 2024

--- a/docs/news/2025-08-10-opencue-project-review-2025.md
+++ b/docs/news/2025-08-10-opencue-project-review-2025.md
@@ -2,7 +2,7 @@
 layout: default
 title: "August 10, 2025: OpenCue Project Review 2025"
 parent: News
-nav_order: 3
+nav_order: 4
 ---
 
 # OpenCue Project Review 2025

--- a/docs/news/2025-12-12-distributed-scheduler-release.md
+++ b/docs/news/2025-12-12-distributed-scheduler-release.md
@@ -2,7 +2,7 @@
 layout: default
 title: "December 12, 2025: Distributed Scheduler Release"
 parent: News
-nav_order: 2
+nav_order: 3
 ---
 
 # Distributed Scheduler Release

--- a/docs/news/2026-01-21-opencue-major-releases-2026-roadmap.md
+++ b/docs/news/2026-01-21-opencue-major-releases-2026-roadmap.md
@@ -2,7 +2,7 @@
 layout: default
 title: "January 21, 2026: OpenCue Project Update: Major Releases and 2026 Roadmap"
 parent: News
-nav_order: 1
+nav_order: 2
 ---
 
 # OpenCue Project Update: Major Releases and 2026 Roadmap

--- a/docs/news/2026-07-07-cueweb-full-cuegui-parity-release.md
+++ b/docs/news/2026-07-07-cueweb-full-cuegui-parity-release.md
@@ -2,7 +2,7 @@
 layout: default
 title: "July 7, 2026: Announcing OpenCueWeb: The Complete Web-Based OpenCue GUI"
 parent: News
-nav_order: 0
+nav_order: 1
 ---
 
 # Announcing OpenCueWeb: The Complete Web-Based OpenCue GUI

--- a/docs/news/2026-08-06-rqd-log-exit-status-rules.md
+++ b/docs/news/2026-08-06-rqd-log-exit-status-rules.md
@@ -2,7 +2,7 @@
 layout: default
 title: "August 6, 2026: Log-Based Exit-Status Rules in Rust RQD"
 parent: News
-nav_order: -1
+nav_order: 0
 ---
 
 # Log-Based Exit-Status Rules in Rust RQD

--- a/docs/news/2026-08-06-rqd-log-exit-status-rules.md
+++ b/docs/news/2026-08-06-rqd-log-exit-status-rules.md
@@ -1,0 +1,64 @@
+---
+layout: default
+title: "August 6, 2026: Log-Based Exit-Status Rules in Rust RQD"
+parent: News
+nav_order: -1
+---
+
+# Log-Based Exit-Status Rules in Rust RQD
+
+### Reclassify failed frames by scanning their log output
+
+#### August 6, 2026
+
+---
+
+The Rust RQD can now **reclassify a failed frame's exit status based on what appears in its log**. When a frame exits non-zero, RQD scans the tail of the frame log against a list of operator-defined regular expressions and, on the first match, reports a substitute exit status to Cuebot instead of the process's real exit code.
+
+## The Challenge
+
+Some failures are worth handling differently from a generic crash, but the render process doesn't always expose that intent through its exit code. A classic example is a **Houdini license shortage**: `hython` fails with a plain exit status `3`, and the only signal that it was a licensing problem is a message buried in the log:
+
+```
+A usable license to run the application is installed but they are all in use.
+Please contact your companies license administrator to create availability
+for your use or wait until there is availability to try again.
+```
+
+To Cuebot, that looks identical to any other exit-3 failure. Distinguishing it previously required editing the render wrapper on every show to translate the message into a dedicated exit code — brittle, and easy to get wrong across a large studio.
+
+## The Solution
+
+RQD now does the classification itself, driven entirely by configuration. When a frame fails, RQD reads the last `log_scan_last_lines` lines of the frame log and evaluates them top-to-bottom against `log_exit_status_rules`. The first rule whose `regex` matches wins, and its `exit_status` is what Cuebot receives — so operators can route license shortages (or any other recognizable failure) to different dispatcher handling without touching the render command.
+
+### Configuration
+
+Add the following to the `runner` section of your `rqd.yaml`:
+
+```yaml
+runner:
+  # Number of trailing log lines scanned on failure (default: 50).
+  log_scan_last_lines: 50
+
+  # Ordered list of regex -> exit-status rules. First match wins.
+  log_exit_status_rules:
+    - name: "HOUDINI_LICENSE_ERROR"
+      regex: "A usable license to run the application is installed but they are all in use"
+      exit_status: 330
+```
+
+Key behaviors:
+
+- **Opt-in and safe by default** — the feature is disabled when `log_exit_status_rules` is empty or `log_scan_last_lines` is `0`.
+- **Only failed frames are scanned** — a successful (exit `0`) frame is never read, so there is no cost on the happy path.
+- **First match wins** — rules are evaluated in order, letting you place more specific patterns above general ones.
+- **Typo-tolerant** — an invalid regex is skipped with a warning rather than disabling the whole rule set.
+- **Human-readable `name`** — used only in RQD's log messages to make matches easy to trace.
+
+### Efficient by Design
+
+The log tail is read **backward in fixed-size chunks**, stopping as soon as enough lines have been collected. For the default 50-line scan RQD typically touches only a few kilobytes near the end of the file — even for multi-megabyte frame logs — with a hard 1 MiB cap that guarantees a pathologically large log is never read in full. Scanning a failed frame's log adds negligible overhead to the completion path.
+
+## Availability
+
+Log-based exit-status rules are available now in the Rust RQD (`rust/crates/rqd/`). See the [Rust RQD reference](/docs/reference/rust-rqd/) for full configuration details, and the sample `rust/config/rqd.yaml` for a commented example.

--- a/rust/config/rqd.yaml
+++ b/rust/config/rqd.yaml
@@ -220,3 +220,18 @@ runner:
   #     source: "/shared/storage"   # Source path on host
   #     typ: "bind"                # Mount type (bind, volume, tmpfs)
   #     bind_propagation: "rprivate" # Bind propagation mode
+
+  # Log-based exit-status reclassification.
+  # When a frame fails (non-zero exit), RQD scans the last `log_scan_last_lines` lines of the
+  # frame log and, on the first rule whose `regex` matches, reports `exit_status` to Cuebot
+  # instead of the process's real exit code. Useful for flagging failures that Cuebot should
+  # retry differently (e.g. license shortages). Rules are evaluated top-to-bottom; first match
+  # wins. Leave `log_exit_status_rules` empty to disable. Not applied to Loki-only frames.
+  #
+  # Number of trailing log lines to scan on failure (Default: 50)
+  # log_scan_last_lines: 50
+  #
+  # log_exit_status_rules:
+  #   - name: "HOUDINI_LICENSE_ERROR"
+  #     regex: "A usable license to run the application is installed but they are all in use"
+  #     exit_status: 330

--- a/rust/crates/rqd/src/config/mod.rs
+++ b/rust/crates/rqd/src/config/mod.rs
@@ -188,6 +188,26 @@ mod tests {
     }
 }
 
+/// A rule that reclassifies a failed frame's exit status based on its log output.
+///
+/// When a frame finishes with a non-zero exit code, RQD scans the tail of its log (see
+/// [`RunnerConfig::log_scan_last_lines`]). The first rule whose `regex` matches causes the
+/// frame to report `exit_status` to Cuebot instead of the process's real exit code. This lets
+/// operators single out failures that deserve special dispatcher handling, e.g. a Houdini
+/// license shortage that should be retried differently without the render wrapper needing to
+/// translate the error into an exit code itself.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LogExitStatusRule {
+    /// Human-readable identifier, used only in log messages (e.g. "HOUDINI_LICENSE_ERROR").
+    #[serde(default)]
+    pub name: String,
+    /// Regular expression tested against the scanned log tail. Invalid patterns are skipped
+    /// (with a warning) at scan time so a single typo can't disable the whole feature.
+    pub regex: String,
+    /// Exit status reported to Cuebot when `regex` matches.
+    pub exit_status: u32,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(default)]
 pub struct RunnerConfig {
@@ -209,6 +229,12 @@ pub struct RunnerConfig {
     pub docker_mounts: Vec<DockerMountConfig>,
     pub docker_default_image: String,
     pub docker_images: HashMap<String, String>,
+    /// Number of trailing log lines scanned against `log_exit_status_rules` when a frame
+    /// fails. Set to 0, or leave `log_exit_status_rules` empty, to disable log scanning.
+    pub log_scan_last_lines: usize,
+    /// Ordered list of regex→exit-status rules applied to failed frames' logs. The first
+    /// matching rule wins. Empty by default, which disables the feature.
+    pub log_exit_status_rules: Vec<LogExitStatusRule>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -256,6 +282,8 @@ impl Default for RunnerConfig {
             docker_mounts: Vec::new(),
             docker_default_image: "ubuntu:latest".to_string(),
             docker_images: HashMap::new(),
+            log_scan_last_lines: 50,
+            log_exit_status_rules: Vec::new(),
         }
     }
 }

--- a/rust/crates/rqd/src/config/mod.rs
+++ b/rust/crates/rqd/src/config/mod.rs
@@ -16,8 +16,16 @@ use crate::config::error::RqdConfigError;
 use bytesize::ByteSize;
 use config::{Config as ConfigBase, Environment, File};
 use lazy_static::lazy_static;
+use regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize};
-use std::{collections::HashMap, env, fs, path::Path, time::Duration};
+use std::{
+    collections::HashMap,
+    env, fs,
+    path::Path,
+    sync::{Arc, OnceLock},
+    time::Duration,
+};
+use tracing::warn;
 
 static DEFAULT_CONFIG_FILE: &str = "~/.local/share/rqd.yaml";
 
@@ -202,10 +210,42 @@ pub struct LogExitStatusRule {
     #[serde(default)]
     pub name: String,
     /// Regular expression tested against the scanned log tail. Invalid patterns are skipped
-    /// (with a warning) at scan time so a single typo can't disable the whole feature.
+    /// (with a warning) at startup so a single typo can't disable the whole feature.
     pub regex: String,
     /// Exit status reported to Cuebot when `regex` matches.
     pub exit_status: i32,
+}
+
+/// A [`LogExitStatusRule`] with its regex compiled, ready for matching.
+#[derive(Debug, Clone)]
+pub struct CompiledExitStatusRule {
+    pub name: String,
+    pub regex: Regex,
+    pub exit_status: i32,
+}
+
+/// Compiles the configured rules, skipping (with a warning) any whose regex is invalid so a
+/// single bad pattern can neither disable the whole feature nor fail frame completion.
+pub(crate) fn compile_exit_status_rules(
+    rules: &[LogExitStatusRule],
+) -> Vec<CompiledExitStatusRule> {
+    rules
+        .iter()
+        .filter_map(|rule| match Regex::new(&rule.regex) {
+            Ok(regex) => Some(CompiledExitStatusRule {
+                name: rule.name.clone(),
+                regex,
+                exit_status: rule.exit_status,
+            }),
+            Err(err) => {
+                warn!(
+                    "Ignoring invalid log_exit_status_rule '{}' (regex {:?}): {}",
+                    rule.name, rule.regex, err
+                );
+                None
+            }
+        })
+        .collect()
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -235,6 +275,11 @@ pub struct RunnerConfig {
     /// Ordered list of regex→exit-status rules applied to failed frames' logs. The first
     /// matching rule wins. Empty by default, which disables the feature.
     pub log_exit_status_rules: Vec<LogExitStatusRule>,
+    /// Compiled form of `log_exit_status_rules`, populated lazily on first access and cached
+    /// so the regexes are compiled once (at startup via [`RunnerConfig::compiled_exit_status_rules`])
+    /// rather than on every failed frame. Not part of the serialized config.
+    #[serde(skip)]
+    compiled_exit_status_rules: OnceLock<Arc<Vec<CompiledExitStatusRule>>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -284,7 +329,21 @@ impl Default for RunnerConfig {
             docker_images: HashMap::new(),
             log_scan_last_lines: 50,
             log_exit_status_rules: Vec::new(),
+            compiled_exit_status_rules: OnceLock::new(),
         }
+    }
+}
+
+impl RunnerConfig {
+    /// Returns the compiled `log_exit_status_rules`, compiling and caching them on first call.
+    ///
+    /// Because compilation happens once (forced at startup, see `async_main`), the warning for
+    /// an invalid pattern is emitted a single time rather than repeating on every failed frame,
+    /// and no frame pays the cost of recompiling every regex when it fails.
+    pub fn compiled_exit_status_rules(&self) -> &[CompiledExitStatusRule] {
+        self.compiled_exit_status_rules
+            .get_or_init(|| Arc::new(compile_exit_status_rules(&self.log_exit_status_rules)))
+            .as_slice()
     }
 }
 

--- a/rust/crates/rqd/src/config/mod.rs
+++ b/rust/crates/rqd/src/config/mod.rs
@@ -205,7 +205,7 @@ pub struct LogExitStatusRule {
     /// (with a warning) at scan time so a single typo can't disable the whole feature.
     pub regex: String,
     /// Exit status reported to Cuebot when `regex` matches.
-    pub exit_status: u32,
+    pub exit_status: i32,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/rust/crates/rqd/src/frame/docker_running_frame.rs
+++ b/rust/crates/rqd/src/frame/docker_running_frame.rs
@@ -10,7 +10,7 @@
 // or implied. See the License for the specific language governing permissions and limitations under
 // the License.
 
-use std::{cmp, sync::Arc};
+use std::{cmp, sync::Arc, time::Duration};
 
 use bollard::{
     container::{
@@ -64,6 +64,10 @@ impl RunningFrame {
         let exit_code = if recover_mode {
             match self.recover_inner(Arc::clone(&logger)).await {
                 Ok((exit_code, exit_signal)) => {
+                    let exit_code = self
+                        .scan_log_for_exit_status_override(exit_code)
+                        .await
+                        .unwrap_or(exit_code);
                     if let Err(err) = self.finish(exit_code, exit_signal, None) {
                         warn!("Failed to mark frame {} as finished. {}", self, err);
                     }
@@ -81,6 +85,10 @@ impl RunningFrame {
             let run_result = self.run_docker_inner(Arc::clone(&logger)).await;
             match run_result {
                 Ok((exit_code, exit_signal)) => {
+                    let exit_code = self
+                        .scan_log_for_exit_status_override(exit_code)
+                        .await
+                        .unwrap_or(exit_code);
                     if let Err(err) = self.finish(exit_code, exit_signal, None) {
                         warn!("Failed to mark frame {} as finished. {}", self, err);
                     }
@@ -243,7 +251,7 @@ impl RunningFrame {
         );
 
         let _ = self.create_snapshot().await;
-        let log_watcher_handle = tokio::task::spawn(async move {
+        let mut log_watcher_handle = tokio::task::spawn(async move {
             while let Some(Ok(output)) = log_stream.next().await {
                 logger.write(output.into_bytes().as_ref());
             }
@@ -256,7 +264,16 @@ impl RunningFrame {
         if let Some(Ok(output)) = output_stream.take(1).next().await {
             (exit_code, exit_signal) = Self::interprete_output_docker(Either::Right(output));
         }
-        log_watcher_handle.abort();
+        // Once the container has exited, its log stream reaches EOF and the watcher finishes on
+        // its own. Give it a bounded moment to drain any buffered tail into the log file before
+        // stopping it — the exit-status scan reads that tail, and the lines it needs (e.g. a
+        // license error) are typically the very last ones. Only abort if it overstays.
+        if tokio::time::timeout(Duration::from_secs(5), &mut log_watcher_handle)
+            .await
+            .is_err()
+        {
+            log_watcher_handle.abort();
+        }
 
         let msg = match exit_code {
             0 => format!("Frame {}(pid={}) finished successfully", self, pid),

--- a/rust/crates/rqd/src/frame/running_frame.rs
+++ b/rust/crates/rqd/src/frame/running_frame.rs
@@ -73,7 +73,7 @@ const LOG_SCAN_CHUNK_BYTES: u64 = 16 * 1024; // 16 KiB
 struct CompiledExitStatusRule {
     name: String,
     regex: Regex,
-    exit_status: u32,
+    exit_status: i32,
 }
 
 /// Compiles the configured rules, skipping (with a warning) any whose regex is invalid so a
@@ -102,7 +102,7 @@ fn compile_exit_status_rules(rules: &[LogExitStatusRule]) -> Vec<CompiledExitSta
 fn match_exit_status_rules(
     log_tail: &str,
     rules: &[CompiledExitStatusRule],
-) -> Option<(String, u32)> {
+) -> Option<(String, i32)> {
     rules
         .iter()
         .find(|rule| rule.regex.is_match(log_tail))
@@ -692,7 +692,7 @@ impl RunningFrame {
                     "Frame {}: log matched rule '{}'; overriding exit status {} -> {}",
                     self, name, exit_code, exit_status
                 );
-                Some(exit_status as i32)
+                Some(exit_status)
             }
             None => None,
         }
@@ -1948,7 +1948,7 @@ mod tests {
 [12:40:14] Process completed with exit status: 3
 ";
 
-    fn rule(name: &str, regex: &str, exit_status: u32) -> LogExitStatusRule {
+    fn rule(name: &str, regex: &str, exit_status: i32) -> LogExitStatusRule {
         LogExitStatusRule {
             name: name.to_string(),
             regex: regex.to_string(),

--- a/rust/crates/rqd/src/frame/running_frame.rs
+++ b/rust/crates/rqd/src/frame/running_frame.rs
@@ -52,10 +52,8 @@ use miette::{miette, Context, IntoDiagnostic, Result};
 use opencue_proto::{report::RunningFrameInfo, rqd::RunFrame};
 use uuid::Uuid;
 
-use regex::Regex;
-
 use super::logging::{FrameLogger, FrameLoggerBuilder};
-use crate::config::{LogExitStatusRule, RunnerConfig};
+use crate::config::{CompiledExitStatusRule, RunnerConfig};
 
 /// Maximum number of bytes read from the tail of a frame log when scanning for
 /// exit-status-override patterns. Bounds the IO regardless of the configured line count so a
@@ -68,35 +66,6 @@ const LOG_SCAN_MAX_BYTES: u64 = 1024 * 1024; // 1 MiB
 /// default 50-line tail of a frame log (~4 KiB, including the multi-line process footer) fits in
 /// a single read with headroom.
 const LOG_SCAN_CHUNK_BYTES: u64 = 16 * 1024; // 16 KiB
-
-/// A [`LogExitStatusRule`] with its regex compiled, ready for matching.
-struct CompiledExitStatusRule {
-    name: String,
-    regex: Regex,
-    exit_status: i32,
-}
-
-/// Compiles the configured rules, skipping (with a warning) any whose regex is invalid so a
-/// single bad pattern can neither disable the whole feature nor fail frame completion.
-fn compile_exit_status_rules(rules: &[LogExitStatusRule]) -> Vec<CompiledExitStatusRule> {
-    rules
-        .iter()
-        .filter_map(|rule| match Regex::new(&rule.regex) {
-            Ok(regex) => Some(CompiledExitStatusRule {
-                name: rule.name.clone(),
-                regex,
-                exit_status: rule.exit_status,
-            }),
-            Err(err) => {
-                warn!(
-                    "Ignoring invalid log_exit_status_rule '{}' (regex {:?}): {}",
-                    rule.name, rule.regex, err
-                );
-                None
-            }
-        })
-        .collect()
-}
 
 /// Returns the `(name, exit_status)` of the first rule that matches anywhere in `log_tail`.
 fn match_exit_status_rules(
@@ -650,13 +619,18 @@ impl RunningFrame {
     /// Only failed frames are scanned (`exit_code != 0`), so a successful frame is never
     /// reclassified. Any error like a missing/unreadable log, a Loki-only frame with no local
     /// log file is treated as "no override" and never blocks or fails frame completion.
-    pub(super) async fn scan_log_for_exit_status_override(&self, exit_code: i32) -> Option<i32> {
+    ///
+    /// On a match returns the matching rule's name alongside the override status, so the caller
+    /// can record the reclassification in the frame log for artists debugging the frame.
+    pub(super) async fn scan_log_for_exit_status_override(
+        &self,
+        exit_code: i32,
+    ) -> Option<(String, i32)> {
         // A successful frame keeps its status; only failures are reinterpreted.
         if exit_code == 0 {
             return None;
         }
-        let rules = &self.config.log_exit_status_rules;
-        if rules.is_empty() || self.config.log_scan_last_lines == 0 {
+        if self.config.log_exit_status_rules.is_empty() || self.config.log_scan_last_lines == 0 {
             return None;
         }
         // If RQD itself killed this frame (OOM, NIMBY, timeout, manual kill), that reason is
@@ -669,7 +643,7 @@ impl RunningFrame {
         if !self.request.loki_url.is_empty() {
             return None;
         }
-        let compiled = compile_exit_status_rules(rules);
+        let compiled = self.config.compiled_exit_status_rules();
         if compiled.is_empty() {
             return None;
         }
@@ -686,13 +660,13 @@ impl RunningFrame {
         };
 
         let log_tail = lines.join("\n");
-        match match_exit_status_rules(&log_tail, &compiled) {
+        match match_exit_status_rules(&log_tail, compiled) {
             Some((name, exit_status)) => {
                 info!(
                     "Frame {}: log matched rule '{}'; overriding exit status {} -> {}",
                     self, name, exit_code, exit_status
                 );
-                Some(exit_status)
+                Some((name, exit_status))
             }
             None => None,
         }
@@ -733,10 +707,18 @@ impl RunningFrame {
             Ok((exit_code, exit_signal)) => {
                 // Reclassify known failures (e.g. license shortages) before persisting the
                 // finished state, so both the footer and the report to Cuebot see the override.
-                let exit_code = self
-                    .scan_log_for_exit_status_override(exit_code)
-                    .await
-                    .unwrap_or(exit_code);
+                let exit_code = match self.scan_log_for_exit_status_override(exit_code).await {
+                    Some((name, override_code)) => {
+                        // Record the reclassification in the frame log itself; otherwise the
+                        // footer would show only the overridden status and the original exit
+                        // code the process actually returned would appear nowhere artists look.
+                        logger.writeln(&format!(
+                            "Exit status {exit_code} overridden to {override_code} by rule '{name}'"
+                        ));
+                        override_code
+                    }
+                    None => exit_code,
+                };
                 if let Err(err) = self.finish(exit_code, exit_signal, None) {
                     error!("Failed to mark frame {} as finished. {}", self, err);
                 }
@@ -1839,14 +1821,11 @@ mod tests {
     use std::sync::Arc;
     use uuid::Uuid;
 
-    use crate::config::{Config, LogExitStatusRule, RunnerConfig};
+    use crate::config::{compile_exit_status_rules, Config, LogExitStatusRule, RunnerConfig};
     use crate::frame::logging::FrameLoggerT;
     use crate::frame::logging::TestLogger;
 
-    use super::{
-        compile_exit_status_rules, match_exit_status_rules, read_last_lines, RunningFrame,
-        LOG_SCAN_MAX_BYTES,
-    };
+    use super::{match_exit_status_rules, read_last_lines, RunningFrame, LOG_SCAN_MAX_BYTES};
 
     fn create_running_frame(
         command: &str,
@@ -2109,7 +2088,10 @@ mod tests {
     async fn test_scan_overrides_on_license_match() {
         // End-to-end: a failed frame whose log contains the license message is reclassified.
         let frame = frame_with_license_rule("", LICENSE_LOG);
-        assert_eq!(frame.scan_log_for_exit_status_override(3).await, Some(330));
+        assert_eq!(
+            frame.scan_log_for_exit_status_override(3).await,
+            Some(("HOUDINI_LICENSE_ERROR".to_string(), 330))
+        );
         let _ = std::fs::remove_file(&frame.log_path);
     }
 

--- a/rust/crates/rqd/src/frame/running_frame.rs
+++ b/rust/crates/rqd/src/frame/running_frame.rs
@@ -52,8 +52,115 @@ use miette::{miette, Context, IntoDiagnostic, Result};
 use opencue_proto::{report::RunningFrameInfo, rqd::RunFrame};
 use uuid::Uuid;
 
+use regex::Regex;
+
 use super::logging::{FrameLogger, FrameLoggerBuilder};
-use crate::config::RunnerConfig;
+use crate::config::{LogExitStatusRule, RunnerConfig};
+
+/// Maximum number of bytes read from the tail of a frame log when scanning for
+/// exit-status-override patterns. Bounds the IO regardless of the configured line count so a
+/// pathologically large log can never be read in full.
+const LOG_SCAN_MAX_BYTES: u64 = 1024 * 1024; // 1 MiB
+
+/// Granularity of the backward tail read in [`read_last_lines`]. The tail is read in chunks of
+/// this size, newest-first, stopping as soon as enough line breaks have been seen — so a typical
+/// scan touches only one chunk instead of the full [`LOG_SCAN_MAX_BYTES`] cap. Sized so the
+/// default 50-line tail of a frame log (~4 KiB, including the multi-line process footer) fits in
+/// a single read with headroom.
+const LOG_SCAN_CHUNK_BYTES: u64 = 16 * 1024; // 16 KiB
+
+/// A [`LogExitStatusRule`] with its regex compiled, ready for matching.
+struct CompiledExitStatusRule {
+    name: String,
+    regex: Regex,
+    exit_status: u32,
+}
+
+/// Compiles the configured rules, skipping (with a warning) any whose regex is invalid so a
+/// single bad pattern can neither disable the whole feature nor fail frame completion.
+fn compile_exit_status_rules(rules: &[LogExitStatusRule]) -> Vec<CompiledExitStatusRule> {
+    rules
+        .iter()
+        .filter_map(|rule| match Regex::new(&rule.regex) {
+            Ok(regex) => Some(CompiledExitStatusRule {
+                name: rule.name.clone(),
+                regex,
+                exit_status: rule.exit_status,
+            }),
+            Err(err) => {
+                warn!(
+                    "Ignoring invalid log_exit_status_rule '{}' (regex {:?}): {}",
+                    rule.name, rule.regex, err
+                );
+                None
+            }
+        })
+        .collect()
+}
+
+/// Returns the `(name, exit_status)` of the first rule that matches anywhere in `log_tail`.
+fn match_exit_status_rules(
+    log_tail: &str,
+    rules: &[CompiledExitStatusRule],
+) -> Option<(String, u32)> {
+    rules
+        .iter()
+        .find(|rule| rule.regex.is_match(log_tail))
+        .map(|rule| (rule.name.clone(), rule.exit_status))
+}
+
+/// Reads up to `max_lines` from the end of `path`, reading at most [`LOG_SCAN_MAX_BYTES`] from
+/// the tail. When the byte cap truncates mid-line, the leading partial line is dropped so a
+/// rule can't match against half a line. (Consequence of that cap: a single trailing line
+/// longer than [`LOG_SCAN_MAX_BYTES`] is dropped entirely and won't be scanned — acceptable,
+/// since the patterns this feature targets are short diagnostic messages.)
+async fn read_last_lines(path: &str, max_lines: usize) -> Result<Vec<String>> {
+    use tokio::io::{AsyncReadExt, AsyncSeekExt, SeekFrom};
+
+    let mut file = tokio::fs::File::open(path)
+        .await
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to open {path} for exit-status scan"))?;
+    let size = file.metadata().await.into_diagnostic()?.len();
+
+    // Read the tail backward in fixed-size chunks, stopping once we've seen one more newline than
+    // requested: `max_lines` lines are delimited by `max_lines` newlines, plus one extra whose
+    // trailing partial line is dropped below. `floor` keeps the total read within the byte cap.
+    let want_newlines = max_lines + 1;
+    let floor = size.saturating_sub(LOG_SCAN_MAX_BYTES);
+    let mut buf: Vec<u8> = Vec::new();
+    let mut newlines = 0usize;
+    let mut pos = size;
+    while pos > floor {
+        let chunk = LOG_SCAN_CHUNK_BYTES.min(pos - floor);
+        let chunk_start = pos - chunk;
+        file.seek(SeekFrom::Start(chunk_start))
+            .await
+            .into_diagnostic()?;
+        let mut chunk_buf = vec![0u8; chunk as usize];
+        file.read_exact(&mut chunk_buf).await.into_diagnostic()?;
+        newlines += chunk_buf.iter().filter(|&&b| b == b'\n').count();
+        // Prepend this earlier chunk in front of the tail collected so far.
+        chunk_buf.extend_from_slice(&buf);
+        buf = chunk_buf;
+        pos = chunk_start;
+        if newlines >= want_newlines {
+            break;
+        }
+    }
+    // `pos == 0` means we reached the real start of the file, so the first line is complete and
+    // must be kept. Otherwise the read began mid-file and the leading line is possibly truncated.
+    let at_file_start = pos == 0;
+
+    let text = String::from_utf8_lossy(&buf);
+    let mut lines = text.lines();
+    if !at_file_start {
+        lines.next();
+    }
+    let collected: Vec<String> = lines.map(|line| line.to_string()).collect();
+    let begin = collected.len().saturating_sub(max_lines);
+    Ok(collected[begin..].to_vec())
+}
 
 /// Wrapper around protobuf message RunningFrameInfo
 #[derive(Serialize, Deserialize)]
@@ -66,6 +173,11 @@ pub struct RunningFrame {
     pub log_path: String,
     pub(super) uid: u32,
     pub(super) gid: u32,
+    // The runner config is host-level policy, not per-frame state, and is always replaced from
+    // the live config on recovery (`from_snapshot`). Keeping it out of the snapshot avoids
+    // bloating every snapshot and, because bincode is positional, stops future additions to
+    // RunnerConfig from breaking the layout of previously written snapshots.
+    #[serde(skip)]
     pub(super) config: RunnerConfig,
     pub thread_ids: Option<Vec<u32>>,
     pub gpu_list: Option<Vec<u32>>,
@@ -523,6 +635,69 @@ impl RunningFrame {
         "bat"
     }
 
+    /// Returns the kill reason if RQD has requested this (still-running) frame be killed.
+    fn kill_reason(&self) -> Option<String> {
+        let state = self.state.read().unwrap_or_else(|err| err.into_inner());
+        match &*state {
+            FrameState::Running(running_state) => running_state.kill_reason.clone(),
+            _ => None,
+        }
+    }
+
+    /// Scans the tail of the frame log for configured `log_exit_status_rules` and returns an
+    /// override exit status when one matches.
+    ///
+    /// Only failed frames are scanned (`exit_code != 0`), so a successful frame is never
+    /// reclassified. Any error like a missing/unreadable log, a Loki-only frame with no local
+    /// log file is treated as "no override" and never blocks or fails frame completion.
+    pub(super) async fn scan_log_for_exit_status_override(&self, exit_code: i32) -> Option<i32> {
+        // A successful frame keeps its status; only failures are reinterpreted.
+        if exit_code == 0 {
+            return None;
+        }
+        let rules = &self.config.log_exit_status_rules;
+        if rules.is_empty() || self.config.log_scan_last_lines == 0 {
+            return None;
+        }
+        // If RQD itself killed this frame (OOM, NIMBY, timeout, manual kill), that reason is
+        // authoritative and drives its own retry semantics (e.g. OOM -> exit_signal 33). Don't
+        // let an incidental log-pattern match reclassify it and hide why the frame really died.
+        if self.kill_reason().is_some() {
+            return None;
+        }
+        // Loki-backed frames don't write a local log file, so there is nothing to scan.
+        if !self.request.loki_url.is_empty() {
+            return None;
+        }
+        let compiled = compile_exit_status_rules(rules);
+        if compiled.is_empty() {
+            return None;
+        }
+
+        let lines = match read_last_lines(&self.log_path, self.config.log_scan_last_lines).await {
+            Ok(lines) => lines,
+            Err(err) => {
+                warn!(
+                    "Frame {}: skipping exit-status log scan, could not read {}: {}",
+                    self, self.log_path, err
+                );
+                return None;
+            }
+        };
+
+        let log_tail = lines.join("\n");
+        match match_exit_status_rules(&log_tail, &compiled) {
+            Some((name, exit_status)) => {
+                info!(
+                    "Frame {}: log matched rule '{}'; overriding exit status {} -> {}",
+                    self, name, exit_code, exit_status
+                );
+                Some(exit_status as i32)
+            }
+            None => None,
+        }
+    }
+
     /// Runs the frame as a subprocess.
     ///
     /// This method is the main entry point for executing a frame. It:
@@ -556,6 +731,12 @@ impl RunningFrame {
         };
         let was_spawned = match output {
             Ok((exit_code, exit_signal)) => {
+                // Reclassify known failures (e.g. license shortages) before persisting the
+                // finished state, so both the footer and the report to Cuebot see the override.
+                let exit_code = self
+                    .scan_log_for_exit_status_override(exit_code)
+                    .await
+                    .unwrap_or(exit_code);
                 if let Err(err) = self.finish(exit_code, exit_signal, None) {
                     error!("Failed to mark frame {} as finished. {}", self, err);
                 }
@@ -1658,11 +1839,14 @@ mod tests {
     use std::sync::Arc;
     use uuid::Uuid;
 
-    use crate::config::Config;
+    use crate::config::{Config, LogExitStatusRule, RunnerConfig};
     use crate::frame::logging::FrameLoggerT;
     use crate::frame::logging::TestLogger;
 
-    use super::RunningFrame;
+    use super::{
+        compile_exit_status_rules, match_exit_status_rules, read_last_lines, RunningFrame,
+        LOG_SCAN_MAX_BYTES,
+    };
 
     fn create_running_frame(
         command: &str,
@@ -1670,11 +1854,25 @@ mod tests {
         uid: u32,
         environment: HashMap<String, String>,
     ) -> RunningFrame {
+        create_running_frame_cfg(command, num_cores, uid, environment, "", |_| {})
+    }
+
+    /// Like [`create_running_frame`], but allows setting a Loki URL and mutating the runner
+    /// config (e.g. to install `log_exit_status_rules`) before the frame is built.
+    fn create_running_frame_cfg<F: FnOnce(&mut RunnerConfig)>(
+        command: &str,
+        num_cores: u32,
+        uid: u32,
+        environment: HashMap<String, String>,
+        loki_url: &str,
+        configure: F,
+    ) -> RunningFrame {
         let frame_id = Uuid::new_v4().to_string();
         let general_config = Config::default();
         general_config.setup().unwrap();
         let mut config = general_config.runner;
         config.run_as_user = false;
+        configure(&mut config);
 
         RunningFrame::init(
             RunFrame {
@@ -1702,7 +1900,7 @@ mod tests {
                 soft_memory_limit: 0,
                 hard_memory_limit: 0,
                 pid: 0,
-                loki_url: "".to_string(),
+                loki_url: loki_url.to_string(),
 
                 #[allow(deprecated)]
                 job_temp_dir: "".to_string(),
@@ -1723,6 +1921,222 @@ mod tests {
             "localhost".to_string(),
             1,
         )
+    }
+
+    /// Builds a frame whose runner config has a single license-error rule (exit status 330) and
+    /// writes `log_contents` to a unique log file, ready for a scan. The frame's `log_path` is
+    /// repointed at that file so parallel tests never collide on the derived path.
+    fn frame_with_license_rule(loki_url: &str, log_contents: &str) -> RunningFrame {
+        let mut frame = create_running_frame_cfg("false", 1, 1, HashMap::new(), loki_url, |cfg| {
+            cfg.log_scan_last_lines = 50;
+            cfg.log_exit_status_rules = vec![rule(
+                "HOUDINI_LICENSE_ERROR",
+                "A usable license to run the application is installed but they are all in use",
+                330,
+            )];
+        });
+        let log_file = std::env::temp_dir().join(format!("rqd_scan_test_{}.rqlog", Uuid::new_v4()));
+        std::fs::write(&log_file, log_contents).unwrap();
+        frame.log_path = log_file.to_string_lossy().to_string();
+        frame
+    }
+
+    const LICENSE_LOG: &str = "\
+[12:40:13] Some earlier unrelated output
+[12:40:13] A usable license to run the application is installed but they are all in use.
+[12:40:13] Please contact your companies license administrator to create availability
+[12:40:14] Process completed with exit status: 3
+";
+
+    fn rule(name: &str, regex: &str, exit_status: u32) -> LogExitStatusRule {
+        LogExitStatusRule {
+            name: name.to_string(),
+            regex: regex.to_string(),
+            exit_status,
+        }
+    }
+
+    #[test]
+    fn test_match_exit_status_rules_first_match_wins() {
+        let rules = compile_exit_status_rules(&[
+            rule("LICENSE", "all in use", 330),
+            rule("GENERIC", "error", 331),
+        ]);
+        // Both patterns are present; the earlier rule in the list must win.
+        let tail = "some error occurred\nlicenses are all in use now";
+        assert_eq!(
+            match_exit_status_rules(tail, &rules),
+            Some(("LICENSE".to_string(), 330))
+        );
+    }
+
+    #[test]
+    fn test_match_exit_status_rules_no_match() {
+        let rules = compile_exit_status_rules(&[rule("LICENSE", "all in use", 330)]);
+        assert_eq!(match_exit_status_rules("frame rendered fine", &rules), None);
+    }
+
+    #[test]
+    fn test_compile_exit_status_rules_skips_invalid_regex() {
+        // The middle rule has an invalid pattern and must be dropped without failing the rest.
+        let compiled = compile_exit_status_rules(&[
+            rule("GOOD", "valid", 1),
+            rule("BAD", "(unclosed", 2),
+            rule("ALSO_GOOD", "also", 3),
+        ]);
+        assert_eq!(compiled.len(), 2);
+        assert_eq!(
+            match_exit_status_rules("also valid", &compiled),
+            Some(("GOOD".to_string(), 1))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_read_last_lines_returns_tail() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        use std::io::Write;
+        for i in 0..100 {
+            writeln!(file, "line {i}").unwrap();
+        }
+        let path = file.path().to_string_lossy().to_string();
+
+        let lines = read_last_lines(&path, 5).await.unwrap();
+        assert_eq!(
+            lines,
+            vec!["line 95", "line 96", "line 97", "line 98", "line 99"]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_read_last_lines_fewer_than_requested() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        use std::io::Write;
+        writeln!(file, "only line").unwrap();
+        let path = file.path().to_string_lossy().to_string();
+
+        let lines = read_last_lines(&path, 50).await.unwrap();
+        assert_eq!(lines, vec!["only line"]);
+    }
+
+    #[tokio::test]
+    async fn test_read_last_lines_matches_license_error() {
+        // End-to-end: the exact license message from a real Houdini failure must match.
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        use std::io::Write;
+        writeln!(file, "[12:40:13] Some earlier unrelated output").unwrap();
+        writeln!(
+            file,
+            "[12:40:13] A usable license to run the application is installed but they are all in use."
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "[12:40:13] Please contact your companies license administrator to create availability"
+        )
+        .unwrap();
+        writeln!(file, "[12:40:14] Process completed with exit status: 3").unwrap();
+        let path = file.path().to_string_lossy().to_string();
+
+        let lines = read_last_lines(&path, 10).await.unwrap();
+        let tail = lines.join("\n");
+        let rules = compile_exit_status_rules(&[rule(
+            "HOUDINI_LICENSE_ERROR",
+            "A usable license to run the application is installed but they are all in use",
+            330,
+        )]);
+        assert_eq!(
+            match_exit_status_rules(&tail, &rules),
+            Some(("HOUDINI_LICENSE_ERROR".to_string(), 330))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_read_last_lines_spans_multiple_chunks() {
+        // A file far larger than LOG_SCAN_CHUNK_BYTES forces the backward read to walk several
+        // chunks; the tail must still be exact and correctly ordered across chunk boundaries.
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        use std::io::Write;
+        // ~200 bytes/line * 2000 lines ≈ 400 KiB, well beyond the 16 KiB chunk.
+        let filler = "x".repeat(180);
+        for i in 0..2000 {
+            writeln!(file, "line {i:04} {filler}").unwrap();
+        }
+        file.flush().unwrap();
+        let path = file.path().to_string_lossy().to_string();
+
+        let lines = read_last_lines(&path, 3).await.unwrap();
+        assert_eq!(
+            lines,
+            vec![
+                format!("line 1997 {filler}"),
+                format!("line 1998 {filler}"),
+                format!("line 1999 {filler}"),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_read_last_lines_respects_byte_cap() {
+        // A single line longer than LOG_SCAN_MAX_BYTES is dropped entirely (its leading partial
+        // is truncated at the floor and discarded), matching the documented cap behavior.
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        use std::io::Write;
+        let giant = "y".repeat((LOG_SCAN_MAX_BYTES as usize) + 4096);
+        writeln!(file, "{giant}").unwrap();
+        writeln!(file, "short tail line").unwrap();
+        file.flush().unwrap();
+        let path = file.path().to_string_lossy().to_string();
+
+        let lines = read_last_lines(&path, 10).await.unwrap();
+        assert_eq!(lines, vec!["short tail line"]);
+    }
+
+    #[tokio::test]
+    async fn test_scan_returns_none_on_success() {
+        let frame = create_running_frame("true", 1, 1, HashMap::new());
+        // exit_code 0 must never trigger a scan/override, regardless of config.
+        assert_eq!(frame.scan_log_for_exit_status_override(0).await, None);
+    }
+
+    #[tokio::test]
+    async fn test_scan_returns_none_without_rules() {
+        // Default config has no rules configured, so a failure yields no override.
+        let frame = create_running_frame("false", 1, 1, HashMap::new());
+        assert_eq!(frame.scan_log_for_exit_status_override(1).await, None);
+    }
+
+    #[tokio::test]
+    async fn test_scan_overrides_on_license_match() {
+        // End-to-end: a failed frame whose log contains the license message is reclassified.
+        let frame = frame_with_license_rule("", LICENSE_LOG);
+        assert_eq!(frame.scan_log_for_exit_status_override(3).await, Some(330));
+        let _ = std::fs::remove_file(&frame.log_path);
+    }
+
+    #[tokio::test]
+    async fn test_scan_no_override_when_pattern_absent() {
+        // A failure whose log doesn't match any rule keeps its original exit status.
+        let frame = frame_with_license_rule("", "frame rendered fine\nexit status: 1\n");
+        assert_eq!(frame.scan_log_for_exit_status_override(1).await, None);
+        let _ = std::fs::remove_file(&frame.log_path);
+    }
+
+    #[tokio::test]
+    async fn test_scan_skips_loki_frames() {
+        // Even with a matching local file, a Loki-backed frame must not be scanned.
+        let frame = frame_with_license_rule("http://loki.example.com", LICENSE_LOG);
+        assert_eq!(frame.scan_log_for_exit_status_override(3).await, None);
+        let _ = std::fs::remove_file(&frame.log_path);
+    }
+
+    #[tokio::test]
+    async fn test_scan_skips_killed_frames() {
+        // A frame RQD killed keeps its kill-driven classification, even if the log matches.
+        let frame = frame_with_license_rule("", LICENSE_LOG);
+        frame.start(12345);
+        frame.get_pid_to_kill("manual kill").unwrap();
+        assert_eq!(frame.scan_log_for_exit_status_override(1).await, None);
+        let _ = std::fs::remove_file(&frame.log_path);
     }
 
     #[tokio::test]

--- a/rust/crates/rqd/src/main.rs
+++ b/rust/crates/rqd/src/main.rs
@@ -64,6 +64,11 @@ async fn async_main() -> miette::Result<()> {
         log_builder.init();
     }
 
+    // Compile the log_exit_status_rules once now that logging is up, so an operator's typo in a
+    // rule's regex surfaces as a single startup warning instead of repeating on every failed
+    // frame (and no frame later pays to recompile them).
+    let _ = CONFIG.runner.compiled_exit_status_rules();
+
     // Fail fast if the config requires elevated privileges the process does not hold,
     // instead of letting every frame fail later with an opaque error.
     capabilities::preflight(&CONFIG.runner)?;

--- a/rust/crates/rqd/src/system/machine.rs
+++ b/rust/crates/rqd/src/system/machine.rs
@@ -568,24 +568,35 @@ impl MachineMonitor {
         };
 
         for frame in finished_frames {
-            let exit_code_and_signal: Option<(u32, u32)> = match frame.get_state_copy() {
+            // (exit_code, exit_signal, run_time_seconds)
+            let exit_report: Option<(u32, u32, u32)> = match frame.get_state_copy() {
                 FrameState::Finished(finished_state) => {
                     let exit_signal = match finished_state.exit_signal {
                         Some(signal) => signal as u32,
                         None => 0,
                     };
-                    Some((finished_state.exit_code as u32, exit_signal))
+                    // Wall-clock runtime of the frame in seconds. Cuebot relies on run_time
+                    // to enforce layer runtime timeouts and the 12h no-retry cap
+                    // (see Dispatcher.FRAME_TIME_NO_RETRY / determineFrameState). Sending 0
+                    // disables those timeout-based DEAD decisions and skews usage counters.
+                    let run_time = finished_state
+                        .end_time
+                        .duration_since(finished_state.start_time)
+                        .map(|d| d.as_secs() as u32)
+                        .unwrap_or(0);
+                    Some((finished_state.exit_code as u32, exit_signal, run_time))
                 }
                 FrameState::FailedBeforeStart => {
                     Some((
                         1,  // Mark frame as failed
                         10, // Use signal to indicate it failed before starting
+                        0,  // Never ran, so no runtime
                     ))
                 }
                 _ => None,
             };
 
-            if let Some((exit_code, exit_signal)) = exit_code_and_signal {
+            if let Some((exit_code, exit_signal, run_time)) = exit_report {
                 let frame_report = frame.clone_into_running_frame_info();
                 info!("Sending frame complete report: {}", frame);
 
@@ -605,7 +616,7 @@ impl MachineMonitor {
                         frame_report,
                         exit_code,
                         exit_signal,
-                        0,
+                        run_time,
                     )
                     .await
                 {


### PR DESCRIPTION
Allow configuring a regex + exit_status combination to reclassify failed frames.
This feature is part of an effort to allow frames that failed due to License limitations to be
handled differently by Cuebot.

Includes a small fix to failed frame's run time misreporting: Whenever a frame fails, it is failing to report its runtime, which impacts Cuebot's frame completion logic, allowing frames from retrying when above their stated timeout.

Please read docs/news/2026-08-06-rqd-log-exit-status-rules.md for more information.

## LLM usage disclosure
Claude Opus was used in the implementation of this feature.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable log-based exit-status rules for failed frames.
  - RQD scans recent log output and applies the first matching rule.
  - Completed frame reports now include runtime in seconds.
  - Added sample configuration with bounded scanning and disabled-by-default behavior.

- **Bug Fixes**
  - Improved Docker log handling to capture buffered output before classification.

- **Documentation**
  - Added reference and release documentation for log-based exit-status rules.
  - Corrected news-page navigation ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->