### PR TITLE
[cuebot] Prevent Lost procs from being deferred forever

### DIFF
--- a/cuebot/src/main/java/com/imageworks/spcue/dao/ProcDao.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/ProcDao.java
@@ -199,6 +199,29 @@ public interface ProcDao {
     List<VirtualProc> findOrphanedVirtualProcs(int limit);
 
     /**
+     * Returns true if the proc's last ping ({@code ts_ping}, the last time a host report proved the
+     * proc's frame was still running on its host) is older than the given age. Measured against the
+     * database clock. A proc that no longer exists returns false.
+     *
+     * @param proc
+     * @param ageMs
+     * @return
+     */
+    boolean isPingOlderThan(ProcInterface proc, long ageMs);
+
+    /**
+     * Returns true if the proc's host reports a boot time later than the proc's dispatch time (by a
+     * safety margin covering host/database clock skew). A host that booted after the proc was
+     * dispatched cannot still be running the proc's frame -- the render died with the reboot -- so
+     * this is definitive proof the frame is not running, even when the host cannot be reached to
+     * confirm. Returns false when the proc or its host stats no longer exist.
+     *
+     * @param proc
+     * @return
+     */
+    boolean isHostRebootedSinceDispatch(ProcInterface proc);
+
+    /**
      * Returns procs with a host in a particular hardware state.
      *
      * @param state

--- a/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/ProcDaoJdbc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dao/postgres/ProcDaoJdbc.java
@@ -579,7 +579,11 @@ public class ProcDaoJdbc extends JdbcDaoSupport implements ProcDao {
                 + "job.pk_job = proc.pk_job "
                 + "AND "
                 + "current_timestamp - proc.ts_ping > "
-            + ORPHANED_PROC_INTERVAL;
+            + ORPHANED_PROC_INTERVAL
+            // Oldest ping first, so a limited batch is deterministic across passes: the
+            // longest-stale procs are always retried (and eventually hit the deferral bound)
+            // instead of a nondeterministic subset cycling through the batch window.
+            + " ORDER BY proc.ts_ping";
     // spotless:on
 
     public List<VirtualProc> findOrphanedVirtualProcs() {
@@ -589,6 +593,54 @@ public class ProcDaoJdbc extends JdbcDaoSupport implements ProcDao {
     public List<VirtualProc> findOrphanedVirtualProcs(int limit) {
         return getJdbcTemplate().query(GET_ORPHANED_PROC_LIST + " LIMIT " + limit,
                 VIRTUAL_PROC_MAPPER);
+    }
+
+    // spotless:off
+    private static final String IS_PING_OLDER_THAN =
+            "SELECT "
+                + "COUNT(1) "
+            + "FROM "
+                + "proc "
+            + "WHERE "
+                + "proc.pk_proc = ? "
+                + "AND "
+                + "current_timestamp - proc.ts_ping > (? * interval '1 millisecond')";
+    // spotless:on
+
+    @Override
+    public boolean isPingOlderThan(ProcInterface proc, long ageMs) {
+        return getJdbcTemplate().queryForObject(IS_PING_OLDER_THAN, Integer.class, proc.getProcId(),
+                ageMs) > 0;
+    }
+
+    /**
+     * Safety margin required between a proc's dispatch time (database clock) and its host's
+     * reported boot time (host clock) before the reboot counts as proof the render is dead. Covers
+     * clock skew between the host and the database: a host whose clock runs ahead by less than this
+     * margin cannot make a pre-dispatch boot look post-dispatch.
+     */
+    private static final String BOOT_AFTER_DISPATCH_SKEW_MARGIN = "interval '300' second";
+
+    // spotless:off
+    private static final String IS_HOST_REBOOTED_SINCE_DISPATCH =
+            "SELECT "
+                + "COUNT(1) "
+            + "FROM "
+                + "proc, "
+                + "host_stat "
+            + "WHERE "
+                + "proc.pk_proc = ? "
+                + "AND "
+                + "host_stat.pk_host = proc.pk_host "
+                + "AND "
+                + "host_stat.ts_booted > proc.ts_dispatched + "
+            + BOOT_AFTER_DISPATCH_SKEW_MARGIN;
+    // spotless:on
+
+    @Override
+    public boolean isHostRebootedSinceDispatch(ProcInterface proc) {
+        return getJdbcTemplate().queryForObject(IS_HOST_REBOOTED_SINCE_DISPATCH, Integer.class,
+                proc.getProcId()) > 0;
     }
 
     // spotless:off

--- a/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/dispatcher/DispatchSupportService.java
@@ -71,6 +71,15 @@ import com.imageworks.spcue.util.FrameSet;
 public class DispatchSupportService implements DispatchSupport {
     private static final Logger logger = LogManager.getLogger(DispatchSupportService.class);
 
+    /**
+     * How long a lost proc's release may stay deferred -- measured as time since the proc's last
+     * ping proved its frame alive -- before {@link #lostProc} fails closed (frame DEAD, manual
+     * retry) instead of deferring again. Mirrors {@code maintenance.orphaned_frame_max_defer_ms}.
+     * Overridable via the {@code dispatcher.lost_proc_max_defer_ms} property; negative disables the
+     * bound.
+     */
+    private static final long DEFAULT_LOST_PROC_MAX_DEFER_MS = 1200000;
+
     private JobDao jobDao;
     private FrameDao frameDao;
     private LayerDao layerDao;
@@ -559,19 +568,47 @@ public class DispatchSupportService implements DispatchSupport {
          * reclaimed later, once the host is confirmed DOWN (clearDownProcs) or the frame completes
          * naturally. A genuinely dead host (marked DOWN, or no longer Up) leaves no live RQD, so
          * release is safe. See design/frame_double_booking_v2.md.
+         *
+         * The deferral is bounded: a proc whose frame has gone unproven-alive (no ping) for longer
+         * than dispatcher.lost_proc_max_defer_ms is failed closed instead -- the proc is released
+         * but the frame is parked DEAD (manual retry), never WAITING, so an unconfirmable render
+         * can neither linger RUNNING forever nor be auto-rebooked. This mirrors
+         * maintenance.orphaned_frame_max_defer_ms on the orphaned-frame side.
          */
+        FrameState stopState = FrameState.WAITING;
         boolean deferReleaseEnabled = env.getProperty(
                 "dispatcher.defer_release_on_failed_kill_enabled", Boolean.class, true);
         if (deferReleaseEnabled && !frameKilled && proc.frameId != null) {
             boolean hostConfirmedDead =
                     exitStatus == Dispatcher.EXIT_STATUS_DOWN_HOST || !hostDao.isHostUp(proc);
+            /*
+             * A host that booted after this proc was dispatched cannot still be running the render
+             * -- it died with the reboot -- so the release is safe even though the kill could not
+             * confirm it (e.g. the restarted host is not reachable yet).
+             */
+            if (!hostConfirmedDead && procDao.isHostRebootedSinceDispatch(proc)) {
+                logger.info("Releasing lost proc " + proc.getName() + ": its host reports a boot "
+                        + "time later than the proc's dispatch, so frame " + proc.frameId
+                        + " cannot still be running there.");
+                hostConfirmedDead = true;
+            }
             if (!hostConfirmedDead) {
-                DispatchSupport.deferredReleaseProcs.incrementAndGet();
-                logger.warn("Deferring release of lost proc " + proc.getName()
-                        + ": kill-before-release could not confirm the frame stopped and the host "
-                        + "is not confirmed dead. Leaving frame " + proc.frameId
-                        + " RUNNING to avoid double-booking. reason=" + reason);
-                return false;
+                long maxDeferMs = env.getProperty("dispatcher.lost_proc_max_defer_ms", Long.class,
+                        DEFAULT_LOST_PROC_MAX_DEFER_MS);
+                if (maxDeferMs < 0 || !procDao.isPingOlderThan(proc, maxDeferMs)) {
+                    DispatchSupport.deferredReleaseProcs.incrementAndGet();
+                    logger.warn("Deferring release of lost proc " + proc.getName()
+                            + ": kill-before-release could not confirm the frame stopped and the "
+                            + "host is not confirmed dead. Leaving frame " + proc.frameId
+                            + " RUNNING to avoid double-booking. reason=" + reason);
+                    return false;
+                }
+                logger.warn("Releasing lost proc " + proc.getName() + " after " + maxDeferMs
+                        + "ms without a ping proving frame " + proc.frameId + " alive; the kill "
+                        + "still could not confirm the frame stopped, so the frame is marked DEAD "
+                        + "(manual retry) instead of WAITING to avoid double-booking. reason="
+                        + reason);
+                stopState = FrameState.DEAD;
             }
         }
 
@@ -591,7 +628,7 @@ public class DispatchSupportService implements DispatchSupport {
             /*
              * If the proc has a frame, stop the frame. Frames can only be stopped that are running.
              */
-            if (frameDao.updateFrameStopped(f, FrameState.WAITING, exitStatus)) {
+            if (frameDao.updateFrameStopped(f, stopState, exitStatus)) {
                 updateUsageCounters(proc, exitStatus);
             }
             /*

--- a/cuebot/src/main/java/com/imageworks/spcue/rqd/RqdClient.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/rqd/RqdClient.java
@@ -86,12 +86,21 @@ public interface RqdClient {
     /**
      * Kills a running frame by resource
      *
+     * Returning normally means the frame is no longer running on the host: either the kill was
+     * delivered, or RQD answered NOT_FOUND (it does not track the frame, e.g. after a host
+     * restart), which is definitive proof the render is not running there. An
+     * {@link RqdClientException} is raised only when the frame's state remains unknown (host
+     * unreachable, deadline exceeded, etc.).
+     *
      * @param resource
      */
     void killFrame(VirtualProc Proc, String message);
 
     /**
      * Kills a running frame
+     *
+     * Same contract as {@link #killFrame(VirtualProc, String)}: NOT_FOUND counts as
+     * confirmed-stopped, only an unknown outcome throws.
      *
      * @param hostName
      * @param frameId

--- a/cuebot/src/main/java/com/imageworks/spcue/rqd/RqdClientGrpc.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/rqd/RqdClientGrpc.java
@@ -181,7 +181,19 @@ public final class RqdClientGrpc implements RqdClient {
         try {
             logger.info("killing frame on " + host + ", source: " + message);
             getStub(host).killRunningFrame(request);
-        } catch (StatusRuntimeException | ExecutionException e) {
+        } catch (StatusRuntimeException e) {
+            // RQD returns NOT_FOUND when the frame is not in its cache (already reaped, or the
+            // host restarted since the frame was dispatched): the render is confirmed not running
+            // there, which is the state the kill was meant to reach. Treat it as success so
+            // callers do not mistake the strongest possible "not running" proof for a failed
+            // kill (and, e.g., defer releasing a provably dead frame).
+            if (e.getStatus().getCode() == Status.Code.NOT_FOUND) {
+                logger.info("frame " + frameId + " is not running on " + host
+                        + " (NOT_FOUND), nothing to kill");
+                return;
+            }
+            throw new RqdClientException("failed to kill frame " + frameId, e);
+        } catch (ExecutionException e) {
             throw new RqdClientException("failed to kill frame " + frameId, e);
         }
     }

--- a/cuebot/src/main/java/com/imageworks/spcue/service/MaintenanceManagerSupport.java
+++ b/cuebot/src/main/java/com/imageworks/spcue/service/MaintenanceManagerSupport.java
@@ -110,6 +110,15 @@ public class MaintenanceManagerSupport {
     private static final long ORPHAN_KILL_POLL_INTERVAL_MS = 500;
 
     /**
+     * Maximum number of orphaned procs to process in a single hardware-state pass. The orphan query
+     * returns oldest-ping first, so when the orphan set exceeds this batch the longest-stale procs
+     * are always the ones retried; procs whose release keeps being deferred occupy the batch until
+     * they are released or hit the deferral bound ({@code dispatcher.lost_proc_max_defer_ms}).
+     * Overridable via the {@code maintenance.orphaned_proc_batch_size} property.
+     */
+    private static final int DEFAULT_ORPHANED_PROC_BATCH_SIZE = 100;
+
+    /**
      * Outcome of attempting to confirm an orphaned frame's render is dead.
      */
     private enum OrphanKillResult {
@@ -194,7 +203,9 @@ public class MaintenanceManagerSupport {
     }
 
     private void clearOrphanedProcs() {
-        List<VirtualProc> procs = procDao.findOrphanedVirtualProcs(100);
+        int batchSize = env.getProperty("maintenance.orphaned_proc_batch_size", Integer.class,
+                DEFAULT_ORPHANED_PROC_BATCH_SIZE);
+        List<VirtualProc> procs = procDao.findOrphanedVirtualProcs(batchSize);
         for (VirtualProc proc : procs) {
             try {
                 // Only report a cleanup when the proc was actually released; lostProc may defer the

--- a/cuebot/src/main/resources/opencue.properties
+++ b/cuebot/src/main/resources/opencue.properties
@@ -175,6 +175,15 @@ dispatcher.retry_frame_kill_budget_ms=10000
 # true.
 dispatcher.defer_release_on_failed_kill_enabled=true
 
+# Upper bound on the deferral above, measured as time since the proc's last ping proved its frame
+# alive on its host (proc.ts_ping stops advancing once the host stops reporting that frame). Once
+# a lost proc has gone unpinged longer than this and its kill still cannot confirm the frame
+# stopped, the proc is released but the frame is failed closed to DEAD (manual retry) instead of
+# WAITING, so an unconfirmable render can neither linger RUNNING forever nor be auto-rebooked
+# while it may still be alive. Mirrors maintenance.orphaned_frame_max_defer_ms on the
+# orphaned-frame side. Negative disables the bound (defer indefinitely). Default is 20 minutes.
+dispatcher.lost_proc_max_defer_ms=1200000
+
 # When a reported running frame's resource_id maps to a proc that now owns a different frame, the
 # frame is demonstrably owned elsewhere: kill it immediately instead of waiting for the grace and
 # isOrphan windows. Set to false to disable this immediate kill; such mismatched frames are then
@@ -266,6 +275,14 @@ maintenance.orphaned_frame_max_defer_ms=3600000
 # Maximum number of orphaned frames to process per pass. Bounds the work of a fleet-wide event; the
 # remainder is picked up on subsequent passes. Default is 100.
 maintenance.orphaned_frame_batch_size=100
+
+# Maximum number of orphaned procs (proc.ts_ping stale) to process per hardware-state pass. The
+# orphan query returns oldest-ping first, so the longest-stale procs are always retried; procs
+# whose release keeps being deferred (host up but the kill cannot confirm the frame stopped)
+# occupy the batch until they release or hit dispatcher.lost_proc_max_defer_ms. Raise this if a
+# large fleet event leaves more unconfirmable procs than one batch and genuinely-releasable
+# orphans are waiting behind them. Default is 100.
+maintenance.orphaned_proc_batch_size=100
 
 # Interval in milliseconds for subscription recalculation task.
 # Default is 2 hours (7200000 ms). This task fixes subscription

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/ProcDaoTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dao/postgres/ProcDaoTests.java
@@ -502,6 +502,70 @@ public class ProcDaoTests extends AbstractTransactionalJUnit4SpringContextTests 
     @Test
     @Transactional
     @Rollback(true)
+    public void testIsPingOlderThan() {
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1");
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = PK_ALLOC;
+        proc.coresReserved = 100;
+        proc.hostId = host.id;
+        proc.hostName = host.name;
+        proc.jobId = job.id;
+        proc.frameId = frame.id;
+        proc.layerId = frame.layerId;
+        proc.showId = frame.showId;
+        procDao.insertVirtualProc(proc);
+
+        assertFalse(procDao.isPingOlderThan(proc, 3600000L));
+
+        jdbcTemplate.update("UPDATE proc SET ts_ping = (current_timestamp - interval '2' hour)");
+
+        assertTrue(procDao.isPingOlderThan(proc, 3600000L));
+        // Still younger than a 3-hour bound.
+        assertFalse(procDao.isPingOlderThan(proc, 10800000L));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
+    public void testIsHostRebootedSinceDispatch() {
+        DispatchHost host = createHost();
+        JobDetail job = launchJob();
+        FrameDetail frame = frameDao.findFrameDetail(job, "0001-pass_1");
+
+        VirtualProc proc = new VirtualProc();
+        proc.allocationId = PK_ALLOC;
+        proc.coresReserved = 100;
+        proc.hostId = host.id;
+        proc.hostName = host.name;
+        proc.jobId = job.id;
+        proc.frameId = frame.id;
+        proc.layerId = frame.layerId;
+        proc.showId = frame.showId;
+        procDao.insertVirtualProc(proc);
+
+        // Host booted before the proc was dispatched: no proof the render is dead.
+        assertFalse(procDao.isHostRebootedSinceDispatch(proc));
+
+        // A boot only slightly after dispatch stays within the clock-skew safety margin.
+        jdbcTemplate.update(
+                "UPDATE host_stat SET ts_booted = (current_timestamp + interval '1' minute) "
+                        + "WHERE pk_host = ?",
+                host.id);
+        assertFalse(procDao.isHostRebootedSinceDispatch(proc));
+
+        // A boot well after dispatch proves the render died with the reboot.
+        jdbcTemplate
+                .update("UPDATE host_stat SET ts_booted = (current_timestamp + interval '1' hour) "
+                        + "WHERE pk_host = ?", host.id);
+        assertTrue(procDao.isHostRebootedSinceDispatch(proc));
+    }
+
+    @Test
+    @Transactional
+    @Rollback(true)
     public void testUnbookProc() {
 
         DispatchHost host = createHost();

--- a/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/DispatchSupportServiceLostProcTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/dispatcher/DispatchSupportServiceLostProcTests.java
@@ -24,6 +24,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import com.imageworks.spcue.FrameDetail;
 import com.imageworks.spcue.FrameInterface;
 import com.imageworks.spcue.HostInterface;
+import com.imageworks.spcue.ProcInterface;
 import com.imageworks.spcue.VirtualProc;
 import com.imageworks.spcue.dao.FrameDao;
 import com.imageworks.spcue.dao.HostDao;
@@ -36,8 +37,11 @@ import com.imageworks.spcue.dispatcher.Dispatcher;
 import com.imageworks.spcue.grpc.job.FrameState;
 import com.imageworks.spcue.rqd.RqdClient;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -61,6 +65,8 @@ public class DispatchSupportServiceLostProcTests {
             "dispatcher.kill_running_frame_before_release_enabled";
     private static final String DEFER_RELEASE_PROPERTY =
             "dispatcher.defer_release_on_failed_kill_enabled";
+    private static final String MAX_DEFER_PROPERTY = "dispatcher.lost_proc_max_defer_ms";
+    private static final long MAX_DEFER_DEFAULT = 1200000L;
 
     private DispatchSupportService dispatchSupport;
     private RqdClient rqdClient;
@@ -93,9 +99,17 @@ public class DispatchSupportServiceLostProcTests {
                 .thenReturn(true);
         when(env.getProperty(eq(DEFER_RELEASE_PROPERTY), eq(Boolean.class), eq(true)))
                 .thenReturn(true);
+        when(env.getProperty(eq(MAX_DEFER_PROPERTY), eq(Long.class), eq(MAX_DEFER_DEFAULT)))
+                .thenReturn(MAX_DEFER_DEFAULT);
 
         // Default: the host still looks Up in the DB (the dangerous flapping case).
         when(hostDao.isHostUp(any(HostInterface.class))).thenReturn(true);
+
+        // Default: the proc's deferral bound has not expired yet.
+        when(procDao.isPingOlderThan(any(ProcInterface.class), anyLong())).thenReturn(false);
+
+        // Default: the host has not been rebooted since the proc was dispatched.
+        when(procDao.isHostRebootedSinceDispatch(any(ProcInterface.class))).thenReturn(false);
 
         proc = new VirtualProc();
         proc.id = "00000000-0000-0000-0000-000000000001";
@@ -220,6 +234,74 @@ public class DispatchSupportServiceLostProcTests {
         verify(procDao, times(1)).deleteVirtualProc(proc);
         verify(frameDao, times(1)).updateFrameStopped(any(FrameInterface.class),
                 eq(FrameState.WAITING), anyInt());
+    }
+
+    @Test
+    public void releasesWhenHostRebootedSinceDispatch() {
+        // The kill cannot confirm the frame stopped and the host still looks Up, but the host
+        // reports a boot time later than the proc's dispatch: the render died with the reboot, so
+        // release is safe and the frame goes back to WAITING (auto-retry), not deferred.
+        doThrow(new RuntimeException("transient unreachable")).when(rqdClient)
+                .killFrame(any(VirtualProc.class), anyString());
+        when(procDao.isHostRebootedSinceDispatch(any(ProcInterface.class))).thenReturn(true);
+
+        assertTrue(dispatchSupport.lostProc(proc, "orphaned", Dispatcher.EXIT_STATUS_FRAME_ORPHAN));
+
+        verify(procDao, times(1)).deleteVirtualProc(proc);
+        verify(frameDao, times(1)).updateFrameStopped(any(FrameInterface.class),
+                eq(FrameState.WAITING), anyInt());
+    }
+
+    @Test
+    public void failsClosedToDeadWhenDeferralBoundExceeded() {
+        // The kill still cannot confirm the frame stopped and the host still looks Up, but the
+        // proc has gone unpinged longer than the deferral bound: instead of deferring forever the
+        // proc is released and the frame is parked DEAD (manual retry), never WAITING, so it
+        // cannot be auto-rebooked while the original render's fate is unknown.
+        doThrow(new RuntimeException("transient unreachable")).when(rqdClient)
+                .killFrame(any(VirtualProc.class), anyString());
+        when(procDao.isPingOlderThan(any(ProcInterface.class), anyLong())).thenReturn(true);
+
+        assertTrue(dispatchSupport.lostProc(proc, "orphaned", Dispatcher.EXIT_STATUS_FRAME_ORPHAN));
+
+        verify(procDao, times(1)).deleteVirtualProc(proc);
+        verify(frameDao, times(1)).updateFrameStopped(any(FrameInterface.class),
+                eq(FrameState.DEAD), anyInt());
+        verify(frameDao, never()).updateFrameStopped(any(FrameInterface.class),
+                eq(FrameState.WAITING), anyInt());
+    }
+
+    @Test
+    public void failsClosedToDeadForFailedKillExitStatusWhenBoundExceeded() {
+        // Same bound applies to the upstream-failed-kill path (EXIT_STATUS_FAILED_KILL), which
+        // never re-issues the kill but otherwise defers identically.
+        when(procDao.isPingOlderThan(any(ProcInterface.class), anyLong())).thenReturn(true);
+
+        assertTrue(
+                dispatchSupport.lostProc(proc, "failed kill", Dispatcher.EXIT_STATUS_FAILED_KILL));
+
+        verify(rqdClient, never()).killFrame(any(VirtualProc.class), anyString());
+        verify(procDao, times(1)).deleteVirtualProc(proc);
+        verify(frameDao, times(1)).updateFrameStopped(any(FrameInterface.class),
+                eq(FrameState.DEAD), anyInt());
+    }
+
+    @Test
+    public void defersIndefinitelyWhenBoundDisabledByProperty() {
+        // A negative bound disables the fail-closed path entirely: deferral never expires, and
+        // the ping-age query is not even consulted.
+        when(env.getProperty(eq(MAX_DEFER_PROPERTY), eq(Long.class), eq(MAX_DEFER_DEFAULT)))
+                .thenReturn(-1L);
+        doThrow(new RuntimeException("transient unreachable")).when(rqdClient)
+                .killFrame(any(VirtualProc.class), anyString());
+
+        assertFalse(
+                dispatchSupport.lostProc(proc, "orphaned", Dispatcher.EXIT_STATUS_FRAME_ORPHAN));
+
+        verify(procDao, never()).isPingOlderThan(any(ProcInterface.class), anyLong());
+        verify(procDao, never()).deleteVirtualProc(any(VirtualProc.class));
+        verify(frameDao, never()).updateFrameStopped(any(FrameInterface.class),
+                any(FrameState.class), anyInt());
     }
 
     @Test

--- a/cuebot/src/test/java/com/imageworks/spcue/test/rqd/RqdClientGrpcTests.java
+++ b/cuebot/src/test/java/com/imageworks/spcue/test/rqd/RqdClientGrpcTests.java
@@ -1,0 +1,105 @@
+
+/*
+ * Copyright Contributors to the OpenCue Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.imageworks.spcue.test.rqd;
+
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.imageworks.spcue.grpc.rqd.RqdInterfaceGrpc;
+import com.imageworks.spcue.grpc.rqd.RqdStaticKillRunningFrameRequest;
+import com.imageworks.spcue.grpc.rqd.RqdStaticKillRunningFrameResponse;
+import com.imageworks.spcue.rqd.RqdClientException;
+import com.imageworks.spcue.rqd.RqdClientGrpc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link RqdClientGrpc#killFrame} status handling, exercised against a real gRPC server
+ * on an ephemeral localhost port so the actual status-code classification runs. RQD answers
+ * NOT_FOUND when it does not track the frame (already reaped, or the host restarted since
+ * dispatch): that is definitive proof the render is not running, so the kill must report success
+ * rather than an error -- otherwise callers like lostProc defer releasing a provably dead frame.
+ */
+public class RqdClientGrpcTests {
+
+    private Server server;
+    private RqdClientGrpc client;
+
+    /** Status the fake RQD responds to kills with; null means a normal successful kill. */
+    private volatile Status killResponseStatus = null;
+    private volatile String lastKillFrameId = null;
+
+    private class FakeRqdServant extends RqdInterfaceGrpc.RqdInterfaceImplBase {
+        @Override
+        public void killRunningFrame(RqdStaticKillRunningFrameRequest request,
+                StreamObserver<RqdStaticKillRunningFrameResponse> responseObserver) {
+            lastKillFrameId = request.getFrameId();
+            if (killResponseStatus == null) {
+                responseObserver.onNext(RqdStaticKillRunningFrameResponse.newBuilder().build());
+                responseObserver.onCompleted();
+            } else {
+                responseObserver.onError(killResponseStatus.asRuntimeException());
+            }
+        }
+    }
+
+    @Before
+    public void setup() throws Exception {
+        server = ServerBuilder.forPort(0).addService(new FakeRqdServant()).build().start();
+        client = new RqdClientGrpc(server.getPort(), 10, 5, 1, 5);
+    }
+
+    @After
+    public void teardown() {
+        client.shutdown();
+        server.shutdownNow();
+    }
+
+    @Test
+    public void killFrameSucceedsWhenRqdKillsTheFrame() {
+        client.killFrame("localhost", "frame-id", "test kill");
+
+        assertEquals("frame-id", lastKillFrameId);
+    }
+
+    @Test
+    public void killFrameTreatsNotFoundAsConfirmedStopped() {
+        killResponseStatus = Status.NOT_FOUND;
+
+        // Must not throw: the frame is confirmed not running on the host.
+        client.killFrame("localhost", "frame-id", "test kill");
+
+        assertEquals("frame-id", lastKillFrameId);
+    }
+
+    @Test
+    public void killFrameThrowsWhenOutcomeUnknown() {
+        killResponseStatus = Status.UNAVAILABLE;
+
+        try {
+            client.killFrame("localhost", "frame-id", "test kill");
+            fail("expected RqdClientException for an unknown kill outcome");
+        } catch (RqdClientException expected) {
+            // The frame's state is unknown; callers must not treat this as confirmed-stopped.
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #2506: a restarted RQD answers kill-before-release with NOT_FOUND, which was wrapped as a failure, so lostProc deferred provably dead frames indefinitely and re-logged the "Deferring release of lost proc" WARN every 30s.

- RqdClientGrpc.killFrame now treats NOT_FOUND as confirmed-stopped (matching isFrameRunning); only unknown outcomes throw RqdClientException.
- Bound the deferral: after dispatcher.lost_proc_max_defer_ms (default 20 min) without a ping proving the frame alive, release the proc and fail the frame closed to DEAD (manual retry) instead of deferring again. Negative disables the bound.
- Boot-time fence: a host whose reported boot time is later than the proc's dispatch (plus a clock-skew margin) cannot be running the frame, so release it to WAITING even when the kill cannot be delivered.
- Orphaned-proc reaper: order candidates oldest-ping first (deterministic batch turnover) and make the batch size configurable (maintenance.orphaned_proc_batch_size, default 100) so unconfirmable procs cannot starve releasable orphans.

New unit tests cover the fail-closed bound, the boot fence, and killFrame status classification against a real localhost gRPC server; DAO tests cover the new queries.

## LLM usage disclosure
Claude Opus was used for investigating the logs and implementing this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of lost processes by detecting stale pings and host reboots.
  - Automatically marks frames as **DEAD** when lost-process recovery cannot be confirmed within the configured time limit.
  - Treats already-missing frames as successfully stopped during kill operations.
  - Orphaned-process cleanup now processes oldest entries first.

- **Configuration**
  - Added settings for lost-process deferral limits and orphaned-process cleanup batch size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->