### PR TITLE
[cuebot] Replace EOL bullseye base image to unbreak CI

### DIFF
--- a/cuebot/Dockerfile
+++ b/cuebot/Dockerfile
@@ -44,7 +44,7 @@ RUN chmod +x create_rpm.sh && ./create_rpm.sh cuebot "$(cat VERSION)"
 # -----------------
 # RUN
 # -----------------
-FROM openjdk:18-ea-18-slim-bullseye
+FROM eclipse-temurin:17-jdk-noble
 
 # Install curl for healthchecking
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Problem

Every CI run has failed at `Building Cuebot image...` since **2026-09-07**, on `master` and on PRs that touch no Java at all (including dependabot PRs that only bump a cueweb JS dependency). The job console only shows `Process completed with exit code 1`; the real error is in the `test-logs` artifact:

```
E: Release file for http://security.debian.org/debian-security/dists/bullseye-security/InRelease
   is expired (invalid since 2d 1h 42min 28s).
ERROR: process "/bin/sh -c apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*"
   did not complete successfully: exit code: 100
```

Debian 11 has left LTS, and its security pocket now publishes an expired Release file:

```
$ curl -s http://security.debian.org/debian-security/dists/bullseye-security/Release | grep Valid-Until
Valid-Until: Mon, 07 Sep 2026 21:13:04 UTC
```

`apt` refuses an expired Release and exits 100, so installing `curl` for the gRPC healthcheck in `cuebot/Dockerfile` can never succeed. The integration test never gets as far as starting a container — Postgres, Cuebot startup, RQD and job launch have not actually been exercised on any branch since Sep 3.

This is time-based, not code-based: the "invalid since" counter grows run over run, and the last green Testing Pipeline on master was Sep 3 15:35, with the first Integration Test failure on Sep 8 16:43 — the first master run after the expiry timestamp above.

## Fix

Move the runtime stage from `openjdk:18-ea-18-slim-bullseye` to `eclipse-temurin:17-jdk-noble`.

- The `openjdk` Docker Hub images have been deprecated by upstream for years, and `18-ea` is an *early-access* build of a JDK that is itself long EOL. Temurin is the maintained successor.
- **17** matches the `gradle:7.6.4-jdk17` build stage, so the jar runs on the JDK it was compiled against (bytecode target is 11). This is a smaller behavioural step than jumping to 21 under Spring Boot 2.2.
- **jdk**, not `jre`, to preserve the current image's debugging tools (`jstack`, `jcmd`) for a running Cuebot.
- Ubuntu publishes **no `Valid-Until` field on any noble pocket** (`noble`, `noble-updates`, `noble-security`), so this specific failure mode cannot recur.

`cuebot/Dockerfile` was the only Dockerfile in the repo still on bullseye — `rest_gateway` and the three `rust/Dockerfile.*` are already on bookworm, and the rest are Rocky/Alma/Alpine/python.

## Verification

Docker on my machine is currently broken (Docker Desktop VM storage is returning I/O errors), so I verified against the registry and the apt archives directly rather than with a local build:

- `eclipse-temurin:17-jdk-noble` resolves for both `linux/amd64` and `linux/arm64`.
- Its image config sets `PATH=/opt/java/openjdk/bin:...` and `JAVA_HOME=/opt/java/openjdk` with `JAVA_VERSION=jdk-17.0.20+8`, so the bare `java` in the existing `ENTRYPOINT` resolves unchanged. As before, the Dockerfile's `ENTRYPOINT` resets the base image's inherited `CMD`.
- None of the noble pockets set `Valid-Until`, unlike bullseye-security above.

The full end-to-end confirmation is this PR's own Integration Test run — it exercises exactly the build that is currently failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AN3UHLmqQzR5U2Awh7SY9e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application’s runtime environment to Eclipse Temurin JDK 17.
  - The runtime now uses an Ubuntu Noble-based image instead of the previous OpenJDK 18 early-access environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->