### PR TITLE
[pyoutline] Fix reStructuredText error in read_config_from_disk docstring

### DIFF
--- a/pyoutline/outline/config.py
+++ b/pyoutline/outline/config.py
@@ -74,14 +74,16 @@ def read_config_from_disk():
     """Loads configuration settings from config file on the local system.
 
     The configuration file used is, in order of preference:
+
     - Path defined by the OUTLINE_CONFIG_FILE environment variable.
     - Path defined by the OL_CONFIG environment variable.
     - Path within the config base directory (i.e. ~/.config/opencue/outline.cfg)
     - The default outline.cfg file which is distributed with the outline library.
-    - Override config options with environment variables if present.
-      Format: OUTLINE_<SECTION>_<OPTION>
-      Section and option names are converted to uppercase, with non-alphanumeric characters
-      (such as ':' in section names) replaced with '_'.
+
+    Options read from that file are then overridden by environment variables if present, using
+    the format ``OUTLINE_<SECTION>_<OPTION>``. Section and option names are converted to
+    uppercase, with non-alphanumeric characters (such as ``:`` in section names) replaced
+    with ``_``.
 
     :rtype: ConfigParser
     :return: config settings


### PR DESCRIPTION
## Problem

`Test Documentation Build` is failing on `master` and therefore on every open PR:

```
pyoutline/outline/config.py:docstring of outline.config.read_config_from_disk:9:
ERROR: Unexpected indentation. [docutils]
build finished with problems, 1 warning (with warnings treated as errors).
```

Introduced by #2517 (`9fd63f5a`). The run immediately before it (`ee688716`) was green.

## Cause

The bullet list in the docstring is not separated from the paragraph that introduces it by a blank line, so docutils parses the whole block as a single paragraph. That was harmless while every bullet was a single line. #2517 added a bullet with indented continuation lines, and indented lines inside a paragraph are an error. `ci/build_sphinx_docs.sh` runs `sphinx-build -W`, so the one warning fails the build.

## Fix

- Add the blank line so the block parses as an actual bullet list.
- Move the environment-variable note out of that list. It describes how options are overridden *after* a config file has been selected, so it does not belong in the list of config file locations searched "in order of preference".

No behaviour change; docstring only.

## Verification

Built with `sphinx==8.1.3` and `-W`, matching `api_docs/requirements.txt`:

| | `sphinx-build -W` |
|---|---|
| current `master` docstring | exit 1, the error above |
| with this change | exit 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEGXXK67kYKMXWW6F84Si8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified configuration loading behavior, including precedence between configuration files and environment-variable overrides.
  * Documented the environment-variable naming format and character conversion rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->